### PR TITLE
Fix Dockerfile.ubi for docker build

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -15,12 +15,12 @@ ARG PYTHON_VERSION
 WORKDIR /workspace
 
 # Create UV constraint files
-RUN cat > /tmp/build-constraints.txt << 'EOF'
-torch==2.7.1
+RUN cat > /tmp/build-constraints.txt << 'EOF'\
+torch==2.7.1\
 EOF
 
-RUN cat > /tmp/constraints.txt << 'EOF'
-torch==2.7.1
+RUN cat > /tmp/constraints.txt << 'EOF'\
+torch==2.7.1\
 EOF
 
 ENV LANG=C.UTF-8 \
@@ -286,8 +286,8 @@ ARG NVSHMEM_VERSION=3.3.20
 
 
 
-RUN cat > /tmp/constraints.txt << 'EOF'
-torch==2.7.1
+RUN cat > /tmp/constraints.txt << 'EOF'\
+torch==2.7.1\
 EOF
 
 ENV LANG=C.UTF-8 \


### PR DESCRIPTION
Hey, I am not sure whether this is the intended behavior, but attempting to build the `Dockerfile.ubi` image will cause an error right now due to parsing the cat command when writing uv contrainst files.

```
➜  /tmp docker --version 
Docker version 27.1.1, build 6312585

➜  /tmp docker build --build-arg PYTHON_VERSION=3.12 --build-arg VLLM_COMMIT_SHA=.. -f Dockerfile.ubi .                                          
[+] Building 0.3s (1/1) FINISHED                                                                                                                                                       docker:default
 => [internal] load build definition from Dockerfile.ubi                                                                                                                                         0.2s
 => => transferring dockerfile: 15.47kB                                                                                                                                                          0.2s
 => WARN: ConsistentInstructionCasing: Command 'torch==2.7.1' should match the case of the command majority (uppercase) (line 19)                                                                0.2s
 => WARN: ConsistentInstructionCasing: Command 'torch==2.7.1' should match the case of the command majority (uppercase) (line 23)                                                                0.2s
 => WARN: ConsistentInstructionCasing: Command 'torch==2.7.1' should match the case of the command majority (uppercase) (line 290)                                                               0.2s
Dockerfile.ubi:19
--------------------
  17 |     # Create UV constraint files
  18 |     RUN cat > /tmp/build-constraints.txt << 'EOF'
  19 | >>> torch==2.7.1
  20 |     EOF
  21 |     
--------------------
ERROR: failed to solve: dockerfile parse error on line 19: unknown instruction: torch==2.7.1
```

This is a simple fix to address that.
