### PR TITLE
add central landing spot for llm-d observability

### DIFF
--- a/observability/README.md
+++ b/observability/README.md
@@ -1,0 +1,52 @@
+# Observability in llm-d 
+
+Please join [SIG-Observability](../SIGS.md#sig-observability) to contribute to monitoring and observability topics within llm-d.
+
+## Enable Metrics Collection in llm-d Deployments
+
+To collect metrics from llm-d using the llm-d community's helm charts, Prometheus custom resources must be available
+in the cluster. Here are a few options for installing and accessing the necessary Prometheus resources:
+
+1. To install a simple Prometheus and Grafana stack, refer to [prometheus-grafana-stack.md](./prometheus-grafana-stack.md).
+2. User Workload Monitoring enabled on OpenShift provides an accessible Prometheus Stack for scraping metrics.
+   - See the [OpenShift documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/monitoring/configuring-user-workload-monitoring#enabling-monitoring-for-user-defined-projects_preparing-to-configure-the-monitoring-stack-uwm) to enable this feature
+3. Utilize an existing Prometheus stack. Check for the existence of Prometheus and metrics collection custom resources in your Kuberenetes cluster.
+   If they don't exist, reach out to a cluster administrator.
+
+If you have access to Prometheus with PodMonitors and ServiceMonitors, the [llm-d well-lit paths](https://github.com/llm-d-incubation/llm-d-infra/tree/main/quickstart/examples)
+include the option to enable PodMonitors for scraping vLLM metrics.
+
+**Note:** Google Kubernetes Engine (GKE) uses PodMonitoring resources instead of standard PodMonitors/ServiceMonitors. If using GKE, refer to the [Google Cloud Managed Prometheus documentation](https://cloud.google.com/stackdriver/docs/managed-prometheus) for metrics collection and migration guidance.
+
+With any llm-d quickstart well-lit path, update the modelservice values
+to enable monitoring:
+
+```yaml
+# In your ms-*/values.yaml files
+decode:
+  monitoring:
+    podmonitor:
+      enabled: true
+
+prefill:
+  monitoring:
+    podmonitor:
+      enabled: true
+```
+
+Upon installation, view prefill and/or decode podmonitors with:
+
+```bash
+kubectl get podmonitors -A
+```
+
+The vLLM metrics from prefill and decode pods will be visible from the Prometheus UI and/or Grafana UI.
+
+### Grafana Dashboards (optional)
+
+Grafana dashboard raw JSON files can be imported manually into a Grafana UI. Here is a current list of community dashboards:
+
+- [llm-d dashboard](./dashboards/grafana/llm-d-dashboard.json)
+  - vLLM metrics
+- [inference-gateway dashboard](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/tools/dashboards/inference_gateway.json)
+  - EPP pod metrics, requires additional setup to collect metrics. See [GAIE doc](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/tools/dashboards/README.md) 

--- a/observability/dashboards/grafana/llm-d-vllm-dashboard.json
+++ b/observability/dashboards/grafana/llm-d-vllm-dashboard.json
@@ -1,0 +1,1622 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.3.0"
+    },
+    {
+      "type": "panel",
+      "id": "heatmap",
+      "name": "Heatmap",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "monitoring llm-d inference server",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "End to end request latency measured in seconds.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 9,
+      "interval": "10m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(vllm:e2e_request_latency_seconds_bucket{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval])))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "P99",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(vllm:e2e_request_latency_seconds_bucket{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval])))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "P95",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.9, sum by(le) (rate(vllm:e2e_request_latency_seconds_bucket{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval])))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "P90",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum by(le) (rate(vllm:e2e_request_latency_seconds_bucket{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval])))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "P50",
+          "range": true,
+          "refId": "D",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(vllm:e2e_request_latency_seconds_sum{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval])\n/\nrate(vllm:e2e_request_latency_seconds_count{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Average",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title": "E2E Request Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Number of tokens processed per second",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 8,
+      "interval": "10m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "rate(vllm:prompt_tokens_total{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "Prompt Tokens/Sec",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "rate(vllm:generation_tokens_total{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval])",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "Generation Tokens/Sec",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        }
+      ],
+      "title": "Token Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Inter token latency in seconds.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 10,
+      "interval": "10m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(vllm:time_per_output_token_seconds_bucket{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval])))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "P99",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(vllm:time_per_output_token_seconds_bucket{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval])))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "P95",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.9, sum by(le) (rate(vllm:time_per_output_token_seconds_bucket{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval])))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "P90",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum by(le) (rate(vllm:time_per_output_token_seconds_bucket{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval])))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "P50",
+          "range": true,
+          "refId": "D",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(vllm:time_per_output_token_seconds_sum{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval])\n/\nrate(vllm:time_per_output_token_seconds_count{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Mean",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title": "Time Per Output Token Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Number of requests in RUNNING, WAITING, and SWAPPED state",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "vllm:num_requests_running{model_name=\"$model_name\",namespace=\"$namespace\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Num Running",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "vllm:num_requests_swapped{model_name=\"$model_name\",namespace=\"$namespace\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Num Swapped",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "vllm:num_requests_waiting{model_name=\"$model_name\",namespace=\"$namespace\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Num Waiting",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        }
+      ],
+      "title": "Scheduler State",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "P50, P90, P95, and P99 TTFT latency in seconds.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "interval": "10m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(vllm:time_to_first_token_seconds_bucket{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval])))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "P99",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(vllm:time_to_first_token_seconds_bucket{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval])))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "P95",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.9, sum by(le) (rate(vllm:time_to_first_token_seconds_bucket{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval])))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "P90",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum by(le) (rate(vllm:time_to_first_token_seconds_bucket{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval])))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "P50",
+          "range": true,
+          "refId": "D",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(vllm:time_to_first_token_seconds_sum{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval])\n/\nrate(vllm:time_to_first_token_seconds_count{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Average",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title": "Time To First Token Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Percentage of used cache blocks by vLLM.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "vllm:gpu_cache_usage_perc{model_name=\"$model_name\",namespace=\"$namespace\"}",
+          "instant": false,
+          "legendFormat": "GPU Cache Usage",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "vllm:cpu_cache_usage_perc{model_name=\"$model_name\",namespace=\"$namespace\"}",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "CPU Cache Usage",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Cache Utilization",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Heatmap of request prompt length",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 12,
+      "interval": "10m",
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "none"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "min": 0,
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto",
+          "value": "Request count"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisLabel": "Prompt Length",
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by(le) (increase(vllm:request_prompt_tokens_bucket{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Request Prompt Length",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Heatmap of request generation length",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 13,
+      "interval": "10m",
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "none"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "min": 0,
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto",
+          "value": "Request count"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisLabel": "Generation Length",
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by(le) (increase(vllm:request_generation_tokens_bucket{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Request Generation Length",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Number of finished requests by their finish reason: either an EOS token was generated or the max sequence length was reached.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 11,
+      "interval": "10m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by(finished_reason) (increase(vllm:request_success_total{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Finish Reason",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "seconds",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 14,
+      "interval": "10m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "rate(vllm:request_queue_time_seconds_sum{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Queue Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "rate(vllm:request_prefill_time_seconds_sum{model_name=\"$model_name\",namespace=\"$namespace\"}[30m])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Prefill",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(vllm:request_decode_time_seconds_sum{model_name=\"$model_name\",namespace=\"$namespace\"}[30m])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Decode",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Requests Prefill and Decode Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "rate(vllm:request_max_num_generation_tokens_sum{model_name=\"$model_name\",namespace=\"$namespace\"}[$__rate_interval])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Tokens",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Max Generation Token in Sequence Group",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 40,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "includeAll": false,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(vllm:generation_tokens_total,model_name)",
+        "includeAll": false,
+        "label": "model_name",
+        "name": "model_name",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(vllm:generation_tokens_total,model_name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "label_values(namespace)",
+        "label": "namespace",
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(namespace)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-12h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "llm-d dashboard",
+  "weekStart": ""
+}

--- a/observability/prometheus-grafana-stack.md
+++ b/observability/prometheus-grafana-stack.md
@@ -1,0 +1,202 @@
+# Quickstart Observability & Monitoring Guide
+
+This guide explains how to set up monitoring and observability for llm-d deployments.
+The llm-d quickstart provides a Prometheus and Grafana installation script with two deployment patterns:
+
+## Overview
+
+1. **Central Monitoring (Default)**: Single Prometheus instance monitors all namespaces automatically
+2. **Individual User Monitoring**: Each user has their own isolated Prometheus/Grafana stack
+
+## Platform-Specific Setup
+
+### OpenShift Clusters
+
+If you're running on **OpenShift**, you **do not need** to deploy Prometheus using this script. Instead, use OpenShift's built-in user workload monitoring:
+
+1. Enable user workload monitoring (if not already enabled)
+2. Deploy your llm-d workloads with PodMonitor enabled
+3. Metrics will automatically be collected by OpenShift's monitoring stack
+
+The setup script, [install-prometheus-grafana.sh](./scripts/install-prometheus-grafana.sh), will detect OpenShift and guide you through enabling user workload monitoring if needed.
+
+### Kubernetes Clusters
+
+If you're running on **Kubernetes** and you don't already have a Prometheus or observability stack deployed,
+use [install-prometheus-grafana.sh](./scripts/install-prometheus-grafana.sh) to deploy a Prometheus and Grafana stack for metrics collection.
+
+## Key Requirements
+
+- **Individual mode requires explicit namespace**: Use `-n <namespace>` or set `MONITORING_NAMESPACE` environment variable
+- **Central mode supports custom namespaces**: Use `-n <namespace>` to install in any namespace (defaults to `llm-d-monitoring`)
+- **Unique release names**: Each installation uses `prometheus-<namespace>` as the release name to avoid conflicts
+- **Label-based targeting**: Individual mode uses `monitoring-ns=<namespace>` labels to target specific namespaces
+
+## Quick Start
+
+### Step 1: Install Monitoring Stack
+
+**For Kubernetes clusters only** (skip if using OpenShift):
+
+```bash
+# Central monitoring (default - monitors all namespaces)
+./scripts/install-prometheus-grafana.sh
+
+# Central monitoring in custom namespace
+./scripts/install-prometheus-grafana.sh -n monitoring
+
+# Individual user monitoring (isolated) - requires explicit namespace
+./scripts/install-prometheus-grafana.sh --individual -n my-monitoring-namespace
+```
+
+**For OpenShift clusters**: No Prometheus installation needed - use the built-in user workload monitoring.
+
+### Step 2: Enable Monitoring for Your Deployments
+
+Choose the approach that matches your monitoring setup:
+
+#### Option A: Central Monitoring (Default)
+
+**No additional configuration required!** Central monitoring automatically discovers all ServiceMonitors and PodMonitors across all namespaces.
+
+#### Option B: Individual User Monitoring
+
+```bash
+# Label your namespace for individual monitoring
+# Replace 'my-monitoring-namespace' with your actual monitoring namespace
+kubectl label namespace <your-namespace> monitoring-ns=my-monitoring-namespace
+```
+
+### Step 3: Enable Metrics in Your Deployments
+
+Update your modelservice values to enable monitoring:
+
+```yaml
+# In your ms-*/values.yaml files
+decode:
+  monitoring:
+    podmonitor:
+      enabled: true
+
+prefill:
+  monitoring:
+    podmonitor:
+      enabled: true
+```
+
+### Step 4: Access Prometheus & Grafana UIs
+
+```bash
+# For central monitoring (default namespace)
+kubectl port-forward -n llm-d-monitoring svc/prometheus-kube-prometheus-prometheus 9090:9090
+kubectl port-forward -n llm-d-monitoring svc/prometheus-grafana 3000:80
+
+# For central monitoring (custom namespace)
+kubectl port-forward -n <your-namespace> svc/prometheus-kube-prometheus-prometheus 9090:9090
+kubectl port-forward -n <your-namespace> svc/prometheus-grafana 3000:80
+
+# For individual monitoring
+kubectl port-forward -n <your-monitoring-namespace> svc/prometheus-kube-prometheus-prometheus 9090:9090
+kubectl port-forward -n <your-monitoring-namespace> svc/prometheus-grafana 3000:80
+
+# Grafana login: admin/admin
+```
+
+## Integration with Helmfile Examples
+
+### Central Monitoring (Recommended)
+
+Since central monitoring watches all namespaces automatically, no additional configuration is needed in your helmfiles. Simply enable monitoring in your values files:
+
+```yaml
+# In your ms-*/values.yaml
+decode:
+  monitoring:
+    podmonitor:
+      enabled: true
+
+prefill:
+  monitoring:
+    podmonitor:
+      enabled: true
+```
+
+### Individual Monitoring Integration
+
+Add this hook to your `helmfile.yaml` to automatically label namespaces:
+
+```yaml
+# Add to any helmfile.yaml for individual monitoring
+# Replace 'my-monitoring-namespace' with your actual monitoring namespace
+hooks:
+  - name: enable-monitoring
+    events: ["postsync"]
+    command: kubectl
+    args:
+      - label
+      - namespace
+      - <your-namespace>  # Replace with actual namespace
+      - monitoring-ns=my-monitoring-namespace
+      - --overwrite
+```
+
+### Manual Namespace Labeling (Individual Mode Only)
+
+For manual control with individual monitoring:
+
+```bash
+# After running helmfile sync
+# Replace 'my-monitoring-namespace' with your actual monitoring namespace
+kubectl label namespace llm-d-sim monitoring-ns=my-monitoring-namespace                     # For sim example
+kubectl label namespace llm-d-pd monitoring-ns=my-monitoring-namespace                      # For pd-disaggregation example
+```
+
+## Security & Multi-Tenant Considerations
+
+### Central Monitoring
+
+- ⚠️ **Single-tenant use only**: All users can see all metrics
+- **Permissions**: Cluster-admin required for installation
+- **Isolation**: No tenant isolation - suitable for trusted environments
+- **Simplicity**: Zero configuration for metric collection
+
+### Individual Monitoring
+
+- ✅ **Multi-tenant safe**: Users only see their own metrics
+- **Permissions**: Namespace creation + ServiceAccount management
+- **Isolation**: Complete isolation between users
+- **Configuration**: Requires namespace labeling
+
+### Debugging Commands
+
+```bash
+# Check Prometheus targets (central mode - default namespace)
+kubectl port-forward -n llm-d-monitoring svc/prometheus-kube-prometheus-prometheus 9090:9090
+# Visit http://localhost:9090/targets
+
+# Check Prometheus targets (individual mode)
+kubectl port-forward -n <your-monitoring-namespace> svc/prometheus-kube-prometheus-prometheus 9090:9090
+# Visit http://localhost:9090/targets
+
+# Check ServiceMonitor/PodMonitor resources
+kubectl get servicemonitor,podmonitor -A
+
+# Check namespace labels (individual mode only)
+kubectl get namespaces --show-labels | grep monitoring-ns
+```
+
+## Cleanup
+
+```bash
+# Remove central monitoring stack (default namespace)
+./scripts/install-prometheus-grafana.sh -u
+
+# Remove central monitoring stack (custom namespace)
+./scripts/install-prometheus-grafana.sh -u -n monitoring
+
+# Remove individual monitoring stack
+./scripts/install-prometheus-grafana.sh -u -n <your-monitoring-namespace>
+
+# Remove namespace labels (individual mode only)
+kubectl label namespace <your-ns> monitoring-ns-
+```

--- a/observability/scripts/install-prometheus-grafana.sh
+++ b/observability/scripts/install-prometheus-grafana.sh
@@ -1,0 +1,448 @@
+#!/usr/bin/env bash
+# -*- indent-tabs-mode: nil; tab-width: 4; sh-indentation: 4; -*-
+
+set -euo pipefail
+
+### GLOBALS ###
+# Use central monitoring namespace by default (configurable via MONITORING_NAMESPACE env var)
+MONITORING_NAMESPACE="${MONITORING_NAMESPACE:-}"
+NAMESPACE_EXPLICITLY_SET=false
+ACTION="install"
+KUBERNETES_CONTEXT=""
+DEBUG=""
+CENTRAL_MODE=true
+
+### HELP & LOGGING ###
+print_help() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Install or uninstall Prometheus and Grafana stack for llm-d metrics collection.
+
+Options:
+  -n, --namespace NAME        Monitoring namespace (default: llm-d-monitoring for central mode)
+  -u, --uninstall             Uninstall Prometheus and Grafana stack
+  -d, --debug                 Add debug mode to the helm install
+  -g, --context               Supply a specific Kubernetes context
+  -i, --individual            Enable individual user monitoring mode (requires -n or MONITORING_NAMESPACE)
+  -h, --help                  Show this help and exit
+
+Environment Variables:
+  MONITORING_NAMESPACE        Override default monitoring namespace
+
+Examples:
+  $(basename "$0")                              # Install central monitoring in llm-d-monitoring (watches all namespaces)
+  $(basename "$0") -n monitoring                # Install central monitoring in 'monitoring' namespace
+  $(basename "$0") -u                           # Uninstall Prometheus/Grafana stack
+  $(basename "$0") -i -n my-monitoring          # Install individual monitoring in specified namespace
+  MONITORING_NAMESPACE=my-monitoring $(basename "$0") -i  # Individual mode via env var
+EOF
+}
+
+# ANSI colour helpers and functions
+COLOR_RESET=$'\e[0m'
+COLOR_GREEN=$'\e[32m'
+COLOR_YELLOW=$'\e[33m'
+COLOR_RED=$'\e[31m'
+COLOR_BLUE=$'\e[34m'
+
+log_info() {
+  echo "${COLOR_BLUE}ℹ️  $*${COLOR_RESET}"
+}
+
+log_success() {
+  echo "${COLOR_GREEN}✅ $*${COLOR_RESET}"
+}
+
+log_error() {
+  echo "${COLOR_RED}❌ $*${COLOR_RESET}" >&2
+}
+
+fail() { log_error "$*"; exit 1; }
+
+### UTILITIES ###
+check_cmd() {
+  command -v "$1" &>/dev/null || fail "Required command not found: $1"
+}
+
+check_dependencies() {
+  local required_cmds=(helm kubectl)
+  for cmd in "${required_cmds[@]}"; do
+    check_cmd "$cmd"
+  done
+}
+
+check_cluster_reachability() {
+  if kubectl cluster-info &> /dev/null; then
+    log_info "kubectl can reach to a running Kubernetes cluster."
+  else
+    fail "kubectl cannot reach any running Kubernetes cluster. The installer requires a running cluster"
+  fi
+}
+
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -n|--namespace)                  MONITORING_NAMESPACE="$2"; NAMESPACE_EXPLICITLY_SET=true; shift 2 ;;
+      -u|--uninstall)                  ACTION="uninstall"; shift ;;
+      -d|--debug)                      DEBUG="--debug"; shift;;
+      -g|--context)                    KUBERNETES_CONTEXT="$2"; shift 2 ;;
+      -i|--individual)                 CENTRAL_MODE=false; shift ;;
+      -h|--help)                       print_help; exit 0 ;;
+      *)                               fail "Unknown option: $1" ;;
+    esac
+  done
+}
+
+setup_env() {
+  if [[ ! -z $KUBERNETES_CONTEXT ]]; then
+    if [[ ! -f $KUBERNETES_CONTEXT ]]; then
+      log_error "Error, the context file \"$KUBERNETES_CONTEXT\", passed via command-line option, does not exist!"
+      exit 1
+    fi
+    KCMD="kubectl --kubeconfig $KUBERNETES_CONTEXT"
+    HCMD="helm --kubeconfig $KUBERNETES_CONTEXT"
+  else
+    KCMD="kubectl"
+    HCMD="helm"
+  fi
+
+  # Set up monitoring namespace and labels based on mode
+  if [[ "$CENTRAL_MODE" == "true" ]]; then
+    # Central mode: use specified namespace or default to llm-d-monitoring
+    if [[ -z "$MONITORING_NAMESPACE" ]]; then
+      MONITORING_NAMESPACE="llm-d-monitoring"
+    fi
+    MONITORING_LABEL_KEY=""
+    MONITORING_LABEL_VALUE=""
+  else
+    # Individual mode: require explicit namespace
+    if [[ -z "$MONITORING_NAMESPACE" ]]; then
+      fail "Individual monitoring mode (-i) requires a namespace to be specified via -n flag or MONITORING_NAMESPACE environment variable"
+    fi
+    MONITORING_LABEL_KEY="monitoring-ns"
+    MONITORING_LABEL_VALUE="${MONITORING_NAMESPACE}"
+  fi
+}
+
+is_openshift() {
+  # Check for OpenShift-specific resources
+  if $KCMD get clusterversion &>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+check_servicemonitor_crd() {
+  log_info "🔍 Checking for ServiceMonitor CRD (monitoring.coreos.com)..."
+  if ! $KCMD get crd servicemonitors.monitoring.coreos.com &>/dev/null; then
+    log_info "⚠️ ServiceMonitor CRD (monitoring.coreos.com) not found - will be installed with Prometheus stack"
+    return 1
+  fi
+
+  API_VERSION=$($KCMD get crd servicemonitors.monitoring.coreos.com -o jsonpath='{.spec.versions[?(@.served)].name}' 2>/dev/null || echo "")
+
+  if [[ -z "$API_VERSION" ]]; then
+    log_info "⚠️ Could not determine ServiceMonitor CRD API version"
+    return 1
+  fi
+
+  if [[ "$API_VERSION" == "v1" ]]; then
+    log_success "ServiceMonitor CRD (monitoring.coreos.com/v1) found - using existing installation"
+    return 0
+  else
+    log_info "⚠️ Found ServiceMonitor CRD but with unexpected API version: ${API_VERSION}"
+    return 1
+  fi
+}
+
+check_existing_node_exporter() {
+  log_info "🔍 Checking for existing node-exporter installations..."
+  # Shared clusters with existing monitoring commonly have pre-existing node-exporters,
+  # and it's not necessary to have multiple of these running (they would conflict on port 9100)
+  # Check for existing node-exporter pods in other namespaces
+  local existing_exporters=$($KCMD get pods --all-namespaces -l app=node-exporter -o name 2>/dev/null | wc -l)
+
+  if [[ $existing_exporters -eq 0 ]]; then
+    # Also check for common node-exporter naming patterns
+    existing_exporters=$($KCMD get pods --all-namespaces | grep -E "node-exporter|nodeexporter" | grep -v "prometheus-${MONITORING_NAMESPACE}" | wc -l)
+  fi
+
+  if [[ $existing_exporters -gt 0 ]]; then
+    log_info "⚠️ Found $existing_exporters existing node-exporter pod(s) in other namespaces"
+    log_info "ℹ️ Node-exporter will be disabled to avoid port conflicts (port 9100)"
+    # Show which namespaces have node-exporters
+    log_info "📋 Existing node-exporter pods:"
+    $KCMD get pods --all-namespaces | grep -E "node-exporter|nodeexporter" | grep -v "prometheus-${MONITORING_NAMESPACE}" | head -3
+    return 0  # Existing node-exporters found, should disable
+  else
+    log_info "✅ No existing node-exporter installations detected"
+    return 1  # No existing node-exporters, can enable
+  fi
+
+}
+
+check_openshift_monitoring() {
+  if ! is_openshift; then
+    return 0
+  fi
+
+  log_info "🔍 Checking OpenShift user workload monitoring configuration..."
+
+  # Check if user workload monitoring is enabled
+  if $KCMD get configmap cluster-monitoring-config -n openshift-monitoring -o yaml 2>/dev/null | grep -q "enableUserWorkload: true"; then
+    log_success "✅ OpenShift user workload monitoring is properly configured"
+    return 0
+  fi
+
+  log_info "⚠️ OpenShift user workload monitoring is not enabled"
+  log_info "ℹ️ Enabling user workload monitoring allows metrics collection for the llm-d chart."
+
+  local monitoring_yaml=$(cat <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+EOF
+)
+
+  # Prompt the user
+  log_info "📜 The following ConfigMap will be applied to enable user workload monitoring:"
+  echo "$monitoring_yaml"
+  read -p "Would you like to apply this ConfigMap to enable user workload monitoring? (y/N): " response
+  case "$response" in
+    [yY][eE][sS]|[yY])
+      log_info "🚀 Applying ConfigMap to enable user workload monitoring..."
+      echo "$monitoring_yaml" | oc create -f -
+      if [[ $? -eq 0 ]]; then
+        log_success "✅ OpenShift user workload monitoring enabled"
+        return 0
+      else
+        log_error "❌ Failed to apply ConfigMap. Metrics collection may not work."
+        return 1
+      fi
+      ;;
+    *)
+      log_info "⚠️ User chose not to enable user workload monitoring."
+      log_info "⚠️ Metrics collection may not work properly in OpenShift without user workload monitoring enabled."
+      return 1
+      ;;
+  esac
+}
+
+install_prometheus_grafana() {
+  log_info "🌱 Provisioning Prometheus operator…"
+
+  if ! $KCMD get namespace "${MONITORING_NAMESPACE}" &>/dev/null; then
+    log_info "📦 Creating monitoring namespace..."
+    $KCMD create namespace "${MONITORING_NAMESPACE}"
+  else
+    log_info "📦 Monitoring namespace already exists"
+  fi
+
+  if ! $HCMD repo list 2>/dev/null | grep -q "prometheus-community"; then
+    log_info "📚 Adding prometheus-community helm repo..."
+    $HCMD repo add prometheus-community https://prometheus-community.github.io/helm-charts
+    $HCMD repo update
+  fi
+
+  # Check if release already exists using the same naming scheme
+  RELEASE_NAME="prometheus-${MONITORING_NAMESPACE}"
+
+  if $HCMD list -n "${MONITORING_NAMESPACE}" | grep -q "${RELEASE_NAME}"; then
+    log_info "⚠️ Prometheus stack already installed as '${RELEASE_NAME}' in ${MONITORING_NAMESPACE} namespace"
+    if [[ "$CENTRAL_MODE" == "true" ]]; then
+      log_info "ℹ️ To update existing installation to central mode, first uninstall with: $0 -u -n ${MONITORING_NAMESPACE}"
+    else
+      log_info "ℹ️ To update configuration, first uninstall with: $0 -u -n ${MONITORING_NAMESPACE}"
+    fi
+    return 0
+  fi
+
+  # Check if CRDs already exist (installed by another user)
+  if check_servicemonitor_crd; then
+    log_info "🔄 ServiceMonitor CRDs already exist - installing without CRDs to avoid conflicts"
+    CRD_INSTALL_FLAG="--skip-crds"
+  else
+    log_info "🆕 Installing Prometheus stack with CRDs"
+    CRD_INSTALL_FLAG=""
+  fi
+
+  # Check for existing node-exporters and determine if we should disable them
+  local DISABLE_NODE_EXPORTER=""
+  if check_existing_node_exporter; then
+    DISABLE_NODE_EXPORTER="nodeExporter:\n  enabled: false"
+  fi
+
+  log_info "🚀 Installing Prometheus stack in namespace ${MONITORING_NAMESPACE}..."
+
+  if [[ "$CENTRAL_MODE" == "true" ]]; then
+    # Central mode: Monitor all namespaces without label restrictions
+    cat <<EOF > /tmp/prometheus-values.yaml
+grafana:
+  adminPassword: admin
+  service:
+    type: ClusterIP
+prometheus:
+  service:
+    type: ClusterIP
+  prometheusSpec:
+    # Central monitoring: watch all ServiceMonitors and PodMonitors in all namespaces
+    serviceMonitorSelectorNilUsesHelmValues: false
+    serviceMonitorSelector: {}
+    serviceMonitorNamespaceSelector: {}
+    podMonitorSelectorNilUsesHelmValues: false
+    podMonitorSelector: {}
+    podMonitorNamespaceSelector: {}
+    maximumStartupDurationSeconds: 300
+    # Higher resource limits for central monitoring
+    resources:
+      limits:
+        memory: 8Gi
+        cpu: 4000m
+      requests:
+        memory: 4Gi
+        cpu: 1000m
+$(if [[ -n "$DISABLE_NODE_EXPORTER" ]]; then echo -e "$DISABLE_NODE_EXPORTER"; fi)
+EOF
+  else
+    # Individual mode: Monitor only user's labeled namespaces
+    cat <<EOF > /tmp/prometheus-values.yaml
+grafana:
+  adminPassword: admin
+  service:
+    type: ClusterIP
+prometheus:
+  service:
+    type: ClusterIP
+  prometheusSpec:
+    # Limit monitoring to user's namespaces for multi-tenancy
+    serviceMonitorSelectorNilUsesHelmValues: false
+    serviceMonitorSelector:
+      matchLabels:
+        ${MONITORING_LABEL_KEY}: "${MONITORING_LABEL_VALUE}"
+    serviceMonitorNamespaceSelector:
+      matchLabels:
+        ${MONITORING_LABEL_KEY}: "${MONITORING_LABEL_VALUE}"
+    podMonitorSelectorNilUsesHelmValues: false
+    podMonitorSelector:
+      matchLabels:
+        ${MONITORING_LABEL_KEY}: "${MONITORING_LABEL_VALUE}"
+    podMonitorNamespaceSelector:
+      matchLabels:
+        ${MONITORING_LABEL_KEY}: "${MONITORING_LABEL_VALUE}"
+    maximumStartupDurationSeconds: 300
+    # Resource limits for individual monitoring
+    resources:
+      limits:
+        memory: 4Gi
+        cpu: 2000m
+      requests:
+        memory: 2Gi
+        cpu: 500m
+$(if [[ -n "$DISABLE_NODE_EXPORTER" ]]; then echo -e "$DISABLE_NODE_EXPORTER"; fi)
+EOF
+  fi
+
+  # Use unique release name based on namespace to avoid conflicts
+  RELEASE_NAME="prometheus-${MONITORING_NAMESPACE}"
+
+  $HCMD install "${RELEASE_NAME}" prometheus-community/kube-prometheus-stack \
+    --namespace "${MONITORING_NAMESPACE}" \
+    ${DEBUG} \
+    ${CRD_INSTALL_FLAG} \
+    -f /tmp/prometheus-values.yaml
+
+  rm -f /tmp/prometheus-values.yaml
+
+  log_info "⏳ Waiting for Prometheus stack pods to be ready..."
+  $KCMD wait --for=condition=ready pod -l app.kubernetes.io/name=prometheus -n "${MONITORING_NAMESPACE}" --timeout=300s || true
+  $KCMD wait --for=condition=ready pod -l app.kubernetes.io/name=grafana -n "${MONITORING_NAMESPACE}" --timeout=300s || true
+
+  log_success "🚀 Prometheus and Grafana installed."
+
+  # Display access information
+  log_info "📊 Access Information:"
+  log_info "   Prometheus: kubectl port-forward -n ${MONITORING_NAMESPACE} svc/prometheus-kube-prometheus-prometheus 9090:9090"
+  log_info "   Grafana: kubectl port-forward -n ${MONITORING_NAMESPACE} svc/prometheus-grafana 3000:80"
+  log_info "   Grafana admin password: admin"
+  log_info ""
+  log_info "📋 Monitoring Configuration:"
+  if [[ "$CENTRAL_MODE" == "true" ]]; then
+    log_info "   🌐 Central monitoring: This Prometheus monitors ALL ServiceMonitors and PodMonitors in ALL namespaces"
+    log_info "   No namespace labeling is required - all metrics will be collected automatically"
+    log_info "   ⚠️  This mode should only be used by cluster administrators or in single-tenant environments"
+  else
+    log_info "   👤 Individual monitoring: This Prometheus monitors resources labeled with '${MONITORING_LABEL_KEY}: ${MONITORING_LABEL_VALUE}'"
+    log_info "   To enable monitoring for your deployments, add this label to your namespaces:"
+    log_info "   kubectl label namespace <namespace> ${MONITORING_LABEL_KEY}=${MONITORING_LABEL_VALUE}"
+  fi
+}
+
+install() {
+  if is_openshift; then
+    log_info "🔍 OpenShift detected - checking user workload monitoring..."
+    if ! check_openshift_monitoring; then
+      log_info "⚠️ Metrics collection may not work properly in OpenShift without user workload monitoring enabled."
+    fi
+    # No Prometheus installation needed if OpenShift monitoring is properly configured
+    log_info "ℹ️ Using OpenShift's built-in monitoring stack. No additional Prometheus installation needed."
+    log_success "🎉 OpenShift monitoring configuration complete."
+  else
+    log_info "🔍 Checking for existing ServiceMonitor CRD..."
+    if check_servicemonitor_crd; then
+      log_info "✅ ServiceMonitor CRD found. Installing namespace-scoped Prometheus stack..."
+    else
+      log_info "⚠️ ServiceMonitor CRD not found. Installing Prometheus stack with CRDs..."
+    fi
+    install_prometheus_grafana
+    log_success "🎉 Prometheus and Grafana installation complete."
+  fi
+}
+
+uninstall() {
+  log_info "🗑️ Uninstalling Prometheus and Grafana stack..."
+
+  # Use the same release naming scheme as install
+  RELEASE_NAME="prometheus-${MONITORING_NAMESPACE}"
+
+  if $HCMD list -n "${MONITORING_NAMESPACE}" | grep -q "${RELEASE_NAME}" 2>/dev/null; then
+    log_info "🗑️ Uninstalling Prometheus helm release '${RELEASE_NAME}'..."
+    $HCMD uninstall "${RELEASE_NAME}" --namespace "${MONITORING_NAMESPACE}" || true
+  fi
+
+  log_info "🗑️ Deleting monitoring namespace..."
+  $KCMD delete namespace "${MONITORING_NAMESPACE}" --ignore-not-found || true
+
+  # Check if we should delete the ServiceMonitor CRD (only if no other Prometheus installations exist)
+  if ! $KCMD get crd servicemonitors.monitoring.coreos.com &>/dev/null; then
+    log_info "ℹ️ ServiceMonitor CRD not found (already deleted or never installed)"
+  else
+    log_info "ℹ️ ServiceMonitor CRD still exists (may be used by other monitoring installations)"
+    log_info "ℹ️ To manually delete: kubectl delete crd servicemonitors.monitoring.coreos.com"
+  fi
+
+  log_success "💀 Uninstallation complete"
+}
+
+main() {
+  parse_args "$@"
+  setup_env
+  check_dependencies
+  check_cluster_reachability
+
+  if [[ "$ACTION" == "install" ]]; then
+    install
+  elif [[ "$ACTION" == "uninstall" ]]; then
+    uninstall
+  else
+    fail "Unknown action: $ACTION"
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
Provide a central location for llm-d observability resources. 
Another option would be a separate repository. 

Once this central location is established, the duplicate files in `llm-d-infra` will be removed in place of a reference to them. 
(https://github.com/llm-d-incubation/llm-d-infra/blob/main/quickstart/MONITORING.md) 
