### PR TITLE
Allow additional values for the Helmfile projects

### DIFF
--- a/guides/inference-scheduling/helmfile.yaml.gotmpl
+++ b/guides/inference-scheduling/helmfile.yaml.gotmpl
@@ -54,6 +54,9 @@ releases:
     values:
       - gateway:
           {{ .Environment.Values.gateway | toYaml | nindent 10 }}
+    {{- if hasKey .Environment.Values "llmdInfra" }}
+      - {{ .Environment.Values.llmdInfra | toYaml | nindent 10 }}
+    {{- end }}
   {{- end }}
 
   - name: {{ printf "gaie-%s" $rn | quote }}
@@ -101,6 +104,9 @@ releases:
           flags: 
             {{ .Environment.Values.inferenceExtension.flags | toYaml | nindent 12 }}
     {{- end }}
+    {{- if hasKey .Environment.Values "gatewayInferenceExtension" }}
+      - {{ .Environment.Values.gatewayInferenceExtension | toYaml | nindent 10 }}
+    {{- end }}
     labels:
       kind: inference-stack
 
@@ -131,6 +137,9 @@ releases:
     {{- if (eq .Environment.Name "istioBench") }}
       - routing: 
           {{ .Environment.Values.routing | toYaml | nindent 10 }}
+    {{- end }}
+    {{- if hasKey .Environment.Values "modelService" }}
+      - {{ .Environment.Values.modelService | toYaml | nindent 10 }}
     {{- end }}
     set:
     {{- if or (eq .Environment.Name "gke") (eq .Environment.Name "gke_tpu") }}  

--- a/guides/pd-disaggregation/helmfile.yaml.gotmpl
+++ b/guides/pd-disaggregation/helmfile.yaml.gotmpl
@@ -45,6 +45,9 @@ releases:
     values:
       - gateway:
           {{ .Environment.Values.gateway | toYaml | nindent 10 }}
+    {{- if hasKey .Environment.Values "llmdInfra" }}
+      - {{ .Environment.Values.llmdInfra | toYaml | nindent 10 }}
+    {{- end }}
 
   - name: {{ printf "gaie-%s" $rn | quote }}
     namespace: {{ $ns }}
@@ -85,6 +88,9 @@ releases:
           flags:
             {{ .Environment.Values.inferenceExtension.flags | toYaml | nindent 12 }}
     {{- end }}
+    {{- if hasKey .Environment.Values "gatewayInferenceExtension" }}
+      - {{ .Environment.Values.gatewayInferenceExtension | toYaml | nindent 10 }}
+    {{- end }}
     labels:
       kind: inference-stack
 
@@ -122,6 +128,9 @@ releases:
               - type: memlock
                 hard: 17179869184
                 soft: 17179869184
+    {{- end }}
+    {{- if hasKey .Environment.Values "modelService" }}
+      - {{ .Environment.Values.modelService | toYaml | nindent 10 }}
     {{- end }}
     set:
     {{- if or (eq .Environment.Name "gke") (eq .Environment.Name "gke_tpu") }}

--- a/guides/precise-prefix-cache-aware/helmfile.yaml.gotmpl
+++ b/guides/precise-prefix-cache-aware/helmfile.yaml.gotmpl
@@ -38,7 +38,9 @@ releases:
     values:
       - gateway: 
           {{ .Environment.Values.gateway | toYaml | nindent 10 }}
-
+    {{- if hasKey .Environment.Values "llmdInfra" }}
+      - {{ .Environment.Values.llmdInfra | toYaml | nindent 10 }}
+    {{- end }}
   - name: {{ printf "gaie-%s" $rn | quote }}
     namespace: {{ $ns }}
     chart: oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
@@ -76,6 +78,9 @@ releases:
           flags: 
             {{ .Environment.Values.inferenceExtension.flags | toYaml | nindent 12 }}
     {{- end }}
+    {{- if hasKey .Environment.Values "gatewayInferenceExtension" }}
+      - {{ .Environment.Values.gatewayInferenceExtension | toYaml | nindent 10 }}
+    {{- end }}
     labels:
       kind: inference-stack
 
@@ -92,6 +97,9 @@ releases:
     {{- if (eq .Environment.Name "istioBench") }}
       - routing: 
           {{ .Environment.Values.routing | toYaml | nindent 10 }}
+    {{- end }}
+    {{- if hasKey .Environment.Values "modelService" }}
+      - {{ .Environment.Values.modelService | toYaml | nindent 10 }}
     {{- end }}
     set:
       - name: "decode.containers[0].env[0].value"

--- a/guides/simulated-accelerators/helmfile.yaml.gotmpl
+++ b/guides/simulated-accelerators/helmfile.yaml.gotmpl
@@ -34,7 +34,9 @@ releases:
     values:
       - gateway: 
           {{ .Environment.Values.gateway | toYaml | nindent 10 }}
-
+    {{- if hasKey .Environment.Values "llmdInfra" }}
+      - {{ .Environment.Values.llmdInfra | toYaml | nindent 10 }}
+    {{- end }}
   - name: {{ printf "gaie-%s" $rn | quote }}
     namespace: {{ $ns }}
     chart: oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
@@ -65,6 +67,9 @@ releases:
             destinationRule:
               host: {{ printf "gaie-%s-epp.%s.svc.cluster.local" $rn $ns | quote }}
     {{- end }}
+    {{- if hasKey .Environment.Values "gatewayInferenceExtension" }}
+      - {{ .Environment.Values.gatewayInferenceExtension | toYaml | nindent 10 }}
+    {{- end }}
     labels:
       kind: inference-stack
 
@@ -78,6 +83,9 @@ releases:
       - {{ printf "gaie-%s" $rn | quote }}
     values:
       - ms-sim/values.yaml
+    {{- if hasKey .Environment.Values "modelService" }}
+      - {{ .Environment.Values.modelService | toYaml | nindent 10 }}
+    {{- end }}
     set:
     {{- if (eq .Environment.Name "gke") }}  
       - name: "decode.monitoring.podmonitor.enabled"


### PR DESCRIPTION
Currently, if a user wants to deploy a well-lit path following the guides in this repository, they cannot change the values set for the releases in a given Helmfile without changing the values.yaml files in the repo or, in general, with ease.

This commit adds this capability by appending an additional set of
values if defined in the Helm environment at the keys llmdInfra, gatewayInferenceExtension, modelService, respectively for the charts llm-d-infra, gaie-*, ms-*

Users can create a values YAML file, as shown below, and apply it in conjunction with the environment-specific values already set in the available Helmfile templates.

Example usage:
```shell
helmfile -f /path/to/llmd/repo/guides/inference-scheduling/helmfile.yaml.gotmpl --state-values-file /path/to/additional/values.yaml apply
```

Example values.yaml:
```yaml
tolerations: &tolerations
  - effect: NoSchedule
    key: benchmark.llm-d.ai/test-gpu-amd64
    operator: Exists

modelService:
  modelArtifacts:
    uri: "hf://meta-llama/Llama-3.1-8B"
    size: 64Gi
    authSecretName: "llm-d-hf-token"
    name: "meta-llama/Llama-3.1-8B"
  decode:
    tolerations: *tolerations
  prefill:
    tolerations: *tolerations

llmdInfra: {}

gatewayInferenceExtension: {}
```