### PR TITLE
Patch nvshmem to avoid an uninitialized value passed to RoCE

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -33,6 +33,7 @@ WORKDIR /workspace
 # Create UV constraint files
 COPY docker/build-constraints.txt /tmp/build-constraints.txt
 COPY docker/constraints.txt /tmp/constraints.txt
+COPY patches/ /tmp/patches/
 
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
@@ -55,6 +56,12 @@ RUN chmod +x /tmp/install-base-packages.sh && \
     rm /tmp/install-base-packages.sh /tmp/package-utils.sh && \
     rm -rf /tmp/packages
 
+# Install cmake from script for consistency between ubuntu22.04 and rhel9
+COPY docker/scripts/cuda/builder/install-cmake.sh /tmp/install-cmake.sh
+RUN --mount=type=cache,target=/var/cache/git \
+    /tmp/install-cmake.sh && \
+    rm -f /tmp/install-cmake.sh
+
 # Install sccache (after base packages which include curl and openssl-devel)
 COPY docker/scripts/common/setup-sccache.sh /usr/local/bin/setup-sccache
 COPY docker/scripts/cuda/builder/install-sccache.sh /tmp/install-sccache.sh
@@ -75,13 +82,8 @@ ENV PATH="${VIRTUAL_ENV}/bin:${PATH}" \
     CPATH="/usr/include:/usr/local/include:/usr/local/cuda/include" \
     PKG_CONFIG_PATH="/usr/lib/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig"
 
-# NVSHMEM installed from nvidia repos via libnvshmem3-cuda-${CUDA_MAJOR}-3.4.5-1
-# Libraries on RHEL: /usr/lib64/nvshmem/${CUDA_MAJOR}/, on Ubuntu: /usr/lib/{arch}-linux-gnu/nvshmem/${CUDA_MAJOR}/
-# Headers: /usr/include/nvshmem_${CUDA_MAJOR}/
-ENV NVSHMEM_DIR="/usr/bin/nvshmem_${CUDA_MAJOR}" \
-    PATH="/usr/bin/nvshmem_${CUDA_MAJOR}:${PATH}" \
-    CPATH="/usr/include/nvshmem_${CUDA_MAJOR}:${CPATH}" \
-    LIBRARY_PATH="/usr/lib64/nvshmem/${CUDA_MAJOR}:/usr/lib/x86_64-linux-gnu/nvshmem/${CUDA_MAJOR}:/usr/lib/aarch64-linux-gnu/nvshmem/${CUDA_MAJOR}:${LIBRARY_PATH}"
+# Create wheels directory
+RUN mkdir -p /wheels
 
 # Build and install gdrcopy
 COPY docker/scripts/cuda/builder/build-gdrcopy.sh /tmp/build-gdrcopy.sh
@@ -92,27 +94,25 @@ RUN --mount=type=cache,target=/var/cache/git \
     TARGETPLATFORM=${TARGETPLATFORM} TARGETOS=${TARGETOS} /tmp/build-gdrcopy.sh && \
     rm /tmp/build-gdrcopy.sh
 
-# Determine NVSHMEM library path based on OS and architecture, and create symlinks
-RUN if [ "${TARGETOS:-rhel}" = "ubuntu" ]; then \
-        if [ "${TARGETPLATFORM:-linux/amd64}" = "linux/arm64" ]; then \
-            NVSHMEM_LIBDIR="/usr/lib/aarch64-linux-gnu/nvshmem/${CUDA_MAJOR}"; \
-        else \
-            NVSHMEM_LIBDIR="/usr/lib/x86_64-linux-gnu/nvshmem/${CUDA_MAJOR}"; \
-        fi; \
-    else \
-        NVSHMEM_LIBDIR="/usr/lib64/nvshmem/${CUDA_MAJOR}"; \
-    fi && \
-    echo "${NVSHMEM_LIBDIR}" > /tmp/nvshmem_libdir && \
-    mkdir -p /usr/bin/nvshmem_${CUDA_MAJOR} && \
-    ln -sf "${NVSHMEM_LIBDIR}" /usr/bin/nvshmem_${CUDA_MAJOR}/lib && \
-    ln -sf /usr/include/nvshmem_${CUDA_MAJOR} /usr/bin/nvshmem_${CUDA_MAJOR}/include
+# Build and install NVSHMEM
+ARG NVSHMEM_VERSION=3.3.20
 
