### PR TITLE
Set the OffloadingConnector as default in the web UI docs

### DIFF
--- a/guides/tiered-prefix-cache/cpu/README.md
+++ b/guides/tiered-prefix-cache/cpu/README.md
@@ -33,14 +33,14 @@ Deploy the Gateway and HTTPRoute using the [gateway recipe](../../recipes/gatewa
 
 <!-- TABS:START -->
 
-<!-- TAB:Offloading Connector -->
+<!-- TAB:Offloading Connector:default -->
 #### Offloading Connector
 Deploy the vLLM model server with the `OffloadingConnector` enabled.
 ```bash
 kubectl apply -k ./manifests/vllm/offloading-connector -n ${NAMESPACE}
 ```
 
-<!-- TAB:LMCache Connector:default -->
+<!-- TAB:LMCache Connector -->
 #### LMCache Connector
 
 Deploy the vLLM model server with the `LMCache` connector enabled.


### PR DESCRIPTION
This flips the tab view on the web UI docs so that Offloading connector is the default view. 

https://llm-d.ai/docs/guide/Installation/tiered-prefix-cache/cpu

<img width="914" height="300" alt="Screenshot 2026-01-08 at 10 02 41 AM" src="https://github.com/user-attachments/assets/47823f84-4933-4345-a6e6-a403a90b3984" />
