### PR TITLE
Fix: duplicated default datasources for Grafana

### DIFF
--- a/docs/monitoring/scripts/install-prometheus-grafana.sh
+++ b/docs/monitoring/scripts/install-prometheus-grafana.sh
@@ -348,6 +348,9 @@ grafana:
   service:
     type: ClusterIP
     sessionAffinity: ""
+  sidecar:
+    datasources:
+      defaultDatasourceEnabled: false
   datasources:
     datasources.yaml:
       apiVersion: 1
@@ -387,6 +390,9 @@ grafana:
   service:
     type: ClusterIP
     sessionAffinity: ""
+  sidecar:
+    datasources:
+      defaultDatasourceEnabled: false
   datasources:
     datasources.yaml:
       apiVersion: 1


### PR DESCRIPTION
### Problem
#494 The kube-prometheus-stack Helm chart enables automatic creation of a default Prometheus datasource when grafana.sidecar.datasources.defaultDatasourceEnabled is set to true (which is the default behavior). However, the installation script also manually defines a Prometheus datasource through grafana.datasources.datasources.yaml. This results in duplicate Prometheus datasources being created in Grafana.

### Solution
Set grafana.sidecar.datasources.defaultDatasourceEnabled: false to disable the automatic datasource creation, ensuring only the manually configured datasource is used.