### PR TITLE
docs: Make getting started commands more copy/paste friendly

### DIFF
--- a/docs/getting-started-inferencing.md
+++ b/docs/getting-started-inferencing.md
@@ -156,7 +156,7 @@ Now lets try hitting the `/v1/completions` endpoint (this is model dependent, en
 curl -X POST ${ENDPOINT}/v1/completions \
   -H 'Content-Type: application/json' \
   -d '{
-        "model": "Qwen3/Qwen3-0.6B",
+        "model": "Qwen/Qwen3-32B",
         "prompt": "How are you today?"
       }' | jq
 ```
@@ -177,7 +177,7 @@ Expected output:
   ],
   "created": 1752727735,
   "id": "chatcmpl-af42e9e3-dab0-420f-872b-d23353d982da",
-  "model": "Qwen3/Qwen3-0.6B",
+  "model": "Qwen/Qwen3-32B",
 }
 ```
 


### PR DESCRIPTION
Some sample commands used `random` as a model name. Since `random`
would always have to be edited, use `Qwen3/Qwen3-0.6B`, which makes
the commands copy/paste friendly if someone is using this after going
through `guides/inference-scheduling/` or
`guides/precise-prefix-cache-aware`. Otherwise, they can still change
it to match whatever model is in use.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
