### PR TITLE
guides/prereq/client-setup/install-deps.sh - increment HELMFILE_VERSION to 1.2.1

### DIFF
--- a/guides/prereq/client-setup/install-deps.sh
+++ b/guides/prereq/client-setup/install-deps.sh
@@ -11,7 +11,7 @@ HELM_VER="v3.17.3"
 # Helmdiff version
 HELMDIFF_VERSION="v3.11.0"
 # Helmfile version
-HELMFILE_VERSION="1.1.3"
+HELMFILE_VERSION="1.2.1"
 # chart-testing version
 CT_VERSION="3.12.0"
 


### PR DESCRIPTION
Running `$ helmfile apply -n ${NAMESPACE}` with `1.1.3` gave this error:
 
 ```
panic: error find helm srmver version '3.16.4+g7877b45
        ': unable to find semver info in 3.16.4+g7877b45
```

Updating `helmfile` to the latest release `1.2.1` fixed the issue.

Big thanks to @fgharo for finding this.