### PR TITLE
fix: helm diff plugin install

### DIFF
--- a/guides/prereq/client-setup/install-deps.sh
+++ b/guides/prereq/client-setup/install-deps.sh
@@ -166,7 +166,7 @@ fi
 ########################################
 if ! helm plugin list | grep -q diff; then
   echo "📦 helm-diff plugin not found. Installing ${HELMDIFF_VERSION}..."
-  helm plugin install --version "${HELMDIFF_VERSION}" https://github.com/databus23/helm-diff
+  helm plugin install --version "${HELMDIFF_VERSION}" --verify=false https://github.com/databus23/helm-diff
 fi
 
 ########################################


### PR DESCRIPTION
With helm 4.0.4 install-deps.sh fails on installation of helm-diff with:
plugin source does not support verification. Use --verify=false to skip verification

Thus, adding --verify=false to the script.