### PR TITLE
misc: change settings for minikube test

### DIFF
--- a/guides/precise-prefix-cache-aware/helmfile.yaml.gotmpl
+++ b/guides/precise-prefix-cache-aware/helmfile.yaml.gotmpl
@@ -38,6 +38,8 @@ releases:
     values:
       - gateway: 
           {{ .Environment.Values.gateway | toYaml | nindent 10 }}
+          service:
+            type: LoadBalancer
 
   - name: {{ printf "gaie-%s" $rn | quote }}
     namespace: {{ $ns }}

--- a/guides/precise-prefix-cache-aware/ms-kv-events/values.yaml
+++ b/guides/precise-prefix-cache-aware/ms-kv-events/values.yaml
@@ -17,7 +17,7 @@ routing:
     create: false
 
   httpRoute:
-    create: false
+    create: true
 
   epp:
     create: false


### PR DESCRIPTION
- Set Gateway service type to LoadBalancer for external access
- Enable HTTPRoute creation for Gateway API routing

This allows external requests to be properly routed through the Gateway API to the inference pods with precise-prefix-cache-aware scheduling.