### PR TITLE
Add GHA for updating semver links

### DIFF
--- a/.github/workflows/update_semver.yml
+++ b/.github/workflows/update_semver.yml
@@ -1,0 +1,23 @@
+---
+name: Update Semver
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+  release:
+    types:
+      - published
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update-semver:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: haya14busa/action-update-semver@v1.3.0
+        with:
+          major_version_tag_only: false # (optional, default is "false")


### PR DESCRIPTION
Updates release links so that when a new 0.0.10 release is executed, 0.0 and 0 tags are pointing to the new one, so that users can decide to 'follow' major, minor or z releases for the code