### PR TITLE
Add notifications for test failures

### DIFF
--- a/.github/workflows/e2e-inference-scheduling-gke.yaml
+++ b/.github/workflows/e2e-inference-scheduling-gke.yaml
@@ -57,7 +57,7 @@ jobs:
       NAMESPACE: llm-d-inference-scheduling
       GATEWAY: gke-l7-regional-external-managed
       GATEWAY_TYPE: gke
-      PR_OR_BRANCH: ${{ github.event.inputs.pr_or_branch || github.event.issue.number || github.event.number || 'dev' }}
+      PR_OR_BRANCH: ${{ github.event.inputs.pr_or_branch || github.event.issue.number || github.event.number || 'main' }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
     steps:

--- a/.github/workflows/e2e-inference-scheduling-gke.yaml
+++ b/.github/workflows/e2e-inference-scheduling-gke.yaml
@@ -200,11 +200,11 @@ jobs:
 
       - name: Send Google Chat notification on failure
         if: failure()
-        uses: Co-qn/google-chat-notification@3691ccf4763537d6e544bc6cdcccc1965799d056
+        uses: SimonScholz/google-chat-action@3b3519e5102dba8aa5046fd711c4b553586409bb
         with:
-          url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
-          name: '${{ github.workflow }} - ${{ matrix.accelerator.name }}'
-          status: ${{ job.status }}
+          webhookUrl: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
+          jobStatus: ${{ job.status }}
+          title: '${{ github.workflow }} - ${{ matrix.accelerator.name }}'
 
       - name: Cleanup deployment
         if: always()

--- a/.github/workflows/e2e-inference-scheduling-gke.yaml
+++ b/.github/workflows/e2e-inference-scheduling-gke.yaml
@@ -133,7 +133,7 @@ jobs:
             --for=condition=Ready \
             --all \
             -n "${NAMESPACE}" \
-            --timeout=10m
+            --timeout=15m
           sleep ${{ matrix.accelerator.pod_readiness_sleep_seconds }} # TODO: remove this once examples have readiness probes
           echo "✅ All pods are ready."
           kubectl get pods -n "${NAMESPACE}"

--- a/.github/workflows/e2e-inference-scheduling-gke.yaml
+++ b/.github/workflows/e2e-inference-scheduling-gke.yaml
@@ -1,6 +1,9 @@
 name: GKE Inference Scheduling Test
 
 on:
+  # This is for testing only, will remove later
+  pull_request:
+    types: [opened, synchronize, reopened]
   # Runs with a PR comment /run-gke-inference-scheduling
   issue_comment:
     types: [created]

--- a/.github/workflows/e2e-inference-scheduling-gke.yaml
+++ b/.github/workflows/e2e-inference-scheduling-gke.yaml
@@ -201,6 +201,14 @@ jobs:
           name: llmd-pod-logs-inference-scheduling-${{ matrix.accelerator.name }}
           path: pod-logs-inference-scheduling
 
+      - name: Send Google Chat notification on failure
+        if: failure()
+        uses: Co-qn/google-chat-notification@3691ccf4763537d6e544bc6cdcccc1965799d056
+        with:
+          url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
+          name: '${{ github.workflow }} - ${{ matrix.accelerator.name }}'
+          status: ${{ job.status }}
+
       - name: Cleanup deployment
         if: always()
         run: |

--- a/.github/workflows/e2e-inference-scheduling-gke.yaml
+++ b/.github/workflows/e2e-inference-scheduling-gke.yaml
@@ -60,7 +60,7 @@ jobs:
       NAMESPACE: llm-d-inference-scheduling
       GATEWAY: gke-l7-regional-external-managed
       GATEWAY_TYPE: gke
-      PR_OR_BRANCH: ${{ github.event.inputs.pr_or_branch || github.event.issue.number || github.event.number }}
+      PR_OR_BRANCH: ${{ github.event.inputs.pr_or_branch || github.event.issue.number || github.event.number || 'dev' }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
     steps:

--- a/.github/workflows/e2e-inference-scheduling-gke.yaml
+++ b/.github/workflows/e2e-inference-scheduling-gke.yaml
@@ -1,9 +1,6 @@
 name: GKE Inference Scheduling Test
 
 on:
-  # This is for testing only, will remove later
-  pull_request:
-    types: [opened, synchronize, reopened]
   # Runs with a PR comment /run-gke-inference-scheduling
   issue_comment:
     types: [created]

--- a/.github/workflows/e2e-pd-disaggregation-gke.yaml
+++ b/.github/workflows/e2e-pd-disaggregation-gke.yaml
@@ -44,7 +44,7 @@ jobs:
       NAMESPACE: llm-d-pd
       GATEWAY: gke-l7-regional-external-managed
       GATEWAY_TYPE: gke
-      PR_OR_BRANCH: ${{ github.event.inputs.pr_or_branch || github.event.issue.number || github.event.number || 'dev' }}
+      PR_OR_BRANCH: ${{ github.event.inputs.pr_or_branch || github.event.issue.number || github.event.number || 'main' }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
     steps:

--- a/.github/workflows/e2e-pd-disaggregation-gke.yaml
+++ b/.github/workflows/e2e-pd-disaggregation-gke.yaml
@@ -44,7 +44,7 @@ jobs:
       NAMESPACE: llm-d-pd
       GATEWAY: gke-l7-regional-external-managed
       GATEWAY_TYPE: gke
-      PR_OR_BRANCH: ${{ github.event.inputs.pr_or_branch || github.event.issue.number || github.event.number }}
+      PR_OR_BRANCH: ${{ github.event.inputs.pr_or_branch || github.event.issue.number || github.event.number || 'dev' }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
     steps:

--- a/.github/workflows/e2e-pd-disaggregation-gke.yaml
+++ b/.github/workflows/e2e-pd-disaggregation-gke.yaml
@@ -244,6 +244,14 @@ jobs:
           name: llmd-pod-logs-pd-disaggregation
           path: pod-logs-pd-disaggregation
 
+      - name: Send Google Chat notification on failure
+        if: failure()
+        uses: Co-qn/google-chat-notification@3691ccf4763537d6e544bc6cdcccc1965799d056
+        with:
+          url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
+          name: '${{ github.workflow }} - ${{ matrix.accelerator.name }}'
+          status: ${{ job.status }}
+
       - name: Cleanup deployment
         if: always()
         run: |

--- a/.github/workflows/e2e-pd-disaggregation-gke.yaml
+++ b/.github/workflows/e2e-pd-disaggregation-gke.yaml
@@ -159,7 +159,7 @@ jobs:
             --for=condition=Ready \
             --all \
             -n "${NAMESPACE}" \
-            --timeout=10m
+            --timeout=15m
           sleep 480 # Allow extra time for model loading in PD setup
           echo "✅ All pods are ready."
           kubectl get pods -n "${NAMESPACE}"

--- a/.github/workflows/e2e-pd-disaggregation-gke.yaml
+++ b/.github/workflows/e2e-pd-disaggregation-gke.yaml
@@ -246,11 +246,11 @@ jobs:
 
       - name: Send Google Chat notification on failure
         if: failure()
-        uses: Co-qn/google-chat-notification@3691ccf4763537d6e544bc6cdcccc1965799d056
+        uses: SimonScholz/google-chat-action@3b3519e5102dba8aa5046fd711c4b553586409bb
         with:
-          url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
-          name: ${{ github.workflow }}
-          status: ${{ job.status }}
+          webhookUrl: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
+          jobStatus: ${{ job.status }}
+          title: ${{ github.workflow }}
 
       - name: Cleanup deployment
         if: always()

--- a/.github/workflows/e2e-pd-disaggregation-gke.yaml
+++ b/.github/workflows/e2e-pd-disaggregation-gke.yaml
@@ -249,7 +249,7 @@ jobs:
         uses: Co-qn/google-chat-notification@3691ccf4763537d6e544bc6cdcccc1965799d056
         with:
           url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
-          name: '${{ github.workflow }} - ${{ matrix.accelerator.name }}'
+          name: ${{ github.workflow }}
           status: ${{ job.status }}
 
       - name: Cleanup deployment


### PR DESCRIPTION
1. I am adding notifications for GKE test failures through Google Chat Webhook.
2. I added a default branch for nightly runs - this is set to the 'dev' branch.
3. During my testing I noticed the helm templates are broken, so I fixed the environment paths.