### PR TITLE
Update to NVSHMEM 3.4.5

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -101,7 +101,7 @@ RUN --mount=type=cache,target=/var/cache/git \
     rm /tmp/build-gdrcopy.sh
 
 # Build and install NVSHMEM
-ARG NVSHMEM_VERSION=3.3.20
+ARG NVSHMEM_VERSION=3.4.5
 
 # Set NVSHMEM paths for CMake discovery
 ENV NVSHMEM_DIR="/opt/nvshmem-${NVSHMEM_VERSION}" \
@@ -196,7 +196,7 @@ ARG CUDA_MAJOR=12
 ARG CUDA_MINOR=9
 ARG CUDA_PATCH=1
 ARG PYTHON_VERSION
-ARG NVSHMEM_VERSION=3.3.20
+ARG NVSHMEM_VERSION=3.4.5
 ARG FLASHINFER_VERSION=v0.5.2
 
 COPY docker/constraints.txt /tmp/constraints.txt

--- a/patches/nvshmem_zero_ibv_ah_attr_3.4.5.patch
+++ b/patches/nvshmem_zero_ibv_ah_attr_3.4.5.patch
@@ -1,0 +1,18 @@
+diff --git a/src/modules/transport/ibgda/ibgda.cpp b/src/modules/transport/ibgda/ibgda.cpp
+index 4c69cce..bfe1009 100644
+--- a/src/modules/transport/ibgda/ibgda.cpp
++++ b/src/modules/transport/ibgda/ibgda.cpp
+@@ -2336,6 +2336,13 @@ static int ibgda_create_dct_shared_objects(nvshmemt_ibgda_state_t *ibgda_state,
+     struct ibv_ah_attr ah_attr;
+     struct mlx5dv_obj dv;
+ 
++    // static_rate must be a known value and is passed directly to the device - and is not
++    // validated prior to https://github.com/torvalds/linux/commit/c534ffda781f44a1c6ac25ef6e0e444da38ca8af
++    // which leads to different behavior depending on kernel version.
++    // Always clear the memory.
++    memset(&ah_attr, 0, sizeof(ah_attr));
++    NVSHMEMI_WARN_PRINT("Zeroing ah_attr to avoid 'Unable to create ah' error on RoCE devices\n");
++
+     bool support_half_av_seg;
+     int hca_support_compact_address_vector;
+ 


### PR DESCRIPTION
Move to 3.4.5.

This has been tested on GCP.  It is not urgent - aimed at 0.4, not 0.3.1.