### PR TITLE
Patch nvshmem to avoid an uninitialized value passed to RoCE

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -75,14 +75,6 @@ ENV PATH="${VIRTUAL_ENV}/bin:${PATH}" \
     CPATH="/usr/include:/usr/local/include:/usr/local/cuda/include" \
     PKG_CONFIG_PATH="/usr/lib/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig"
 
-# NVSHMEM installed from nvidia repos via libnvshmem3-cuda-${CUDA_MAJOR}-3.4.5-1
-# Libraries on RHEL: /usr/lib64/nvshmem/${CUDA_MAJOR}/, on Ubuntu: /usr/lib/{arch}-linux-gnu/nvshmem/${CUDA_MAJOR}/
-# Headers: /usr/include/nvshmem_${CUDA_MAJOR}/
-ENV NVSHMEM_DIR="/usr/bin/nvshmem_${CUDA_MAJOR}" \
-    PATH="/usr/bin/nvshmem_${CUDA_MAJOR}:${PATH}" \
-    CPATH="/usr/include/nvshmem_${CUDA_MAJOR}:${CPATH}" \
-    LIBRARY_PATH="/usr/lib64/nvshmem/${CUDA_MAJOR}:/usr/lib/x86_64-linux-gnu/nvshmem/${CUDA_MAJOR}:/usr/lib/aarch64-linux-gnu/nvshmem/${CUDA_MAJOR}:${LIBRARY_PATH}"
-
 # Build and install gdrcopy
 COPY docker/scripts/cuda/builder/build-gdrcopy.sh /tmp/build-gdrcopy.sh
 RUN --mount=type=cache,target=/var/cache/git \
@@ -92,24 +84,25 @@ RUN --mount=type=cache,target=/var/cache/git \
     TARGETPLATFORM=${TARGETPLATFORM} TARGETOS=${TARGETOS} /tmp/build-gdrcopy.sh && \
     rm /tmp/build-gdrcopy.sh
 
-# Determine NVSHMEM library path based on OS and architecture, and create symlinks
-RUN if [ "${TARGETOS:-rhel}" = "ubuntu" ]; then \
-        if [ "${TARGETPLATFORM:-linux/amd64}" = "linux/arm64" ]; then \
-            NVSHMEM_LIBDIR="/usr/lib/aarch64-linux-gnu/nvshmem/${CUDA_MAJOR}"; \
-        else \
-            NVSHMEM_LIBDIR="/usr/lib/x86_64-linux-gnu/nvshmem/${CUDA_MAJOR}"; \
-        fi; \
-    else \
-        NVSHMEM_LIBDIR="/usr/lib64/nvshmem/${CUDA_MAJOR}"; \
-    fi && \
-    echo "${NVSHMEM_LIBDIR}" > /tmp/nvshmem_libdir && \
-    mkdir -p /usr/bin/nvshmem_${CUDA_MAJOR} && \
-    ln -sf "${NVSHMEM_LIBDIR}" /usr/bin/nvshmem_${CUDA_MAJOR}/lib && \
-    ln -sf /usr/include/nvshmem_${CUDA_MAJOR} /usr/bin/nvshmem_${CUDA_MAJOR}/include
+# Build and install NVSHMEM
+ARG NVSHMEM_VERSION=3.3.20
 
-# Set compiler flags - include all possible nvshmem paths (linker ignores non-existent ones)
-ENV CPPFLAGS="-I/usr/include/nvshmem_${CUDA_MAJOR} ${CPPFLAGS}" \
-    LDFLAGS="-L/usr/lib64/nvshmem/${CUDA_MAJOR} -L/usr/lib/x86_64-linux-gnu/nvshmem/${CUDA_MAJOR} -L/usr/lib/aarch64-linux-gnu/nvshmem/${CUDA_MAJOR} ${LDFLAGS}"
+# Set NVSHMEM paths for CMake discovery
+ENV NVSHMEM_DIR="/opt/nvshmem-${NVSHMEM_VERSION}" \
+    PATH="/opt/nvshmem-${NVSHMEM_VERSION}/bin:${PATH}" \
+    CPATH="/opt/nvshmem-${NVSHMEM_VERSION}/include:${CPATH}" \
+    LIBRARY_PATH="/opt/nvshmem-${NVSHMEM_VERSION}/lib:${LIBRARY_PATH}"
+
+ENV CPPFLAGS="-I$NVSHMEM_DIR/include ${CPPFLAGS}" \
+    LDFLAGS="-L$NVSHMEM_DIR/lib ${LDFLAGS}"
+
+COPY docker/scripts/cuda/builder/build-nvshmem.sh /tmp/build-nvshmem.sh
+RUN --mount=type=cache,target=/var/cache/git \
+    --mount=type=secret,id=aws_access_key_id \
+    --mount=type=secret,id=aws_secret_access_key \
+    chmod +x /tmp/build-nvshmem.sh && \
+    TARGETPLATFORM=${TARGETPLATFORM} TARGETOS=${TARGETOS} /tmp/build-nvshmem.sh && \
+    rm /tmp/build-nvshmem.sh
 
 # Create wheels directory
 RUN mkdir -p /wheels

