### PR TITLE
Upgrade CUDA to 12.8

### DIFF
--- a/Dockerfile.vllm-nixl
+++ b/Dockerfile.vllm-nixl
@@ -1,10 +1,10 @@
 # NeuralMagic vLLM fork [NIXL workstream] + LMCache fork dev branch
 
 ARG BASE_IMAGE="nvcr.io/nvidia/cuda"
-ARG BASE_IMAGE_TAG="12.5.1-devel-ubuntu24.04"
+ARG BASE_IMAGE_TAG="12.8.1-devel-ubuntu24.04"
 
 ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"
-ARG RUNTIME_IMAGE_TAG="12.5.1-devel-ubuntu24.04"
+ARG RUNTIME_IMAGE_TAG="12.8.1-devel-ubuntu24.04"
 
 FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS nixl_base
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Upgrade to 12.8 as:
1. CUDA >= 12.8 is required for blackwell
2. PyTorch 2.7.0 dropped the CUDA 12.4 wheel, so we need to use an image that is compatible with either the 12.6 or 12.8 PyTorch wheel.