### PR TITLE
Update link to the `llm-d-vllm-dashboard.json` in monitoring doc

### DIFF
--- a/docs/monitoring/README.md
+++ b/docs/monitoring/README.md
@@ -44,7 +44,7 @@ The vLLM metrics from prefill and decode pods will be visible from the Prometheu
 
 Grafana dashboard raw JSON files can be imported manually into a Grafana UI. Here is a current list of community dashboards:
 
-- [llm-d dashboard](./dashboards/grafana/llm-d-vllm-dashboard.json)
+- [llm-d dashboard](./grafana/dashboards/llm-d-dashboard.json)
   - vLLM metrics
 - [inference-gateway dashboard](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/tools/dashboards/inference_gateway.json)
   - EPP pod metrics, requires additional setup to collect metrics. See [GAIE doc](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/tools/dashboards/README.md)


### PR DESCRIPTION
minor update to the documentation, correcting the file path for the llm-d dashboard JSON in the monitoring README.

- Updated the link to the llm-d dashboard JSON in `docs/monitoring/README.md` to point to `./grafana/dashboards/llm-d-dashboard.json` instead of the outdated location.