### PR TITLE
Update model len to 3200 for GKE PD test

### DIFF
--- a/.github/workflows/e2e-pd-disaggregation-gke.yaml
+++ b/.github/workflows/e2e-pd-disaggregation-gke.yaml
@@ -104,6 +104,10 @@ jobs:
           # Set Prefill to 1 GPU
           yq e '.prefill.replicas = 1' -i guides/pd-disaggregation/ms-pd/values.yaml
 
+          # Reduce model length to 3200
+          yq e '.decode.containers[].args |= ( (.. | select(. == "--max-model-len") | key) as $idx | .[$idx + 1] = "3200" )' -i guides/pd-disaggregation/ms-pd/values.yaml
+          yq e '.prefill.containers[].args |= ( (.. | select(. == "--max-model-len") | key) as $idx | .[$idx + 1] = "3200" )' -i guides/pd-disaggregation/ms-pd/values.yaml
+
           # Verify the slimmed down values
           echo "📋 Verifying transformation results..."
           echo "Replicas in ms-pd prefill:"


### PR DESCRIPTION
For the PD Test, using 32000 as model len may cause the prefill node to crash on H100. Updating to 3200 instead.