### PR TITLE
feat: Add Prometheus alerting rules and runbook for SLO enforcement

### DIFF
--- a/docs/monitoring/alerting-runbook.md
+++ b/docs/monitoring/alerting-runbook.md
@@ -1,0 +1,490 @@
+# llm-d Alerting Runbook
+
+This runbook provides response procedures for llm-d Prometheus alerts. Each section corresponds to an alert defined in [prometheus-alerting-rules.yaml](./prometheus-alerting-rules.yaml).
+
+## Quick Reference
+
+| Severity | Response Time | Escalation |
+|----------|---------------|------------|
+| Critical | Immediate (< 5 min) | Page on-call, notify stakeholders |
+| Warning | 30 minutes | Investigate during business hours |
+| Info | Next business day | Review during regular maintenance |
+
+## Critical Alerts
+
+### LLMDHighErrorRate
+
+**Summary**: Platform-wide error rate exceeds 5%
+
+**Impact**: Significant user impact - many inference requests are failing
+
+**Diagnosis**:
+```bash
+# Check error distribution by type
+kubectl logs -l app=epp -n ${NAMESPACE} | grep -i error | tail -50
+
+# Check error rate by model
+curl -s http://prometheus:9090/api/v1/query \
+  --data-urlencode 'query=sum by(model_name, error_code) (rate(inference_model_request_error_total[5m]))'
+
+# Check backend pod health
+kubectl get pods -n ${NAMESPACE} -l llm-d.ai/inferenceServing=true
+```
+
+**Resolution Steps**:
+1. Identify which models/backends are generating errors
+2. Check vLLM pod logs for OOM, model loading failures, or GPU errors
+3. Verify network connectivity between scheduler and backends
+4. Check if specific error codes dominate (see Error Code Reference below)
+5. Consider rolling restart of affected pods if issue is transient
+
+**Escalation**: If error rate persists >10 minutes, escalate to platform team lead
+
+---
+
+### LLMDModelHighErrorRate
+
+**Summary**: Specific model error rate exceeds 10%
+
+**Impact**: Users of this model are experiencing high failure rates
+
+**Diagnosis**:
+```bash
+# Get affected model pods
+kubectl get pods -n ${NAMESPACE} -l model_name=${MODEL_NAME}
+
+# Check model-specific logs
+kubectl logs -l model_name=${MODEL_NAME} -c vllm -n ${NAMESPACE} --tail=100
+
+# Check if model is loaded
+kubectl exec ${POD} -c vllm -n ${NAMESPACE} -- curl -s localhost:8200/v1/models
+```
+
+**Resolution Steps**:
+1. Verify model is properly loaded on all replicas
+2. Check for GPU memory issues specific to this model
+3. Review model configuration (max_model_len, tensor_parallel_size)
+4. Consider redeploying model pods
+5. Check HuggingFace token validity if model requires authentication
+
+---
+
+### LLMDSchedulerDown
+
+**Summary**: Inference scheduler (EPP) is unavailable
+
+**Impact**: All inference requests will fail - no traffic routing possible
+
+**Diagnosis**:
+```bash
+# Check EPP pod status
+kubectl get pods -l app=epp -n ${NAMESPACE}
+
+# Check EPP logs
+kubectl logs -l app=epp -n ${NAMESPACE} --tail=100
+
+# Check EPP service
+kubectl get svc -l app=epp -n ${NAMESPACE}
+kubectl get endpoints -l app=epp -n ${NAMESPACE}
+```
+
+**Resolution Steps**:
+1. **Immediate**: Check if EPP pods are in CrashLoopBackOff
+2. Review EPP logs for startup errors
+3. Verify InferencePool configuration: `kubectl get inferencepool -n ${NAMESPACE} -o yaml`
+4. Check Gateway status: `kubectl get gateway -n ${NAMESPACE} -o yaml`
+5. If persistent, redeploy EPP: `helm upgrade --reuse-values gaie-* ...`
+
+**Escalation**: Page on-call immediately - this is a total outage condition
+
+---
+
+### LLMDNoHealthyBackends
+
+**Summary**: All vLLM backend pods are down
+
+**Impact**: Complete service outage - no inference capacity available
+
+**Diagnosis**:
+```bash
+# Check all vLLM pods
+kubectl get pods -n ${NAMESPACE} -l llm-d.ai/inferenceServing=true -o wide
+
+# Check recent events
+kubectl get events -n ${NAMESPACE} --sort-by='.lastTimestamp' | grep -i vllm
+
+# Check node status
+kubectl get nodes -o wide
+```
+
+**Resolution Steps**:
+1. Identify why pods are down (OOM, node failure, GPU issues)
+2. Check for cluster-wide issues (node failures, network problems)
+3. Review resource quotas and limits
+4. Force pod restart: `kubectl delete pods -l llm-d.ai/inferenceServing=true -n ${NAMESPACE}`
+5. Scale up if capacity insufficient
+
+**Escalation**: Page on-call immediately - this is a total outage condition
+
+---
+
+### LLMDExtremeTTFT
+
+**Summary**: P99 time-to-first-token exceeds 30 seconds
+
+**Impact**: Users are experiencing extremely slow initial response times
+
+**Diagnosis**:
+```bash
+# Check prefill pod utilization
+kubectl top pods -l role=prefill -n ${NAMESPACE}
+
+# Check queue depth
+curl -s http://prometheus:9090/api/v1/query \
+  --data-urlencode 'query=sum by(pod) (vllm:num_requests_waiting)'
+
+# Check prefix cache hit rate
+curl -s http://prometheus:9090/api/v1/query \
+  --data-urlencode 'query=sum(rate(vllm:prefix_cache_hits_total[5m])) / sum(rate(vllm:prefix_cache_queries_total[5m]))'
+```
+
+**Resolution Steps**:
+1. Scale up prefill workers if queue depth is high
+2. Check if prefix cache is warming up after restart
+3. Review prompt sizes - extremely long prompts will have high TTFT
+4. Verify KV cache transfer is working (for P/D disaggregation)
+5. Consider enabling tiered prefix cache for better hit rates
+
+---
+
+## Warning Alerts
+
+### LLMDElevatedErrorRate
+
+**Summary**: Platform error rate above 1% (below critical threshold)
+
+**Impact**: Some users experiencing failures - trend toward degradation
+
+**Diagnosis**: Same as LLMDHighErrorRate
+
+**Resolution Steps**:
+1. Monitor trend - is error rate increasing or stable?
+2. Identify error patterns before they escalate
+3. Proactive capacity check
+4. Review recent deployments or configuration changes
+
+---
+
+### LLMDHighLatencyP99
+
+**Summary**: P99 request latency exceeds 10 seconds
+
+**Impact**: Tail latency affecting user experience
+
+**Diagnosis**:
+```bash
+# Check latency distribution
+curl -s http://prometheus:9090/api/v1/query \
+  --data-urlencode 'query=histogram_quantile(0.99, sum by(le, model_name) (rate(inference_model_request_duration_seconds_bucket[5m])))'
+
+# Check for outlier pods
+kubectl top pods -n ${NAMESPACE} --containers | sort -k4 -rn | head -10
+```
+
+**Resolution Steps**:
+1. Identify which models/pods are contributing to high latency
+2. Check if KV cache is saturated
+3. Review batch sizes and concurrency settings
+4. Consider enabling request prioritization
+
+---
+
+### LLMDHighTTFT
+
+**Summary**: P99 time-to-first-token exceeds 10 seconds
+
+**Impact**: Users waiting too long for initial response
+
+**Resolution Steps**:
+1. Scale prefill workers
+2. Review prefix cache hit rates
+3. Consider enabling P/D disaggregation if not already
+4. Check network latency between prefill and decode workers
+
+---
+
+### LLMDHighPreemptions
+
+**Summary**: Request preemptions indicate memory pressure
+
+**Impact**: Requests being interrupted, potential quality degradation
+
+**Diagnosis**:
+```bash
+# Check preemption rate
+kubectl logs ${POD} -c vllm -n ${NAMESPACE} | grep -i preempt
+
+# Check memory utilization
+kubectl exec ${POD} -c vllm -n ${NAMESPACE} -- nvidia-smi
+```
+
+**Resolution Steps**:
+1. Reduce `--max-num-seqs` to limit concurrent requests
+2. Decrease `--gpu-memory-utilization` (default 0.9)
+3. Limit `--max-model-len` if using long sequences
+4. Scale out to distribute load
+
+---
+
+### LLMDKVCacheSaturation
+
+**Summary**: KV cache utilization above 90%
+
+**Impact**: Near capacity - preemptions likely if load increases
+
+**Resolution Steps**:
+1. Scale out decode workers
+2. Enable tiered prefix cache to offload to CPU memory
+3. Review max sequence lengths
+4. Consider model quantization for smaller KV cache footprint
+
+---
+
+### LLMDRequestQueueBuildup
+
+**Summary**: More than 50 requests waiting in queue
+
+**Impact**: Increasing latency as queue grows
+
+**Resolution Steps**:
+1. Scale decode workers immediately
+2. Enable request prioritization to serve interactive requests first
+3. Consider rate limiting batch workloads
+4. Review autoscaling thresholds
+
+---
+
+### LLMDLowPrefixCacheHitRate
+
+**Summary**: Prefix cache hit rate below 30%
+
+**Impact**: Inefficient prefix reuse - higher compute cost
+
+**Resolution Steps**:
+1. Analyze workload patterns - are prompts cacheable?
+2. Increase cache size if workload has reusable prefixes
+3. Enable prefix-cache-aware routing
+4. Consider tiered prefix cache for larger working set
+
+---
+
+### LLMDGPUUnderutilization
+
+**Summary**: GPU utilization below 30% for extended period
+
+**Impact**: Wasted resources - cost optimization opportunity
+
+**Resolution Steps**:
+1. Consolidate workloads to fewer nodes
+2. Reduce replica count
+3. Review autoscaling min replicas
+4. Consider right-sizing GPU types
+
+---
+
+## P/D Disaggregation Alerts
+
+### LLMDPrefillDecodeImbalance
+
+**Summary**: Prefill workers significantly busier than decode workers
+
+**Resolution Steps**:
+1. Increase prefill replica count
+2. Adjust autoscaler to respond to prefill queue depth
+3. Review traffic patterns - high prompt-to-output ratio?
+
+---
+
+### LLMDPrefillQueueSaturation
+
+**Summary**: Prefill queue has >100 waiting requests
+
+**Resolution Steps**:
+1. Scale prefill workers immediately
+2. Enable prefix caching to reduce prefill time
+3. Consider request admission control
+
+---
+
+### LLMDDecodeKVCacheCritical
+
+**Summary**: Decode worker KV cache at >95% utilization
+
+**Impact**: Critical - OOM or request failures imminent
+
+**Resolution Steps**:
+1. Scale decode workers immediately
+2. Reduce max concurrent requests
+3. Consider emergency restart to clear cache
+
+---
+
+## SLO Alerts
+
+### LLMDAvailabilitySLOBurn
+
+**Summary**: Error budget burning faster than sustainable
+
+**Impact**: SLO violation likely if trend continues
+
+**Resolution Steps**:
+1. Review recent changes - was there a deployment?
+2. Identify root cause of errors
+3. Consider rollback if recent change caused degradation
+4. Increase capacity if load-related
+
+---
+
+### LLMDLatencySLOViolation
+
+**Summary**: P99 latency exceeding SLO target
+
+**Resolution Steps**:
+1. Scale out to reduce per-pod load
+2. Review optimization opportunities
+3. Consider traffic shaping for latency-sensitive requests
+
+---
+
+### LLMDTTFTSLO
+
+**Summary**: Time-to-first-token exceeding SLO target
+
+**Resolution Steps**:
+1. Scale prefill workers
+2. Optimize prefix caching
+3. Review P/D disaggregation configuration
+
+---
+
+## Infrastructure Alerts
+
+### LLMDPodRestartLoop
+
+**Summary**: Pod restarting frequently (>5 times/hour)
+
+**Diagnosis**:
+```bash
+# Check restart reason
+kubectl describe pod ${POD} -n ${NAMESPACE} | grep -A 5 "Last State"
+
+# Check for OOM
+kubectl logs ${POD} -c vllm -n ${NAMESPACE} --previous
+```
+
+**Resolution Steps**:
+1. Check logs for crash reason
+2. Review resource limits - OOM?
+3. Check liveness/readiness probe settings
+4. Review startup time vs. startup probe timeout
+
+---
+
+### LLMDMemoryPressure
+
+**Summary**: Container memory at >85% of limit
+
+**Resolution Steps**:
+1. Monitor trend - is it increasing?
+2. Increase memory limits if under-provisioned
+3. Reduce concurrent requests to lower memory pressure
+4. Review for memory leaks in long-running processes
+
+---
+
+### LLMDLowReplicaCount
+
+**Summary**: Fewer than 2 healthy replicas
+
+**Impact**: Reduced redundancy - single point of failure
+
+**Resolution Steps**:
+1. Scale up to minimum viable replica count
+2. Investigate why replicas are down
+3. Review autoscaling min replicas setting
+
+---
+
+### LLMDPodsPending
+
+**Summary**: Pods pending for >15 minutes
+
+**Diagnosis**:
+```bash
+# Check pending reason
+kubectl describe pod ${POD} -n ${NAMESPACE} | grep -A 10 Events
+
+# Check resource availability
+kubectl describe nodes | grep -A 10 "Allocated resources"
+```
+
+**Resolution Steps**:
+1. Check for GPU availability
+2. Review node affinity/tolerations
+3. Check resource quotas
+4. Consider adding cluster capacity
+
+---
+
+## Error Code Reference
+
+| Error Code | Description | Common Cause |
+|------------|-------------|--------------|
+| 500 | Internal Server Error | vLLM crash, OOM, model error |
+| 502 | Bad Gateway | Backend pod down, network issue |
+| 503 | Service Unavailable | No healthy backends, overloaded |
+| 504 | Gateway Timeout | Request timed out, slow backend |
+| 429 | Too Many Requests | Rate limited |
+
+---
+
+## Useful Commands
+
+```bash
+# Quick health check
+kubectl get pods -n ${NAMESPACE} -o wide
+kubectl get events -n ${NAMESPACE} --sort-by='.lastTimestamp' | tail -20
+
+# Check metrics endpoints
+kubectl port-forward ${VLLM_POD} 8200:8200 -n ${NAMESPACE} &
+curl -s http://localhost:8200/metrics | grep vllm
+
+# Check scheduler
+kubectl port-forward svc/gaie-*-epp 9090:9090 -n ${NAMESPACE} &
+curl -s http://localhost:9090/metrics | grep inference
+
+# Force pod restart
+kubectl delete pod ${POD} -n ${NAMESPACE}
+
+# Scale deployment
+kubectl scale deployment ${DEPLOYMENT} --replicas=3 -n ${NAMESPACE}
+```
+
+---
+
+## Escalation Contacts
+
+| Role | Contact | When to Escalate |
+|------|---------|------------------|
+| On-Call Engineer | PagerDuty | Critical alerts |
+| Platform Team Lead | Slack #llm-d-oncall | Persistent issues >30 min |
+| SRE Manager | Phone | Total outage >1 hour |
+
+---
+
+## Related Documentation
+
+- [Troubleshooting Guide](../troubleshooting.md)
+- [Prometheus PromQL Queries](./example-promQL-queries.md)
+- [Monitoring Setup](./README.md)
+- [llm-d Guides](../../guides/README.md)

