### PR TITLE
Updating guide docs to fix typo on chart variable name

### DIFF
--- a/guides/recipes/inferencepool/README.md
+++ b/guides/recipes/inferencepool/README.md
@@ -18,7 +18,7 @@ helm install llm-d-infpool \
   -n ${NAMESPACE} \
   -f ./values.yaml \
   --set "provider.name=gke" \
-  --set "inferenceExtension.monitoring.gke.enable=true" \
+  --set "inferenceExtension.monitoring.gke.enabled=true" \
   oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool \
   --version v1.2.0
 ```
@@ -33,7 +33,7 @@ helm install llm-d-infpool \
   -n ${NAMESPACE} \
   -f ./values.yaml \
   --set "provider.name=istio" \
-  --set "inferenceExtension.monitoring.prometheus.enable=true" \
+  --set "inferenceExtension.monitoring.prometheus.enabled=true" \
   oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool \
   --version v1.2.0
 ```

--- a/guides/tiered-prefix-cache/cpu/README.md
+++ b/guides/tiered-prefix-cache/cpu/README.md
@@ -70,7 +70,7 @@ helm install llm-d-infpool \
     -n ${NAMESPACE} \
     -f ./manifests/inferencepool/values.yaml \
     --set "provider.name=gke" \
-    --set "inferenceExtension.monitoring.gke.enable=true" \
+    --set "inferenceExtension.monitoring.gke.enabled=true" \
     oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool \
     --version v1.2.0
 ```
@@ -86,7 +86,7 @@ helm install llm-d-infpool \
     -n ${NAMESPACE} \
     -f ./manifests/inferencepool/values.yaml \
     --set "provider.name=istio" \
-    --set "inferenceExtension.monitoring.prometheus.enable=true" \
+    --set "inferenceExtension.monitoring.prometheus.enabled=true" \
     oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool \
     --version v1.2.0
 ```

--- a/guides/wide-ep-lws/README.md
+++ b/guides/wide-ep-lws/README.md
@@ -88,7 +88,7 @@ helm install llm-d-infpool \
   -n ${NAMESPACE} \
   -f ./manifests/inferencepool.values.yaml \
   --set "provider.name=gke" \
-  --set "inferenceExtension.monitoring.gke.enable=true" \
+  --set "inferenceExtension.monitoring.gke.enabled=true" \
   oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool \
   --version v1.2.0
 ```
@@ -101,7 +101,7 @@ helm install llm-d-infpool \
   -n ${NAMESPACE} \
   -f ./manifests/inferencepool.values.yaml \
   --set "provider.name=istio" \
-  --set "inferenceExtension.monitoring.prometheus.enable=true" \
+  --set "inferenceExtension.monitoring.prometheus.enabled=true" \
   oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool \
   --version v1.2.0
 ```


### PR DESCRIPTION
There is a typo in the variable names for "inferenceExtension.monitoring.gke.enabled" and "inferenceExtension.monitoring.prometheus.enabled" from the gateway-api-inference-extension/charts/inferencepool helm chart. Without this change for example on a GKE deployment dashboards do not shows data since the PodMonitoring object is not installed with the helm install instructions. 

This PR is to fix it and also change the version to v1.2.0 from v1.2.0-rc.1 since the release is done