### PR TITLE
update epp metrics auth to align with upstream changes

### DIFF
--- a/guides/inference-scheduling/gaie-inference-scheduling/values.yaml
+++ b/guides/inference-scheduling/gaie-inference-scheduling/values.yaml
@@ -20,12 +20,12 @@ inferenceExtension:
   pluginsConfigFile: "default-plugins.yaml"
   monitoring:
     interval: "10s"
-    # Service account token secret for authentication
-    secret:
-      name: inference-scheduling-gateway-sa-metrics-reader-secret
     # Prometheus ServiceMonitor will be created when enabled for EPP metrics collection
     prometheus:
       enabled: true
+      auth:
+        # To allow unauthenticated /metrics access (e.g., for debugging with curl), set to false
+        enabled: true
 inferencePool:
   apiVersion: inference.networking.x-k8s.io/v1alpha2 # use old API version for inference
   targetPortNumber: 8000

--- a/guides/inference-scheduling/standalone-inference-scheduling/values.yaml
+++ b/guides/inference-scheduling/standalone-inference-scheduling/values.yaml
@@ -281,12 +281,12 @@ inferenceExtension:
               path: envoy.yaml
   monitoring:
     interval: "10s"
-    # Service account token secret for authentication
-    secret:
-      name: inference-scheduling-gateway-sa-metrics-reader-secret
     # Prometheus ServiceMonitor will be created when enabled for EPP metrics collection
     prometheus:
       enabled: true
+      auth:
+        # To allow unauthenticated /metrics access (e.g., for debugging with curl), set to false
+        enabled: true
 inferencePool:
   apiVersion: inference.networking.x-k8s.io/v1alpha2 # use old API version for inference
   targetPortNumber: 8000

--- a/guides/pd-disaggregation/gaie-pd/values.yaml
+++ b/guides/pd-disaggregation/gaie-pd/values.yaml
@@ -47,12 +47,12 @@ inferenceExtension:
   # Monitoring configuration for EPP
   monitoring:
     interval: "10s"
-    # Service account token secret for authentication
-    secret:
-      name: pd-gateway-sa-metrics-reader-secret
     # Prometheus ServiceMonitor will be created when enabled for EPP metrics collection
     prometheus:
       enabled: true
+      auth:
+        # To allow unauthenticated /metrics access (e.g., for debugging with curl), set to false
+        enabled: true
 
 inferencePool:
   apiVersion: inference.networking.x-k8s.io/v1alpha2 # use old API version for inference

--- a/guides/precise-prefix-cache-aware/gaie-kv-events/values.yaml
+++ b/guides/precise-prefix-cache-aware/gaie-kv-events/values.yaml
@@ -69,13 +69,12 @@ inferenceExtension:
   # Monitoring configuration for EPP
   monitoring:
     interval: "10s"
-    # Service account token secret for authentication
-    secret:
-      name: prefix-routing-gateway-sa-metrics-reader-secret
-
     # Prometheus ServiceMonitor will be created when enabled for EPP metrics collection
     prometheus:
       enabled: true
+      auth:
+        # To allow unauthenticated /metrics access (e.g., for debugging with curl), set to false
+        enabled: true
 inferencePool:
   apiVersion: inference.networking.x-k8s.io/v1alpha2 # use old API version for inference
   targetPortNumber: 8000

--- a/guides/simulated-accelerators/gaie-sim/values.yaml
+++ b/guides/simulated-accelerators/gaie-sim/values.yaml
@@ -22,12 +22,12 @@ inferenceExtension:
   # Monitoring configuration for EPP
   monitoring:
     interval: "10s"
-    # Service account token secret for authentication
-    secret:
-      name: sim-gateway-sa-metrics-reader-secret
     # Prometheus ServiceMonitor will be created when enabled for EPP metrics collection
     prometheus:
       enabled: true
+      auth:
+        # To allow unauthenticated /metrics access (e.g., for debugging with curl), set to false
+        enabled: true
 inferencePool:
   targetPortNumber: 8000
   apiVersion: inference.networking.x-k8s.io/v1alpha2 # use old API version for inference

--- a/guides/workload-autoscaling/gaie-workload-autoscaling/values.yaml
+++ b/guides/workload-autoscaling/gaie-workload-autoscaling/values.yaml
@@ -15,12 +15,12 @@ inferenceExtension:
   pluginsConfigFile: "default-plugins.yaml"
   monitoring:
     interval: "10s"
-    # Service account token secret for authentication
-    secret:
-      name: workload-autoscaler-gateway-sa-metrics-reader-secret
     # Prometheus ServiceMonitor will be created when enabled for EPP metrics collection
     prometheus:
       enabled: true
+      auth:
+        # To allow unauthenticated /metrics access (e.g., for debugging with curl), set to false
+        enabled: true
 inferencePool:
   apiVersion: inference.networking.x-k8s.io/v1alpha2 # use old API version for inference
   targetPortNumber: 8000


### PR DESCRIPTION
GAIE added the option to configure unauthenticated epp metrics endpoint. The new prometheus.auth.enabled flag was not added to llm-d values, so metrics-reader-secret wasn't aligned properly. This fixes the issue. Metrics auth is set to 'true' by default (also the default in GAIE charts), with a comment on how to configure unauthenticated metrics endpoint.