### PR TITLE
Update FLASHINFER_VERSION to v0.5.2

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -172,7 +172,7 @@ ARG DEEPGEMM_VERSION="v2.1.0"
 ARG PPLX_KERNELS_REPO="https://github.com/perplexityai/pplx-kernels"
 ARG PPLX_KERNELS_SHA="12cecfda252e4e646417ac263d96e994d476ee5d"
 
-ARG FLASHINFER_VERSION="v0.3.1"
+ARG FLASHINFER_VERSION="v0.5.2"
 
 # Build compiled packages as wheels (only ones that need build tools)
 COPY docker/scripts/cuda/builder/build-compiled-wheels.sh /tmp/build-compiled-wheels.sh

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -195,6 +195,7 @@ ARG CUDA_MINOR=9
 ARG CUDA_PATCH=1
 ARG PYTHON_VERSION
 ARG NVSHMEM_VERSION=3.3.20
+ARG FLASHINFER_VERSION=v0.5.2
 
 COPY docker/constraints.txt /tmp/constraints.txt
 
@@ -205,7 +206,10 @@ ENV LANG=C.UTF-8 \
     UV_CONSTRAINT=/tmp/constraints.txt \
     VIRTUAL_ENV=/opt/vllm \
     NVSHMEM_DIR="/opt/nvshmem-${NVSHMEM_VERSION}" \
-    TORCH_CUDA_ARCH_LIST="9.0a;10.0+PTX"
+    TORCH_CUDA_ARCH_LIST="9.0a;10.0+PTX" \
+    FLASHINFER_VERSION=${FLASHINFER_VERSION} \
+    CUDA_MAJOR=${CUDA_MAJOR} \
+    CUDA_MINOR=${CUDA_MINOR}
 
 # LD_LIBRARY_PATH needs the torch path to apply proper linkers so as not to produce torch ABI missmatch
 ENV LD_LIBRARY_PATH="/opt/vllm/lib64/python${PYTHON_VERSION}/site-packages/torch/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:/usr/local/lib:/usr/local/lib64:${NVSHMEM_DIR}/lib:${LD_LIBRARY_PATH}"

--- a/docker/scripts/cuda/builder/build-compiled-wheels.sh
+++ b/docker/scripts/cuda/builder/build-compiled-wheels.sh
@@ -23,7 +23,8 @@ source "${VIRTUAL_ENV}/bin/activate"
 source /usr/local/bin/setup-sccache
 
 # install build tools (cmake from pip provides 3.22+ needed by pplx-kernels)
-uv pip install build cuda-python numpy setuptools-scm ninja cmake
+uv pip install build cuda-python numpy setuptools-scm ninja cmake apache
+uv pip install apache-tvm-ffi>=0.1,<0.2 requests filelock tqdm
 
 # install nvshmem4py from PyPI (works on both x86 and ARM64)
 uv pip install nvshmem4py-cu"${CUDA_MAJOR}"==0.1.2
@@ -37,7 +38,6 @@ cd flashinfer
 git checkout -q "${FLASHINFER_VERSION}"
 git submodule update --init --recursive
 uv build --wheel --no-build-isolation --out-dir /wheels
-uv pip install apache-tvm-ffi
 cd flashinfer-cubin && \
 uv build --wheel --no-build-isolation --out-dir /wheels
 cd ../flashinfer-jit-cache && \

--- a/docker/scripts/cuda/builder/build-compiled-wheels.sh
+++ b/docker/scripts/cuda/builder/build-compiled-wheels.sh
@@ -24,7 +24,7 @@ source /usr/local/bin/setup-sccache
 
 # install build tools (cmake from pip provides 3.22+ needed by pplx-kernels)
 uv pip install build cuda-python numpy setuptools-scm ninja cmake apache
