### PR TITLE
Remove unused formatting imports from README

### DIFF
--- a/guides/wide-ep-lws/README.md
+++ b/guides/wide-ep-lws/README.md
@@ -1,6 +1,3 @@
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # Well-lit Path: Wide Expert Parallelism (EP/DP) with LeaderWorkerSet
 
 ## Overview


### PR DESCRIPTION
Looks like there were some leftover imports in the markdown that aren't used.