### PR TITLE
DO NOT MERGE: A patch to DeepEP v1.2.1 to test RDMA binding

### DIFF
--- a/guides/wide-ep-lws/manifests/modelserver/base/prefill.yaml
+++ b/guides/wide-ep-lws/manifests/modelserver/base/prefill.yaml
@@ -39,6 +39,30 @@ spec:
             - -c
           args:
             - |-
+              set -e
+
+              patch -d /app/venv/lib/python3.12/site-packages -lup0 <<'EOF'
+              --- deep_ep/buffer.py
+              +++ deep_ep/buffer.py
+              @@ -114,6 +114,15 @@ class Buffer:
+                              # Disable multi-node NVLink detection
+                              os.environ['NVSHMEM_DISABLE_MNNVL'] = '1'
+              
+              +            # GCP specific patch
+              +            if 'DISABLE_GCP_PATCH' not in os.environ or os.environ['DISABLE_GCP_PATCH'] != '1':
+              +                os.environ['NVSHMEM_ENABLE_NIC_PE_MAPPING'] = '1'
+              +                local_rank = os.environ['LOCAL_RANK'] if 'LOCAL_RANK' in os.environ else self.rank % 8
+              +                os.environ['NVSHMEM_HCA_LIST'] = f'mlx5_{local_rank}:1'
+              +                print(f"GCP patch enabled: Setting {self.rank} to use {local_rank}", flush=True)
+              +            else:
+              +                print("GCP patch disabled", flush=True)
+              +
+                          # Synchronize using the root ID
+                          if (low_latency_mode and self.rank == 0) or (not low_latency_mode and self.runtime.get_rdma_rank() == 0):
+                              root_unique_id = self.runtime.get_local_nvshmem_unique_id()
+              EOF
+              export NVSHMEM_DEBUG=INFO NVSHMEM_INFO=true DISABLE_GCP_PATCH=
+
               #################
               # RUN vLLM prefill worker
               #################

--- a/guides/wide-ep-lws/manifests/modelserver/gke/kustomization.yaml
+++ b/guides/wide-ep-lws/manifests/modelserver/gke/kustomization.yaml
@@ -101,20 +101,20 @@ patches:
           mountPath: /usr/local/gib
           name: gib
       # Env vars 
-      - op: add
-        path: /spec/leaderWorkerTemplate/workerTemplate/spec/containers/0/env/-
-        value:
-          # GCP pairs GPU NICs to PCIe bridges (https://cloud.google.com/compute/docs/gpus/gpu-network-bandwidth#h200-gpus),
-          # which can lead to NVSHMEM's automatic distance assignment algorithm selecting NICs
-          # inefficiently. Instead, instruct NVSHMEM to select the NIC that aligns to the
-          # index of the GPU on the node.
-          name: NVSHMEM_ENABLE_NIC_PE_MAPPING
-          value: "1"
-      - op: add
-        path: /spec/leaderWorkerTemplate/workerTemplate/spec/containers/0/env/-
-        value:
-          name: NVSHMEM_HCA_LIST
-          value: "mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_6:1,mlx5_7:1"
+      # - op: add
+      #   path: /spec/leaderWorkerTemplate/workerTemplate/spec/containers/0/env/-
+      #   value:
+      #     # GCP pairs GPU NICs to PCIe bridges (https://cloud.google.com/compute/docs/gpus/gpu-network-bandwidth#h200-gpus),
+      #     # which can lead to NVSHMEM's automatic distance assignment algorithm selecting NICs
+      #     # inefficiently. Instead, instruct NVSHMEM to select the NIC that aligns to the
+      #     # index of the GPU on the node.
+      #     name: NVSHMEM_ENABLE_NIC_PE_MAPPING
+      #     value: "1"
+      # - op: add
+      #   path: /spec/leaderWorkerTemplate/workerTemplate/spec/containers/0/env/-
+      #   value:
+      #     name: NVSHMEM_HCA_LIST
+      #     value: "mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_6:1,mlx5_7:1"
       # https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute-custom#configure-pod-manifests-rdma
       - op: add
         path: /spec/leaderWorkerTemplate/workerTemplate/spec/containers/0/env/-


### PR DESCRIPTION
Prefer the device for the local rank GPU during NVSHMEM init,
to avoid using the same device for all GPUs or for randomly
assigning a GPU based on distance (vs PCIe host bus affinity).

Can be disabled with DISABLE_GCP_PATCH=1