### PR TITLE
docs: Update docs to reflect current gateway service type default

### DIFF
--- a/docs/getting-started-inferencing.md
+++ b/docs/getting-started-inferencing.md
@@ -13,7 +13,7 @@ You are assumed to have deployed the llm-d inference stack from a guide, using t
 
 First we need to choose what strategy we are going to use to expose / interact with your gateway. It should be noted that this will be affected by the values you used when installing the `llm-d-infra` chart for your given guide. Select the tab that matches your environment.
 
-**_NOTE:_** If you're unsure which to use—start with port-forward as it's the most reliable and easiest. For anything shareable, use Ingress/Route. Use LoadBalancer if your provider supports it and you just need raw L4 access.
+**_NOTE:_** If you're unsure which to use—start with a ClusterIP gateway service type and port-forward as it's the most reliable and easiest. Use LoadBalancer if your provider supports it and you just need raw L4 access. Use Nodeport if you want an externally accessible gateway but your k8s provider does not support LoadBalancer integration and you have a functioning load balancer ctronller in your cluster, such as MetalLB.
 
 <!-- TABS:START -->
 
@@ -35,7 +35,7 @@ gaie-inference-scheduling-epp                        ClusterIP      10.16.3.250 
 gaie-inference-scheduling-ip-18c12339                ClusterIP      None          <none>        54321/TCP                      12s
 gaie-sim-epp                                         ClusterIP      10.16.1.220   <none>        9002/TCP,9090/TCP              80m
 infra-inference-scheduling-inference-gateway-istio   LoadBalancer   10.16.3.226   10.16.4.3     15021:34529/TCP,80:35734/TCP   22s
-infra-sim-inference-gateway                          LoadBalancer   10.16.1.62    10.16.4.2     80:38348/TCP                   81
+infra-sim-inference-gateway                          ClusterIP      None          <none>        80:38348/TCP                   81
 export GATEWAY_SVC="infra-inference-scheduling-inference-gateway-istio"
 ```
 

--- a/guides/inference-scheduling/README.md
+++ b/guides/inference-scheduling/README.md
@@ -173,7 +173,7 @@ pod/ms-inference-scheduling-llm-d-modelservice-decode-8ff7fd5bt5f9s   1/1     Ru
 NAME                                                         TYPE           CLUSTER-IP    EXTERNAL-IP   PORT(S)                        AGE
 service/gaie-inference-scheduling-epp                        ClusterIP      10.16.3.151   <none>        9002/TCP,9090/TCP              3m59s
 service/gaie-inference-scheduling-ip-18c12339                ClusterIP      None          <none>        54321/TCP                      3m59s
-service/infra-inference-scheduling-inference-gateway-istio   LoadBalancer   10.16.1.195   10.16.4.2     15021:30274/TCP,80:32814/TCP   4m3s
+service/infra-inference-scheduling-inference-gateway-istio   ClusterIP      10.16.1.195   10.16.4.2     15021:30274/TCP,80:32814/TCP   4m3s
 
 NAME                                                                 READY   UP-TO-DATE   AVAILABLE   AGE
 deployment.apps/gaie-inference-scheduling-epp                        1/1     1            1           4m

--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -131,7 +131,7 @@ pod/ms-pd-llm-d-modelservice-prefill-86f6fb7cdc-vzcb8   1/1     Running   0     
 NAME                                       TYPE           CLUSTER-IP    EXTERNAL-IP   PORT(S)                        AGE
 service/gaie-pd-epp                        ClusterIP      10.16.0.255   <none>        9002/TCP,9090/TCP              2m35s
 service/gaie-pd-ip-bb618139                ClusterIP      None          <none>        54321/TCP                      2m35s
-service/infra-pd-inference-gateway-istio   LoadBalancer   10.16.3.74    10.16.4.3     15021:31707/TCP,80:34096/TCP   2m41s
+service/infra-pd-inference-gateway-istio   ClusterIP      10.16.3.74    10.16.4.3     15021:31707/TCP,80:34096/TCP   2m41s
 
 NAME                                               READY   UP-TO-DATE   AVAILABLE   AGE
 deployment.apps/gaie-pd-epp                        1/1     1            1           2m36s

--- a/guides/precise-prefix-cache-aware/README.md
+++ b/guides/precise-prefix-cache-aware/README.md
@@ -87,7 +87,7 @@ pod/ms-kv-events-llm-d-modelservice-decode-b874d48d9-ph64c    1/1     Running   
 NAME                                              TYPE           CLUSTER-IP   EXTERNAL-IP   PORT(S)                        AGE
 service/gaie-kv-events-epp                        ClusterIP      10.16.2.44   <none>        9002/TCP,9090/TCP,5557/TCP     81s
 service/gaie-kv-events-ip-805c964d                ClusterIP      None         <none>        54321/TCP                      75s
-service/infra-kv-events-inference-gateway-istio   LoadBalancer   10.16.1.30   10.16.4.2     15021:32033/TCP,80:39332/TCP   86s
+service/infra-kv-events-inference-gateway-istio   ClusterIP      10.16.1.30   10.16.4.2     15021:32033/TCP,80:39332/TCP   86s
 
 NAME                                                      READY   UP-TO-DATE   AVAILABLE   AGE
 deployment.apps/gaie-kv-events-epp                        1/1     1            1           81s

--- a/guides/recipes/gateway/istio/configmap.yaml
+++ b/guides/recipes/gateway/istio/configmap.yaml
@@ -32,4 +32,4 @@ data:
                 memory: 4Gi
   service: |
     spec:
-      type: LoadBalancer
+      type: ClusterIP

--- a/guides/simulated-accelerators/README.md
+++ b/guides/simulated-accelerators/README.md
@@ -92,7 +92,7 @@ pod/ms-sim-llm-d-modelservice-prefill-76c86dd9f8-pvbzm   1/1     Running   0    
 NAME                                        TYPE           CLUSTER-IP    EXTERNAL-IP   PORT(S)                        AGE
 service/gaie-sim-epp                        ClusterIP      10.16.0.143   <none>        9002/TCP,9090/TCP              7m14s
 service/gaie-sim-ip-207d1d4c                ClusterIP      None          <none>        54321/TCP                      7m14s
-service/infra-sim-inference-gateway-istio   LoadBalancer   10.16.1.112   10.16.4.2     15021:33302/TCP,80:31413/TCP   7m19s
+service/infra-sim-inference-gateway-istio   ClusterIP      10.16.1.112   10.16.4.2     15021:33302/TCP,80:31413/TCP   7m19s
 
 NAME                                                READY   UP-TO-DATE   AVAILABLE   AGE
 deployment.apps/gaie-sim-epp                        1/1     1            1           7m14s


### PR DESCRIPTION
The docs here refer to an old default of `LoadBalancer`, while the
current default is `ClusterIP`. That was changed in this commit:

https://github.com/llm-d-incubation/llm-d-infra/commit/af640f2641760b7c13afbee1f64a513c72cff6fc

Also note that this works on bare-metal clusters if you install
MetalLB.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
