### PR TITLE
doc: enrich the prefix-cache-storage vllm cpu native offloading with benchmark results

### DIFF
--- a/guides/prefix-cache-storage/cpu/README.md
+++ b/guides/prefix-cache-storage/cpu/README.md
@@ -34,15 +34,20 @@ Deploy the InferencePool using the [InferencePool recipe](../../recipes/inferenc
 ### 3. Deploy vLLM Model Server
 
 === "LMCache"
-    Deploy the vLLM model server with the `LMCache` connector enabled.
-    ```bash
-    kubectl apply -k ./manifests/vllm/lm-cache-connector -n ${NAMESPACE}
-    ```
-=== "Offloading"
-    Deploy the vLLM model server with the `OffloadingConnector` enabled.
-    ```bash
-    kubectl apply -k ./manifests/vllm/offloading-connector -n ${NAMESPACE}
-    ```
+
+        Deploy the vLLM model server with the `LMCache` connector enabled.
+
+        ```bash
+        kubectl apply -k ./manifests/vllm/lm-cache-connector -n ${NAMESPACE}
+        ```
+
+=== "CPU Offloading"
+
+        Deploy the vLLM model server with the `OffloadingConnector` enabled.
+
+        ```bash
+        kubectl apply -k ./manifests/vllm/offloading-connector -n ${NAMESPACE}
+        ```
 
 ## Verifying the installation
 
@@ -96,19 +101,26 @@ NAME                                  READY   STATUS    RESTARTS   AGE
 llm-d-infpool-epp-xxxxxxxx-xxxxx     1/1     Running   0          16m
 llm-d-model-server-xxxxxxxx-xxxxx   1/1     Running   0          11m
 llm-d-model-server-xxxxxxxx-xxxxx   1/1     Running   0          11m
-llm-d-model-server-xxxxxxxx-xxxxx   1/1     Running   0          11m
-llm-d-model-server-xxxxxxxx-xxxxx   1/1     Running   0          11m
-llm-d-model-server-xxxxxxxx-xxxxx   1/1     Running   0          11m
-llm-d-model-server-xxxxxxxx-xxxxx   1/1     Running   0          11m
-llm-d-model-server-xxxxxxxx-xxxxx   1/1     Running   0          11m
-llm-d-model-server-xxxxxxxx-xxxxx   1/1     Running   0          11m
 ```
 
-## Benchmark
+## Cleanup
+
+To remove the deployment:
+
+```bash
+helm uninstall llm-d-infpool -n ${NAMESPACE}
+kubectl delete -k ./manifests/vllm/offloading-connector -n ${NAMESPACE}
+kubectl delete -k ../../../../recipes/gateway/gke-l7-regional-external-managed -n ${NAMESPACE}
+kubectl delete namespace ${NAMESPACE}
+```
+
+## Appendix
+
+### Benchmark
 
 The following benchmark results demonstrate the performance improvements of using vLLM's native CPU offloading.
 
-### Benchmark Setup
+#### Benchmark Setup
 
 *   **Hardware:**
     *   A total of 16 H100 GPUs, each with 80GB of HBM, were used.
@@ -142,7 +154,7 @@ The benchmark was conducted using the [inference-perf](https://github.com/kubern
     *   The available HBM for KVCache per engine is approximately 24.3GB (9271block * 2.62 MB/block).
     *   The total available HBM for the KVCache across the entire system was 193.4 GB (8 engines * 24.3 GB/engine ).
 
-### Key Findings
+#### Key Findings
 
 *   In **memory-bound scenarios**, where the KVCache size exceeds the available HBM, the vLLM native CPU offloading connector significantly enhances performance:
     *   Mean Time to First Token (TTFT) decreased by 25%.
@@ -150,7 +162,7 @@ The benchmark was conducted using the [inference-perf](https://github.com/kubern
     *   Overall throughput increased by 21.1%.
 *   In **compute-bound scenarios**, where the KVCache fits entirely within the GPU's HBM, all offloading configurations perform similarly to the baseline. This indicates that enabling CPU offloading does not negatively impact performance when it is not actively utilized.
 
-### Memory-Bound Performance
+#### Memory-Bound Performance
 
 The following table compares the performance of the baseline vLLM with the vLLM using the CPU offloading connector when the KVCache size is larger than the available HBM.
 
@@ -159,7 +171,7 @@ The following table compares the performance of the baseline vLLM with the vLLM 
 | **Baseline vllm** | 9.0 | 20.9 | 37.8 | 49.7 | 38534.8 |
 | **vllm + CPU offloading 100GB** | 6.7 (-25%) | 15.9 (-24%) | 31.0 (-18%) | 40.0 (-24%) | 46662.5 (+21.1%) |
 
-### Compute-Bound Performance
+#### Compute-Bound Performance
 
 The following table shows that when the KVCache fits within the HBM, the performance of all configurations is similar, indicating negligible overhead from the CPU offloading mechanism.
 
@@ -168,14 +180,3 @@ The following table shows that when the KVCache fits within the HBM, the perform
 | **Baseline vllm** | 0.12 | 0.09 | 18.4 | 19.6 | 23389.6 |
 | **vllm + CPU offloading 100GB** | 0.13 | 0.11 | 18.6 | 20.6 | 23032.6 |
 
-
-## Cleanup
-
-To remove the deployment:
-
-```bash
-helm uninstall llm-d-infpool -n ${NAMESPACE}
-kubectl delete -k ./manifests/vllm/offloading-connector -n ${NAMESPACE}
-kubectl delete -k ../../../../recipes/gateway/gke-l7-regional-external-managed -n ${NAMESPACE}
-kubectl delete namespace ${NAMESPACE}
-```

--- a/guides/prefix-cache-storage/cpu/manifests/vllm/offloading-connector/kustomization.yaml
+++ b/guides/prefix-cache-storage/cpu/manifests/vllm/offloading-connector/kustomization.yaml
@@ -27,7 +27,4 @@ patches:
           nvidia.com/gpu: 2
         requests:
           nvidia.com/gpu: 2
-          memory: 400G
-    - op: replace
-      path: /spec/replicas
-      value: 8
+          memory: 400G  

--- a/guides/prefix-cache-storage/cpu/manifests/vllm/offloading-connector/kustomization.yaml
+++ b/guides/prefix-cache-storage/cpu/manifests/vllm/offloading-connector/kustomization.yaml
@@ -27,4 +27,7 @@ patches:
           nvidia.com/gpu: 2
         requests:
           nvidia.com/gpu: 2
-          memory: 400G  
+          memory: 400G
+    - op: replace
+      path: /spec/replicas
+      value: 8


### PR DESCRIPTION
Add a section for the benchmark results.