### PR TITLE
Update wide-ep example to 0.4.0 image and tune startup threshold

### DIFF
--- a/guides/wide-ep-lws/manifests/modelserver/base/decode.yaml
+++ b/guides/wide-ep-lws/manifests/modelserver/base/decode.yaml
@@ -24,8 +24,9 @@ spec:
               - --port=8000
               - --vllm-port=8200
               - --connector=nixlv2
-              - -v=1
+              - --zap-log-level=1
               - --secure-proxy=false
+              - --enable-prefiller-sampling
             image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.4.0-rc.1
             imagePullPolicy: Always
             ports:
@@ -48,7 +49,7 @@ spec:
             emptyDir: {}
         containers:
         - name: vllm
-          image: ghcr.io/llm-d/llm-d-cuda:v0.3.1
+          image: ghcr.io/llm-d/llm-d-cuda:v0.4.0
           securityContext:
             capabilities:
               add:
@@ -173,7 +174,7 @@ spec:
             initialDelaySeconds: 0
             periodSeconds: 1
             timeoutSeconds: 5
-            failureThreshold: 1800
+            failureThreshold: 2700
           livenessProbe:
             httpGet:
               path: /health

--- a/guides/wide-ep-lws/manifests/modelserver/base/prefill.yaml
+++ b/guides/wide-ep-lws/manifests/modelserver/base/prefill.yaml
@@ -29,7 +29,7 @@ spec:
             emptyDir: {}
         containers:
         - name: vllm
-          image: ghcr.io/llm-d/llm-d-cuda:v0.3.1
+          image: ghcr.io/llm-d/llm-d-cuda:v0.4.0
           securityContext:
             capabilities:
               add:
@@ -143,7 +143,7 @@ spec:
             initialDelaySeconds: 0
             periodSeconds: 1
             timeoutSeconds: 5
-            failureThreshold: 1800
+            failureThreshold: 2700
           livenessProbe:
             httpGet:
               path: /health


### PR DESCRIPTION
Use the correct log statement for the new sidecar.

DeepSeek B200 is taking about 45m to startup due to both model download
and warmup for flashinfer.

Enable the sampling prefiller option in the sidecar to make local
round robin testing easier.