--- a/docs/monitoring/prometheus-alerting-rules.yaml
+++ b/docs/monitoring/prometheus-alerting-rules.yaml
@@ -1,0 +1,434 @@
+# llm-d Prometheus Alerting Rules
+# Production-ready alerting rules for SLO enforcement in llm-d deployments
+#
+# Installation:
+#   kubectl apply -f prometheus-alerting-rules.yaml -n llm-d-monitoring
+#
+# Or include in your Prometheus Operator configuration
+#
+# These rules align with the PromQL queries in example-promQL-queries.md
+# and provide production-grade alerting for LLM inference workloads.
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: llm-d-alerting-rules
+  namespace: llm-d-monitoring
+  labels:
+    app: llm-d
+    prometheus: llm-d
+    release: llmd
+spec:
+  groups:
+    # =========================================================================
+    # TIER 1: CRITICAL - Immediate Action Required
+    # These alerts indicate service degradation affecting users
+    # =========================================================================
+    - name: llm-d-critical
+      interval: 30s
+      rules:
+        # High Error Rate - Platform Wide
+        - alert: LLMDHighErrorRate
+          expr: |
+            (
+              sum(rate(inference_model_request_error_total[5m]))
+              /
+              sum(rate(inference_model_request_total[5m]))
+            ) > 0.05
+          for: 2m
+          labels:
+            severity: critical
+            team: inference-platform
+          annotations:
+            summary: "High inference error rate detected"
+            description: |
+              Platform-wide error rate is {{ $value | humanizePercentage }}, exceeding 5% threshold.
+              This indicates widespread service degradation affecting user requests.
+            runbook_url: "https://github.com/llm-d/llm-d/blob/main/docs/monitoring/alerting-runbook.md#llmdhigherrorrate"
+
+        # High Error Rate - Per Model
+        - alert: LLMDModelHighErrorRate
+          expr: |
+            (
+              sum by(model_name) (rate(inference_model_request_error_total[5m]))
+              /
+              sum by(model_name) (rate(inference_model_request_total[5m]))
+            ) > 0.10
+          for: 5m
+          labels:
+            severity: critical
+            team: inference-platform
+          annotations:
+            summary: "High error rate for model {{ $labels.model_name }}"
+            description: |
+              Model {{ $labels.model_name }} has error rate of {{ $value | humanizePercentage }}.
+              Investigate model-specific issues or backend pod health.
+            runbook_url: "https://github.com/llm-d/llm-d/blob/main/docs/monitoring/alerting-runbook.md#llmdmodelhigherrorrate"
+
+        # Scheduler Down
+        - alert: LLMDSchedulerDown
+          expr: |
+            avg_over_time(up{job=~".*epp.*"}[5m]) < 0.5
+          for: 2m
+          labels:
+            severity: critical
+            team: inference-platform
+          annotations:
+            summary: "Inference scheduler (EPP) is down"
+            description: |
+              The Endpoint Picker (EPP) scheduler has been unavailable for >2 minutes.
+              All inference requests will fail without a functioning scheduler.
+            runbook_url: "https://github.com/llm-d/llm-d/blob/main/docs/monitoring/alerting-runbook.md#llmdschedulerdown"
+
+        # No Healthy Backends
+        - alert: LLMDNoHealthyBackends
+          expr: |
+            sum(up{job=~".*vllm.*"}) == 0
+          for: 1m
+          labels:
+            severity: critical
+            team: inference-platform
+          annotations:
+            summary: "No healthy vLLM backends available"
+            description: |
+              All vLLM backend pods are down. Inference requests cannot be served.
+              Immediate investigation required.
+            runbook_url: "https://github.com/llm-d/llm-d/blob/main/docs/monitoring/alerting-runbook.md#llmdnohealthybackends"
+
+        # Extreme Latency - P99 TTFT
+        - alert: LLMDExtremeTTFT
+          expr: |
+            histogram_quantile(0.99, sum by(le, model_name) (rate(vllm:time_to_first_token_seconds_bucket[5m]))) > 30
+          for: 5m
+          labels:
+            severity: critical
+            team: inference-platform
+          annotations:
+            summary: "Extreme time-to-first-token latency for {{ $labels.model_name }}"
+            description: |
+              P99 TTFT is {{ $value | humanizeDuration }} for model {{ $labels.model_name }}.
+              Users are experiencing unacceptable wait times before receiving responses.
+            runbook_url: "https://github.com/llm-d/llm-d/blob/main/docs/monitoring/alerting-runbook.md#llmdextremettft"
+
+    # =========================================================================
+    # TIER 2: WARNING - Investigation Required
+    # These alerts indicate potential issues requiring attention
+    # =========================================================================
+    - name: llm-d-warning
+      interval: 60s
+      rules:
+        # Elevated Error Rate
+        - alert: LLMDElevatedErrorRate
+          expr: |
+            (
+              sum(rate(inference_model_request_error_total[5m]))
+              /
+              sum(rate(inference_model_request_total[5m]))
+            ) > 0.01
+          for: 10m
+          labels:
+            severity: warning
+            team: inference-platform
+          annotations:
+            summary: "Elevated inference error rate"
+            description: |
+              Platform error rate is {{ $value | humanizePercentage }}, above 1% threshold.
+              Investigate before this escalates to critical levels.
+            runbook_url: "https://github.com/llm-d/llm-d/blob/main/docs/monitoring/alerting-runbook.md#llmdelevatederrorrate"
+
+        # High Latency - P99
+        - alert: LLMDHighLatencyP99
+          expr: |
+            histogram_quantile(0.99, sum by(le) (rate(inference_model_request_duration_seconds_bucket[5m]))) > 10
+          for: 10m
+          labels:
+            severity: warning
+            team: inference-platform
+          annotations:
+            summary: "High P99 request latency"
+            description: |
+              P99 request latency is {{ $value | humanizeDuration }}, exceeding 10s threshold.
+              This may indicate backend saturation or inefficient routing.
+            runbook_url: "https://github.com/llm-d/llm-d/blob/main/docs/monitoring/alerting-runbook.md#llmdhighlatencyp99"
+
+        # High TTFT
+        - alert: LLMDHighTTFT
+          expr: |
+            histogram_quantile(0.99, sum by(le, model_name) (rate(vllm:time_to_first_token_seconds_bucket[5m]))) > 10
+          for: 10m
+          labels:
+            severity: warning
+            team: inference-platform
+          annotations:
+            summary: "High time-to-first-token for {{ $labels.model_name }}"
+            description: |
+              P99 TTFT is {{ $value | humanizeDuration }} for model {{ $labels.model_name }}.
+              Consider scaling prefill workers or enabling prefix caching.
+            runbook_url: "https://github.com/llm-d/llm-d/blob/main/docs/monitoring/alerting-runbook.md#llmdhighttft"
+
+        # High Request Preemptions
+        - alert: LLMDHighPreemptions
+          expr: |
+            sum by(pod) (rate(vllm:num_preemptions[5m])) > 1
+          for: 5m
+          labels:
+            severity: warning
+            team: inference-platform
+          annotations:
+            summary: "High request preemptions on {{ $labels.pod }}"
+            description: |
+              Pod {{ $labels.pod }} has {{ $value | humanize }} preemptions/sec.
+              This indicates memory pressure and may cause request failures.
+            runbook_url: "https://github.com/llm-d/llm-d/blob/main/docs/monitoring/alerting-runbook.md#llmdhighpreemptions"
+
+        # KV Cache Saturation
+        - alert: LLMDKVCacheSaturation
+          expr: |
+            avg by(pod, model_name) (vllm:kv_cache_usage_perc) > 0.90
+          for: 10m
+          labels:
+            severity: warning
+            team: inference-platform
+          annotations:
+            summary: "KV cache near saturation on {{ $labels.pod }}"
+            description: |
+              KV cache utilization is {{ $value | humanizePercentage }} on pod {{ $labels.pod }}.
+              High utilization leads to preemptions and degraded throughput.
+            runbook_url: "https://github.com/llm-d/llm-d/blob/main/docs/monitoring/alerting-runbook.md#llmdkvcachesaturation"
+
+        # Request Queue Buildup
+        - alert: LLMDRequestQueueBuildup
+          expr: |
+            sum by(pod, model_name) (vllm:num_requests_waiting) > 50
+          for: 5m
+          labels:
+            severity: warning
+            team: inference-platform
+          annotations:
+            summary: "Request queue building up on {{ $labels.pod }}"
+            description: |
+              {{ $value | humanize }} requests waiting in queue on pod {{ $labels.pod }}.
+              Consider scaling decode replicas or optimizing batch size.
+            runbook_url: "https://github.com/llm-d/llm-d/blob/main/docs/monitoring/alerting-runbook.md#llmdrequestqueuebuildup"
+
+        # Low Prefix Cache Hit Rate
+        - alert: LLMDLowPrefixCacheHitRate
+          expr: |
+            (
+              sum(rate(vllm:prefix_cache_hits_total[5m]))
+              /
+              sum(rate(vllm:prefix_cache_queries_total[5m]))
+            ) < 0.30
+          for: 15m
+          labels:
+            severity: warning
+            team: inference-platform
+          annotations:
+            summary: "Low prefix cache hit rate"
+            description: |
+              Prefix cache hit rate is {{ $value | humanizePercentage }}, below 30% threshold.
+              Review cache sizing or consider tiered prefix caching.
+            runbook_url: "https://github.com/llm-d/llm-d/blob/main/docs/monitoring/alerting-runbook.md#llmdlowprefixcachehitrate"
+
+        # GPU Underutilization
+        - alert: LLMDGPUUnderutilization
+          expr: |
+            avg by(node) (DCGM_FI_DEV_GPU_UTIL or nvidia_gpu_duty_cycle) < 30
+          for: 30m
+          labels:
+            severity: warning
+            team: inference-platform
+          annotations:
+            summary: "GPU underutilization on node {{ $labels.node }}"
+            description: |
+              Average GPU utilization is {{ $value | humanize }}% on node {{ $labels.node }}.
+              Consider consolidating workloads or reducing replica count.
+            runbook_url: "https://github.com/llm-d/llm-d/blob/main/docs/monitoring/alerting-runbook.md#llmdgpuunderutilization"
+
+    # =========================================================================
+    # TIER 3: PREFILL/DECODE DISAGGREGATION
+    # Alerts specific to P/D disaggregated deployments
+    # =========================================================================
+    - name: llm-d-pd-disaggregation
+      interval: 60s
+      rules:
+        # Prefill/Decode Imbalance
+        - alert: LLMDPrefillDecodeImbalance
+          expr: |
+            (
+              avg(vllm:num_requests_running{pod=~".*prefill.*"})
+              /
+              avg(vllm:num_requests_running{pod=~".*decode.*"})
+            ) > 3
+          for: 10m
+          labels:
+            severity: warning
+            team: inference-platform
+          annotations:
+            summary: "Prefill/Decode workload imbalance detected"
+            description: |
+              Prefill workers are {{ $value | humanize }}x busier than decode workers.
+              Consider rebalancing replica counts or adjusting autoscaling policies.
+            runbook_url: "https://github.com/llm-d/llm-d/blob/main/docs/monitoring/alerting-runbook.md#llmdprefilldecodeimbalance"
+
+        # Prefill Queue Saturation
+        - alert: LLMDPrefillQueueSaturation
+          expr: |
+            sum by(pod) (vllm:num_requests_waiting{pod=~".*prefill.*"}) > 100
+          for: 5m
+          labels:
+            severity: warning
+            team: inference-platform
+          annotations:
+            summary: "Prefill queue saturated on {{ $labels.pod }}"
+            description: |
+              {{ $value | humanize }} requests waiting in prefill queue on {{ $labels.pod }}.
+              Scale prefill replicas to reduce TTFT.
+            runbook_url: "https://github.com/llm-d/llm-d/blob/main/docs/monitoring/alerting-runbook.md#llmdprefillqueuesaturation"
+
+        # Decode KV Cache Critical
+        - alert: LLMDDecodeKVCacheCritical
+          expr: |
+            avg by(pod) (vllm:kv_cache_usage_perc{pod=~".*decode.*"}) > 0.95
+          for: 5m
+          labels:
+            severity: critical
+            team: inference-platform
+          annotations:
+            summary: "Decode worker KV cache critical on {{ $labels.pod }}"
+            description: |
+              KV cache utilization is {{ $value | humanizePercentage }} on decode pod {{ $labels.pod }}.
+              Imminent OOM or request failures expected.
+            runbook_url: "https://github.com/llm-d/llm-d/blob/main/docs/monitoring/alerting-runbook.md#llmddecodekvCachecritical"
+
+    # =========================================================================
+    # TIER 4: SLO TRACKING
+    # Error budget and SLO compliance alerts
+    # =========================================================================
+    - name: llm-d-slo
+      interval: 60s
+      rules:
+        # Availability SLO Burn Rate (Multi-Window)
+        - alert: LLMDAvailabilitySLOBurn
+          expr: |
+            (
+              # 1h burn rate
+              (1 - (sum(rate(inference_model_request_error_total[1h])) / sum(rate(inference_model_request_total[1h])))) < 0.999
+              and
+              # 5m burn rate (confirms trend)
+              (1 - (sum(rate(inference_model_request_error_total[5m])) / sum(rate(inference_model_request_total[5m])))) < 0.999
+            )
+          for: 5m
+          labels:
+            severity: critical
+            team: inference-platform
+            slo: availability
+          annotations:
+            summary: "Availability SLO burn rate critical"
+            description: |
+              Availability is below 99.9% SLO target over multiple time windows.
+              Error budget is being consumed at an unsustainable rate.
+            runbook_url: "https://github.com/llm-d/llm-d/blob/main/docs/monitoring/alerting-runbook.md#llmdavailabilitysloburn"
+
+        # Latency SLO - P99 Response Time
+        - alert: LLMDLatencySLOViolation
+          expr: |
+            histogram_quantile(0.99, sum by(le) (rate(inference_model_request_duration_seconds_bucket[1h]))) > 5
+          for: 15m
+          labels:
+            severity: warning
+            team: inference-platform
+            slo: latency
+          annotations:
+            summary: "Latency SLO violation detected"
+            description: |
+              P99 latency over 1h is {{ $value | humanizeDuration }}, exceeding 5s SLO target.
+              Review capacity and optimization opportunities.
+            runbook_url: "https://github.com/llm-d/llm-d/blob/main/docs/monitoring/alerting-runbook.md#llmdlatencysloviolation"
+
+        # TTFT SLO - Time to First Token
+        - alert: LLMDTTFTSLO
+          expr: |
+            histogram_quantile(0.95, sum by(le) (rate(vllm:time_to_first_token_seconds_bucket[1h]))) > 3
+          for: 15m
+          labels:
+            severity: warning
+            team: inference-platform
+            slo: ttft
+          annotations:
+            summary: "TTFT SLO violation"
+            description: |
+              P95 TTFT over 1h is {{ $value | humanizeDuration }}, exceeding 3s SLO target.
+              Consider adding prefill capacity or optimizing prefix caching.
+            runbook_url: "https://github.com/llm-d/llm-d/blob/main/docs/monitoring/alerting-runbook.md#llmdttftslo"
+
+    # =========================================================================
+    # TIER 5: INFRASTRUCTURE & CAPACITY
+    # Resource and capacity planning alerts
+    # =========================================================================
+    - name: llm-d-infrastructure
+      interval: 120s
+      rules:
+        # Pod Restart Loop
+        - alert: LLMDPodRestartLoop
+          expr: |
+            increase(kube_pod_container_status_restarts_total{container=~"vllm|epp|routing-proxy"}[1h]) > 5
+          for: 5m
+          labels:
+            severity: warning
+            team: inference-platform
+          annotations:
+            summary: "Pod {{ $labels.pod }} restarting frequently"
+            description: |
+              Container {{ $labels.container }} in pod {{ $labels.pod }} has restarted
+              {{ $value | humanize }} times in the last hour. Investigate crash loops.
+            runbook_url: "https://github.com/llm-d/llm-d/blob/main/docs/monitoring/alerting-runbook.md#llmdpodrestartloop"
+
+        # Approaching Resource Limits
+        - alert: LLMDMemoryPressure
+          expr: |
+            (
+              container_memory_working_set_bytes{container="vllm"}
+              /
+              container_spec_memory_limit_bytes{container="vllm"}
+            ) > 0.85
+          for: 10m
+          labels:
+            severity: warning
+            team: inference-platform
+          annotations:
+            summary: "Memory pressure on {{ $labels.pod }}"
+            description: |
+              Container memory is at {{ $value | humanizePercentage }} of limit on {{ $labels.pod }}.
+              Risk of OOM kill if memory usage continues to grow.
+            runbook_url: "https://github.com/llm-d/llm-d/blob/main/docs/monitoring/alerting-runbook.md#llmdmemorypressure"
+
+        # Low Replica Count
+        - alert: LLMDLowReplicaCount
+          expr: |
+            count(up{job=~".*vllm.*"} == 1) < 2
+          for: 5m
+          labels:
+            severity: warning
+            team: inference-platform
+          annotations:
+            summary: "Low vLLM replica count"
+            description: |
+              Only {{ $value | humanize }} vLLM replicas are healthy.
+              Reduced redundancy increases risk of service disruption.
+            runbook_url: "https://github.com/llm-d/llm-d/blob/main/docs/monitoring/alerting-runbook.md#llmdlowreplicacount"
+
+        # Pending Pods
+        - alert: LLMDPodsPending
+          expr: |
+            sum(kube_pod_status_phase{phase="Pending", namespace=~".*llm.*"}) > 0
+          for: 15m
+          labels:
+            severity: warning
+            team: inference-platform
+          annotations:
+            summary: "Pods pending in llm-d namespace"
+            description: |
+              {{ $value | humanize }} pods have been pending for >15 minutes.
+              Check for resource constraints or scheduling issues.
+            runbook_url: "https://github.com/llm-d/llm-d/blob/main/docs/monitoring/alerting-runbook.md#llmdpodspending"


