### PR TITLE
fix XPU ci release workflow trivy step

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -136,7 +136,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ github.repository }}-xpu@${{ env.TAG }}
+          image-ref: ${{ env.REGISTRY }}/${{ github.repository }}-xpu:${{ env.TAG }}
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH,MEDIUM'


### PR DESCRIPTION
Issue:
[Build step pushes](https://github.com/llm-d/llm-d/actions/runs/18044251176/job/51350980158#step:5:7032): `ghcr.io/llm-d/llm-d-xpu:v0.3.0-rc.1-test`
[Trivy step scans](https://github.com/llm-d/llm-d/actions/runs/18044251176/job/51350980158#step:6:216): `ghcr.io/llm-d/llm-d-xpu@v0.3.0-rc.1-test`

Tag vs SHA syntax on scanning