### PR TITLE
docs: add link to KServe llm-d integration

### DIFF
--- a/docs/proposals/llm-d.md
+++ b/docs/proposals/llm-d.md
@@ -162,7 +162,7 @@ Unlike production-stack, llm-d:
 
 ### Use KServe
 
-KServe offers a comprehensive platform for teams running large numbers of traditional and generative models on Kubernetes. Consider KServe when you have high numbers of model deployments or if you have many teams that need distinct deployments of models. llm-d intends to expose [large model optimizations into KServe](https://docs.google.com/document/d/11ZQJ2VhTc42S9K4yau2dMs3Q3f4jqWJL_7Sq14C3hzY/edit?usp=sharing).
+KServe offers a comprehensive platform for teams running large numbers of traditional and generative models on Kubernetes. Consider KServe when you have high numbers of model deployments or if you have many teams that need distinct deployments of models. llm-d exposes [large model optimizations into KServe's new CRD `LLMInferenceService`](https://kserve.github.io/website/docs/model-serving/generative-inference/llmisvc/llmisvc-overview).
 
 Unlike KServe, llm-d:
 * Is focused on reducing the operational friction for serving single workloads and enabling large-model-as-a-service offerings with core capabilities rather than offering an integrated and broad platform

--- a/docs/proposals/modelservice.md
+++ b/docs/proposals/modelservice.md
@@ -68,7 +68,7 @@ Manual composition via raw Kubernetes resources:  One possible approach is for p
 
 ## Alternative: Extending KServe
 
-KServe provides a general-purpose model serving abstraction but was originally designed for traditional predictive models; it now provides several LLM specific features as of release 0.15 (see [this blogpost](https://kserve.github.io/website/blog/kserve-0.15-release) for details). As we evolve the ModelService Helm chart, we also plan to collaborate with the KServe community to develop production-grade KServe mechanisms that integrate well with llm-d. This collaboration will support a variety of useful features, including prefill/decode disaggregation, dynamic LoRA loading, and configuration search and tuning.
+KServe provides a general-purpose model serving abstraction but was originally designed for traditional predictive models; it now provides several LLM specific features as of release 0.15 (see [this blogpost](https://kserve.github.io/website/blog/kserve-0.15-release) for details). We also collaborated with the KServe community and added [the integration of llm-d in KServe via a new CRD `LLMInferenceService`](https://kserve.github.io/website/docs/model-serving/generative-inference/llmisvc/llmisvc-overview), which supports a variety of useful features, including prefill/decode disaggregation, dynamic LoRA loading, and configuration search and tuning.
 
 ## Acknowledgements
 


### PR DESCRIPTION
The integration has been added in KServe and this PR updates the link to the instructions.