### PR TITLE
fix: Remove redundant GPU and tensor-parallel-size settings

### DIFF
--- a/guides/pd-disaggregation/ms-pd/values.yaml
+++ b/guides/pd-disaggregation/ms-pd/values.yaml
@@ -30,9 +30,8 @@ decode:
     image: ghcr.io/llm-d/llm-d-cuda:v0.3.1
     modelCommand: vllmServe
     args:
-      # Keep tensor-parallelism as the first set of arguments
-      - "--tensor-parallel-size"
-      - "4"
+      # Note: --tensor-parallel-size is auto-generated from parallelism.tensor
+      # Do NOT set it here manually to avoid mismatch with GPU resources
       - "--block-size"
       - "128"
       - "--kv-transfer-config"
@@ -52,15 +51,15 @@ decode:
         name: metrics
         protocol: TCP
     resources:
+      # Note: nvidia.com/gpu is auto-generated from parallelism.tensor
+      # Do NOT set it here manually to avoid mismatch
       limits:
         memory: 64Gi
         cpu: "16"
-        nvidia.com/gpu: "4"
         rdma/ib: 1
       requests:
         memory: 64Gi
         cpu: "16"
-        nvidia.com/gpu: "4"
         rdma/ib: 1
     mountModelVolume: true
     volumeMounts:
@@ -103,6 +102,7 @@ decode:
     emptyDir: {}
 
 prefill:
+  # parallelism defaults to tensor: 1, data: 1 (1 GPU per replica)
   create: true
   replicas: 4
   monitoring:
@@ -135,15 +135,14 @@ prefill:
         name: metrics
         protocol: TCP
     resources:
+      # Note: nvidia.com/gpu is auto-generated from parallelism.tensor (default: 1)
       limits:
         memory: 64Gi
         cpu: "8"
-        nvidia.com/gpu: "1"
         rdma/ib: 1
       requests:
         memory: 64Gi
         cpu: "8"
-        nvidia.com/gpu: "1"
         rdma/ib: 1
     mountModelVolume: true
     volumeMounts:


### PR DESCRIPTION
 This PR depends on: https://github.com/llm-d-incubation/llm-d-modelservice/pull/176

The ModelService chart auto-generates these values from parallelism.tensor:
- nvidia.com/gpu in resources.limits/requests
- --tensor-parallel-size in vLLM args

Setting them manually can cause mismatch errors when the chart validates that GPU resources match parallelism configuration.

Changes:
- Remove --tensor-parallel-size from decode args (auto-generated)
- Remove nvidia.com/gpu from decode resources (auto-generated from tensor:4)
- Remove nvidia.com/gpu from prefill resources (auto-generated from default tensor:1)
- Add comments explaining the auto-generation behavior
 Remaining Guides (Follow-up PRs)

  The following guides also have redundant nvidia.com/gpu settings that could be cleaned up:

```
  | Guide                      | File                                    | Status  |
  |----------------------------|-----------------------------------------|---------|
  | inference-scheduling       | ms-inference-scheduling/values.yaml     | Pending |
  | inference-scheduling       | ms-inference-scheduling/values_tpu.yaml | Pending |
  | precise-prefix-cache-aware | ms-kv-events/values.yaml                | Pending |
  | workload-autoscaling       | ms-workload-autoscaling/values.yaml     | Pending |
  | pd-disaggregation          | ms-pd/values_tpu.yaml                   | Pending |
```


Relates to: https://github.com/llm-d/llm-d/issues/481