-uv pip install apache-tvm-ffi>=0.1,<0.2 requests filelock tqdm
+uv pip install 'apache-tvm-ffi>=0.1,<0.2' requests filelock tqdm
 
 # install nvshmem4py from PyPI (works on both x86 and ARM64)
 uv pip install nvshmem4py-cu"${CUDA_MAJOR}"==0.1.2

--- a/docker/scripts/cuda/builder/build-compiled-wheels.sh
+++ b/docker/scripts/cuda/builder/build-compiled-wheels.sh
@@ -23,8 +23,8 @@ source "${VIRTUAL_ENV}/bin/activate"
 source /usr/local/bin/setup-sccache
 
 # install build tools (cmake from pip provides 3.22+ needed by pplx-kernels)
-uv pip install build cuda-python numpy setuptools-scm ninja cmake apache
-uv pip install -vv "apache-tvm-ffi>=0.1,<0.2" requests filelock tqdm
+uv pip install build cuda-python numpy setuptools-scm ninja cmake requests filelock tqdm
+uv pip install -vv "apache-tvm-ffi>=0.1,<0.2"
 
 # install nvshmem4py from PyPI (works on both x86 and ARM64)
 uv pip install nvshmem4py-cu"${CUDA_MAJOR}"==0.1.2

--- a/docker/scripts/cuda/builder/build-compiled-wheels.sh
+++ b/docker/scripts/cuda/builder/build-compiled-wheels.sh
@@ -23,8 +23,7 @@ source "${VIRTUAL_ENV}/bin/activate"
 source /usr/local/bin/setup-sccache
 
 # install build tools (cmake from pip provides 3.22+ needed by pplx-kernels)
-uv pip install build cuda-python numpy setuptools-scm ninja cmake requests filelock tqdm
-uv pip install -vv "apache-tvm-ffi>=0.1,<0.2"
+uv pip install build cuda-python numpy setuptools-scm ninja cmake requests filelock tqdm "apache-tvm-ffi>=0.1,<0.2"
 
 # install nvshmem4py from PyPI (works on both x86 and ARM64)
 uv pip install nvshmem4py-cu"${CUDA_MAJOR}"==0.1.2
@@ -38,12 +37,12 @@ cd flashinfer
 git checkout -q "${FLASHINFER_VERSION}"
 git submodule update --init --recursive
 uv build --wheel --no-build-isolation --out-dir /wheels
-cd flashinfer-cubin && \
-uv build --wheel --no-build-isolation --out-dir /wheels
-cd ../flashinfer-jit-cache && \
-FLASHINFER_CUDA_ARCH_LIST="9.0a 10.0a" uv build --wheel --no-build-isolation --out-dir /wheels
-cd ../../ && \
-rm -rf flashinfer
+cd flashinfer-cubin &&
+  FLASHINFER_LOGGING_LEVEL=WARNING uv build --wheel --no-build-isolation --out-dir /wheels
+cd ../flashinfer-jit-cache &&
+  FLASHINFER_CUDA_ARCH_LIST="9.0a 10.0a" uv build --wheel --no-build-isolation --out-dir /wheels
+cd ../../ &&
+  rm -rf flashinfer
 
 # build DeepEP wheel
 git clone "${DEEPEP_REPO}" deepep
@@ -64,17 +63,17 @@ rm -rf deepgemm
 
 # build pplx-kernels wheel (skip on ARM64)
 if [ "${TARGETPLATFORM}" != "linux/arm64" ]; then
-    git clone "${PPLX_KERNELS_REPO}" pplx-kernels
-    cd pplx-kernels
-    git checkout "${PPLX_KERNELS_SHA}"
-    TORCH_CUDA_ARCH_LIST="9.0a;10.0+PTX" NVSHMEM_PREFIX="${NVSHMEM_DIR}" uv build --wheel --out-dir /wheels
-    cd ..
-    rm -rf pplx-kernels
+  git clone "${PPLX_KERNELS_REPO}" pplx-kernels
+  cd pplx-kernels
+  git checkout "${PPLX_KERNELS_SHA}"
+  TORCH_CUDA_ARCH_LIST="9.0a;10.0+PTX" NVSHMEM_PREFIX="${NVSHMEM_DIR}" uv build --wheel --out-dir /wheels
+  cd ..
+  rm -rf pplx-kernels
 else
