### PR TITLE
release.tag_name does not exist for a tag not part of a release

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -185,7 +185,7 @@ jobs:
 
           # create manifest and tag it
           docker buildx imagetools create \
-            -t ${{ env.REGISTRY }}/${{ github.repository }}-cuda${{ matrix.image_suffix }}:${{ github.event.release.tag_name }} \
+            -t ${{ env.REGISTRY }}/${{ github.repository }}-cuda${{ matrix.image_suffix }}:${{ github.event.release.tag_name || github.ref_name }} \
             -t ${{ env.REGISTRY }}/${{ github.repository }}-cuda${{ matrix.image_suffix }}:sha-${SHORT_SHA} \
             $sources
 


### PR DESCRIPTION
cc @liu-cong @smarterclayton 

fixes:
```
  # create manifest and tag it
  docker buildx imagetools create \
    -t ghcr.io/llm-d/llm-d-cuda-ubuntu: \
    -t ghcr.io/llm-d/llm-d-cuda-ubuntu:sha-${SHORT_SHA} \
    $sources
```
where:
```
    -t ghcr.io/llm-d/llm-d-cuda-ubuntu: \
```
does not have a tag