### PR TITLE
fix kutomization error and model flag error in cpu offloading.

### DIFF
--- a/guides/prefix-cache-storage/cpu/manifests/vllm/offloading-connector/kustomization.yaml
+++ b/guides/prefix-cache-storage/cpu/manifests/vllm/offloading-connector/kustomization.yaml
@@ -11,7 +11,7 @@ patches:
       path: /spec/template/spec/containers/0/args/0
       value: |-
         exec vllm serve \
-          --model Qwen/Qwen3-32B \
+          Qwen/Qwen3-32B \
           --tensor-parallel-size 2 \
           --kv-transfer-config '{"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"num_cpu_blocks":41000}}' \
           --port 8000 \

--- a/guides/recipes/gateway/gke-l7-regional-external-managed/kustomization.yaml
+++ b/guides/recipes/gateway/gke-l7-regional-external-managed/kustomization.yaml
@@ -1,8 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../base/gateway.yaml
-- ../base/httproute.yaml
+- ../base
 patches:
 - target:
     kind: Gateway


### PR DESCRIPTION
Tested by running manually

```
❯ kg pods -n $NAMESPACE
NAME                                  READY   STATUS    RESTARTS   AGE
llm-d-infpool-epp-b89ddb6c9-n6jnl     1/1     Running   0          79m
llm-d-model-server-74cc9cd58d-f5gw5   1/1     Running   0          45m
llm-d-model-server-74cc9cd58d-jscmv   1/1     Running   0          50m
```