### PR TITLE
gateway-provider: fix proxyMetadata type in istio MeshConfig

### DIFF
--- a/guides/prereq/gateway-provider/istio.helmfile.yaml
+++ b/guides/prereq/gateway-provider/istio.helmfile.yaml
@@ -19,7 +19,7 @@ releases:
       - meshConfig:
           defaultConfig:
             proxyMetadata:
-              SUPPORT_GATEWAY_API_INFERENCE_EXTENSION: true
+              SUPPORT_GATEWAY_API_INFERENCE_EXTENSION: "true"
         pilot:
           env:
             SUPPORT_GATEWAY_API_INFERENCE_EXTENSION: true

--- a/guides/prereq/gateway-provider/istio.helmfile.yaml
+++ b/guides/prereq/gateway-provider/istio.helmfile.yaml
@@ -22,7 +22,7 @@ releases:
               SUPPORT_GATEWAY_API_INFERENCE_EXTENSION: "true"
         pilot:
           env:
-            SUPPORT_GATEWAY_API_INFERENCE_EXTENSION: true
+            SUPPORT_GATEWAY_API_INFERENCE_EXTENSION: "true"
         tag: 1.28-alpha.89f30b26ba71bf5e538083a4720d0bc2d8c06401
         hub: "gcr.io/istio-testing"
     labels:


### PR DESCRIPTION
As [per docs](https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#ProxyConfig-proxy_metadata) for proxyMetadata in MeshConfig is a `map<string, string>` and the current config was failing with 
```
2025-10-03T11:16:58.109506859Z 2025-10-03T11:16:58.109347Z      warn    invalid mesh config, using last known state: failed to convert to proto. json: cannot unmarshal bool into Go value of type string
```
because a boolean value was being passed.