### PR TITLE
Fix incorrect link to prefix cache northstar doc in llm-d.md

### DIFF
--- a/docs/proposals/llm-d.md
+++ b/docs/proposals/llm-d.md
@@ -78,7 +78,7 @@ Our current Northstar designs lay out the initial scope (join llm-d-contributors
 
 * [vLLM-Optimized Inference Scheduler](https://docs.google.com/document/d/1kE1LY8OVjiOgKVD9-9Po96HODbTIbgHp4qgvw06BCOc/edit)
 * [Disaggregated Serving with vLLM](https://docs.google.com/document/d/1FNN5snmipaTxEA1FGEeSH7Z_kEqskouKD1XYhVyTHr8/edit)
-* [Prefix Cache Hierarchy](https://docs.google.com/document/d/1inTneLEZTv3rDEBB9KLOB9K6oMq8c3jkogARJqdt_58/edit)
+* [Prefix Cache Hierarchy](https://docs.google.com/document/d/1d-jKVHpTJ_tkvy6Pfbl3q2FM59NpfnqPAh__Uz_bEZ8/edit?tab=t.0#heading=h.6qazyl873259)
 * [Variant Autoscaling over Hardware, Workload, and Traffic](https://docs.google.com/document/d/1inTneLEZTv3rDEBB9KLOB9K6oMq8c3jkogARJqdt_58/edit)
 
 ## Alternatives


### PR DESCRIPTION
The current link leads to autoscaling northstar doc.