### PR TITLE
build(github): add timeout for image build jobs + filter out file changes to trigger build

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -42,6 +42,7 @@ jobs:
   pre-commit:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -70,6 +71,7 @@ jobs:
 
   detect-changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     outputs:
       cuda: ${{ steps.filter.outputs.cuda || steps.dispatch.outputs.cuda }}
       rocm: ${{ steps.filter.outputs.rocm || steps.dispatch.outputs.rocm }}
@@ -85,15 +87,13 @@ jobs:
           filters: |
             cuda:
               - 'docker/Dockerfile.cuda'
+              - 'docker/build-constraints.txt'
+              - 'docker/constraints.txt'
               - 'docker/scripts/common/**'
               - 'docker/scripts/cuda/**'
-              - 'docker/packages/common/**'
-              - 'docker/packages/cuda/**'
-              - 'docker/packages/rpms/**'
-              - 'patches/cks_nvshmem3.3.20.patch'
-              - 'patches/cks_nvshmem3.3.9.patch'
-              - 'patches/nvshmem_zero_ibv_ah_attr_3.3.20.patch'
+              - 'docker/packages/**'
               - 'patches/nvshmem_zero_ibv_ah_attr_v3.4.5-0.patch'
+              - 'scripts/warn-vllm-precompiled.sh'
             rocm:
               - 'docker/Dockerfile.rocm'
             xpu:
@@ -267,6 +267,7 @@ jobs:
             base_image_suffix: ubuntu24.04
             image_suffix: "-ubuntu"
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -393,6 +394,7 @@ jobs:
     needs: cuda-build-llm-d
     if: ${{ always() }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       any_succeeded: ${{ steps.check.outputs.any_succeeded }}
       rhel_ok: ${{ steps.check.outputs.rhel_ok }}
@@ -450,6 +452,7 @@ jobs:
     needs: cuda-success-check
     if: ${{ needs.cuda-success-check.outputs.any_succeeded == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -564,7 +567,7 @@ jobs:
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH,MEDIUM"
           scanners: vuln
-          timeout: 30m
+          timeout: 10m
           skip-dirs: /root/.cache/uv
         env:
           TRIVY_USERNAME: ${{ secrets.GHCR_USER }}
@@ -590,9 +593,8 @@ jobs:
   xpu-build-llm-d:
     needs: [detect-changes]
     if: ${{ needs.detect-changes.outputs.xpu == 'true' }}
-    strategy:
-      fail-fast: false
     runs-on: xpu
+    timeout-minutes: 60
     steps:
       - name: Checkout push ref
         if: github.event_name == 'push'
@@ -683,6 +685,7 @@ jobs:
     needs: [detect-changes]
     if: ${{ needs.detect-changes.outputs.rocm == 'true' }}
     runs-on: vllm-runner
+    timeout-minutes: 120
     steps:
       - name: Checkout push ref
         if: github.event_name == 'push'
@@ -764,9 +767,8 @@ jobs:
   hpu-build-llm-d:
     needs: [detect-changes]
     if: ${{ needs.detect-changes.outputs.hpu == 'true' }}
-    strategy:
-      fail-fast: false
     runs-on: vllm-runner
+    timeout-minutes: 60
     steps:
       - name: Checkout push ref
         if: github.event_name == 'push'
@@ -811,7 +813,7 @@ jobs:
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH,MEDIUM'
           scanners: vuln              # skip secrets/config/license analyzers
-          timeout: 30m
+          timeout: 10m
           skip-dirs: /root/.cache/uv
         env:
           TRIVY_USERNAME: ${{ secrets.GHCR_USER }}
@@ -835,6 +837,7 @@ jobs:
     needs: [detect-changes]
     if: ${{ needs.detect-changes.outputs.cpu == 'true' }}
     runs-on: vllm-runner
+    timeout-minutes: 60
     steps:
       - name: Checkout push ref
         if: github.event_name == 'push'
@@ -896,11 +899,11 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{ env.REGISTRY }}/${{ github.repository }}-cpu-dev:${{ steps.set-tag.outputs.tag }}
-          format: "sarif"
-          output: "trivy-results.sarif"
-          severity: "CRITICAL,HIGH,MEDIUM"
-          scanners: vuln # skip secrets/config/license analyzers
-          timeout: 30m
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+          scanners: vuln              # skip secrets/config/license analyzers
+          timeout: 10m
           skip-dirs: /root/.cache/uv
         env:
           TRIVY_USERNAME: ${{ github.actor }}

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -44,6 +44,7 @@ jobs:
             base_image_suffix: ubuntu24.04
             image_suffix: "-ubuntu"
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -326,7 +327,7 @@ jobs:
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH,MEDIUM"
           scanners: vuln
-          timeout: 30m
+          timeout: 10m
           skip-dirs: /root/.cache/uv
         env:
           TRIVY_USERNAME: ${{ secrets.GHCR_USER }}
@@ -348,6 +349,7 @@ jobs:
 
   release-cpu-llm-d:
     runs-on: vllm-runner
+    timeout-minutes: 60
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -395,7 +397,7 @@ jobs:
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH,MEDIUM"
           scanners: vuln
-          timeout: 30m
+          timeout: 10m
           skip-dirs: /root/.cache/uv
         env:
           TRIVY_USERNAME: ${{ secrets.GHCR_USER }}
@@ -417,6 +419,7 @@ jobs:
 
   release-rocm-llm-d:
     runs-on: vllm-runner
+    timeout-minutes: 60
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -463,7 +466,7 @@ jobs:
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH,MEDIUM'
           scanners: vuln
-          timeout: 30m
+          timeout: 10m
           skip-dirs: /root/.cache/uv
         env:
           TRIVY_USERNAME: ${{ secrets.GHCR_USER }}
@@ -484,9 +487,8 @@ jobs:
           fi
 
   release-xpu-llm-d:
-    strategy:
-      fail-fast: false
     runs-on: vllm-runner
+    timeout-minutes: 60
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -533,7 +535,7 @@ jobs:
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH,MEDIUM"
           scanners: vuln
-          timeout: 30m
+          timeout: 10m
           skip-dirs: /root/.cache/uv
         env:
           TRIVY_USERNAME: ${{ secrets.GHCR_USER }}


### PR DESCRIPTION
#Description      
- Without timeout explicitly set in the job, job get cancelled either by default timout 3hr(or config on the org-level), or manual cancalled by user.
- Narrow down files changes to trigger build. e.g "patches/" should not require a build on cpu/tpu
- remove unnessary config in github workflow "strategy: fail-fast: false"


# Changes 
    - default job run 6hrs(300m), now:
    - set 120mins for build: cuda in Dev changes and Release
    - set 60mins for build: cpu/XPU in Dev change and Release
    - set 120mins for build: aws in Release
    - reduce timeout on trivy from 30mins to 10mins
    - remove unnecessary fail-fast as it only works with matrix
    - filter out files change which should not trigger build on cuda/cpu/xpu
    - remove old patches not used by nvshmem current version