### PR TITLE
chore(github): uplift github action versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Contact Details
       description: How can we get in touch with you if we need more info?
-      placeholder: ex. email@ibm.com
+      placeholder: ex. email@company.com
     validations:
       required: false
   - type: textarea
@@ -36,7 +36,7 @@ body:
         - v0.3.0
         - v0.3.1
         - v0.4.0
-      default: v0.3.0
+      default: v0.4.0
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/assign-on-team-label.yaml
+++ b/.github/workflows/assign-on-team-label.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign based on label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8.0.0
         with:
           script: |
             const label = context.payload.label.name;

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
 
       - name: Install shellcheck
         run: |
@@ -61,14 +61,14 @@ jobs:
       - name: Install hadolint
         run: |
           wget -O /usr/local/bin/hadolint \
-            https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64
+            https://github.com/hadolint/hadolint/releases/download/v2.14.0/hadolint-Linux-x86_64
           chmod +x /usr/local/bin/hadolint
         shell: bash
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.1.0
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - name: Run pre-commit
         uses: j178/prek-action@v1
@@ -82,7 +82,7 @@ jobs:
       xpu: ${{ steps.filter.outputs.xpu || steps.dispatch.outputs.xpu }}
       cpu: ${{ steps.filter.outputs.cpu || steps.dispatch.outputs.cpu }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.1
       - uses: dorny/paths-filter@v3
         if: github.event_name != 'workflow_dispatch'
         id: filter
@@ -150,13 +150,13 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.12.0
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.GHCR_USER }}
@@ -164,7 +164,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}-cuda-dev${{ matrix.image_suffix }}
           tags: |
@@ -180,7 +180,7 @@ jobs:
 
       - name: Build the builder image layer
         id: build-image-build-layer
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6.18.0
         with:
           context: .
           file: ./docker/Dockerfile.cuda
@@ -210,7 +210,7 @@ jobs:
 
       - name: Build the final image layer
         id: build-image-final-layer
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6.18.0
         with:
           context: .
           file: ./docker/Dockerfile.cuda
@@ -302,7 +302,7 @@ jobs:
           ls -la /tmp/digests/ubuntu/ || echo "No Ubuntu digests"
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
 
       - name: Export Git Sha
         id: export-sha
@@ -382,11 +382,11 @@ jobs:
 
       - name: Set up Docker Buildx
         if: ${{ steps.should-run.outputs.os_succeeded == 'true' }}
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.12.0
 
       - name: Log in to Container Registry
         if: ${{ steps.should-run.outputs.os_succeeded == 'true' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.GHCR_USER }}
@@ -395,7 +395,7 @@ jobs:
       - name: Extract metadata
         if: ${{ steps.should-run.outputs.os_succeeded == 'true' }}
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}-cuda-dev${{ matrix.image_suffix }}
           tags: |
@@ -434,7 +434,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         if: ${{ steps.should-run.outputs.os_succeeded == 'true' }}
         continue-on-error: true
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.33.1
         with:
           image-ref: >-
             ${{ env.REGISTRY }}/${{ github.repository }}-cuda-dev${{ matrix.image_suffix }}@${{
@@ -452,7 +452,7 @@ jobs:
       - name: Upload Trivy scan results to GitHub Security tab
         if: ${{ steps.should-run.outputs.os_succeeded == 'true' }}
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'
 
@@ -475,11 +475,11 @@ jobs:
     steps:
       - name: Checkout push ref
         if: github.event_name == 'push'
-        uses: Actions/checkout@v4
+        uses: actions/checkout@v6.0.1
 
       - name: Checkout PR branch
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -487,7 +487,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.GHCR_USER }}
@@ -530,7 +530,7 @@ jobs:
           BUILDKIT_PROGRESS: "plain"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.33.1
         with:
           image-ref: ${{ env.REGISTRY }}/${{ github.repository }}-xpu-dev:${{ steps.set-tag.outputs.tag }}
           format: 'sarif'
@@ -545,7 +545,7 @@ jobs:
 
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'
 
@@ -565,11 +565,11 @@ jobs:
     steps:
       - name: Checkout push ref
         if: github.event_name == 'push'
-        uses: Actions/checkout@v4
+        uses: actions/checkout@v6.0.1
 
       - name: Checkout PR branch
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -577,7 +577,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.GHCR_USER }}
@@ -620,7 +620,7 @@ jobs:
           BUILDKIT_PROGRESS: "plain"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.33.1
         with:
           image-ref: ${{ env.REGISTRY }}/${{ github.repository }}-cpu-dev:${{ steps.set-tag.outputs.tag }}
           format: 'sarif'
@@ -634,7 +634,7 @@ jobs:
           TRIVY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'
 

--- a/.github/workflows/build-vllm-wheel-on-dispatch.yaml
+++ b/.github/workflows/build-vllm-wheel-on-dispatch.yaml
@@ -50,13 +50,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v6.0.1
         with:
           path: main
 
       - name: Checkout terraform module
         id: checkout-module
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v6.0.1
         with:
           repository: containers/terraform-test-environment-module
           path: terraform-test-environment-module

--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
 
       - name: Install shellcheck
         run: |
@@ -20,14 +20,14 @@ jobs:
       - name: Install hadolint
         run: |
           wget -O /usr/local/bin/hadolint \
-            https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64
+            https://github.com/hadolint/hadolint/releases/download/v2.14.0/hadolint-Linux-x86_64
           chmod +x /usr/local/bin/hadolint
         shell: bash
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.1.0
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - name: Run pre-commit
         uses: j178/prek-action@v1
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
 
       - name: warning about ignored paths
         run: |

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -46,16 +46,16 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
         with:
           ref: ${{ env.TAG }}
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.12.0
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.GHCR_USER }}
@@ -63,7 +63,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}-cuda${{ matrix.image_suffix }}
           tags: |
