### PR TITLE
Add the XPU CI test

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,18 +1,11 @@
 name: Dev LLM-D Image Build
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - .github/workflows/build-image.yml
-      - docker/**
-      - patches/**
-  pull_request:
-    branches: [main]
-    paths:
-      - .github/workflows/build-image.yml
-      - docker/**
-      - patches/**
+  workflow_call:
+    outputs:
+      xpu:
+        description: 'Whether XPU image was built'
+        value: ${{ jobs.detect-changes.outputs.xpu }}
   workflow_dispatch:
     inputs:
       platforms:

--- a/.github/workflows/ci-pr-test.yaml
+++ b/.github/workflows/ci-pr-test.yaml
@@ -1,0 +1,131 @@
+name: CI-PR-Test
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/ci-pr-test.yaml
+      - .github/workflows/e2e-*.yaml
+      - .github/workflows/build-image.yml
+      - docker/**
+      - patches/**
+      - scripts/**
+      - guides/**/*.yaml
+      - guides/**/*.yml
+      - guides/**/*.gotmpl
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/ci-pr-test.yaml
+      - .github/workflows/e2e-*.yaml
+      - .github/workflows/build-image.yml
+      - docker/**
+      - patches/**
+      - scripts/**
+      - guides/**/*.yaml
+      - guides/**/*.yml
+      - guides/**/*.gotmpl
+  workflow_dispatch:
+    inputs:
+      pr_or_branch:
+        description: 'Pull-request number or branch name to test'
+        required: true
+        default: 'main'
+        type: string
+      custom_image_tag:
+        description: 'Custom XPU image tag to use (optional)'
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+  security-events: write
+
+jobs:
+  # Detect which files have changed to determine which tests to run
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      xpu-inference-scheduling: ${{ steps.filter.outputs.xpu-inference-scheduling }}
+      xpu-pd-disaggregation: ${{ steps.filter.outputs.xpu-pd-disaggregation }}
+      xpu-prefix-cache: ${{ steps.filter.outputs.xpu-prefix-cache }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            xpu-inference-scheduling:
+              - .github/workflows/ci-pr-test.yaml
+              - .github/workflows/e2e-inference-scheduling-xpu.yaml
+              - docker/Dockerfile.xpu
+              - guides/**/values_xpu.yaml
+              - guides/inference-scheduling/ms-inference-scheduling/values_xpu.yaml
+              - guides/inference-scheduling/helmfile.yaml.gotmpl
+            xpu-pd-disaggregation:
+              - .github/workflows/ci-pr-test.yaml
+              - .github/workflows/e2e-pd-xpu.yaml
+              - docker/Dockerfile.xpu
+              - guides/**/values_xpu.yaml
+              - guides/pd-disaggregation/ms-pd/values_xpu.yaml
+              - guides/pd-disaggregation/README.xpu.md
+              - guides/pd-disaggregation/helmfile.yaml.gotmpl
+            xpu-prefix-cache:
+              - .github/workflows/ci-pr-test.yaml
+              - .github/workflows/e2e-prefix-cache-xpu.yaml
+              - docker/Dockerfile.xpu
+              - guides/**/values_xpu.yaml
+              - guides/precise-prefix-cache-aware/**/values_xpu.yaml
+              - guides/precise-prefix-cache-aware/helmfile.yaml.gotmpl
+
+  # Call the build-image workflow to build any changed images
+  build-images:
+    uses: ./.github/workflows/build-image.yml
+    secrets: inherit
+
+  # Call the XPU Inference Scheduling test workflow
+  test-xpu-inference-scheduling:
+    needs: [detect-changes, build-images]
+    # Run tests if:
+    # 1. It's a manual workflow_dispatch, OR
+    # 2. Related files changed AND (build succeeded OR build was skipped)
+    if: ${{ (github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.xpu-inference-scheduling == 'true') && (needs.build-images.result == 'success' || needs.build-images.result == 'skipped') }}
+    uses: ./.github/workflows/e2e-inference-scheduling-xpu.yaml
+    with:
+      pr_or_branch: ${{ github.event.inputs.pr_or_branch || github.event.pull_request.number }}
+      # Only use custom image tag if user provides it, or if XPU image was actually built in this PR
+      # Otherwise, let the test use the default image from values_xpu.yaml
+      custom_image_tag: ${{ github.event.inputs.custom_image_tag != '' && github.event.inputs.custom_image_tag || (needs.build-images.outputs.xpu == 'true' && github.event.pull_request.number != '' && format('pr-{0}', github.event.pull_request.number) || '') }}
+    secrets: inherit
+
+  # Call the XPU PD test workflow
+  test-xpu-pd:
+    needs: [detect-changes, build-images]
+    # Run tests if:
+    # 1. It's a manual workflow_dispatch, OR
+    # 2. Related files changed AND (build succeeded OR build was skipped)
+    if: ${{ (github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.xpu-pd-disaggregation == 'true') && (needs.build-images.result == 'success' || needs.build-images.result == 'skipped') }}
+    uses: ./.github/workflows/e2e-pd-xpu.yaml
+    with:
+      pr_or_branch: ${{ github.event.inputs.pr_or_branch || github.event.pull_request.number }}
+      # Only use custom image tag if user provides it, or if XPU image was actually built in this PR
+      # Otherwise, let the test use the default image from values_xpu.yaml
+      custom_image_tag: ${{ github.event.inputs.custom_image_tag != '' && github.event.inputs.custom_image_tag || (needs.build-images.outputs.xpu == 'true' && github.event.pull_request.number != '' && format('pr-{0}', github.event.pull_request.number) || '') }}
+    secrets: inherit
+
+  # Call the XPU Prefix Cache test workflow
+  test-xpu-prefix-cache:
+    needs: [detect-changes, build-images]
+    # Run tests if:
+    # 1. It's a manual workflow_dispatch, OR
+    # 2. Related files changed AND (build succeeded OR build was skipped)
+    if: ${{ (github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.xpu-prefix-cache == 'true') && (needs.build-images.result == 'success' || needs.build-images.result == 'skipped') }}
+    uses: ./.github/workflows/e2e-prefix-cache-xpu.yaml
+    with:
+      pr_or_branch: ${{ github.event.inputs.pr_or_branch || github.event.pull_request.number }}
+      # Only use custom image tag if user provides it, or if XPU image was actually built in this PR
+      # Otherwise, let the test use the default image from values_xpu.yaml
+      custom_image_tag: ${{ github.event.inputs.custom_image_tag != '' && github.event.inputs.custom_image_tag || (needs.build-images.outputs.xpu == 'true' && github.event.pull_request.number != '' && format('pr-{0}', github.event.pull_request.number) || '') }}
+    secrets: inherit

--- a/.github/workflows/e2e-inference-scheduling-xpu.yaml
+++ b/.github/workflows/e2e-inference-scheduling-xpu.yaml
@@ -3,12 +3,6 @@ name: XPU Inference Scheduling Test
 on:
   schedule:
     - cron: '0 10 * * *'  # 3AM PST (10:00 UTC)
-  pull_request:
-    paths:
-      - 'guides/inference-scheduling/**/values_xpu.yaml'
-      - 'guides/inference-scheduling/helmfile.yaml.gotmpl'
-      - 'guides/inference-scheduling/httproute.yaml'
-      - '.github/workflows/e2e-inference-scheduling-xpu.yaml'
   workflow_dispatch:
     inputs:
       pr_or_branch:
@@ -116,7 +110,7 @@ jobs:
               FULL_IMAGE="ghcr.io/${{ github.repository }}-xpu-dev:${CUSTOM_TAG}"
             fi
             echo "IMAGE_TAG=${CUSTOM_TAG}" >> $GITHUB_ENV
-            echo "HELM_SET_IMAGE=--set decode.containers[0].image=${FULL_IMAGE}" >> $GITHUB_ENV
+            echo "HELM_SET_IMAGE=--set decode.containers[0].image=${FULL_IMAGE} --set decode.containers[0].imagePullPolicy=Always" >> $GITHUB_ENV
           else
             echo "Using default image tag from values file"
             echo "HELM_SET_IMAGE=" >> $GITHUB_ENV
@@ -244,6 +238,9 @@ jobs:
 
             mv ~/inference-scheduling-xpu-deployment.log . || true
             mv ~/install-deps.log . || true
+            
+            echo "Log collection completed."
+            ls -la
 
             echo "Log collection completed."
             ls -la

--- a/.github/workflows/e2e-pd-xpu.yaml
+++ b/.github/workflows/e2e-pd-xpu.yaml
@@ -3,12 +3,6 @@ name: XPU PD Test
 on:
   schedule:
     - cron: '0 10 * * *'  # 3AM PST (10:00 UTC)
-  pull_request:
-    paths:
-      - 'guides/pd-disaggregation/**/values_xpu.yaml'
-      - 'guides/pd-disaggregation/helmfile.yaml.gotmpl'
-      - 'guides/pd-disaggregation/httproute.yaml'
-      - '.github/workflows/e2e-pd-xpu.yaml'
   workflow_dispatch:
     inputs:
       pr_or_branch:
@@ -246,6 +240,9 @@ jobs:
 
             mv ~/pd-xpu-deployment.log . || true
             mv ~/install-deps.log . || true
+            
+            echo "Log collection completed."
+            ls -la
 
             echo "Log collection completed."
             ls -la

--- a/.github/workflows/e2e-prefix-cache-xpu.yaml
+++ b/.github/workflows/e2e-prefix-cache-xpu.yaml
@@ -3,12 +3,6 @@ name: XPU Prefix Cache Test
 on:
   schedule:
     - cron: '0 10 * * *'  # 3AM PST (10:00 UTC)
-  pull_request:
-    paths:
-      - 'guides/precise-prefix-cache-aware/**/values_xpu.yaml'
-      - 'guides/precise-prefix-cache-aware/helmfile.yaml.gotmpl'
-      - 'guides/precise-prefix-cache-aware/httproute.yaml'
-      - '.github/workflows/e2e-prefix-cache-xpu.yaml'
   workflow_dispatch:
     inputs:
       pr_or_branch:

--- a/guides/inference-scheduling/README.md
+++ b/guides/inference-scheduling/README.md
@@ -144,6 +144,19 @@ This case expects using 4th Gen Intel Xeon processors (Sapphire Rapids) or later
 
 Follow provider specific instructions for installing HTTPRoute.
 
+**_IMPORTANT:_** If you set the `$RELEASE_NAME_POSTFIX` environment variable, you **must** update the HTTPRoute file to match your custom release names before applying it. The HTTPRoute references the Gateway and InferencePool names which include the release name postfix.
+
+For example, if you set `RELEASE_NAME_POSTFIX=my-custom`, you need to update the HTTPRoute:
+```bash
+# Update the HTTPRoute to match your release names
+sed -e "s/infra-inference-scheduling-inference-gateway/infra-my-custom-inference-gateway/g" \
+    -e "s/gaie-inference-scheduling/gaie-my-custom/g" \
+    httproute.yaml > httproute-custom.yaml
+
+# Then apply the customized HTTPRoute
+kubectl apply -f httproute-custom.yaml -n ${NAMESPACE}
+```
+
 #### Install for "kgateway" or "istio"
 
 ```bash

--- a/guides/pd-disaggregation/README.xpu.md
+++ b/guides/pd-disaggregation/README.xpu.md
@@ -267,6 +267,20 @@ Note
 
 If no HTTPRoute was found, create one manually:
 
+**_IMPORTANT:_** If you used a custom `$RELEASE_NAME_POSTFIX` environment variable during deployment, you **must** update the HTTPRoute file to match your custom release names before applying it. The HTTPRoute references the Gateway and InferencePool names which include the release name postfix.
+
+For example, if you set `RELEASE_NAME_POSTFIX=pd-xpu`, you need to update the HTTPRoute:
+```shell
+# Update the HTTPRoute to match your release names
+sed -e "s/infra-pd-inference-gateway/infra-pd-xpu-inference-gateway/g" \
+    -e "s/gaie-pd/gaie-pd-xpu/g" \
+    httproute.yaml > httproute-custom.yaml
+
+# Then apply the customized HTTPRoute
+kubectl apply -f httproute-custom.yaml -n llm-d-pd
+```
+
+If using default release names (no custom `RELEASE_NAME_POSTFIX`), simply apply:
 ```shell
 # Apply the HTTPRoute configuration from the PD disaggregation guide
 kubectl apply -f httproute.yaml


### PR DESCRIPTION
This patch series adds CI/CD support for Intel XPU (GPU) workloads.

## Changes Overview

### 1. CI/CD Infrastructure (`ci-pr-test.yaml`)
- Implements automated pull request testing for Intel XPU-related changes
- Orchestrates end-to-end testing pipeline with image building and deployment validation
- Supports both PR review-triggered and manual workflow dispatch modes
- Provides custom image tag override capability for testing specific builds

### 2. E2E Test Workflows

**Inference Scheduling** (`e2e-inference-scheduling-xpu.yaml`)
**PD Disaggregation** (`e2e-pd-xpu.yaml`)

Both workflows now support:
- `workflow_call` trigger for CI integration
- Custom image tag injection via input parameters
-  Three-stage deployment (infra → gaie → model service) to apply image overrides only to decode/prefill containers that need custom images
- 
### 3. Image Build Workflow Updates (`build-image.yml`)

- Enhanced to support `workflow_call` trigger
- Refined path filters to prevent unnecessary builds
- Integrates with CI pipeline for automated image building on PR events

### 5. Documentation Fixes

- Fixed markdown link checker error in OpenShift documentation (escaped underscore in URL)

### 6. Dockerfile.xpu
0.12.0  OK
### 7. Transitioned to out-of-band HTTPRoute deployment approach
- HTTPRoute deployed separately after Helm releases complete
- Dynamic name substitution based on environment variables in CI workflow.
- Added **important warnings** about HTTPRoute customization when using `RELEASE_NAME_POSTFIX`
