### PR TITLE
remove requirements for specifying environment when tearing down

### DIFF
--- a/guides/inference-scheduling/README.md
+++ b/guides/inference-scheduling/README.md
@@ -124,7 +124,7 @@ To remove the deployment:
 
 ```bash
 # From examples/inference-scheduling
-helmfile destroy -n ${NAMESPACE} -e <your_environment>
+helmfile destroy -n ${NAMESPACE}
 
 # Or uninstall manually
 helm uninstall infra-inference-scheduling -n ${NAMESPACE}
@@ -133,8 +133,6 @@ helm uninstall ms-inference-scheduling -n ${NAMESPACE}
 ```
 
 **_NOTE:_** If you set the `$RELEASE_NAME_POSTFIX` environment variable, your release names will be different from the command above: `infra-$RELEASE_NAME_POSTFIX`, `gaie-$RELEASE_NAME_POSTFIX` and `ms-$RELEASE_NAME_POSTFIX`.
-
-**_NOTE:_** You need to specify your `environment` with the `-e <environment>` flag to `helmfile` for removing a installation of the guide when using a non-default option. IE if you deploy with `-e istio` and undeploy `-e istioBench` or vice versa, it may fail. If you encounter this it is recommended to manually uninstall all 3 releases with `helm` as shown above.
 
 ### Cleanup HTTPRoute
 

--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -165,7 +165,7 @@ To remove the deployment:
 
 ```bash
 # Remove the model services
-helmfile destroy -n ${NAMESPACE} -e <your_environment>
+helmfile destroy -n ${NAMESPACE}
 
 # Remove the infrastructure
 helm uninstall ms-pd -n ${NAMESPACE}
@@ -174,8 +174,6 @@ helm uninstall infra-pd -n ${NAMESPACE}
 ```
 
 **_NOTE:_** If you set the `$RELEASE_NAME_POSTFIX` environment variable, your release names will be different from the command above: `infra-$RELEASE_NAME_POSTFIX`, `gaie-$RELEASE_NAME_POSTFIX` and `ms-$RELEASE_NAME_POSTFIX`.
-
-**_NOTE:_** You need to specify your `environment` with the `-e <environment>` flag to `helmfile` for removing a installation of the guide when using a non-default option. IE if you deploy with `-e istio` and undeploy `-e istioBench` or vice versa, it may fail. If you encounter this it is recommended to manually uninstall all 3 releases with `helm` as shown above.
 
 ### Cleanup HTTPRoute
 

--- a/guides/precise-prefix-cache-aware/README.md
+++ b/guides/precise-prefix-cache-aware/README.md
@@ -146,7 +146,7 @@ To remove the deployment:
 ```bash
 # Remove the model services
 # From examples/precise-prefix-cache-aware
-helmfile destroy -n ${NAMESPACE} -e <your_environment>
+helmfile destroy -n ${NAMESPACE}
 
 # Or uninstall manually
 helm uninstall infra-kv-events -n ${NAMESPACE}
@@ -155,8 +155,6 @@ helm uninstall ms-kv-events -n ${NAMESPACE}
 ```
 
 **_NOTE:_** If you set the `$RELEASE_NAME_POSTFIX` environment variable, your release names will be different from the command above: `infra-$RELEASE_NAME_POSTFIX`, `gaie-$RELEASE_NAME_POSTFIX` and `ms-$RELEASE_NAME_POSTFIX`.
-
-**_NOTE:_** You need to specify your `environment` with the `-e <environment>` flag to `helmfile` for removing a installation of the guide when using a non-default option. IE if you deploy with `-e istio` and undeploy `-e istioBench` or vice versa, it may fail. If you encounter this it is recommended to manually uninstall all 3 releases with `helm` as shown above.
 
 ## Customization
 

--- a/guides/simulated-accelerators/README.md
+++ b/guides/simulated-accelerators/README.md
@@ -120,8 +120,6 @@ helm uninstall ms-sim -n ${NAMESPACE}
 
 **_NOTE:_** If you set the `$RELEASE_NAME_POSTFIX` environment variable, your release names will be different from the command above: `infra-$RELEASE_NAME_POSTFIX`, `gaie-$RELEASE_NAME_POSTFIX` and `ms-$RELEASE_NAME_POSTFIX`.
 
-**_NOTE:_** You need to specify your `environment` with the `-e <environment>` flag to `helmfile` for removing a installation of the guide when using a non-default option. IE if you deploy with `-e istio` and undeploy `-e istioBench` or vice versa, it may fail. If you encounter this it is recommended to manually uninstall all 3 releases with `helm` as shown above.
-
 ## Customization
 
 For information on customizing a guide and tips to build your own, see [our docs](../../docs/customizing-a-guide.md)


### PR DESCRIPTION
Another release prep PR. This requirement was removed with how we handle the `helmfile`s and common values files.