### PR TITLE
Fix version for the helm-diff plugin in pre-req script

### DIFF
--- a/.github/workflows/e2e-simulated-accelerators-test.yaml
+++ b/.github/workflows/e2e-simulated-accelerators-test.yaml
@@ -109,7 +109,7 @@ jobs:
         env:
           GATEWAY_TYPE: ${{ env.GATEWAY_TYPE }}
         run: |
-          cd guides/gateway-provider
+          cd guides/prereq/gateway-provider
           ./install-gateway-provider-dependencies.sh
           helmfile apply -f ${GATEWAY_TYPE}.helmfile.yaml
 

--- a/.github/workflows/e2e-wide-ep-accelerator-test.yaml
+++ b/.github/workflows/e2e-wide-ep-accelerator-test.yaml
@@ -364,7 +364,7 @@ jobs:
           ssh -o StrictHostKeyChecking=no -i key.pem ubuntu@$INSTANCE_IP "GATEWAY_TYPE=$GATEWAY_TYPE bash -s" <<'EOF'
             set -euo pipefail
             set -x
-            cd llm-d/guides/gateway-provider
+            cd llm-d/guides/prereq/gateway-provider
             ./install-gateway-provider-dependencies.sh
             helmfile apply -f ${GATEWAY_TYPE}.helmfile.yaml
           EOF

--- a/guides/prereq/client-setup/install-deps.sh
+++ b/guides/prereq/client-setup/install-deps.sh
@@ -8,6 +8,8 @@ set -euo pipefail
 ########################################
 # Helm version
 HELM_VER="v3.17.3"
+# Helmdiff version
+HELMDIFF_VERSION="v3.11.0"
 # Helmfile version
 HELMFILE_VERSION="1.1.3"
 # chart-testing version
@@ -163,7 +165,8 @@ fi
 #  Helm diff plugin
 ########################################
 if ! helm plugin list | grep -q diff; then
-  helm plugin install https://github.com/databus23/helm-diff
+  echo "📦 helm-diff plugin not found. Installing ${HELMDIFF_VERSION}..."
+  helm plugin install --version "${HELMDIFF_VERSION}" https://github.com/databus23/helm-diff
 fi
 
 ########################################


### PR DESCRIPTION
The version of helm is fixed at v3.17.3 however helm-diff uses the
latest version, which results in a compatibility-related error now:

"failed to load plugins: [...] error unmarshaling JSON: while decoding JSON: json: unknown field "platformHooks"

Resolve by fixing helm-diff at a similar, known-good vintage as helm.

Signed-off-by: Nathan Scott <nathans@redhat.com>