-    echo "Skipping pplx-kernels build on ARM64"
+  echo "Skipping pplx-kernels build on ARM64"
 fi
 
 if [ "${USE_SCCACHE}" = "true" ]; then
-    echo "=== Compiled wheels build complete - sccache stats ==="
-    sccache --show-stats
+  echo "=== Compiled wheels build complete - sccache stats ==="
+  sccache --show-stats
 fi

--- a/docker/scripts/cuda/builder/build-compiled-wheels.sh
+++ b/docker/scripts/cuda/builder/build-compiled-wheels.sh
@@ -37,16 +37,6 @@ cd flashinfer
 git checkout -q "${FLASHINFER_VERSION}"
 git submodule update --init --recursive
 uv build --wheel --no-build-isolation --out-dir /wheels
-
-# download pre-built flashinfer-cubin and flashinfer-jit-cache wheels
-# building from source times out due to compiling hundreds of kernel variants for multiple arches
-FLASHINFER_WHEEL_VERSION="${FLASHINFER_VERSION#v}"
-CUDA_SHORT_VERSION="${CUDA_MAJOR}$(echo "${CUDA_VERSION}" | cut -d. -f2)"
-uv pip download --dest /wheels \
-  flashinfer-cubin=="${FLASHINFER_WHEEL_VERSION}" \
-  flashinfer-jit-cache=="${FLASHINFER_WHEEL_VERSION}" \
-  --extra-index-url "https://flashinfer.ai/whl/cu${CUDA_SHORT_VERSION}"
-
 cd ..
 rm -rf flashinfer
 

--- a/docker/scripts/cuda/builder/build-compiled-wheels.sh
+++ b/docker/scripts/cuda/builder/build-compiled-wheels.sh
@@ -24,7 +24,7 @@ source /usr/local/bin/setup-sccache
 
 # install build tools (cmake from pip provides 3.22+ needed by pplx-kernels)
 uv pip install build cuda-python numpy setuptools-scm ninja cmake apache
-uv pip install 'apache-tvm-ffi>=0.1,<0.2' requests filelock tqdm
+uv pip install -vv 'apache-tvm-ffi>=0.1,<0.2' requests filelock tqdm
 
 # install nvshmem4py from PyPI (works on both x86 and ARM64)
 uv pip install nvshmem4py-cu"${CUDA_MAJOR}"==0.1.2

--- a/docker/scripts/cuda/builder/build-compiled-wheels.sh
+++ b/docker/scripts/cuda/builder/build-compiled-wheels.sh
@@ -37,12 +37,18 @@ cd flashinfer
 git checkout -q "${FLASHINFER_VERSION}"
 git submodule update --init --recursive
 uv build --wheel --no-build-isolation --out-dir /wheels
-cd flashinfer-cubin &&
-  FLASHINFER_LOGGING_LEVEL=WARNING uv build --wheel --no-build-isolation --out-dir /wheels
-cd ../flashinfer-jit-cache &&
-  FLASHINFER_CUDA_ARCH_LIST="9.0a 10.0a" uv build --wheel --no-build-isolation --out-dir /wheels
-cd ../../ &&
-  rm -rf flashinfer
+
+# download pre-built flashinfer-cubin and flashinfer-jit-cache wheels
+# building from source times out due to compiling hundreds of kernel variants for multiple arches
+FLASHINFER_WHEEL_VERSION="${FLASHINFER_VERSION#v}"
+CUDA_SHORT_VERSION="${CUDA_MAJOR}$(echo "${CUDA_VERSION}" | cut -d. -f2)"
+uv pip download --dest /wheels \
+  flashinfer-cubin=="${FLASHINFER_WHEEL_VERSION}" \
+  flashinfer-jit-cache=="${FLASHINFER_WHEEL_VERSION}" \
+  --extra-index-url "https://flashinfer.ai/whl/cu${CUDA_SHORT_VERSION}"
+
+cd ..
+rm -rf flashinfer
 
 # build DeepEP wheel
 git clone "${DEEPEP_REPO}" deepep

