### PR TITLE
Rename the llm-d-kv-cache-manager project in the docs

### DIFF
--- a/SIGS.md
+++ b/SIGS.md
@@ -40,7 +40,7 @@ SIGs operate within the broader llm-d project governance framework defined in [P
 | **[SIG Inference Scheduler](#sig-inference-scheduler)** | Intelligent request routing, load balancing, and traffic management | • [Meeting Recordings and Docs](https://drive.google.com/drive/folders/1aKTJru43krjHP2ORayEEp4JP-N7dJL8S)<br>• [llm-d-inference-scheduler Repository](https://github.com/llm-d/llm-d-inference-scheduler/) |
 | **[SIG Benchmarking](#sig-benchmarking)** | Performance testing, benchmarking frameworks, and optimization | • [Meeting Recordings and Docs](https://drive.google.com/drive/folders/1Hd-rCRLDbucl-LD0RlQwOCLqERWF-obT)<br>• [llm-d-benchmark Repository](https://github.com/llm-d/llm-d-benchmark) |
 | **[SIG PD-Disaggregation](#sig-pd-disaggregation)** | Prefill/decode separation, distributed serving, and workload disaggregation | • [Meeting Recordings and Docs](https://drive.google.com/drive/folders/1jk7wtojsWNbYQVf7BY8BEvIg8FMRZV0q)<br>• [llm-d-routing-sidecar Repository](https://github.com/llm-d/llm-d-routing-sidecar) |
-| **[SIG KV-Disaggregation](#sig-kv-disaggregation)** | KV caching, prefix caching, and distributed storage systems | • [Meeting Recordings and Docs](https://drive.google.com/drive/folders/1mFbzwEWL2-LvD21owgxlKRcQD0eSmcz6)<br>• [llm-d-kv-cache-manager Repository](https://github.com/llm-d/llm-d-kv-cache-manager) |
+| **[SIG KV-Disaggregation](#sig-kv-disaggregation)** | KV caching, prefix caching, and distributed storage systems | • [Meeting Recordings and Docs](https://drive.google.com/drive/folders/1mFbzwEWL2-LvD21owgxlKRcQD0eSmcz6)<br>• [llm-d-kv-cache Repository](https://github.com/llm-d/llm-d-kv-cache) |
 | **[SIG Installation](#sig-installation)** | Kubernetes integration, deployment tooling, and platform operations | • [Meeting Recordings and Docs](https://drive.google.com/drive/folders/1H-0Y8fXepzrYpcaUOBfuphn1Cl-gU0xr)<br>• [llm-d-modelservice Repository](https://github.com/llm-d-incubation/llm-d-modelservice)<br>• [llm-d-infra Repository](https://github.com/llm-d-incubation/llm-d-infra) |
 | **[SIG Autoscaling](#sig-autoscaling)** | Traffic-aware autoscaling, resource management, and capacity planning | • [Meeting Recordings and Docs](https://drive.google.com/drive/folders/1iDlTgpFPOrSQn7dWR3uCQLtqhz86HTAi)<br>• [workload-variant-autoscaler Repository](https://github.com/llm-d-incubation/workload-variant-autoscaler) |
 | **[SIG Observability](#sig-observability)** | Monitoring, logging, metrics, and operational visibility | • [Meeting Recordings and Docs](https://drive.google.com/drive/folders/1H-TVTCKYVxUn4fER7xuTPmscNttZCutN)<br>• [llm-d Observability Documentation](https://github.com/llm-d/llm-d/tree/main/docs/monitoring) |
@@ -127,7 +127,7 @@ SIGs operate within the broader llm-d project governance framework defined in [P
 **💬 Communication**:
 - **Slack Channel**: [#sig-kv-disaggregation](https://llm-d.slack.com/archives/C08TB7ZDV7S)
 - **Meeting Recordings and Docs**: [Public Google Drive](https://drive.google.com/drive/folders/1mFbzwEWL2-LvD21owgxlKRcQD0eSmcz6)
-- **GitHub Issues**: [github.com/llm-d/llm-d-kv-cache-manager](https://github.com/llm-d/llm-d-kv-cache-manager/issues)
+- **GitHub Issues**: [github.com/llm-d/llm-d-kv-cache](https://github.com/llm-d/llm-d-kv-cache/issues)
 
 ### SIG Installation
 

--- a/docs/getting-started-inferencing.md
+++ b/docs/getting-started-inferencing.md
@@ -196,7 +196,7 @@ For more information options to set for the `/v1/completions` endpoint, see the 
 
 While `/v1/completions` is a legacy API, it is still supported for now. We are in the process of converting over to `/v1/chat/completions`, and this work is being tracked in a few places.
 
-The [initial implementation for the kv-cache-manager package](https://github.com/llm-d/llm-d-kv-cache-manager/issues/10) landed as part of the v0.2 sprint.
+The [initial implementation for the kv-cache-manager package](https://github.com/llm-d/llm-d-kv-cache/issues/10) landed as part of the v0.2 sprint.
 
 [Support within the `llm-d-inference-scheduler` image](https://github.com/llm-d/llm-d-inference-scheduler/issues/83) is in progress and part of the v0.3 roadmap, and further support to the upstream `epp` image is in progress and being [tracked here](https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/827).
 


### PR DESCRIPTION
Per [this slack thread](https://llm-d.slack.com/archives/C08QNQBTBCK/p1764621558966349) - updating the docs to point to the new project name

/cc @vMaroon 