### PR TITLE
Top level header needs to be H2

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# Code of Conduct and Covenant
+## Code of Conduct and Covenant
 
 ## Our Pledge  
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing Guidelines
+## Contributing Guidelines
 
 Thank you for your interest in contributing to llm-d. Community involvement is highly valued and crucial for the project's growth and success. The llm-d project accepts contributions via GitHub pull requests. This outlines the process to help get your contribution accepted.
 


### PR DESCRIPTION
Because when we sync to the llm-d.ai site we want to manage the header in that configuration vs having the header here conflict.

For example on the preview of the [security.md page](https://deploy-preview-54--elaborate-kangaroo-25e1ee.netlify.app/docs/community/security) - the h1 header can be controlled by the site and show up before the content sync notice. 

But in the [code_of_conduct.md preview](https://deploy-preview-54--elaborate-kangaroo-25e1ee.netlify.app/docs/community/code-of-conduct) the header is below.  