### PR TITLE
fixing AWS image

### DIFF
--- a/docker/Dockerfile.aws
+++ b/docker/Dockerfile.aws
@@ -407,6 +407,7 @@ COPY --from=builder /wheels/*.whl /tmp/wheels/
 
 # Define commit SHAs as build args to avoid layer invalidation
 ARG LMCACHE_COMMIT_SHA
+ARG VLLM_PRECOMPILED_WHEEL_COMMIT="75648b16ddce1bff02c39c6f06be62a58385ff52"
 ARG VLLM_COMMIT_SHA="439368496db48d8f992ba8c606a0c0b1eebbfa69"
 
 ARG VLLM_PREBUILT=0
@@ -440,8 +441,7 @@ RUN --mount=type=cache,target=/var/cache/git \
         export VLLM_WHEEL_VERSION="0.0.0+${VLLM_COMMIT_SHA_SHORT}.${CUDA_SHORT}"; \
         VLLM_USE_PRECOMPILED=1 uv pip install --index-url "${VLLM_WHEEL_URL}" "vllm==${VLLM_WHEEL_VERSION}"; \
     else \
-        VLLM_COMMIT="$(git merge-base HEAD origin/main)"; \
-        VLLM_PRECOMPILED_WHEEL_LOCATION="https://wheels.vllm.ai/${VLLM_COMMIT}/vllm-1.0.0.dev-cp38-abi3-manylinux1_${VLLM_WHEEL_ARCH}.whl"; \
+        VLLM_PRECOMPILED_WHEEL_LOCATION="https://wheels.vllm.ai/${VLLM_PRECOMPILED_WHEEL_COMMIT:-${VLLM_COMMIT_SHA}}/vllm-1.0.0.dev-cp38-abi3-manylinux1_${VLLM_WHEEL_ARCH}.whl"; \
         VLLM_USE_PRECOMPILED=1 uv pip install --editable .; \
     fi; \
     uv pip install "nvidia-nccl-cu12>=2.26.2.post1" && \

--- a/docker/scripts/cuda/runtime/install-vllm.sh
+++ b/docker/scripts/cuda/runtime/install-vllm.sh
@@ -62,9 +62,9 @@ fi
 
 if [ -n "${WHEEL_FILENAME}" ]; then
   # construct full URL (wheels are in parent directory)
-  # note: actual files don't have +cuXXX suffix despite HTML index showing it
+  # URL-encode the + sign in the wheel filename
   WHEEL_URL="https://wheels.vllm.ai/${VLLM_PRECOMPILED_WHEEL_COMMIT}/${WHEEL_FILENAME}"
-  WHEEL_URL=$(echo "${WHEEL_URL}" | sed -E 's/\.cu[0-9]+-/-/g; s/%2Bcu[0-9]+-/%2B/g; s/\+cu[0-9]+-/+/g')
+  WHEEL_URL=$(echo "${WHEEL_URL}" | sed -E 's/\+/%2B/g')
   echo "DEBUG: Found wheel: ${WHEEL_FILENAME}"
   echo "DEBUG: Wheel URL: ${WHEEL_URL}"
 else


### PR DESCRIPTION
This issue arose because we swapped our vLLM repo to be a fork, and so we need to ensure were manually invoking the precompiled commit with a known base in the VLLM wheels index