### PR TITLE
feat: Add OpenAI API server dependencies to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -206,6 +206,10 @@ RUN . .vllm/bin/activate && \
     VLLM_PRECOMPILED_WHEEL_LOCATION=https://wheels.vllm.ai/${VLLM_COMMIT}/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl \
     VLLM_USE_PRECOMPILED=1 uv pip install --editable .
 
+# Install additional dependencies for openai api server
+RUN . .vllm/bin/activate && \
+    uv pip install accelerate hf_transfer modelscope
+
 # Install related packages and cleanup
 RUN . .vllm/bin/activate && \
     uv pip install ../LMCache/ && \


### PR DESCRIPTION
The current llm-d image does not support modelscope.  

This PR adds essential dependencies for enhanced OpenAI API server functionality to the existing Dockerfile; reference implementation at https://github.com/vllm-project/vllm/blob/main/docker/Dockerfile#L503 .