### PR TITLE
Update the correct vllm kv cache utilization metric name in inference scheduler

### DIFF
--- a/guides/inference-scheduling/gaie-inference-scheduling/values.yaml
+++ b/guides/inference-scheduling/gaie-inference-scheduling/values.yaml
@@ -1,5 +1,9 @@
 inferenceExtension:
   replicas: 1
+  flags:
+    # in vLLM 10.0+, the metric is renamed while upstream GAIE is still using the old name as default.
+    # See https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1905.
+    kv-cache-usage-percentage-metric: "vllm:kv_cache_usage_perc"
   image:
     # both downstream infernece-scheduler and upstream epp image can support inference-scheduling example
     ###################

--- a/guides/pd-disaggregation/gaie-pd/values.yaml
+++ b/guides/pd-disaggregation/gaie-pd/values.yaml
@@ -1,5 +1,9 @@
 inferenceExtension:
   replicas: 1
+  flags:
+    # in vLLM 10.0+, the metric is renamed while upstream GAIE is still using the old name as default.
+    # See https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1905.
+    kv-cache-usage-percentage-metric: "vllm:kv_cache_usage_perc"
   image:
     name: llm-d-inference-scheduler
     hub: ghcr.io/llm-d

--- a/guides/precise-prefix-cache-aware/gaie-kv-events/values.yaml
+++ b/guides/precise-prefix-cache-aware/gaie-kv-events/values.yaml
@@ -1,5 +1,10 @@
 inferenceExtension:
   replicas: 1
+  flags:
+    # in vLLM 10.0+, the metric is renamed while upstream GAIE is still using the old name as default.
+    # See https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1905.
+    kv-cache-usage-percentage-metric: "vllm:kv_cache_usage_perc"
+    v: 4 # log verbosity
   image:
     # both downstream infernece-scheduler and upstream epp images can support precise KV Cache awareness based on the configurations here
     ###################
@@ -30,10 +35,6 @@ inferenceExtension:
         secretKeyRef:
           name: llm-d-hf-token
           key: HF_TOKEN
-  flags:
-    # Log verbosity
-    - name: v
-      value: 4
   
   pluginsConfigFile: "precise-prefix-cache-config.yaml"
   pluginsCustomConfig:

--- a/guides/recipes/inferencepool/values.yaml
+++ b/guides/recipes/inferencepool/values.yaml
@@ -4,6 +4,10 @@ inferencePool:
     matchLabels:
       "llm-d.ai/inferenceServing": "true"
 inferenceExtension:
+  flags:
+    # in vLLM 10.0+, the metric is renamed while upstream GAIE is still using the old name as default.
+    # See https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1905.
+    kv-cache-usage-percentage-metric: "vllm:kv_cache_usage_perc"
   monitoring:
     gke:
       enable: false

--- a/guides/simulated-accelerators/gaie-sim/values.yaml
+++ b/guides/simulated-accelerators/gaie-sim/values.yaml
@@ -1,5 +1,9 @@
 inferenceExtension:
   replicas: 1
+  flags:
+    # in vLLM 10.0+, the metric is renamed while upstream GAIE is still using the old name as default.
+    # See https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1905.
+    kv-cache-usage-percentage-metric: "vllm:kv_cache_usage_perc"
   image:
     # both downstream infernece-scheduler and upstream epp image can support simulated-accelerators example
     ###################

--- a/guides/tiered-prefix-cache/cpu/manifests/inferencepool/values.yaml
+++ b/guides/tiered-prefix-cache/cpu/manifests/inferencepool/values.yaml
@@ -4,6 +4,10 @@ inferencePool:
     matchLabels:
       "llm-d.ai/inferenceServing": "true"
 inferenceExtension:
+  flags:
+    # in vLLM 10.0+, the metric is renamed while upstream GAIE is still using the old name as default.
+    # See https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1905.
+    kv-cache-usage-percentage-metric: "vllm:kv_cache_usage_perc"
   monitoring:
     gke:
       enable: false

--- a/guides/wide-ep-lws/manifests/inferencepool.values.yaml
+++ b/guides/wide-ep-lws/manifests/inferencepool.values.yaml
@@ -1,5 +1,10 @@
 inferenceExtension:
   replicas: 1
+  flags:
+    # in vLLM 10.0+, the metric is renamed while upstream GAIE is still using the old name as default.
+    # See https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1905.
+    kv-cache-usage-percentage-metric: "vllm:kv_cache_usage_perc"
+    v: 1
   image:
     name: llm-d-inference-scheduler
     hub: ghcr.io/llm-d
@@ -43,8 +48,6 @@ inferenceExtension:
         plugins:
         - pluginRef: decode-filter
         - pluginRef: random-picker
-  flags:
-    v: 1
 
 inferencePool:
   apiVersion: inference.networking.k8s.io/v1

--- a/guides/workload-autoscaling/gaie-workload-autoscaling/values.yaml
+++ b/guides/workload-autoscaling/gaie-workload-autoscaling/values.yaml
@@ -1,5 +1,9 @@
 inferenceExtension:
   replicas: 1
+  flags:
+    # in vLLM 10.0+, the metric is renamed while upstream GAIE is still using the old name as default.
+    # See https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1905.
+    kv-cache-usage-percentage-metric: "vllm:kv_cache_usage_perc"
   image:
     # both downstream inference-scheduler and upstream epp image can support workload-autoscaling example
     ###################


### PR DESCRIPTION
vLLM 10.0 updated the kv cache metric name, which is updated in upstream gaie in https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1905/ .

This PR ensures we use the correct metric name, even without the bug fix PR is patched into the gaie release.

Tested:

Logs from inference scheduler
```
 {"level":"info","ts":"2025-11-26T21:49:45Z","logger":"setup","caller":"runner/runner.go:221","msg":"Flags processed","flags":{"cache-info-metric":"vllm:cache_config_info","cert-path":"","config-file":"/config/default-plugins.yaml","config-text":"","enable-pprof":true,"endpoint-selector":"","endpoint-target-ports":"","grpc-health-port":9003,"grpc-port":9002,"ha-enable-leader-election":false,"health-checking":false,"kubeconfig":"","kv-cache-usage-percentage-metric":"vllm:kv_cache_usage_perc","lora-info-metric":"vllm:lora_requests_info","metrics-endpoint-auth":false,"metrics-port":9090,"metrics-staleness-threshold":2000000000,"model-server-metrics-https-insecure-skip-verify":true,"model-server-metrics-path":"/metrics ","model-server-metrics-port":0,"model-server-metrics-scheme":"http","pool-group":"inference.networking.k8s.io","pool-name":"gaie-inference-scheduling","pool-namespace":"llm-d-inference-scheduler","refresh-metrics-interval":50000000,"refresh -prometheus-metrics-interval":5000000000,"secure-serving":true,"total-queued-requests-metric":"vllm:num_requests_waiting","tracing":false,"v":1,"zap-devel":true,"zap-encoder":{},"zap-log-level":{},"zap-stacktrace-level":{},"zap-time-encoding  ":{}}}
```

Also tested that the llm-d image has the updated metric

```
# HELP vllm:kv_cache_usage_perc KV-cache usage. 1 means 100 percent usage.
# TYPE vllm:kv_cache_usage_perc gauge
```

cc @nirrozenbaum 