### PR TITLE
Update Slack links in documentation to reflect new URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ This project adheres to the llm-d [Code of Conduct and Covenant](CODE_OF_CONDUCT
 
 ## Community and Communication
 
-* **Developer Slack:** [Join our developer Slack workspace](https://inviter.co/llm-d-slack) to connect with the core maintainers and other contributors, ask questions, and participate in discussions.
+* **Developer Slack:** [Join our developer Slack workspace](https://llm-d.ai/slack) to connect with the core maintainers and other contributors, ask questions, and participate in discussions.
 * **Weekly Meetings:** Project updates, ongoing work discussions, and Q&A will be covered in our weekly project meeting every Wednesday at 12:30 PM ET. Please join by [adding the shared calendar](https://red.ht/llm-d-public-calendar). You can also [join our Google Group](https://groups.google.com/g/llm-d-contributors) for access to shared diagrams and other content.
   * Access meeting recordings and meeting notes on the [llm-d Public Google Drive](https://drive.google.com/drive/folders/1Y9ahJ9BhhDuwnPK6QHmKTi8uoz1FTqvA)
 * **SIGs:** Join one of our [Special Interest Groups (SIGs)](SIGS.md) to contribute to specific areas of the project and collaborate with domain experts.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Kubernetes-Native Distributed Inference at Scale
  [![Documentation](https://img.shields.io/badge/Documentation-8A2BE2?logo=readthedocs&logoColor=white&color=1BC070)](https://www.llm-d.ai)
  [![Release Status](https://img.shields.io/badge/Version-0.2-yellow)](https://github.com/llm-d/llm-d/releases)
  [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
- [![Join Slack](https://img.shields.io/badge/Join_Slack-blue?logo=slack)](https://inviter.co/llm-d-slack)
+ [![Join Slack](https://img.shields.io/badge/Join_Slack-blue?logo=slack)](https://llm-d.ai/slack)
 
 Latest News 🔥
 - [2025-07] Release of our first three well-lit paths in [v0.2](https://llm-d.ai/blog/llm-d-v0.2-our-first-well-lit-paths): intelligent inference scheduling, simple disaggregated serving, and wide expert-parallelism.
@@ -115,7 +115,7 @@ Check out our [roadmap for upcoming releases](https://github.com/llm-d/llm-d/iss
 - See [our project overview](PROJECT.md) for more details on our development process and governance.
 - Review [our contributing guidelines](CONTRIBUTING.md) for detailed information on how to contribute to the project.
 - Join one of our [Special Interest Groups (SIGs)](SIGS.md) to contribute to specific areas of the project and collaborate with domain experts.
-- We use Slack to discuss development across organizations. Please join: [Slack](https://inviter.co/llm-d-slack)
+- We use Slack to discuss development across organizations. Please join: [Slack](https://llm-d.ai/slack)
 - We host a weekly standup for contributors on Wednesdays at 12:30 PM ET, as well as meetings for various SIGs. You can find them in the [shared llm-d calendar](https://red.ht/llm-d-public-calendar)
 - We use Google Groups to share architecture diagrams and other content. Please join: [Google Group](https://groups.google.com/g/llm-d-contributors)
 

--- a/SIGS.md
+++ b/SIGS.md
@@ -184,7 +184,7 @@ SIGs operate within the broader llm-d project governance framework defined in [P
 
 ### Joining a SIG
 1. **Attend a meeting**: Check the [project calendar](https://red.ht/llm-d-public-calendar) for SIG meeting times
-2. **Join the conversation**: Participate in SIG-specific channels on [Slack](https://inviter.co/llm-d-slack)
+2. **Join the conversation**: Participate in SIG-specific channels on [Slack](https://llm-d.ai/slack)
 3. **Review documentation**: Read the SIG's charter and current initiatives
 4. **Start contributing**: Look for "good first issues" labeled with the SIG's area
 


### PR DESCRIPTION
This got lost in our dev -> main move.  New PR into the right mainline