### PR TITLE
ignore linkedin links, its returning 999 to avoid scraping

### DIFF
--- a/.github/actions/markdown-link-checker/action.yaml
+++ b/.github/actions/markdown-link-checker/action.yaml
@@ -27,7 +27,7 @@ runs:
         while IFS= read -r -d '' file; do
           echo "------------------------------------------------------------"
           echo "📄 Checking: $file"
-          output=$(markdown-link-check ${{ inputs.args }} "$file" 2>&1)
+          output=$(markdown-link-check -c .markdownlinkcheck.json ${{ inputs.args }} "$file" 2>&1)
           echo "$output"
 
           if echo "$output" | grep -q '✖'; then

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -1,40 +1,38 @@
 name: CI - PR Checks
 
 on:
-  workflow_dispatch:
-  # pull_request:
-  #   branches:
-  #     - main
-
+  push:
+    branches:
+      - main
+      - dev  
+    paths:
+      - ./**.md
+      - .github/workflows/ci-pr-checks.yaml
+      - .github/actions/markdown-link-checker/action.yaml
+  pull_request:
+    branches:
+      - main
+      - dev
+    paths:
+      - ./**.md
+      - .github/workflows/ci-pr-checks.yaml
+      - .github/actions/markdown-link-checker/action.yaml
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
-        
-      - name: Sanity check repo contents
-        run: ls -la
-    
-      - name: Set up go with cache
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.24.0'
-          cache-dependency-path: ./go.sum
+
+      - name: warning about ignored paths
+        run: |
+          echo "Warning! Some paths are ignored in the markdown link checker config.
+          This is because those websites have strong anti-scraping behaviours. For
+          the full list of ignored paths, see the .markdownlinkcheck.json file:"
+          cat .markdownlinkcheck.json
 
       - name: Run markdown link checker
         uses: ./.github/actions/markdown-link-checker
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          args: "--quiet --retry"  
-
-      - name: Run lint checks
-        uses: golangci/golangci-lint-action@v8
-        with:
-          version: 'v2.1.6'
-          args: "--config=./.golangci.yml"
-          
-      - name: Run go test
-        shell: bash 
-        run: |
-          make test
+          # args: "--retry"  

--- a/.markdownlinkcheck.json
+++ b/.markdownlinkcheck.json
@@ -1,0 +1,10 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "linkedin.com"
+    },
+    { 
+      "pattern": "^(https?://)?(www\\.)?(old\\.)?reddit\\.com/" 
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ This project adheres to the llm-d [Code of Conduct and Covenant](CODE_OF_CONDUCT
 * **Mailing List**: [llm-d-contributors@googlegroups.com](mailto:llm-d-contributors@googlegroups.com) for document sharing and collaboration
 * **Social Media:** Follow us on social media for the latest news, announcements, and updates:
   * **X:** [https://x.com/\_llm_d\_](https://x.com/_llm_d_)
-  * **LinkedIn:** [https://linkedin.com/company/llm-d ](https://linkedin.com/company/llm-d)
+  * **LinkedIn:** [https://linkedin.com/company/llm-d](https://linkedin.com/company/llm-d)
   * **Reddit:** [https://www.reddit.com/r/llm_d/](https://www.reddit.com/r/llm_d/)
   * **YouTube** [@llm-d-project](https://youtube.com/@llm-d-project)
 

--- a/docs/proposals/modelservice.md
+++ b/docs/proposals/modelservice.md
@@ -68,7 +68,7 @@ Manual composition via raw Kubernetes resources:  One possible approach is for p
 
 ## Alternative: Extending KServe
 
-KServe provides a general-purpose model serving abstraction but was originally designed for traditional predictive models; it now provides several LLM specific features as of release 0.15 (see [this blogpost](https://kserve.github.io/website/master/blog/articles/2025-05-27-KServe-0.15-release/) for details). As we evolve the ModelService Helm chart, we also plan to collaborate with the KServe community to develop production-grade KServe mechanisms that integrate well with llm-d. This collaboration will support a variety of useful features, including prefill/decode disaggregation, dynamic LoRA loading, and configuration search and tuning.
+KServe provides a general-purpose model serving abstraction but was originally designed for traditional predictive models; it now provides several LLM specific features as of release 0.15 (see [this blogpost](https://kserve.github.io/website/blog/kserve-0.15-release) for details). As we evolve the ModelService Helm chart, we also plan to collaborate with the KServe community to develop production-grade KServe mechanisms that integrate well with llm-d. This collaboration will support a variety of useful features, including prefill/decode disaggregation, dynamic LoRA loading, and configuration search and tuning.
 
 ## Acknowledgements
 


### PR DESCRIPTION
cc @jjasghar @petecheslock 

Linked in blocks all web scraping so this returns status code 999 (request denied I think). This should help us fix our markdown checker which we can start working in.