--- a/docker/scripts/cuda/builder/build-compiled-wheels.sh
+++ b/docker/scripts/cuda/builder/build-compiled-wheels.sh
@@ -24,7 +24,7 @@ source /usr/local/bin/setup-sccache
 
 # install build tools (cmake from pip provides 3.22+ needed by pplx-kernels)
 uv pip install build cuda-python numpy setuptools-scm ninja cmake apache
-uv pip install -vv 'apache-tvm-ffi>=0.1,<0.2' requests filelock tqdm
+uv pip install -vv "apache-tvm-ffi>=0.1,<0.2" requests filelock tqdm
 
 # install nvshmem4py from PyPI (works on both x86 and ARM64)
 uv pip install nvshmem4py-cu"${CUDA_MAJOR}"==0.1.2

--- a/docker/scripts/cuda/builder/build-compiled-wheels.sh
+++ b/docker/scripts/cuda/builder/build-compiled-wheels.sh
@@ -37,6 +37,7 @@ cd flashinfer
 git checkout -q "${FLASHINFER_VERSION}"
 git submodule update --init --recursive
 uv build --wheel --no-build-isolation --out-dir /wheels
+uv pip install apache-tvm-ffi
 cd flashinfer-cubin && \
 uv build --wheel --no-build-isolation --out-dir /wheels
 cd ../flashinfer-jit-cache && \

--- a/docker/scripts/cuda/runtime/install-vllm.sh
+++ b/docker/scripts/cuda/runtime/install-vllm.sh
@@ -48,9 +48,12 @@ echo "DEBUG: Architecture: $(uname -m), Python: $(python3 --version)"
 # determine platform tag from architecture
 MACHINE=$(uname -m)
 case "${MACHINE}" in
-  x86_64) PLATFORM_TAG="manylinux1_x86_64" ;;
-  aarch64) PLATFORM_TAG="manylinux2014_aarch64" ;;
-  *) echo "unsupported architecture: ${MACHINE}"; exit 1 ;;
+x86_64) PLATFORM_TAG="manylinux1_x86_64" ;;
+aarch64) PLATFORM_TAG="manylinux2014_aarch64" ;;
+*)
+  echo "unsupported architecture: ${MACHINE}"
+  exit 1
+  ;;
 esac
 
 # scrape wheel filename from HTML index

--- a/docker/scripts/cuda/runtime/install-vllm.sh
+++ b/docker/scripts/cuda/runtime/install-vllm.sh
@@ -25,6 +25,15 @@ INSTALL_PACKAGES=(
   /tmp/wheels/*.whl
 )
 
+# install flashinfer pre-built cubin and jit-cache
+# cubin is on PyPI, jit-cache uses flashinfer wheel index
+# building these from source times out due to compiling hundreds of kernel variants for multiple arches
+FLASHINFER_WHEEL_VERSION="${FLASHINFER_VERSION#v}"
+CUDA_SHORT_VERSION="cu${CUDA_MAJOR}${CUDA_MINOR}"
+uv pip install flashinfer-cubin=="${FLASHINFER_WHEEL_VERSION}"
+uv pip install flashinfer-jit-cache=="${FLASHINFER_WHEEL_VERSION}" \
+  --index-url "https://flashinfer.ai/whl/${CUDA_SHORT_VERSION}"
+
 # clone vllm repository
 git clone "${VLLM_REPO}" /opt/vllm-source
 git -C /opt/vllm-source config --system --add safe.directory /opt/vllm-source


### PR DESCRIPTION
SUMMARY:
* bump to 0.5.2, which is the version used in current vllm release