### PR TITLE
Clear /dev/shm before process startup to prevent crashloops

### DIFF
--- a/guides/wide-ep-lws/manifests/modelserver/base/decode.yaml
+++ b/guides/wide-ep-lws/manifests/modelserver/base/decode.yaml
@@ -39,7 +39,7 @@ spec:
           - name: dshm
             emptyDir:
               medium: Memory
-              sizeLimit: 3Gi # 3Gi for NCCL 2.27 to be safe
+              sizeLimit: 1Gi # roughly 32MB per local DP plus scratch space
         containers:
         - name: vllm-worker
           image: ghcr.io/llm-d/llm-d-cuda:v0.3.0
@@ -56,6 +56,10 @@ spec:
             - -c
           args:
             - |-
+              # Clear /dev/shm on start to prevent running out of space when crashes occur
+              # https://github.com/llm-d/llm-d/issues/352
+              find /dev/shm -type f -delete
+
               #################
               # RUN vLLM decode worker
               #################

--- a/guides/wide-ep-lws/manifests/modelserver/base/prefill.yaml
+++ b/guides/wide-ep-lws/manifests/modelserver/base/prefill.yaml
@@ -22,7 +22,7 @@ spec:
           - name: dshm
             emptyDir:
               medium: Memory
-              sizeLimit: 3Gi # 3Gi for NCCL 2.27 to be safe
+              sizeLimit: 1Gi # roughly 32MB per local DP plus scratch space
         containers:
         - name: vllm-worker
           image: ghcr.io/llm-d/llm-d-cuda:v0.3.0
@@ -39,6 +39,10 @@ spec:
             - -c
           args:
             - |-
+              # Clear /dev/shm on start to prevent running out of space when crashes occur
+              # https://github.com/llm-d/llm-d/issues/352
+              find /dev/shm -type f -delete
+
               #################
               # RUN vLLM prefill worker
               #################


### PR DESCRIPTION
When vLLM crashes there is no guarantee that /dev/shm will
be cleaned up. Since we are the only consumer of the volume
ensure it is empty before the process starts. Otherwise we
may run out of shm for NCCL init during subsequent crashes
converting temporary crashes to a permanent one.

Fixes issue #352