### PR TITLE
Fix missing environment variable documentation in build scripts

### DIFF
--- a/docker/scripts/cuda/builder/build-lmcache.sh
+++ b/docker/scripts/cuda/builder/build-lmcache.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -Eeu
 
-# builds and installs gdrcopy from source
+# builds and installs LMCache and Infinistore from source
 #
 # Required environment variables:
 # - USE_SCCACHE: whether to use sccache (true/false)
+# - VIRTUAL_ENV: path to Python virtual environment
 # - INFINISTORE_REPO: git repo to build Infinistore from
 # - INFINISTORE_VERSION: git ref to build Infinistore from
 # - LMCACHE_REPO: git repo to build LMCache from

--- a/docker/scripts/cuda/builder/build-nvshmem.sh
+++ b/docker/scripts/cuda/builder/build-nvshmem.sh
@@ -16,6 +16,7 @@ set -Eeux
 # - UCX_PREFIX: Path to UCX installation
 # - VIRTUAL_ENV: Path to the virtual environment from which python will be pulled
 # - USE_SCCACHE: whether to use sccache (true/false)
+# - PYTHON_VERSION: Python version (e.g., 3.12)
 
 cd /tmp
 

--- a/docker/scripts/cuda/builder/build-ucx.sh
+++ b/docker/scripts/cuda/builder/build-ucx.sh
@@ -13,6 +13,7 @@ set -Eeu
 # - UCX_VERSION: git ref to build UCX from
 # - UCX_PREFIX: prefix dir that contains installation path
 # - USE_SCCACHE: whether to use sccache (true/false)
+# - TARGETOS: OS type (ubuntu or rhel)
 
 cd /tmp
 


### PR DESCRIPTION
## Summary

Fixes documentation gaps in three Docker build scripts where environment variables
are used but not documented in the "Required environment variables" header section.

## Changes

### `docker/scripts/cuda/builder/build-ucx.sh`
- Added `TARGETOS` to required env vars (used on line 30 for EFA flag conditional)

### `docker/scripts/cuda/builder/build-nvshmem.sh`  
- Added `PYTHON_VERSION` to required env vars (used on line 82 for wheel filename)

### `docker/scripts/cuda/builder/build-lmcache.sh`
- Added `VIRTUAL_ENV` to required env vars (used on line 19 for venv activation)
- Fixed incorrect script description: was "builds and installs gdrcopy" but script actually builds LMCache and Infinistore

## Why This Matters

The `lint-dockerfile-envvars.py` linter validates that scripts document their required
environment variables. These fixes ensure consistency between what scripts use and
what they document, making it easier for contributors to understand build requirements.

## Test Plan

- [x] Changes are documentation-only (no code changes)
- [x] Each added variable matches actual usage in the script