### PR TITLE
Add an infra-provider prereq and use GKE as an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ See the path descriptions for more details about the accelerators, networks, and
   * Large language models (LLMs) with 1 billion or more parameters
   * Using most or all of the capacity of one or more hardware accelerators
 * On recent generation datacenter-class accelerators
-  * NVIDIA H100 or newer for larger models and L4, A100 for smaller models
+  * NVIDIA A100 / L4 or newer
   * AMD MI250 or newer
-  * Google TPU v5e, v6e, and newer
+  * Google TPU v5e or newer
 * With extremely fast accelerator interconnect and datacenter networking
   * 600-16,000 Gbps per accelerator NVLINK on host or across narrow domains like NVL72
   * 1,600-5,000 Gbps per chip TPU OCS links within TPU pods
@@ -85,7 +85,9 @@ For more see the [project proposal](./docs/proposals/llm-d.md).
 
 ### Pre-requisites
 
-`llm-d` requires a Kubernetes 1.29+ cluster and accelerators capable of running large models supported by vLLM. Our well-lit paths are focused on datacenter accelerators and networks and issues encountered outside these may not receive the same level of attention.
+`llm-d` requires accelerators capable of running large models supported by vLLM. Our well-lit paths are focused on datacenter accelerators and networks and issues encountered outside these may not receive the same level of attention.
+
+See the [prerequisites for our guides](./guides/prereq/) for more details on supported hardware, networking, Kubernetes cluster configuration, and client tooling.
 
 ### Deploying llm-d
 