@@ -73,7 +73,7 @@ jobs:
 
       - name: Build & Push
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6.18.0
         with:
           context: .
           file: ./docker/Dockerfile.cuda
@@ -149,10 +149,10 @@ jobs:
             printf '${{ env.REGISTRY }}/${{ github.repository }}-cuda${{ matrix.image_suffix }}@sha256:%s ' *
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.12.0
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.GHCR_USER }}
@@ -160,7 +160,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}-cuda${{ matrix.image_suffix }}
           tags: |
@@ -193,7 +193,7 @@ jobs:
           echo "digest=${MANIFEST_DIGEST}" >> $GITHUB_OUTPUT
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.33.1
         with:
           image-ref: >-
             ${{ env.REGISTRY }}/${{ github.repository }}-cuda${{ matrix.image_suffix }}@${{
@@ -209,7 +209,7 @@ jobs:
           TRIVY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'
 
@@ -226,18 +226,18 @@ jobs:
     runs-on: vllm-runner
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
         with:
           # fetch tags for docker/metadata semver handling (if you use git describe etc.)
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.12.0
         with:
           buildkitd-flags: --oci-worker-gc
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.GHCR_USER }}
@@ -263,7 +263,7 @@ jobs:
           BUILDKIT_PROGRESS: "plain"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.33.1
         with:
           image-ref: ${{ env.REGISTRY }}/${{ github.repository }}-cpu:${{ env.TAG }}
           format: 'sarif'
@@ -277,7 +277,7 @@ jobs:
           TRIVY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'
 
@@ -296,18 +296,18 @@ jobs:
     runs-on: vllm-runner
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
         with:
           # fetch tags for docker/metadata semver handling (if you use git describe etc.)
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.12.0
         with:
           buildkitd-flags: --oci-worker-gc
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.GHCR_USER }}
@@ -333,7 +333,7 @@ jobs:
           BUILDKIT_PROGRESS: "plain"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.33.1
         with:
           image-ref: ${{ env.REGISTRY }}/${{ github.repository }}-xpu:${{ env.TAG }}
           format: 'sarif'
@@ -347,7 +347,7 @@ jobs:
           TRIVY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'
 

--- a/.github/workflows/e2e-accelerator-test.yaml
+++ b/.github/workflows/e2e-accelerator-test.yaml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
         with:
           persist-credentials: false
 
@@ -355,7 +355,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/e2e-inference-scheduling-gke.yaml
+++ b/.github/workflows/e2e-inference-scheduling-gke.yaml
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/e2e-inference-scheduling-xpu.yaml
+++ b/.github/workflows/e2e-inference-scheduling-xpu.yaml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/e2e-pd-disaggregation-accelerator-test.yaml
+++ b/.github/workflows/e2e-pd-disaggregation-accelerator-test.yaml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
         with:
           persist-credentials: false
 
@@ -389,7 +389,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/e2e-pd-disaggregation-gke.yaml
+++ b/.github/workflows/e2e-pd-disaggregation-gke.yaml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/e2e-pd-xpu.yaml
+++ b/.github/workflows/e2e-pd-xpu.yaml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/e2e-simulated-accelerators-test.yaml
+++ b/.github/workflows/e2e-simulated-accelerators-test.yaml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
         with:
           persist-credentials: false
 
@@ -93,7 +93,7 @@ jobs:
           EOF
 
       - name: Create kind cluster
-        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3  # v1.12.0
+        uses: helm/kind-action@v1.13.0
         with:
           config: helpers/kind-testing/kind-config.yaml
           cluster_name: llm-d-test

--- a/.github/workflows/e2e-wide-ep-accelerator-gke.yaml
+++ b/.github/workflows/e2e-wide-ep-accelerator-gke.yaml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/e2e-wide-ep-accelerator-test.yaml
+++ b/.github/workflows/e2e-wide-ep-accelerator-test.yaml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
         with:
           persist-credentials: false
 
@@ -355,7 +355,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/re-run-action.yml
+++ b/.github/workflows/re-run-action.yml
@@ -8,9 +8,10 @@ jobs:
   rerun_pr_tests:
     name: rerun_pr_tests
     if: ${{ github.event.issue.pull_request }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: estroz/rerun-actions@main
+      - name: Re-run PR tests
+        uses: estroz/rerun-actions@v0.3.0  # current latest commit on main has no function change since 0.3.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           comment_id: ${{ github.event.comment.id }}

--- a/.github/workflows/update_semver.yml
+++ b/.github/workflows/update_semver.yml
@@ -17,7 +17,7 @@ jobs:
   update-semver:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: haya14busa/action-update-semver@v1.3.0
+      - uses: actions/checkout@v6.0.1
+      - uses: haya14busa/action-update-semver@v1.5.1
         with:
           major_version_tag_only: false  # (optional, default is "false")


### PR DESCRIPTION
- Migrate runners from ubuntu-latest ( 20 EOL 2025-04-15)
- Pin actions/checkout from v4 to v6.0.1
- Pin docker actions (setup-buildx, login, metadata, build-push) to the current latest versions
- Pin Python setup from v5 to v6.1.0 with explicit version 3.12 as supported one
- Pin security tools (trivy-action from @master to v0.33.1, codeql-action to v4)
- Update hadolint from v2.12.0 to v2.14.0
- Update action-update-semver from v1.3.0 to v1.5.1
- Update kind-action to v1.13.0
- Update github-script from v7 to v8.0.0
- Update bug template default version to the latest released v0.4.0