### PR TITLE
upgrading to official v0.3.2 image

### DIFF
--- a/guides/inference-scheduling/gaie-inference-scheduling/values.yaml
+++ b/guides/inference-scheduling/gaie-inference-scheduling/values.yaml
@@ -5,7 +5,7 @@ inferenceExtension:
     ###################
     name: llm-d-inference-scheduler
     hub: ghcr.io/llm-d
-    tag: v0.3.2-rc.1
+    tag: v0.3.2
     ###################
     # name: epp
     # hub: registry.k8s.io/gateway-api-inference-extension

--- a/guides/pd-disaggregation/gaie-pd/values.yaml
+++ b/guides/pd-disaggregation/gaie-pd/values.yaml
@@ -3,7 +3,7 @@ inferenceExtension:
   image:
     name: llm-d-inference-scheduler
     hub: ghcr.io/llm-d
-    tag: v0.3.2-rc.1
+    tag: v0.3.2
     pullPolicy: Always
   extProcPort: 9002
   pluginsConfigFile: "pd-config.yaml"

--- a/guides/precise-prefix-cache-aware/gaie-kv-events/values.yaml
+++ b/guides/precise-prefix-cache-aware/gaie-kv-events/values.yaml
@@ -5,7 +5,7 @@ inferenceExtension:
     ###################
     name: llm-d-inference-scheduler
     hub: ghcr.io/llm-d
-    tag: v0.3.2-rc1
+    tag: v0.3.2
     ###################
     # name: epp
     # hub: registry.k8s.io/gateway-api-inference-extension

--- a/guides/simulated-accelerators/gaie-sim/values.yaml
+++ b/guides/simulated-accelerators/gaie-sim/values.yaml
@@ -5,7 +5,7 @@ inferenceExtension:
     ###################
     name: llm-d-inference-scheduler
     hub: ghcr.io/llm-d
-    tag: v0.3.2-rc.1
+    tag: v0.3.2
     ###################
     # name: epp
     # hub: registry.k8s.io/gateway-api-inference-extension

--- a/guides/wide-ep-lws/inferencepool.values.yaml
+++ b/guides/wide-ep-lws/inferencepool.values.yaml
@@ -3,7 +3,7 @@ inferenceExtension:
   image:
     name: llm-d-inference-scheduler
     hub: ghcr.io/llm-d
-    tag: v0.3.2-rc.1
+    tag: v0.3.2
   extProcPort: 9002
   monitoring:
     interval: "10s"


### PR DESCRIPTION
Upgrading to the official `v0.3.2` inference scheduler (release coming soon but container images exist)

cc @kfswain 