### PR TITLE
WIP feat: Add comprehensive readiness probe for vLLM containers

### DIFF
--- a/docker/Dockerfile.aws
+++ b/docker/Dockerfile.aws
@@ -365,6 +365,10 @@ RUN apt-get update -y && apt-get install -y \
         librdmacm1 \
         gcc && apt-get clean all
 
+# Copy readiness probe script
+COPY scripts/readiness_probe.sh /usr/local/bin/readiness_probe.sh
+RUN chmod +x /usr/local/bin/readiness_probe.sh
+
 # Copy UCX libraries from builder
 COPY --from=builder /usr/local/lib/libucp* /usr/local/lib/
 COPY --from=builder /usr/local/lib/libucs* /usr/local/lib/

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -346,6 +346,10 @@ RUN dnf install -y --allowerasing \
         jq \
         gcc && dnf clean all
 
+# Copy readiness probe script
+COPY scripts/readiness_probe.sh /usr/local/bin/readiness_probe.sh
+RUN chmod +x /usr/local/bin/readiness_probe.sh
+
 # Copy gdrcopy libraries from builder
 COPY --from=builder /usr/lib64/libgdrapi.so.2.* /usr/lib64/
 COPY --from=builder /usr/local/lib/libgdrapi.so* /usr/local/lib/

--- a/docker/Dockerfile.xpu
+++ b/docker/Dockerfile.xpu
@@ -142,6 +142,10 @@ RUN dnf install -y --allowerasing \
         curl \
         gcc && dnf clean all
 
+# Copy readiness probe script
+COPY scripts/readiness_probe.sh /usr/local/bin/readiness_probe.sh
+RUN chmod +x /usr/local/bin/readiness_probe.sh
+
 # Setup ldconfig and library paths
 RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/local.conf && \
     echo "/usr/local/lib64" >> /etc/ld.so.conf.d/local.conf && \

