### PR TITLE
guides: Make vLLM log more useful in inference-scheduling

### DIFF
--- a/guides/inference-scheduling/ms-inference-scheduling/values.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values.yaml
@@ -38,6 +38,7 @@ decode:
     args:
       - "--kv-transfer-config"
       - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+      - "--disable-uvicorn-access-log"
     env:
       - name: CUDA_VISIBLE_DEVICES
         value: "0"
@@ -50,7 +51,7 @@ decode:
       - name: VLLM_NIXL_SIDE_CHANNEL_PORT
         value: "5557"
       - name: VLLM_LOGGING_LEVEL
-        value: DEBUG
+        value: INFO
     ports:
       - containerPort: 5557
         protocol: TCP


### PR DESCRIPTION
This change makes the vLLM logging more user friendly out of the box
for someone using this example to try out llm-d.

- `--disable-uvicorn-access-log`

This disables logging every HTTP request received by vLLM. When this
is on, the log is flooded with many requests to `/metrics` every
second. To disable this message only for the `/metrics`, we could use
a custom logger configuraiton, but it would probably double the size
of this example, so I'm not sure it's worth it.

- Change `VLLM_LOGGING_LEVEL` from `DEBUG` to `INFO`

It's nice to have this in the log to make it easy to change quickly,
but the `DEBUG` logs are a bit much for a typical user. The env var is
still in place to make it very easy to change if someone needs to for
debugging something.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