### PR DESCRIPTION
## Summary
- Add production-ready Prometheus alerting rules (PrometheusRule CRD) for SLO enforcement
- Add comprehensive alerting runbook with response procedures for each alert
- Addresses gap in monitoring stack: PromQL queries exist but no alerting rules for production

## Motivation
Production llm-d deployments need proactive alerting for SLO enforcement. The existing monitoring documentation provides excellent PromQL queries and dashboards, but lacks actionable alerting rules that ops teams can deploy immediately.

## Changes

### Prometheus Alerting Rules (`prometheus-alerting-rules.yaml`)
Organized into 5 tiers:
| Tier | Focus | Severity |
|------|-------|----------|
| Critical | Immediate failures, service outages | Page on-call |
| Warning | Degradation, capacity concerns | Investigate same day |
| P/D Disaggregation | Prefill/decode specific issues | Context-dependent |
| SLO Tracking | Error budget burn, SLO violations | Business-hours |
| Infrastructure | Pod health, resource pressure | Preventive |

Key alerts include:
- `LLMDHighErrorRate` - Platform-wide error rate >5%
- `LLMDSchedulerDown` - EPP unavailable
- `LLMDNoHealthyBackends` - All vLLM pods down
- `LLMDExtremeTTFT` - P99 TTFT >30s
- `LLMDKVCacheSaturation` - KV cache >90%
- `LLMDAvailabilitySLOBurn` - Error budget burn rate
- Plus 15+ more alerts for comprehensive coverage

### Alerting Runbook (`alerting-runbook.md`)
- Response procedures for each alert
- Diagnosis commands with kubectl examples
- Common causes and resolution steps
- Escalation guidance
- Error code reference
- Useful commands quick reference

## Test plan
- [ ] Review alerting rule PromQL expressions match existing `example-promQL-queries.md`
- [ ] Validate PrometheusRule CRD syntax with `kubectl apply --dry-run=client`
- [ ] Test alert firing thresholds are appropriate for production workloads
- [ ] Verify runbook procedures are actionable and accurate

## Related
- Extends monitoring documentation in `docs/monitoring/`
- Uses metrics defined in `example-promQL-queries.md`
- Aligns with SIG-Observability scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)