### PR TITLE
Deprecate all references to InferenceModel

### DIFF
--- a/.github/workflows/e2e-wide-ep-accelerator-test.yaml
+++ b/.github/workflows/e2e-wide-ep-accelerator-test.yaml
@@ -462,8 +462,6 @@ jobs:
             helm list -n "${NAMESPACE}" || true
             echo ""
             echo "=== Wide-EP-specific resources ==="
-            echo "Inference Models:"
-            kubectl get inferencemodels -n "${NAMESPACE}" || true
             echo "Inference Pools:"
             kubectl get inferencepools -n "${NAMESPACE}" || true
             echo "HTTP Routes:"

--- a/docs/proposals/modelservice.md
+++ b/docs/proposals/modelservice.md
@@ -64,7 +64,7 @@ The project should graduate from “incubation” to “core” after demonstrat
 
 ## Alternative: Manual Deployment
 
-Manual composition via raw Kubernetes resources:  One possible approach is for platform or model owners to hand-craft Deployments, Services, ConfigMaps, InferencePool, InferenceModel, HTTPRoute, and RBAC configurations. While this provides flexibility, it significantly increases complexity and error surface, especially for PD-disaggregated and multi-node inference deployments.
+Manual composition via raw Kubernetes resources:  One possible approach is for platform or model owners to hand-craft Deployments, Services, ConfigMaps, InferencePool, HTTPRoute, and RBAC configurations. While this provides flexibility, it significantly increases complexity and error surface, especially for PD-disaggregated and multi-node inference deployments.
 
 ## Alternative: Extending KServe
 

--- a/guides/inference-scheduling/ms-inference-scheduling/values.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values.yaml
@@ -19,9 +19,6 @@ routing:
     connector: nixlv2
     secure: false
 
-  inferenceModel:
-    create: false
-
   inferencePool:
     create: false
     # name: gaie-inference-scheduling # set in helmfile

--- a/guides/inference-scheduling/ms-inference-scheduling/values_tpu.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_tpu.yaml
@@ -20,9 +20,6 @@ routing:
     connector: nixlv2
     secure: false
 
-  inferenceModel:
-    create: false
-
   inferencePool:
     create: false
     # name: gaie-inference-scheduling # set in helmfile

--- a/guides/pd-disaggregation/ms-pd/values.yaml
+++ b/guides/pd-disaggregation/ms-pd/values.yaml
@@ -19,10 +19,6 @@ routing:
     connector: nixlv2
     secure: false
 
-  inferenceModel:
-    criticality: Critical
-    create: true
-
   inferencePool:
     create: false
     # name: gaie-pd # set in helmfile

--- a/guides/precise-prefix-cache-aware/ms-kv-events/values.yaml
+++ b/guides/precise-prefix-cache-aware/ms-kv-events/values.yaml
@@ -19,9 +19,6 @@ routing:
     connector: nixlv2
     secure: false
 
-  inferenceModel:
-    create: false
-
   inferencePool:
     create: false
     # name: gaie-kv-events # set in helmfile

--- a/guides/simulated-accelerators/ms-sim/values.yaml
+++ b/guides/simulated-accelerators/ms-sim/values.yaml
@@ -18,9 +18,6 @@ routing:
     connector: nixlv2
     secure: false
 
-  inferenceModel:
-    create: false
-
   inferencePool:
     create: false
     # name: gaie-sim # set in helmfile


### PR DESCRIPTION
By default creation is set to false in modelservice, so it should be safe to remove from the well lit path charts: https://github.com/llm-d-incubation/llm-d-modelservice/blob/main/charts/llm-d-modelservice/values.yaml#L121; @Gregory-Pereira can you confirm?

Fixes #226 

