### PR TITLE
Update DeepEP to a version with a patch for setting NVSHMEM HCA mappings to CUDA device

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -160,8 +160,8 @@ WORKDIR /workspace/vllm
 # set kernel library dependencies
 # note: these libraries don't yet push sdist releases to pypi
 # so down below we do a git clone
-ARG DEEPEP_REPO="https://github.com/deepseek-ai/DeepEP"
-ARG DEEPEP_VERSION="v1.2.1"
+ARG DEEPEP_REPO="https://github.com/smarterclayton/DeepEP"
+ARG DEEPEP_VERSION="nic_pe_alignment"
 ARG DEEPGEMM_REPO="https://github.com/deepseek-ai/DeepGEMM"
 ARG DEEPGEMM_VERSION="v2.1.0"
 ARG PPLX_KERNELS_REPO="https://github.com/perplexityai/pplx-kernels"


### PR DESCRIPTION
Some x86 hosts for NVIDIA GPUs using CX-7 use a shared PCIe host complex for pairs of GPUs and pairs of NICs. Due to how DeepEP initializes NVSHMEM it is not possible to use the existing NVSHMEM env vars to ensure a deterministic "1 GPU to closest NIC" setup - the default behavior ends up selecting overlapping NICs for GPUs (2 GPUs sharing 1 NIC), and setting explicit mappings ends up with all GPUS sharing the same NIC.

This issue occurs on GCP A3U (H200) and GCP A4 (B200) instances, but would not occur on GB200 or future generations using ARM chips (the current sharing is due to tray design and PCIe constraints with x86 chips).

To ensure that DeepEP correctly leverages all 8 NICs in a rank to rank pairing for maximum bandwidth, https://github.com/deepseek-ai/DeepEP/pull/466 introduces a tweak to `deep_ep.Buffer` initialization that sets an explicit `NVSHMEM_HCA_LIST` based on the index of the initializing device.  This patch works for both 0.11.0 (where we used `CUDA_VISIBLE_DEVICES`) and current mainline (where we do not).

We will need to carry this patch until it is accepted upstream, or indefinitely if it is not.