-# Set compiler flags - include all possible nvshmem paths (linker ignores non-existent ones)
-ENV CPPFLAGS="-I/usr/include/nvshmem_${CUDA_MAJOR} ${CPPFLAGS}" \
-    LDFLAGS="-L/usr/lib64/nvshmem/${CUDA_MAJOR} -L/usr/lib/x86_64-linux-gnu/nvshmem/${CUDA_MAJOR} -L/usr/lib/aarch64-linux-gnu/nvshmem/${CUDA_MAJOR} ${LDFLAGS}"
+# Set NVSHMEM paths for CMake discovery
+ENV NVSHMEM_DIR="/opt/nvshmem-${NVSHMEM_VERSION}" \
+    PATH="/opt/nvshmem-${NVSHMEM_VERSION}/bin:${PATH}" \
+    CPATH="/opt/nvshmem-${NVSHMEM_VERSION}/include:${CPATH}" \
+    LIBRARY_PATH="/opt/nvshmem-${NVSHMEM_VERSION}/lib:${LIBRARY_PATH}"
 
-# Create wheels directory
-RUN mkdir -p /wheels
+ENV CPPFLAGS="-I$NVSHMEM_DIR/include ${CPPFLAGS}" \
+    LDFLAGS="-L$NVSHMEM_DIR/lib ${LDFLAGS}"
+
+COPY docker/scripts/cuda/builder/build-nvshmem.sh /tmp/build-nvshmem.sh
+RUN --mount=type=cache,target=/var/cache/git \
+    --mount=type=secret,id=aws_access_key_id \
+    --mount=type=secret,id=aws_secret_access_key \
+    chmod +x /tmp/build-nvshmem.sh && \
+    NVSHMEM_CUDA_ARCHITECTURES="${NVSHMEM_CUDA_ARCHITECTURES}" /tmp/build-nvshmem.sh && \
+    rm /tmp/build-nvshmem.sh
 
 # Pin torch, so all deps are built against the same version
 # as vllm itself
@@ -201,8 +201,6 @@ ENV LANG=C.UTF-8 \
     NVSHMEM_DIR="/usr/bin/nvshmem_${CUDA_MAJOR}" \
     # LD_LIBRARY_PATH needs the torch path to apply proper linkers so as not to produce torch ABI missmatch
     LD_LIBRARY_PATH="/opt/vllm/lib64/python${PYTHON_VERSION}/site-packages/torch/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:/usr/local/lib:/usr/local/lib64:/usr/lib64/nvshmem/${CUDA_MAJOR}:/usr/lib/x86_64-linux-gnu/nvshmem/${CUDA_MAJOR}:/usr/lib/aarch64-linux-gnu/nvshmem/${CUDA_MAJOR}:${LD_LIBRARY_PATH}" \
-    PATH="/usr/bin/nvshmem_${CUDA_MAJOR}:${PATH}" \
-    CPATH="/usr/include/nvshmem_${CUDA_MAJOR}:${CPATH}" \
     TORCH_CUDA_ARCH_LIST="9.0a;10.0+PTX"
 
 # Install runtime dependencies
@@ -242,7 +240,10 @@ RUN if [ -d /tmp/gdrcopy_libs ]; then \
         rm -rf /tmp/gdrcopy_libs; \
     fi
 
