### PR TITLE
 Fix git clone command for llm-d repos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ llm-d can be installed as a full solution, customizing enabled features, or thro
 
 To clone all main components:
 ```
-repos="llm-d llm-d-deployer llm-d-inference-scheduler llm-d-kv-cache-manager llm-d-routing-sidecar llm-d-model-service llm-d-benchmark llm-d-inference-sim"; for r in $repos; do git clone https://github.com/llm-d/$r.git; done
+repos=(llm-d llm-d-deployer llm-d-inference-scheduler llm-d-kv-cache-manager llm-d-routing-sidecar llm-d-model-service llm-d-benchmark llm-d-inference-sim); for r in $repos; do git clone https://github.com/llm-d/$r.git; done
 ``` 
 
 > [!TIP]


### PR DESCRIPTION
previously, an example with echo
```
❯ repos="llm-d llm-d-deployer llm-d-inference-scheduler llm-d-kv-cache-manager llm-d-routing-sidecar llm-d-model-service llm-d-benchmark llm-d-inference-sim"
for r in $repos; do
    echo -e "${r}\n"
done
llm-d llm-d-deployer llm-d-inference-scheduler llm-d-kv-cache-manager llm-d-routing-sidecar llm-d-model-service llm-d-benchmark llm-d-inference-sim`
```

after update example

```
❯ repos=(llm-d llm-d-deployer llm-d-inference-scheduler llm-d-kv-cache-manager llm-d-routing-sidecar llm-d-model-service llm-d-benchmark llm-d-inference-sim)
for r in $repos; do
    echo "$r"
done
llm-d
llm-d-deployer
llm-d-inference-scheduler
llm-d-kv-cache-manager
llm-d-routing-sidecar
llm-d-model-service
llm-d-benchmark
llm-d-inference-sim
```
