### PR TITLE
Fix(monitoring): Resolve Grafana duplicate default datasource conflict

### DIFF
--- a/docs/monitoring/scripts/install-prometheus-grafana.sh
+++ b/docs/monitoring/scripts/install-prometheus-grafana.sh
@@ -348,15 +348,10 @@ grafana:
   service:
     type: ClusterIP
     sessionAffinity: ""
-  datasources:
-    datasources.yaml:
-      apiVersion: 1
-      datasources:
-      - name: Prometheus
-        type: prometheus
-        url: http://${RELEASE_NAME}-kube-prometheus-stack-prometheus.${MONITORING_NAMESPACE}.svc.cluster.local:9090
-        access: proxy
-        isDefault: true
+  sidecar:
+    datasources:
+      enabled: true
+      defaultDatasourceEnabled: false
 prometheus:
   service:
     type: ClusterIP
@@ -387,15 +382,10 @@ grafana:
   service:
     type: ClusterIP
     sessionAffinity: ""
-  datasources:
-    datasources.yaml:
-      apiVersion: 1
-      datasources:
-      - name: Prometheus
-        type: prometheus
-        url: http://${RELEASE_NAME}-kube-prometheus-stack-prometheus.${MONITORING_NAMESPACE}.svc.cluster.local:9090
-        access: proxy
-        isDefault: true
+  sidecar:
+    datasources:
+      enabled: true
+      defaultDatasourceEnabled: true
 prometheus:
   service:
     type: ClusterIP


### PR DESCRIPTION
Fixes Grafana pod crash caused by duplicate default Prometheus datasources when using the monitoring installation script. The kube-prometheus-stack Helm chart automatically creates a default Prometheus datasource, which conflicts with the manually configured datasource in the script's values file.
`Error: ✗ *provisioning.ProvisioningServiceImpl run error: Datasource provisioning error: datasource.yaml config is invalid. Only one datasource per organization can be marked as default`

Root Cause:
The kube-prometheus-stack Helm chart has a default behavior where it automatically provisions a Prometheus datasource in Grafana. The script's configuration adds another one on top, resulting in two datasources both trying to be the default and Grafana pod crashes in CrashLoopBackOff