### PR TITLE
[Build] Add FI JIT Cache to Image

### DIFF
--- a/docker/Dockerfile.aws
+++ b/docker/Dockerfile.aws
@@ -293,7 +293,11 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     cd flashinfer && \
     uv pip install -e . --no-build-isolation && \
     uv build --wheel --no-build-isolation --out-dir /wheels && \
-    cd .. && rm -rf flashinfer && \
+    cd flashinfer-cubin && \
+    uv pip install -e . --no-build-isolation --out-dir /wheel && \
+    cd ../flashinfer-jit-cache && \
+    FLASHINFER_CUDA_ARCH_LIST="9.0a 10.0a" uv pip install -e . --no-build-isolation --out-dir /wheel && \
+    cd ../.. && rm -rf flashinfer && \
     \
     # Build DeepEP wheel
     git clone "${DEEPEP_URL}" deepep && \

--- a/docker/scripts/cuda/builder/build-compiled-wheels.sh
+++ b/docker/scripts/cuda/builder/build-compiled-wheels.sh
@@ -37,7 +37,11 @@ cd flashinfer
 git checkout -q "${FLASHINFER_VERSION}"
 git submodule update --init --recursive
 uv build --wheel --no-build-isolation --out-dir /wheels
-cd ..
+cd flashinfer-cubin && \
+uv build --wheel --no-build-isolation --out-dir /wheels
+cd ../flashinfer-jit-cache && \
+FLASHINFER_CUDA_ARCH_LIST="9.0a 10.0a" uv build --wheel --no-build-isolation --out-dir /wheels
+cd ../../ && \
 rm -rf flashinfer
 
 # build DeepEP wheel


### PR DESCRIPTION
SUMMARY:
- we currently don't install FI kernels in our docker image
- this causes long JIT time, especially for pulling cubins
- this PR adds them to the docker images

Fix: https://github.com/llm-d/llm-d/issues/410 