-# NVSHMEM now installed from nvidia repos (no need to copy from builder)
+# Copy NVSHMEM dir from builder
+ARG NVSHMEM_VERSION=3.3.20
+COPY --from=builder /opt/nvshmem-${NVSHMEM_VERSION}/ /opt/nvshmem-${NVSHMEM_VERSION}/
+ENV NVSHMEM_DIR=/opt/nvshmem-${NVSHMEM_VERSION}
 
 # Setup ldconfig and library paths
 RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/local.conf && \

--- a/docker/packages/common/builder-packages.json
+++ b/docker/packages/common/builder-packages.json
@@ -11,7 +11,6 @@
     "gcc": "gcc",
     "gcc-c++": "g++",
     "make": "make",
-    "cmake": "cmake",
     "autoconf": "autoconf",
     "automake": "automake",
     "libtool": "libtool",

--- a/docker/packages/cuda/builder-packages.json
+++ b/docker/packages/cuda/builder-packages.json
@@ -1,7 +1,5 @@
 {
   "rhel_to_ubuntu": {
-    "libnvshmem3-cuda-${CUDA_MAJOR}-3.4.5-1": "libnvshmem3-cuda-${CUDA_MAJOR}=3.4.5-1",
-    "libnvshmem3-devel-cuda-${CUDA_MAJOR}-3.4.5-1": "libnvshmem3-dev-cuda-${CUDA_MAJOR}=3.4.5-1",
-    "libnvshmem3-static-cuda-${CUDA_MAJOR}-3.4.5-1": "libnvshmem3-static-cuda-${CUDA_MAJOR}=3.4.5-1"
+    "python3.9-devel": null
   }
 }

--- a/docker/packages/cuda/runtime-packages.json
+++ b/docker/packages/cuda/runtime-packages.json
@@ -2,9 +2,6 @@
   "rhel_to_ubuntu": {
     "cuda-nvcc-${CUDA_MAJOR}-${CUDA_MINOR}": "cuda-nvcc-${CUDA_MAJOR}-${CUDA_MINOR}",
     "cuda-cuobjdump-${CUDA_MAJOR}-${CUDA_MINOR}": "cuda-cuobjdump-${CUDA_MAJOR}-${CUDA_MINOR}",
-    "cuda-nvrtc-${CUDA_MAJOR}-${CUDA_MINOR}": "cuda-nvrtc-${CUDA_MAJOR}-${CUDA_MINOR}",
-    "libnvshmem3-cuda-${CUDA_MAJOR}-3.4.5-1": "libnvshmem3-cuda-${CUDA_MAJOR}=3.4.5-1",
-    "libnvshmem3-devel-cuda-${CUDA_MAJOR}-3.4.5-1": "libnvshmem3-dev-cuda-${CUDA_MAJOR}=3.4.5-1",
-    "libnvshmem3-static-cuda-${CUDA_MAJOR}-3.4.5-1": "libnvshmem3-static-cuda-${CUDA_MAJOR}=3.4.5-1"
+    "cuda-nvrtc-${CUDA_MAJOR}-${CUDA_MINOR}": "cuda-nvrtc-${CUDA_MAJOR}-${CUDA_MINOR}"
   }
 }

--- a/docker/scripts/cuda/builder/build-compiled-wheels.sh
+++ b/docker/scripts/cuda/builder/build-compiled-wheels.sh
@@ -35,6 +35,7 @@ uv pip uninstall flashinfer-python || true
 git clone https://github.com/flashinfer-ai/flashinfer.git
 cd flashinfer
 git checkout -q "${FLASHINFER_VERSION}"
+git submodule update --init --recursive
 uv build --wheel --no-build-isolation --out-dir /wheels
 cd ..
 rm -rf flashinfer

--- a/docker/scripts/cuda/builder/build-nvshmem.sh
+++ b/docker/scripts/cuda/builder/build-nvshmem.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -Eeu
+set -Eeux
 
 # builds and installs NVSHMEM from source with coreweave patch
 #
@@ -23,7 +23,13 @@ tar -xf "nvshmem_src_cuda${CUDA_MAJOR}.tar.gz"
 
 cd nvshmem_src
 
