### PR TITLE
v0.4.0 intelligent scheduling plugins

### DIFF
--- a/guides/inference-scheduling/gaie-inference-scheduling/values.yaml
+++ b/guides/inference-scheduling/gaie-inference-scheduling/values.yaml
@@ -13,7 +13,34 @@ inferenceExtension:
     ###################
     pullPolicy: Always
   extProcPort: 9002
-  pluginsConfigFile: "default-plugins.yaml"
+
+  pluginsConfigFile: "intelligent-scheduling-config.yaml"
+  pluginsCustomConfig:
+    intelligent-scheduling-config.yaml: |
+      apiVersion: inference.networking.x-k8s.io/v1alpha1
+      kind: EndpointPickerConfig
+      plugins:
+        - type: single-profile-handler
+        - type: prefix-cache-scorer # in v0.4.0+, automatic parameter tuning is enabled
+        - type: kv-cache-utilization-scorer
+        - type: queue-scorer
+        - type: no-hit-lru-scorer
+          parameters:
+            lruSize: 1000  # 1000 pods for tracking
+        - type: max-score-picker
+      schedulingProfiles:
+        - name: default
+          plugins:
+            - pluginRef: prefix-cache-scorer
+              weight: 3.0
+            - pluginRef: no-hit-lru-scorer
+              weight: 2.0 # effective on cold requests
+            - pluginRef: kv-cache-utilization-scorer
+              weight: 2.0
+            - pluginRef: queue-scorer
+              weight: 2.0
+            - pluginRef: max-score-picker
+
   monitoring:
     interval: "10s"
     # Service account token secret for authentication

--- a/guides/precise-prefix-cache-aware/gaie-kv-events/values.yaml
+++ b/guides/precise-prefix-cache-aware/gaie-kv-events/values.yaml
@@ -50,12 +50,17 @@ inferenceExtension:
                 hashSeed: "42"
         - type: kv-cache-utilization-scorer
         - type: queue-scorer
+        - type: no-hit-lru-scorer
+          parameters:
+            lruSize: 1000  # 1000 pods for tracking
         - type: max-score-picker
       schedulingProfiles:
         - name: default
           plugins:
             - pluginRef: precise-prefix-cache-scorer
               weight: 3.0
+            - pluginRef: no-hit-lru-scorer
+              weight: 2.0 # effective on cold requests
             - pluginRef: kv-cache-utilization-scorer
               weight: 2.0
             - pluginRef: queue-scorer


### PR DESCRIPTION
## Summary

This PR updates the default weighted scorer configurations for the `intelligent-scheduling` and `precise prefix-cache aware scheduling` well-lit paths. 
- The weights are based on benchmarking experiments that were executed throughout the past couple of months
- The new `no-hit-lru-scorer` has been shown to increase the saturation point in standard prefix-cache benchmarks (none published yet). In a simple experiment of 8x Qwen3-32B on 1 H100 node:
      
      target: http://infra-kv-events-inference-gateway.llm-d-precise.svc.cluster.local:80
      model: Qwen/Qwen3-32B
      request_type: text_completions
      profile: constant
      rate: [30, 50]
      max_seconds: 100
      data:
        prefix_buckets:
          - bucket_weight: 750
            prefix_count: 150
            prefix_tokens: 4000
        prompt_tokens: 1500
        output_tokens: 1000


     The scorer keeps the system stable at 50 QPS, while the configuration without it does not.

This requires a v0.4.0 scheduler image - do not merge before then.

cc @Gregory-Pereira @liu-cong 