--- a/docs/infra-providers/README.md
+++ b/docs/infra-providers/README.md
@@ -1,0 +1,5 @@
+# llm-d Infrastructure Providers
+
+This directory contains documentation specific to each Kubernetes provider for deploying llm-d, as well as troubleshooting and known issues.
+
+To add a new infrastructure provider, see [the requirements in the prereq guide](../guides/prereq/infrastructure/README.md#other-providers).

--- a/docs/infra-providers/gke/README.md
+++ b/docs/infra-providers/gke/README.md
@@ -1,0 +1,54 @@
+# llm-d on Google Kubernetes Engine (GKE)
+
+This document covers configuring GKE clusters for running high performance LLM inference with llm-d.
+
+## Prerequisites
+
+llm-d on GKE is tested with the following configurations:
+
+  * Machine types: A3, A4, ct5p, ct5lp, ct6e
+  * Versions: GKE 1.32.3+
+
+## Cluster Configuration
+
+The GCP cluster should be configured with the following settings:
+
+* All prerequisites for [GKE Inference Gateway enablement](https://cloud.google.com/kubernetes-engine/docs/how-to/deploy-gke-inference-gateway#prepare-environment)
+
+For A3 machines, deploy a cluster and [configure high performance networking with TCPX](https://cloud.google.com/kubernetes-engine/docs/how-to/gpu-bandwidth-gpudirect-tcpx) if you plan to leverage Prefill/Decode disaggregation.
+
+For A3 Ultra, A4, and A4X machines, follow the [steps for creating an AI-optimized GKE cluster with GPUs](https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute) and enable GPUDirect RDMA.
+
+For all TPU machines, follow the [TPUs in GKE documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/tpus).
+
+We recommend enabling Google Managed Prometheus and [automatic application monitoring](https://cloud.google.com/kubernetes-engine/docs/how-to/configure-automatic-application-monitoring) to enable automatic metrics collection and dashboards for vLLM deployed on the cluster.
+
+## Workload Configuration
+
+### GPUs
+
+#### Configuring support for RDMA on GKE workload pods
+
+GCP provides CX-7 support on A3 Ultra+ GPU hosts via RoCE.
+
+Model servers that need to use fast internode networking for P/D disaggregation or wide expert parallelism will need to request RDMA resources on your workload pods. The cluster creation guide describes the required changes to a pod to access the RDMA devices (e.g. [for A3 Ultra / A4](https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute-custom#configure-pod-manifests-rdma)).
+
+#### Ensuring network topology aware scheduling of pod replicas with RDMA
+
+Select appropriate node selectors to ensure multi-host replicas are all colocated on the same network fabric. For many deployments, your A3 Ultra or newer reservation will be within a single zone. This ensures reachability but may not achieve the desired aggregate throughput.
+
+On RDMA enabled instances the `cloud.google.com/gce-topology-block` label identifies machines within the same fast network and can be used as the primitive for higher level orchestration to group the pods within a multi-host replica.
+
+GKE recommends using [Topology Aware Scheduling with Kueue and LeaderWorkerSet](https://cloud.google.com/ai-hypercomputer/docs/workloads/schedule-gke-workloads-tas) for multi-host training and inference workloads.
+
+## Known Issues
+
+### `Undetected platform` on vLLM 0.10.0 on GKE
+
+The 12.8 and 12.9 NVIDIA CUDA Docker images used as a base for vLLM moved the location of the installed CUDA drivers from `/usr/local/nvidia` to `/usr/local/cuda`, which prevents GKE managed GPU drivers from being detected.
+
+Until [vLLM issue #18859](https://github.com/vllm-project/vllm/issues/18859) is resolved by updating vLLM to the CUDA 13 base image, users will need to ensure their LD_LIBRARY_PATH in their vLLM image includes `/usr/local/nvidia/lib64`.
+
+#### Google InfiniBand 1.10 required for vLLM 0.11.0 (gIB)
+
+vLLM v0.11.0 and newer require NCCL 2.27, which is supported in gIB 1.10+. See the appropriate section in cluster configuration for installing the RDMA binary and configuring NCCL (e.g. [for A3 Ultra / A4](https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute-custom#install-rdma-configure-nccl)).  To get 1.10, use at least the version of the RDMA installer DaemonSet described in this [1.10 pull request](https://github.com/GoogleCloudPlatform/container-engine-accelerators/pull/511).

--- a/guides/README.md
+++ b/guides/README.md
@@ -13,7 +13,7 @@ These guides are targeted to startups and enterprises to deploy production LLM s
 * Deploying a self-hosted LLM behind a single workload across tens or hundreds of nodes
 * Running a production model-as-a-service platform that supports many users and workloads sharing one or more LLM deployments
 
-## Our Well-Lit Path Guides
+## Well-Lit Path Guides
 
 A well-lit path is a documented, tested, and benchmarked solution of choice to reduce risk and maintenance cost. These are the central best practices common to production deployments of large language model serving.
 
@@ -28,3 +28,11 @@ We currently offer three tested and benchmarked paths to help you deploy large m
 Our supporting guides address common operational challenges with model serving at scale:
 
 - [Simulating model servers](./simulated-accelerators) can deploy a vLLM model server simulator that allows testing inference scheduling and orchestration at scale as each instance does not need accelerators.
+
+## Other Guides
+
+The following guides have been provided by the community but do not fully integrate into the llm-d configuration structure yet and are not fully supported as well-lit paths:
+
+* TBD
+
+Note: New guides added to this list must enable at least one of the core well-lit paths but may directly include prerequisite steps specific to new hardware or infrastructure providers without full abstraction. A guide added here is expected to eventually become path of an existing well-lit path.

--- a/guides/inference-scheduling/README.md
+++ b/guides/inference-scheduling/README.md
@@ -13,6 +13,7 @@ This example out of the box requires 2 Nvidia GPUs of any kind (support determin
 ## Prerequisites
 
 - Have the [proper client tools installed on your local system](../prereq/client-setup/README.md) to use this guide.
+- Ensure your cluster infrastructure is sufficient to [deploy high scale inference](../prereq/infrastructure)
 - Configure and deploy your [Gateway control plane](../prereq/gateway-provider/README.md).
 - [Create the `llm-d-hf-token` secret in your target namespace with the key `HF_TOKEN` matching a valid HuggingFace token](../prereq/client-setup/README.md#huggingface-token) to pull models.
 

--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -41,6 +41,7 @@ This guide expects 8 Nvidia GPUs of any kind, and RDMA via InfiniBand or RoCE be
 ## Prerequisites
 
 - Have the [proper client tools installed on your local system](../prereq/client-setup/README.md) to use this guide.
+- Ensure your cluster infrastructure is sufficient to [deploy high scale inference](../prereq/infrastructure)
 - Configure and deploy your [Gateway control plane](../prereq/gateway-provider/README.md).
 - [Create the `llm-d-hf-token` secret in your target namespace with the key `HF_TOKEN` matching a valid HuggingFace token](../prereq/client-setup/README.md#huggingface-token) to pull models.
 

--- a/guides/prereq/infrastructure/README.md
+++ b/guides/prereq/infrastructure/README.md
@@ -1,0 +1,91 @@
+# Infrastructure Prerequisite
+
+This document will guide you through choosing the Kubernetes infrastructure to run the llm-d guides. It covers both the fundamental hardware and software requirements for llm-d, cluster configuration, as well as configuration specific to infrastructure providers (clouds, specific distributions).
+
+## llm-d infrastructure
+
+llm-d tests on the following configurations, supporting leading-edge AI accelerators:
+
+* Kubernetes: 1.29 or newer
+  * Your cluster scheduler must support placing multiple pods within the same networking domain for running multi-host inference
+* Recent generation datacenter-class accelerators
+  * AMD MI250X or newer
+  * Google TPU v5e, v6e, and newer
+  * NVIDIA L4, A100, H100, H200, B200, and newer
+* Fast internode networking
+  * For accelerators
+    * AMD Infinity Fabric, InfiniBand NICs
+    * Google TPU ICI
+    * NVIDIA NVLink, InfiniBand or RoCE NICs
+  * For hosts and north/south traffic
+    * Fast (100Gbps+ aggregate throughput) datacenter NICs
+* Hosts
+  * 80+ x86 or ARM cores per machine
+  * 500GiB or more of memory
+  * PCIe 5+
+
+Older configurations may function, especially slightly older accelerators, but testing is best-effort.
+
+### (Optional) vLLM container image
+
+llm-d provides container images derived from the [vLLM upstream](https://github.com/vllm-project/vllm/tree/main/docker) that are tested with the supported hardware and have all necessary optimized libraries installed. To build and deploy with your own image, you should integrate:
+
+* General
+  * vLLM: 0.10.0 or newer
+  * NIXL: 0.5.0 or newer
+  * UCX: 0.19.0 or newer
+* NVIDIA-specific
+  * NVSHMEM: 3.3.9 or newer
+
+llm-d guides expect a series of conventions to be followed in the vLLM image:
+
+* General
+  * At least one vLLM compatible Python version must be available (3.9 to 3.12)
+    * We recommend at least 3.10+
+  * Required system libraries must be bundled
+    * `LD_LIBRARY_PATH` must contain all necessary system libraries for vLLM to function
+  * `PATH` must contain the vLLM binary and directly invoking `vllm` should start with the correct Python environment (i.e. a virtual env)
+  * The default image command (or if not specified, entrypoint) should start vLLM in a serving configuration and accept additional arguments
+    * A pod with `args` should see all arguments passed to vLLM
+    * A pod with `command: ["vllm", "serve"]` should override any image defaults
+* Caches
+  * Default compilation cache directory environment variables under a shared root path under `/tmp/cache/compile/<NAME>`
+    * I.e. set `VLLM_CACHE_ROOT=/tmp/cache/compile/vllm` to ensure vLLM compiles to a temporary directory
+    * Future versions of vLLM will recommend mounting a pod volume to `/tmp/cache` to mitigate restart for some caches.
+  * Do not hardcode the model cache directory and model cache environment variables
+    * Future versions of llm-d will provide conventions for vLLM model loading
+* Hardware
+  * Follow best practices for your hardware ecosystem, including:
+    * Expecting to mount hardware-specific drivers and libraries from a standard host location as a value
+    * Ahead Of Time (AOT) compilation of kernels
+  * NVIDIA specific
+    * `LD_LIBRARY_PATH` includes the `/usr/local/nvidia/lib64` directory to allow Kubernetes GPU operators to inject the appropriate driver
+
+### (Optional) Install LeaderWorkerSet for multi-host inference
+
+The LeaderWorkerSet (LWS) Kubernetes workload controller specializes in deploying serving workloads where each replica is composed of multiple pods spread across hosts, specifically accelerator nodes. llm-d defaults to LWS for deployment of multi-host inference for rank to pod mappings, topology aware placement to ensure optimal accelerator network performance, and all-or-nothing failure and restart semantics to recover in the event of a bad node or accelerator.
+
+Use the [LWS installation guide](https://lws.sigs.k8s.io/docs/installation/) to install 0.7.0 or newer when deploying an llm-d guide using LWS.
+
+## Installing on a well-lit infrastructure provider
+
+The following documentation describes llm-d tested setup for cluster infrastructure providers as well as specific deployment settings that will impact how model servers is expected to access accelerators.
+
+* [CoreWeave Kubernetes Service (CKS)](../../docs/infra-providers/cks/README.md)
+<!-- * [Digital Ocean (DO)](../../docs/infra-providers/digitalocean/README.md) -->
+* [Google Kubernetes Engine (GKE)](../../docs/infra-providers/gke/README.md)
+* [OpenShift (OCP)](../../docs/infra-providers/openshift/README.md), [OpenShift on AWS]((../../docs/infra-providers/openshift-aws/README.md))
+* [minikube](../../docs/infra-providers/minikube/README.md) for single-host development
+
+These provider configurations are tested regularly.
+
+Please follow the provider-specific documentation to ensure your Kubernetes cluster and hardware is properly configured before continuing.
+
+## Other providers
+
+To add a new infrastructure provider to our well-lit paths, we request the following support:
+
+* Documentation on configuring the platform to support one or more [well-lit path guides](../README.md#well-lit-path-guides)
+* The appropriate configuration contributed to the guide to deal with provider specific variation
+* An automated test environment that validates the supported guides
+* At least one documented platform maintainer who responds to GitHub issues and is available for regular discussion in the llm-d slack channel `#sig-installation`.

--- a/guides/wide-ep-lws/README.md
+++ b/guides/wide-ep-lws/README.md
@@ -18,6 +18,10 @@ This guide requires 24 Nvidia H200 GPUs and InfiniBand RDMA. It requires 1024 Gi
 ## Prerequisites
 
 - Have the [proper client tools installed on your local system](../prereq/client-setup/README.md) to use this guide.
+- Ensure your cluster infrastructure is sufficient to [deploy high scale inference](../prereq/infrastructure/README.md)
+  - You must have high speed inter-accelerator networking
+  - The pods leveraging inter-node EP must be deployed within the same networking domain
+  - You have deployed the [LeaderWorkerSet optional controller](../prereq/infrastructure/README.md#optional-install-leaderworkerset-for-multi-host inference)
 - Configure and deploy your [Gateway control plane](../prereq/gateway-provider/README.md).
 - [Create the `llm-d-hf-token` secret in your target namespace with the key `HF_TOKEN` matching a valid HuggingFace token](../prereq/client-setup/README.md#huggingface-token) to pull models.
 


### PR DESCRIPTION
Document a process whereby new providers can be added and define what content should go into which section.

Fixes #165 