### PR TITLE
chore: add CLAUDE.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 *.history
+CLAUDE.md


### PR DESCRIPTION
prevents users of Claude Code from commiting
their personal CLAUDE.md files

if desired, a CLAUDE.md could be added at the
project level as a tracked file as an alternative