--- a/docker/packages/cuda/builder-packages.json
+++ b/docker/packages/cuda/builder-packages.json
@@ -1,7 +1,4 @@
 {
   "rhel_to_ubuntu": {
-    "libnvshmem3-cuda-${CUDA_MAJOR}-3.4.5-1": "libnvshmem3-cuda-${CUDA_MAJOR}=3.4.5-1",
-    "libnvshmem3-devel-cuda-${CUDA_MAJOR}-3.4.5-1": "libnvshmem3-dev-cuda-${CUDA_MAJOR}=3.4.5-1",
-    "libnvshmem3-static-cuda-${CUDA_MAJOR}-3.4.5-1": "libnvshmem3-static-cuda-${CUDA_MAJOR}=3.4.5-1"
   }
 }

--- a/docker/packages/cuda/runtime-packages.json
+++ b/docker/packages/cuda/runtime-packages.json
@@ -3,8 +3,5 @@
     "cuda-nvcc-${CUDA_MAJOR}-${CUDA_MINOR}": "cuda-nvcc-${CUDA_MAJOR}-${CUDA_MINOR}",
     "cuda-cuobjdump-${CUDA_MAJOR}-${CUDA_MINOR}": "cuda-cuobjdump-${CUDA_MAJOR}-${CUDA_MINOR}",
     "cuda-nvrtc-${CUDA_MAJOR}-${CUDA_MINOR}": "cuda-nvrtc-${CUDA_MAJOR}-${CUDA_MINOR}",
-    "libnvshmem3-cuda-${CUDA_MAJOR}-3.4.5-1": "libnvshmem3-cuda-${CUDA_MAJOR}=3.4.5-1",
-    "libnvshmem3-devel-cuda-${CUDA_MAJOR}-3.4.5-1": "libnvshmem3-dev-cuda-${CUDA_MAJOR}=3.4.5-1",
-    "libnvshmem3-static-cuda-${CUDA_MAJOR}-3.4.5-1": "libnvshmem3-static-cuda-${CUDA_MAJOR}=3.4.5-1"
   }
 }

--- a/docker/scripts/cuda/builder/build-nvshmem.sh
+++ b/docker/scripts/cuda/builder/build-nvshmem.sh
@@ -24,6 +24,7 @@ tar -xf "nvshmem_src_cuda${CUDA_MAJOR}.tar.gz"
 cd nvshmem_src
 
 git apply /tmp/patches/cks_nvshmem"${NVSHMEM_VERSION}".patch
+git apply /tmp/patches/nvshmem_zero_ib_ah_attr_"${NVSHMEM_VERSION}".patch
 
 mkdir build
 cd build

--- a/patches/nvshmem_nvshmem_zero_ib_ah_attr_3.3.20.patch
+++ b/patches/nvshmem_nvshmem_zero_ib_ah_attr_3.3.20.patch
@@ -1,0 +1,18 @@
+diff --git a/src/modules/transport/ibgda/ibgda.cpp b/src/modules/transport/ibgda/ibgda.cpp
+index d037ccc..924626c 100644
+--- a/src/modules/transport/ibgda/ibgda.cpp
++++ b/src/modules/transport/ibgda/ibgda.cpp
+@@ -2097,6 +2097,13 @@
+     struct ibv_ah_attr ah_attr;
+     struct mlx5dv_obj dv;
+ 
++    // static_rate must be a known value and is passed directly to the device - and is not
++    // validated prior to https://github.com/torvalds/linux/commit/c534ffda781f44a1c6ac25ef6e0e444da38ca8af
++    // which leads to different behavior depending on kernel version.
++    // Always clear the memory.
++    memset(&ibv_ah_attr, 0, sizeof(ah_attr));
++    NVSHMEMI_WARN_PRINT("Zeroing ibv_ah_attr to avoid 'Unable to create ah' error on RoCE devices\n");
++
+     bool support_half_av_seg;
+     int hca_support_compact_address_vector;
+ 


### PR DESCRIPTION
NVSHMEM does not clear a stack allocated struct `ibv_ah_attr`
which is passed directly to the kernel RDMA functions. On
kernels with a patch to validate the value of static_rate
the create_ah() function will return EINVAL (sometimes).

When built in environments that automatically zero stack
values, the library will always initialize the device to
the default rate. Otherwise, it may result in the error

`Unable to create ah.` especially on RoCE devices.