### PR TITLE
Add arm64 support for images

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -33,7 +33,7 @@ runs:
     - name: Build image
       run: |
         docker buildx build \
-          --platform linux/amd64 \
+          --platform linux/amd64,linux/arm64 \
           -t ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.tag }} \
           --push .
       shell: bash


### PR DESCRIPTION
This PR enables multi-architecture Docker images by adding ARM64 support alongside AMD64.

fixed: #100
