### PR TITLE
add epp monitoring values to guides

### DIFF
--- a/docs/monitoring/README.md
+++ b/docs/monitoring/README.md
@@ -17,7 +17,10 @@ Please join [SIG-Observability](https://github.com/llm-d/llm-d/blob/dev/SIGS.md#
 ### Helmfile Integration
 
 Provided Prometheus custom resources exist in the cluster, all [llm-d guides](../../guides/README.md) include the option to enable Prometheus
-PodMonitor creation for scraping vLLM metrics. With any llm-d helmfile example, update the modelservice values to enable monitoring:
+PodMonitor creation for scraping vLLM metrics and ServiceMonitor creation for scraping EPP (Endpoint Picker Protocol) metrics.
+With any llm-d helmfile example, update the values to enable monitoring:
+
+### vLLM Metrics
 
 ```yaml
 # In your ms-*/values.yaml files
@@ -39,6 +42,39 @@ kubectl get podmonitors -n my-llm-d-namespace
 ```
 
 The vLLM metrics from prefill and decode pods will be visible from the Prometheus and/or Grafana user interface.
+
+### EPP (Endpoint Picker Protocol) Metrics
+
+EPP provides additional metrics for request routing, scheduling latency, and plugin performance. To enable EPP metrics collection:
+
+**For Gateway API Inference Extension (GAIE) deployments:**
+
+```yaml
+# In your gaie-*/values.yaml files
+inferenceExtension:
+  monitoring:
+    prometheus:
+      enabled: true
+```
+
+**For modelservice deployments with EPP:**
+
+```yaml
+# In your ms-*/values.yaml files (for deployments that include EPP)
+routing:
+  epp:
+    monitoring:
+      servicemonitor:
+        enabled: true
+```
+
+Upon installation, view EPP servicemonitors with:
+
+```bash
+kubectl get servicemonitors -n my-llm-d-namespace
+```
+
+EPP metrics include request rates, error rates, scheduling latency, and plugin processing times, providing insights into the inference routing and scheduling performance.
 
 ## Dashboards
 

--- a/guides/inference-scheduling/gaie-inference-scheduling/values.yaml
+++ b/guides/inference-scheduling/gaie-inference-scheduling/values.yaml
@@ -17,6 +17,17 @@ inferenceExtension:
   # https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/978c23bb96cce25f11cea2421523cb479026e2e9/config/charts/inferencepool/templates/epp-config.yaml#L57
   # This will become the default in the next gaie release.
   pluginsConfigFile: "plugins-v2.yaml"
+
+  # Monitoring configuration for EPP
+  monitoring:
+    interval: "10s"
+    # Service account token secret for authentication
+    secret:
+      name: inference-gateway-sa-metrics-reader-secret
+    # Prometheus ServiceMonitor will be created when enabled for EPP metrics collection
+    prometheus:
+      enabled: false
+
 inferencePool:
   targetPortNumber: 8000
   modelServerType: vllm

--- a/guides/pd-disaggregation/gaie-pd/values.yaml
+++ b/guides/pd-disaggregation/gaie-pd/values.yaml
@@ -40,6 +40,17 @@ inferenceExtension:
         - pluginRef: queue-scorer
           weight: 1.0
         - pluginRef: max-score-picker
+
+  # Monitoring configuration for EPP
+  monitoring:
+    interval: "10s"
+    # Service account token secret for authentication
+    secret:
+      name: inference-gateway-sa-metrics-reader-secret
+    # Prometheus ServiceMonitor will be created when enabled for EPP metrics collection
+    prometheus:
+      enabled: false
+
 inferencePool:
   targetPortNumber: 8000
   modelServerType: vllm

--- a/guides/precise-prefix-cache-aware/gaie-kv-events/values.yaml
+++ b/guides/precise-prefix-cache-aware/gaie-kv-events/values.yaml
@@ -62,6 +62,17 @@ inferenceExtension:
             - pluginRef: queue-scorer
               weight: 1.0
             - pluginRef: max-score-picker
+
+  # Monitoring configuration for EPP
+  monitoring:
+    interval: "10s"
+    # Service account token secret for authentication
+    secret:
+      name: inference-gateway-sa-metrics-reader-secret
+
+    # Prometheus ServiceMonitor will be created when enabled for EPP metrics collection
+    prometheus:
+      enabled: false
 inferencePool:
   targetPortNumber: 8000
   modelServerType: vllm

--- a/guides/simulated-accelerators/gaie-sim/values.yaml
+++ b/guides/simulated-accelerators/gaie-sim/values.yaml
@@ -14,6 +14,17 @@ inferenceExtension:
     pullPolicy: Always
   extProcPort: 9002
   pluginsConfigFile: "default-plugins.yaml" # using upstream GIE default-plugins, see: https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/config/charts/inferencepool/templates/epp-config.yaml#L7C3-L56C33
+
+  # Monitoring configuration for EPP
+  monitoring:
+    interval: "10s"
+    # Service account token secret for authentication
+    secret:
+      name: inference-gateway-sa-metrics-reader-secret
+    # Prometheus ServiceMonitor will be created when enabled for EPP metrics collection
+    prometheus:
+      enabled: false
+
 inferencePool:
   targetPortNumber: 8000
   modelServerType: vllm

--- a/guides/wide-ep-lws/ms-wide-ep/values.yaml
+++ b/guides/wide-ep-lws/ms-wide-ep/values.yaml
@@ -66,6 +66,14 @@ routing:
           - pluginRef: queue-scorer
             weight: 1.0
           - pluginRef: max-score-picker
+
+    # Monitoring configuration for EPP
+    monitoring:
+      # ServiceMonitor configuration for EPP metrics collection with Prometheus Operator
+      servicemonitor:
+        enabled: false
+        interval: "10s"
+
 decode:
   create: true
   replicas: 1


### PR DESCRIPTION
All guides utilize GAIE charts to deploy EPP except for wide-ep-lws. The PR that adds servicemonitor to GAIE charts merged so we can now add these to the guides. The modelservice PR to add servicemonitor is pending.

* GAIE servicemonitor [values](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/config/charts/inferencepool/values.yaml#L44-#L52)
* llm-d-modelservice EPP [servicemonitor PR](https://github.com/llm-d-incubation/llm-d-modelservice/pull/87)