### PR TITLE
Remove pool-group flag, it is configured by the apiVersion already

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.swp
+*.history

--- a/guides/wide-ep-lws/inferencepool.values.yaml
+++ b/guides/wide-ep-lws/inferencepool.values.yaml
@@ -43,6 +43,9 @@ inferenceExtension:
         plugins:
         - pluginRef: decode-filter
         - pluginRef: random-picker
+  flags:
+    - name: v
+      value: 1
 
 inferencePool:
   apiVersion: inference.networking.x-k8s.io/v1alpha2

--- a/guides/wide-ep-lws/inferencepool.values.yaml
+++ b/guides/wide-ep-lws/inferencepool.values.yaml
@@ -43,11 +43,7 @@ inferenceExtension:
         plugins:
         - pluginRef: decode-filter
         - pluginRef: random-picker
-  flags:
-    - name: v
-      value: 1
-    - name: "pool-group"
-      value: "inference.networking.x-k8s.io"
+
 inferencePool:
   apiVersion: inference.networking.x-k8s.io/v1alpha2
   modelServers:

--- a/guides/wide-ep-lws/manifests/modelserver/base/decode.yaml
+++ b/guides/wide-ep-lws/manifests/modelserver/base/decode.yaml
@@ -103,7 +103,6 @@ spec:
           # Lower values may cause poor performance, especially in load-imbalanced scenarios.
           # The value 512 was chosen to be greater than the concurrency expected to see on any DP rank.
           # Has no effect when VLLM_ALL2ALL_BACKEND=deepep_high_throughput.
-            value: deepep_low_latency
           - name: VLLM_MOE_DP_CHUNK_SIZE
             value: "512" # vLLM default is 256
           - name: DP_SIZE_LOCAL


### PR DESCRIPTION
This is a regression introduced by previous PR. The `pool-group` will be configured by the `apiVersion` value which is already set. 