-git apply /tmp/patches/cks_nvshmem"${NVSHMEM_VERSION}".patch
+for i in /tmp/patches/cks_nvshmem"${NVSHMEM_VERSION}".patch /tmp/patches/nvshmem_zero_ibv_ah_attr_"${NVSHMEM_VERSION}".patch; do
+    if [[ -f $i ]]; then
+        git apply $i
+    else
+        echo "Unable to find patch matching nvshmem version ${NVSHMEM_VERSION}: $i"
+    fi
+done
 
 mkdir build
 cd build
@@ -51,7 +57,7 @@ ninja -j"$(nproc)"
 ninja install
 
 # copy python wheel to /wheels
-cp "${NVSHMEM_DIR}"/lib/python/dist/nvshmem4py_cu"${CUDA_MAJOR}"-*-cp"${PYTHON_VERSION/./}"-cp"${PYTHON_VERSION/./}"-manylinux_*.whl /wheels/
+cp "${NVSHMEM_DIR}"/lib/python/dist/nvshmem4py_cu"${CUDA_MAJOR}"-*-cp"${PYTHON_VERSION/./}"-cp"${PYTHON_VERSION/./}"-manylinux*.whl /wheels/
 
 cd /tmp
 rm -rf nvshmem_src*

--- a/docker/scripts/cuda/builder/install-cmake.sh
+++ b/docker/scripts/cuda/builder/install-cmake.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -Eeu
+
+# purpose: install cmake 3.22.0 as a workaround for building nvshmem from source
+# CMAKE version is locked here because the url changes when downloading from github based on the version
+
+export CMAKE_VERSION="3.22.0"
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+    x86_64)  CMAKE_ARCH=linux-x86_64 ;;
+    amd64)   CMAKE_ARCH=linux-x86_64 ;;
+    aarch64) CMAKE_ARCH=linux-aarch64 ;;
+    arm64)   CMAKE_ARCH=linux-aarch64 ;;
+    *) echo "Unsupported arch: $ARCH" >&2; exit 1 ;;
+esac
+
+# Install to /usr/local without prompts
+curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-${CMAKE_ARCH}.sh" \
+-o /tmp/cmake.sh
+chmod +x /tmp/cmake.sh
+/tmp/cmake.sh --skip-license --prefix=/usr/local --exclude-subdir

--- a/patches/nvshmem_zero_ibv_ah_attr_3.3.20.patch
+++ b/patches/nvshmem_zero_ibv_ah_attr_3.3.20.patch
@@ -1,0 +1,18 @@
+diff --git a/src/modules/transport/ibgda/ibgda.cpp b/src/modules/transport/ibgda/ibgda.cpp
+index d037ccc..924626c 100644
+--- a/src/modules/transport/ibgda/ibgda.cpp
++++ b/src/modules/transport/ibgda/ibgda.cpp
+@@ -2097,6 +2097,13 @@
+     struct ibv_ah_attr ah_attr;
+     struct mlx5dv_obj dv;
+ 
++    // static_rate must be a known value and is passed directly to the device - and is not
++    // validated prior to https://github.com/torvalds/linux/commit/c534ffda781f44a1c6ac25ef6e0e444da38ca8af
++    // which leads to different behavior depending on kernel version.
++    // Always clear the memory.
++    memset(&ah_attr, 0, sizeof(ah_attr));
++    NVSHMEMI_WARN_PRINT("Zeroing ah_attr to avoid 'Unable to create ah' error on RoCE devices\n");
++
+     bool support_half_av_seg;
+     int hca_support_compact_address_vector;
+ 


### PR DESCRIPTION
NVSHMEM does not clear a stack allocated struct `ibv_ah_attr` which is passed directly to the kernel RDMA functions. On kernels with a patch to validate the value of static_rate the create_ah() function will return EINVAL (sometimes).

When built in environments that automatically zero stack values, the library will always initialize the device to the default rate. Otherwise, it may result in the error `Unable to create ah.` especially on RoCE devices.