--- a/docs/readiness-probes.md
+++ b/docs/readiness-probes.md
@@ -1,0 +1,373 @@
+# vLLM Inference Readiness Probes
+
+## Overview
+
+The llm-d inference images include a comprehensive readiness probe script to ensure proper container lifecycle management in Kubernetes. This addresses the three distinct stages of readiness for vLLM inference containers:
+
+1. **Container Running** - Kubernetes native container lifecycle
+2. **API Server Ready** - vLLM OpenAI API server is accepting connections
+3. **Model Loaded** - Model-specific API routes are ready to serve inference requests
+
+## Problem Statement
+
+When deploying vLLM inference servers, there's a significant time gap between when the container starts and when the model is fully loaded and ready to serve requests. Using basic health checks (`/health` endpoint) can lead to:
+
+- Premature traffic routing to pods that aren't ready
+- Failed requests during model loading
+- Need for arbitrary sleep times in deployment pipelines
+- Unreliable E2E testing
+
+The `/health` endpoint only indicates that the vLLM server process is running, not that the model is loaded and ready to serve.
+
+## Solution
+
+The `readiness_probe.sh` script provides a proper readiness check by:
+
+1. Verifying the `/health` endpoint responds (server is up)
+2. Checking the `/v1/models` endpoint (model is loaded)
+3. Validating the response contains model data
+
+### Script Location
+
+The readiness probe script is available in all llm-d inference images at:
+```
+/usr/local/bin/readiness_probe.sh
+```
+
+### Usage
+
+The script accepts two optional arguments:
+```bash
+readiness_probe.sh [PORT] [HOST]
+```
+
+**Arguments:**
+- `PORT` - Port where vLLM server is listening (default: `8000`)
+- `HOST` - Host to connect to (default: `localhost`)
+
+**Environment Variables:**
+- `READINESS_TIMEOUT` - Timeout in seconds for HTTP requests (default: `5`)
+
+### Exit Codes
+
+- `0` - Service is ready (model loaded and API responding)
+- `1` - Service is not ready
+
+## Kubernetes Configuration
+
+### Recommended Probe Configuration
+
+For production deployments, we recommend using all three probe types:
+
+```yaml
+containers:
+  - name: vllm
+    image: ghcr.io/llm-d/llm-d-cuda-dev:latest
+    ports:
+      - containerPort: 8000
+        name: http
+        protocol: TCP
+    
+    # Startup probe - gives the model time to load on initial startup
+    # Disables liveness/readiness checks until this succeeds
+    startupProbe:
+      exec:
+        command:
+          - /usr/local/bin/readiness_probe.sh
+          - "8000"
+          - "localhost"
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 60  # 10 minutes total (60 * 10s)
+    
+    # Liveness probe - detects if the container needs to be restarted
+    # Uses basic health check since we only want to restart on critical failures
+    livenessProbe:
+      httpGet:
+        path: /health
+        port: 8000
+      initialDelaySeconds: 10
+      periodSeconds: 30
+      timeoutSeconds: 5
+      failureThreshold: 3
+    
+    # Readiness probe - determines if pod should receive traffic
+    # Uses the comprehensive readiness check
+    readinessProbe:
+      exec:
+        command:
+          - /usr/local/bin/readiness_probe.sh
+          - "8000"
+          - "localhost"
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+```
+
+### Port Configuration
+
+Adjust the port number in the probe configuration based on your deployment:
+
+- **Prefill pods**: Typically use port `8000`
+- **Decode pods**: May use port `8200` (depends on configuration)
+
+Example for decode pods:
+```yaml
+readinessProbe:
+  exec:
+    command:
+      - /usr/local/bin/readiness_probe.sh
+      - "8200"  # Decode port
+      - "localhost"
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+```
+
+### Prefill/Decode Disaggregation
+
+For P/D disaggregated deployments, configure probes for both pod types:
+
+**Prefill Pods:**
+```yaml
+readinessProbe:
+  exec:
+    command:
+      - /usr/local/bin/readiness_probe.sh
+      - "8000"
+```
+
+**Decode Pods:**
+```yaml
+readinessProbe:
+  exec:
+    command:
+      - /usr/local/bin/readiness_probe.sh
+      - "8200"
+```
+
+## Helm Chart Integration
+
+For the `llm-d-modelservice` Helm chart, you can configure probes in your `values.yaml`:
+
+```yaml
+decode:
+  containers:
+    - name: vllm
+      startupProbe:
+        exec:
+          command:
+            - /usr/local/bin/readiness_probe.sh
+            - "8200"
+        initialDelaySeconds: 30
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 60
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: 8200
+        periodSeconds: 30
+        timeoutSeconds: 5
+        failureThreshold: 3
+      readinessProbe:
+        exec:
+          command:
+            - /usr/local/bin/readiness_probe.sh
+            - "8200"
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 3
+
+prefill:
+  containers:
+    - name: vllm
+      startupProbe:
+        exec:
+          command:
+            - /usr/local/bin/readiness_probe.sh
+            - "8000"
+        initialDelaySeconds: 30
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 60
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: 8000
+        periodSeconds: 30
+        timeoutSeconds: 5
+        failureThreshold: 3
+      readinessProbe:
+        exec:
+          command:
+            - /usr/local/bin/readiness_probe.sh
+            - "8000"
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 3
+```
+
+## Tuning Guidelines
+
+### Startup Probe
+
+The startup probe is critical for model loading. Tune based on:
+- Model size (larger models take longer to load)
+- Storage backend (local SSD vs network storage)
+- Available GPU memory
+
+**Small models (< 7B parameters):**
+```yaml
+initialDelaySeconds: 30
+periodSeconds: 10
+failureThreshold: 30  # 5 minutes
+```
+
+**Medium models (7B - 70B parameters):**
+```yaml
+initialDelaySeconds: 60
+periodSeconds: 15
+failureThreshold: 40  # 10 minutes
+```
+
+**Large models (> 70B parameters):**
+```yaml
+initialDelaySeconds: 120
+periodSeconds: 20
+failureThreshold: 60  # 20 minutes
+```
+
+### Readiness Probe
+
+Keep readiness checks frequent to quickly detect issues:
+```yaml
+periodSeconds: 10        # Check every 10 seconds
+timeoutSeconds: 5        # 5 second timeout
+failureThreshold: 3      # Mark unready after 3 failures (30s)
+```
+
+### Liveness Probe
+
+Be conservative with liveness probes to avoid unnecessary restarts:
+```yaml
+periodSeconds: 30        # Check every 30 seconds
+timeoutSeconds: 5        # 5 second timeout  
+failureThreshold: 3      # Restart after 3 failures (90s)
+```
+
+## Testing
+
+### Manual Testing
+
+Test the readiness probe manually:
+
+```bash
+# Get a shell in the container
+kubectl exec -it <pod-name> -n <namespace> -- bash
+
+# Run the probe
+/usr/local/bin/readiness_probe.sh 8000 localhost
+echo $?  # Should return 0 when ready
+```
+
+### Verification
+
+Verify probes are working:
+
+```bash
+# Check pod events
+kubectl describe pod <pod-name> -n <namespace>
+
+# Watch pod status during startup
+kubectl get pods -n <namespace> -w
+
+# Check probe logs
+kubectl logs <pod-name> -n <namespace> | grep readiness_probe
+```
+
+## E2E Testing
+
+With proper readiness probes, E2E tests can eliminate arbitrary sleep times:
+
+**Before:**
+```yaml
+- name: Wait for all pods to be ready
+  run: |
+    kubectl wait pod --for=condition=Ready --all -n ${NAMESPACE} --timeout=15m
+    sleep 480  # Wait for model loading
+```
+
+**After:**
+```yaml
+- name: Wait for all pods to be ready
+  run: |
+    kubectl wait pod --for=condition=Ready --all -n ${NAMESPACE} --timeout=15m
+    # No sleep needed - readiness probe ensures model is loaded
+```
+
+## Troubleshooting
+
+### Pod Stuck in Not Ready
+
+If pods are stuck in not ready state:
+
+1. Check the probe logs:
+   ```bash
+   kubectl logs <pod-name> -n <namespace> | grep readiness_probe
+   ```
+
+2. Verify the vLLM server is starting:
+   ```bash
+   kubectl logs <pod-name> -n <namespace> | grep -i "uvicorn\|vllm"
+   ```
+
+3. Check for model loading errors:
+   ```bash
+   kubectl logs <pod-name> -n <namespace> | grep -i "error\|failed"
+   ```
+
+4. Manually test the endpoints:
+   ```bash
+   kubectl exec -it <pod-name> -n <namespace> -- curl -s http://localhost:8000/health
+   kubectl exec -it <pod-name> -n <namespace> -- curl -s http://localhost:8000/v1/models
+   ```
+
+### Probe Timeouts
+
+If probes are timing out:
+
+1. Increase the timeout:
+   ```yaml
+   timeoutSeconds: 10  # Increase from 5
+   ```
+
+2. Increase the period for startup:
+   ```yaml
+   periodSeconds: 20  # Check less frequently
+   ```
+
+3. Check network connectivity within the pod
+
+### False Negatives
+
+If the probe reports not ready when the model is loaded:
+
+1. Verify the port matches your vLLM configuration
+2. Check if there are firewall or network policy restrictions
+3. Ensure the probe script is executable: `ls -la /usr/local/bin/readiness_probe.sh`
+
+## Related Issues
+
+- Issue #300: Original feature request for readiness probe implementation
+- See E2E workflow files for integration examples
+
+## Additional Resources
+
+- [Kubernetes Probes Documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
+- [vLLM OpenAI API Documentation](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html)
+- [llm-d Getting Started Guide](./getting-started-inferencing.md)
+

--- a/guides/simulated-accelerators/ms-sim/values.yaml
+++ b/guides/simulated-accelerators/ms-sim/values.yaml
@@ -45,9 +45,10 @@ decode:
     - name: metrics-volume
       mountPath: /.config
     startupProbe:
-      httpGet:
-        path: /health
-        port: 8200
+      exec:
+        command:
+          - /usr/local/bin/readiness_probe.sh
+          - "8200"
       initialDelaySeconds: 15
       periodSeconds: 30
       timeoutSeconds: 5
@@ -60,9 +61,10 @@ decode:
       timeoutSeconds: 5
       failureThreshold: 3
     readinessProbe:
-      httpGet:
-        path: /health
-        port: 8200
+      exec:
+        command:
+          - /usr/local/bin/readiness_probe.sh
+          - "8200"
       periodSeconds: 5
       timeoutSeconds: 2
       failureThreshold: 3
@@ -94,9 +96,10 @@ prefill:
     - name: metrics-volume
       mountPath: /.config
     startupProbe:
-      httpGet:
-        path: /health
-        port: 8000
+      exec:
+        command:
+          - /usr/local/bin/readiness_probe.sh
+          - "8000"
       initialDelaySeconds: 15
       periodSeconds: 30
       timeoutSeconds: 5
@@ -109,9 +112,10 @@ prefill:
       timeoutSeconds: 5
       failureThreshold: 3
     readinessProbe:
-      httpGet:
-        path: /health
-        port: 8000
+      exec:
+        command:
+          - /usr/local/bin/readiness_probe.sh
+          - "8000"
       periodSeconds: 5
       timeoutSeconds: 2
   volumes:

--- a/guides/wide-ep-lws/manifests/modelserver/base/decode.yaml
+++ b/guides/wide-ep-lws/manifests/modelserver/base/decode.yaml
@@ -139,10 +139,30 @@ spec:
           - containerPort: 8200
             name: metrics
             protocol: TCP
-          readinessProbe:
+          startupProbe:
+            exec:
+              command:
+                - /usr/local/bin/readiness_probe.sh
+                - "8200"
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 60
+          livenessProbe:
             httpGet:
               path: /health
               port: 8200
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - /usr/local/bin/readiness_probe.sh
+                - "8200"
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           resources:
             limits:
               ephemeral-storage: 64Gi

--- a/guides/wide-ep-lws/manifests/modelserver/base/prefill.yaml
+++ b/guides/wide-ep-lws/manifests/modelserver/base/prefill.yaml
@@ -115,10 +115,30 @@ spec:
           - containerPort: 8000
             name: metrics
             protocol: TCP
-          readinessProbe:
+          startupProbe:
+            exec:
+              command:
+                - /usr/local/bin/readiness_probe.sh
+                - "8000"
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 80
+          livenessProbe:
             httpGet:
               path: /health
               port: 8000
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - /usr/local/bin/readiness_probe.sh
+                - "8000"
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           resources:
             limits:
               ephemeral-storage: 64Gi

--- a/scripts/readiness_probe.sh
+++ b/scripts/readiness_probe.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# vLLM Readiness Probe Script
+#
+# This script checks if the vLLM inference server is fully ready by verifying:
+# 1. The basic health endpoint is responding
+# 2. The /v1/models endpoint is available (indicates model is loaded)
+# 3. The model metadata is properly returned
+#
+# This addresses the three stages of readiness:
+# - Container is running (handled by Kubernetes)
+# - vLLM API server is up (checked via /health)
+# - Model-specific API routes are ready (checked via /v1/models)
+#
+# Exit codes:
+#   0 - Service is ready
+#   1 - Service is not ready
+#
+# Usage:
+#   readiness_probe.sh PORT [HOST]
+#
+# Arguments:
+#   PORT - Port where vLLM server is listening (required)
+#   HOST - Host to connect to (optional, default: localhost)
+
+set -euo pipefail
+
+# Validate required arguments
+if [ -z "${1:-}" ]; then
+    echo "[readiness_probe] ERROR: PORT argument is required" >&2
+    echo "Usage: readiness_probe.sh PORT [HOST]" >&2
+    exit 1
+fi
+
+# Configuration
+PORT="${1}"
+HOST="${2:-localhost}"
+TIMEOUT="${READINESS_TIMEOUT:-5}"
+HEALTH_ENDPOINT="http://${HOST}:${PORT}/health"
+MODELS_ENDPOINT="http://${HOST}:${PORT}/v1/models"
+
+# Helper function for logging
+log() {
+    echo "[readiness_probe] $*" >&2
+}
+
+# Check if curl is available
+if ! command -v curl &> /dev/null; then
+    log "ERROR: curl command not found"
+    exit 1
+fi
+
+# Step 1: Check basic health endpoint
+log "Checking health endpoint: ${HEALTH_ENDPOINT}"
+if ! curl -sf --max-time "${TIMEOUT}" "${HEALTH_ENDPOINT}" > /dev/null 2>&1; then
+    log "Health endpoint not responding"
+    exit 1
+fi
+log "Health endpoint is responding"
+
+# Step 2: Check /v1/models endpoint (indicates model is loaded)
+log "Checking models endpoint: ${MODELS_ENDPOINT}"
+MODELS_RESPONSE=$(curl -sf --max-time "${TIMEOUT}" "${MODELS_ENDPOINT}" 2>&1)
+CURL_EXIT_CODE=$?
+
+if [ ${CURL_EXIT_CODE} -ne 0 ]; then
+    log "Models endpoint not responding (curl exit code: ${CURL_EXIT_CODE})"
+    exit 1
+fi
+
+# Step 3: Verify response contains model data
+if ! echo "${MODELS_RESPONSE}" | grep -q '"data"'; then
+    log "Models endpoint response does not contain expected 'data' field"
+    exit 1
+fi
+
+# Check if data array is not empty
+if echo "${MODELS_RESPONSE}" | grep -q '"data":\s*\[\s*\]'; then
+    log "Models endpoint returned empty data array - model not loaded yet"
+    exit 1
+fi
+
+log "vLLM server is ready - model is loaded and API is responding"
+exit 0
+


### PR DESCRIPTION
Implements model-aware health checking for Kubernetes readiness probes. Ensures pods are marked Ready only when vLLM has loaded models and API is serving requests, preventing premature traffic routing.

Changes:
- Add readiness_probe.sh script with /health and /v1/models validation
- Update Dockerfiles to include probe script in images
- Update example configurations with exec probes
- Add mandatory PORT parameter to prevent misconfigurations
- Add documentation for probe usage

Tested with simulated accelerator deployment on Kind cluster.

For #300