### PR TITLE
[Docs] Fix InferencePool version number getting cut off in WideEP guide

### DIFF
--- a/guides/wide-ep-lws/README.md
+++ b/guides/wide-ep-lws/README.md
@@ -58,7 +58,8 @@ helm install deepseek-r1 \
   --set "provider.name=gke" \
   --set "inferencePool.apiVersion=inference.networking.k8s.io/v1" \
   --set "inferenceExtension.monitoring.gke.enable=true" \
-  oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool --version v1.0.1
+  oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool \
+  --version v1.0.1
 
 # For Istio
 helm install deepseek-r1 \
@@ -66,13 +67,15 @@ helm install deepseek-r1 \
   -f inferencepool.values.yaml \
   --set "provider.name=istio" \
   --set "inferenceExtension.monitoring.prometheus.enable=true" \
-  oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool --version v1.0.1
+  oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool \
+  --version v1.0.1
 
 # For Kgateway
 helm install deepseek-r1 \
   -n ${NAMESPACE} \
   -f inferencepool.values.yaml \
-  oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool --version v1.0.1
+  oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool \
+  --version v1.0.1
 ```
 
 ### Deploy Gateway and HTTPRoute


### PR DESCRIPTION
Sidestep this UI issue which at least on macOS gives no indication that there's more to the line regardless of how big the window is:
 
<img width="1053" height="527" alt="image" src="https://github.com/user-attachments/assets/42a719bd-a599-42e6-98f5-cb02ba8191ad" />
