### PR TITLE
Add JIT directories and model directories

### DIFF
--- a/guides/wide-ep-lws/manifests/modelserver/base/decode.yaml
+++ b/guides/wide-ep-lws/manifests/modelserver/base/decode.yaml
@@ -42,6 +42,10 @@ spec:
             emptyDir:
               medium: Memory
               sizeLimit: 2Gi # roughly 32MB per local DP plus scratch space
+          - name: hf-cache
+            emptyDir: {}
+          - name: jit-cache
+            emptyDir: {}
         containers:
         - name: vllm
           image: ghcr.io/llm-d/llm-d-cuda:v0.3.1
@@ -142,6 +146,21 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+
+          # Use cache directories from the mounted volume under one easy to mount
+          # root directory.
+          - name: CUDA_CACHE_PATH
+            value: /var/cache/vllm/cuda
+          - name: CCACHE_DIR
+            value: /var/cache/vllm/ccache
+          - name: VLLM_CACHE_ROOT
+            value: /var/cache/vllm/vllm
+          - name: FLASHINFER_WORKSPACE_BASE
+            value: /var/cache/vllm/flashinfer
+          # HuggingFace is likely to be quite a bit larger, give it its own cache
+          - name: HF_HUB_CACHE
+            value: /var/cache/huggingface
+
           ports:
           - containerPort: 8200
             name: metrics
@@ -181,3 +200,7 @@ spec:
           volumeMounts:
             - name: dshm
               mountPath: /dev/shm
+            - name: hf-cache
+              mountPath: /var/cache/huggingface
+            - name: jit-cache
+              mountPath: /var/cache/vllm

--- a/guides/wide-ep-lws/manifests/modelserver/base/prefill.yaml
+++ b/guides/wide-ep-lws/manifests/modelserver/base/prefill.yaml
@@ -23,6 +23,10 @@ spec:
             emptyDir:
               medium: Memory
               sizeLimit: 2Gi # roughly 32MB per local DP plus scratch space
+          - name: hf-cache
+            emptyDir: {}
+          - name: jit-cache
+            emptyDir: {}
         containers:
         - name: vllm
           image: ghcr.io/llm-d/llm-d-cuda:v0.3.1
@@ -112,6 +116,21 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+
+          # Use cache directories from the mounted volume under one easy to mount
+          # root directory.
+          - name: CUDA_CACHE_PATH
+            value: /var/cache/vllm/cuda
+          - name: CCACHE_DIR
+            value: /var/cache/vllm/ccache
+          - name: VLLM_CACHE_ROOT
+            value: /var/cache/vllm/vllm
+          - name: FLASHINFER_WORKSPACE_BASE
+            value: /var/cache/vllm/flashinfer
+          # HuggingFace is likely to be quite a bit larger, give it its own cache
+          - name: HF_HUB_CACHE
+            value: /var/cache/huggingface
+
           ports:
           - containerPort: 8000
             name: metrics
@@ -151,3 +170,7 @@ spec:
           volumeMounts:
             - name: dshm
               mountPath: /dev/shm
+            - name: hf-cache
+              mountPath: /var/cache/huggingface
+            - name: jit-cache
+              mountPath: /var/cache/vllm

--- a/guides/wide-ep-lws/manifests/modelserver/coreweave/kustomization.yaml
+++ b/guides/wide-ep-lws/manifests/modelserver/coreweave/kustomization.yaml
@@ -8,25 +8,20 @@ patches:
       kind: LeaderWorkerSet
     patch: |-
       # We add the volume for different providers since the hostPath can be different.
-      - op: add
-        path: /spec/leaderWorkerTemplate/workerTemplate/spec/volumes/-
-        value: 
+      - op: replace
+        path: /spec/leaderWorkerTemplate/workerTemplate/spec/volumes/1
+        value:
           name: hf-cache
           hostPath:
             path: /mnt/local/hf-cache
             type: DirectoryOrCreate
-      # Since we are loading model in from a host storage, lets patch in the volumeMount
-      - op: add
-        path: /spec/leaderWorkerTemplate/workerTemplate/spec/containers/0/volumeMounts/-
+      - op: replace
+        path: /spec/leaderWorkerTemplate/workerTemplate/spec/volumes/2
         value:
-          name: hf-cache
-          mountPath: /huggingface-cache
-      # Since we are loading model in from a host storage, specify HF_HUB_CACHE
-      - op: add
-        path: /spec/leaderWorkerTemplate/workerTemplate/spec/containers/0/env/-
-        value:
-          name: HF_HUB_CACHE
-          value: /huggingface-cache
+          name: jit-cache
+          hostPath:
+            path: /mnt/local/jit-cache
+            type: DirectoryOrCreate
       # Since we are loading model in from a host storage, disable HF_XET
       - op: add
         path: /spec/leaderWorkerTemplate/workerTemplate/spec/containers/0/env/-

--- a/guides/wide-ep-lws/manifests/modelserver/gke/kustomization.yaml
+++ b/guides/wide-ep-lws/manifests/modelserver/gke/kustomization.yaml
@@ -124,3 +124,18 @@ patches:
         value:
           name: NVSHMEM_DISABLED_GDRCOPY
           value: "true"
+      # We add the volume for different providers since the hostPath can be different.
+      - op: replace
+        path: /spec/leaderWorkerTemplate/workerTemplate/spec/volumes/1
+        value:
+          name: hf-cache
+          hostPath:
+            path: /mnt/stateful_partition/kube-ephemeral-ssd/shared_disk/vllm-hf-cache/
+            type: DirectoryOrCreate
+      - op: replace
+        path: /spec/leaderWorkerTemplate/workerTemplate/spec/volumes/2
+        value:
+          name: jit-cache
+          hostPath:
+            path: /mnt/stateful_partition/kube-ephemeral-ssd/shared_disk/vllm-jit-cache/
+            type: DirectoryOrCreate


### PR DESCRIPTION
Ensure all artifacts that are generated during startup are written to a temporary directory.  Separate models (infrequently change) from JIT caches (frequently changed, may have bugs that require clearing the cache). As a best practice, use the large SSD attached to GPU machines on Coreweave and GCP as an ephemeral store for models and JIT artifacts.