### PR TITLE
feat: add support for weka

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -46,8 +46,8 @@ ARG NIXL_VERSION="v1.0.0"
 ARG INFINISTORE_REPO="https://github.com/bytedance/InfiniStore.git"
 ARG INFINISTORE_VERSION="0.2.33"
 
-ARG LMCACHE_REPO="https://github.com/LMCache/LMCache.git"
-ARG LMCACHE_VERSION="v0.4.1"
+ARG LMCACHE_REPO="https://github.com/vinaychannagiri23/LMCache.git"
+ARG LMCACHE_VERSION="operation-timeout-error-handling"
 
 # Kernels
 # NM fork of Deepep for duplicate nvshmem IBGDA definitions, see: https://github.com/deepseek-ai/DeepEP/pull/581.
@@ -478,6 +478,12 @@ RUN --mount=type=cache,target=/var/cache/git \
 COPY docker/packages/common/runtime-otel-package-requirements.txt /workspace/runtime-otel-package-requirements.txt
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install -r /workspace/runtime-otel-package-requirements.txt
+
+# Copy GDS scripts for Weka
+COPY docker/scripts/cuda/runtime/enable-nvidia-gds.sh /usr/local/bin/enable-nvidia-gds.sh
+COPY docker/scripts/cuda/runtime/gds-startup-probe.sh /usr/local/bin/gds-startup-probe.sh
+RUN chmod +x /usr/local/bin/enable-nvidia-gds.sh \
+    /usr/local/bin/gds-startup-probe.sh
 
 # Cleanup packages
 COPY docker/scripts/cuda/common/package-utils.sh /tmp/package-utils.sh

--- a/docker/common-versions
+++ b/docker/common-versions
@@ -13,16 +13,18 @@ VLLM_COMMIT_SHA=95c0f928cdeeaa21c4906e73cee6a156e1b3b995 # maps to v0.17.1 tag
 # CUDA-only configurations for precompiled binaries
 VLLM_PREBUILT=0                # 0=editable install, 1=use full prebuilt wheel
 VLLM_USE_PRECOMPILED=1         # 1=use precompiled binaries either from VLLM_COMMIT_SHA or VLLM_PRECOMPILED_WHEEL_COMMIT, 0=compile from source
-VLLM_PRECOMPILED_WHEEL_COMMIT=1892993bc18e243e2c05841314c5e9c06a80c70d # which precompiled commit to use. If your commit exists on vllm-project/vllm main, this should match your `VLLM_COMMIT_SHA`.
-
-### Cuda Runtime versions
-CUDA_MAJOR=12
-CUDA_MINOR=9
-CUDA_PATCH=1
-
 # If building vLLM from a precompiled commit in the vLLM wheel index (only commits off main),
 # which commit to use as the base for the copiled bits.
 VLLM_PRECOMPILED_WHEEL_COMMIT=95c0f928cdeeaa21c4906e73cee6a156e1b3b995
+
+
+# ============================================================================
+# CUDA Version Configuration
+# ============================================================================
+# Used by CUDA builds (Dockerfile.cuda, Dockerfile.rdma-tools)
+CUDA_MAJOR=12
+CUDA_MINOR=9
+CUDA_PATCH=1
 
 ### Offloading connector
 LLM_D_OFFLOADING_CONNECTOR_VERSION=0.17.1

--- a/docker/packages/cuda/runtime-packages.json
+++ b/docker/packages/cuda/runtime-packages.json
@@ -19,6 +19,11 @@
     "gcc",
     "hwloc",
     "libhwloc15",
-    "curl"
+    "curl",
+    "nvidia-gds-${CUDA_MAJOR}-${CUDA_MINOR}"
+  ],
+  "rhel_only": [
+    "gds-tools-${CUDA_MAJOR}-${CUDA_MINOR}",
+    "libcufile-${CUDA_MAJOR}-${CUDA_MINOR}"
   ]
 }

--- a/docker/packages/cuda/runtime-rdma-packages.json
+++ b/docker/packages/cuda/runtime-rdma-packages.json
@@ -3,5 +3,8 @@
     "librdmacm": "librdmacm1t64",
     "libibverbs": "libibverbs1",
     "libibumad": "libibumad3"
-  }
+  },
+  "ubuntu_only": [
+    "ibverbs-providers"
+  ]
 }

--- a/docker/scripts/cuda/common/package-utils.sh
+++ b/docker/scripts/cuda/common/package-utils.sh
@@ -143,6 +143,13 @@ load_packages_from_json() {
         while IFS= read -r pkg; do
             packages+=("$pkg")
         done < <(echo "$manifest" | jq -r ".${section} | keys[]")
+
+        # add rhel-only packages if they exist
+        if echo "$manifest" | jq -e '.rhel_only' > /dev/null 2>&1; then
+            while IFS= read -r pkg; do
+                packages+=("$pkg")
+            done < <(echo "$manifest" | jq -r '.rhel_only[]')
+        fi
     fi
 
     printf '%s\n' "${packages[@]}"

--- a/docker/scripts/cuda/runtime/enable-nvidia-gds.sh
+++ b/docker/scripts/cuda/runtime/enable-nvidia-gds.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+# Enable NVIDIA GPU Direct Storage kernel modules for Weka
+
+# Load nvidia_fs (GDS kernel module)
+if ! modinfo nvidia_fs &>/dev/null; then
+    echo "ERROR: nvidia_fs module not found" >&2
+    exit 1
+fi
+
+if ! lsmod | grep -q nvidia_fs; then
+    echo "Loading nvidia_fs..."
+    modprobe nvidia_fs || { echo "ERROR: Failed to load nvidia_fs" >&2; exit 1; }
+fi
+
+# Load nvidia_peermem (PeerDirect for RDMA)
+if ! modinfo nvidia_peermem &>/dev/null; then
+    echo "ERROR: nvidia_peermem module not found" >&2
+    exit 1
+fi
+
+if ! lsmod | grep -q nvidia_peermem; then
+    echo "Loading nvidia_peermem..."
+    modprobe nvidia_peermem || { echo "ERROR: Failed to load nvidia_peermem" >&2; exit 1; }
+fi
+
+exit 0

--- a/docker/scripts/cuda/runtime/gds-startup-probe.sh
+++ b/docker/scripts/cuda/runtime/gds-startup-probe.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+# GDS startup probe for Weka deployments
+#
+# Verifies that GDS requirements are met:
+# - nvidia_fs kernel module is loaded (for GDS)
+# - nvidia_peermem kernel module is loaded (for Weka PeerDirect)
+# - cufile.json exists and is valid
+
+# Check nvidia_fs is loaded
+if ! lsmod | grep -q nvidia_fs; then
+    echo "ERROR: nvidia_fs module not loaded" >&2
+    exit 1
+fi
+
+# Check nvidia_peermem is loaded
+if ! lsmod | grep -q nvidia_peermem; then
+    echo "ERROR: nvidia_peermem module not loaded" >&2
+    exit 1
+fi
+
+# Check cufile.json
+TARGET="${1:-/etc/cufile.json}"
+if [ ! -r "$TARGET" ] || [ ! -s "$TARGET" ]; then
+    echo "ERROR: $TARGET does not exist, is not readable, or is empty" >&2
+    exit 1
+fi
+
+echo "GDS ready: kernel modules loaded and cufile.json valid"
+exit 0

--- a/guides/tiered-prefix-cache/README.md
+++ b/guides/tiered-prefix-cache/README.md
@@ -62,6 +62,12 @@ Any storage connector that is compatible with vLLM can be used **transparently w
 
 To enable shared storage offloading, refer to the [**Storage Offloading Guide**](./storage/README.md).
 
+#### WEKA GPU Direct Storage
+
+WEKA provides high-performance shared storage with GPU Direct Storage (GDS) support, enabling direct data transfer between GPUs and storage, bypassing CPU and system memory for reduced latency.
+
+See the [WEKA GPU Direct guide](./weka/README.md) to learn how to enable WEKA storage with llm-d.
+
 ### P2P Cache Sharing
 
 A P2P network can be formed between the inference engine instances to share caches in HBMs or CPU memory. It enables more cache sharing without needing additional storage resources. However this strategy adds operational overhead, and potential contention between model parallelism traffic such as tensor parallelism. We will add more recommendations in the following releases.

--- a/guides/tiered-prefix-cache/README.md
+++ b/guides/tiered-prefix-cache/README.md
@@ -52,11 +52,11 @@ Offloading prefix cache to a shared (remote) storage tier provides several impor
 * **Shared KV-cache across nodes** - Multiple inference replicas can access and reuse the same prefix cache.
 * **Fast scale-up** - New nodes can immediately reuse existing KV-cache data without warming the cache from scratch.
 * **Persistence across restarts or failures** - KV-cache data survives pod restarts, rescheduling, and node failures.
-* **Enterprise storage integration** - Can leverage mature enterprise storage systems (for example CephFS, GCP Lustre, IBM Storage Scale) with built-in durability, monitoring, and access control.
+* **Enterprise storage integration** - Can leverage mature enterprise storage systems (for example CephFS, GCP Lustre, IBM Storage Scale, WEKA) with built-in durability, monitoring, and access control.
 
 However, shared storage introduces additional operational and performance considerations. Latency and throughput depend on the characteristics of the underlying storage system, so careful evaluation is required to ensure that cache transfer overhead does not negatively impact inference performance.
 
-Integration between the storage system and llm-d is achieved through vLLM connectors. The specific connector and data path depend on the storage system type and the underlying transport mechanism. 
+Integration between the storage system and llm-d is achieved through vLLM connectors. The specific connector and data path depend on the storage system type and the underlying transport mechanism.
 For example, different implementations may use CPU staging buffers, GPU Direct Storage (GDS), or NIXL-based data movement.
 Any storage connector that is compatible with vLLM can be used **transparently within the llm-d project**.
 

--- a/guides/tiered-prefix-cache/storage/README.md
+++ b/guides/tiered-prefix-cache/storage/README.md
@@ -103,6 +103,20 @@ export STORAGE_CLASS=lustre
 
 To provision a managed GCP Lustre instance on GKE and configure the corresponding `StorageClass`, follow the [GCP Lustre guide](./manifests/backends/lustre/README.md).
 
+<!-- TAB:WEKA -->
+
+#### WEKA
+
+Set your storage class which will be used later to provision the PVC.
+
+```bash
+export STORAGE_CLASS=weka-csi-sc
+```
+
+To configure WEKA CSI driver and StorageClass, follow the [WEKA backend guide](./manifests/backends/weka/README.md).
+
+**Note:** For a complete WEKA setup with GPU Direct Storage (GDS), prefill/decode disaggregation, and RDMA networking optimizations, refer to the [WEKA tiered prefix cache guide](../weka/README.md).
+
 <!-- TABS:END -->
 
 #### 2.2. Create the PVC

--- a/guides/tiered-prefix-cache/storage/manifests/backends/weka/README.md
+++ b/guides/tiered-prefix-cache/storage/manifests/backends/weka/README.md
@@ -1,0 +1,38 @@
+# WEKA CSI StorageClass
+
+This directory contains the StorageClass definition for WEKA CSI driver integration.
+
+## Prerequisites
+
+- WEKA CSI driver installed in your cluster
+- WEKA cluster configured and accessible
+- CSI secret created (default name: `weka-csi-cluster` in namespace `weka`)
+
+For WEKA CSI driver installation instructions, see the [WEKA CSI Plugin documentation](https://docs.weka.io/appendices/weka-csi-plugin).
+
+## Configuration
+
+Please update the following parameters in [storage_class.yaml](./storage_class.yaml) to match your WEKA cluster configuration:
+
+- `filesystemName`: Your WEKA filesystem name (default: `default`)
+- `mountOptions`: Adjust performance parameters as needed for your workload
+
+## Deployment
+
+Deploy the StorageClass:
+
+```bash
+kubectl apply -f ./storage_class.yaml
+```
+
+This creates a StorageClass named `weka-csi-sc` that will be used by the PVC.
+
+## Cleanup
+
+To remove the StorageClass:
+
+```bash
+kubectl delete -f ./storage_class.yaml
+```
+
+**Note:** Ensure no PVCs are using this StorageClass before deletion.

--- a/guides/tiered-prefix-cache/storage/manifests/backends/weka/README.md
+++ b/guides/tiered-prefix-cache/storage/manifests/backends/weka/README.md
@@ -12,20 +12,24 @@ For WEKA CSI driver installation instructions, see the [WEKA CSI Plugin document
 
 ## Configuration
 
-Please update the following parameters in [storage_class.yaml](./storage_class.yaml) to match your WEKA cluster configuration:
+Update the following parameters in [storage_class.yaml](./storage_class.yaml) to match your WEKA cluster configuration:
 
 - `filesystemName`: Your WEKA filesystem name (default: `default`)
 - `mountOptions`: Adjust performance parameters as needed for your workload
 
 ## Deployment
 
+Set the storage class name:
+
+```bash
+export STORAGE_CLASS=weka-csi-sc
+```
+
 Deploy the StorageClass:
 
 ```bash
-kubectl apply -f ./storage_class.yaml
+envsubst < ./storage_class.yaml | kubectl apply -f -
 ```
-
-This creates a StorageClass named `weka-csi-sc` that will be used by the PVC.
 
 ## Cleanup
 

--- a/guides/tiered-prefix-cache/storage/manifests/backends/weka/storage_class.yaml
+++ b/guides/tiered-prefix-cache/storage/manifests/backends/weka/storage_class.yaml
@@ -1,0 +1,12 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: weka-csi-sc
+parameters:
+  capacityEnforcement: HARD
+  filesystemName: default
+  volumeType: dir/v1
+  mountOptions: "rw,relatime,readcache,noatime,readahead_kb=32768,dentry_max_age_positive=1000,dentry_max_age_negative=0"
+provisioner: csi.weka.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/guides/tiered-prefix-cache/storage/manifests/backends/weka/storage_class.yaml
+++ b/guides/tiered-prefix-cache/storage/manifests/backends/weka/storage_class.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: weka-csi-sc
+  name: $STORAGE_CLASS
 parameters:
   capacityEnforcement: HARD
   filesystemName: default

--- a/guides/tiered-prefix-cache/weka/README.md
+++ b/guides/tiered-prefix-cache/weka/README.md
@@ -1,0 +1,195 @@
+# Well-lit Path: WEKA GPU Direct Storage
+
+This guide demonstrates how to deploy llm-d with WEKA storage using GPU
+Direct Storage (GDS) for high-performance data transfer between GPUs and
+storage. It covers both PVC and host-path storage configurations.
+
+## Overview
+
+WEKA provides high-performance shared storage with GPU Direct Storage (GDS) support, enabling direct data transfer between GPUs and storage, bypassing CPU and system memory for reduced latency.
+
+The WEKA GDS integration includes:
+
+1. **InitContainers** - Automated setup that loads GDS kernel modules (`nvidia_fs` and `nvidia_peermem`) and creates cufile.json configuration
+2. **Volume Mounts** - Mounts cufile.json from `~/amg_stable/cufile.json` on the host to `/etc/cufile.json` in the container
+3. **Storage Options** - Supports both PersistentVolumeClaim (PVC) and host-path storage configurations
+4. **Startup Probe** - Verifies GDS readiness (kernel modules loaded + cufile.json valid) before starting the container
+
+## Architecture
+
+The manifests use a layered kustomize structure for Prefill/Decode disaggregation:
+
+**Key features:**
+
+- **Prefill/Decode disaggregation**: Separate deployments optimized for each phase
+- **Decode** has routing-sidecar for coordinating with prefill instances
+- **Prefill** has no routing-sidecar, handles initial prompt processing
+- **Storage organized by type**: Choose `pvc/` or `host/` based on your storage setup
+
+## Prerequisites
+
+- Have the [proper client tools installed on your local system](../../prereq/client-setup/README.md) to use this guide
+- WEKA storage system configured with:
+  - WEKA CSI driver installed (for PVC storage option) - see [WEKA CSI Plugin documentation](https://docs.weka.io/appendices/weka-csi-plugin)
+  - WEKA filesystem mounted on nodes (for hostPath storage option)
+  - GPU Direct Storage (GDS) enabled:
+    - NVIDIA GPUs with GPUDirect Storage capability
+    - NVIDIA driver version 450.80.02 or later
+    - kernel modules: `nvidia-fs` and `nvidia_peermem` must be available on host
+    - WEKA client with GDS support installed
+    - **RHEL nodes only**: Install `nvidia-gds` package on the host (`dnf install nvidia-gds-12-9`)
+- AMG Utils for GDS configuration:
+  - The `amgctl` tool will be run via initContainer to create `~/amg_stable/cufile.json` on each node
+  - The file is then mounted into the container at `/etc/cufile.json`
+- Create Installation Namespace:
+
+  ```bash
+  export NAMESPACE=weka
+  kubectl create namespace ${NAMESPACE}
+  ```
+
+  **Note:** This guide uses `weka` as the namespace, which is hardcoded in the kustomization files. If you want to use a different namespace, update the `namespace:` field in:
+  - `./manifests/vllm/overlays/host/kustomization.yaml`
+  - `./manifests/vllm/overlays/pvc/kustomization.yaml`
+  - `./manifests/gateway/overlays/istio/kustomization.yaml`
+
+- Gateway API implementation deployed (Istio) - see [Gateway control plane setup](../../prereq/gateway-provider/README.md) if needed
+
+## Installation
+
+**Note:** The example deployment manifests use the `RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic` model.
+
+### Deploy vLLM Model Servers
+
+Choose either PVC or host-path storage based on your WEKA setup.
+
+#### Option 1: PVC Storage (Recommended)
+
+##### 1. Configure WEKA StorageClass
+
+Configure and deploy the WEKA CSI StorageClass following the [WEKA backend guide](../storage/manifests/backends/weka/README.md).
+
+Set your storage class name for use in the next step:
+
+```bash
+export STORAGE_CLASS=weka-csi-sc
+```
+
+##### 2. Create the PVC
+
+Create a PersistentVolumeClaim named `wekafs-amg` with 100Gi storage using the storage guide's PVC template:
+
+```bash
+envsubst < ../storage/manifests/pvc.yaml | \
+  sed -e 's/llm-d-kv-cache-storage/wekafs-amg/' \
+      -e 's/18000Gi/100Gi/' | \
+  kubectl apply -f - -n ${NAMESPACE}
+```
+
+##### 3. Deploy both decode and prefill with PVC storage
+
+   ```bash
+   kubectl apply -k ./manifests/vllm/overlays/pvc
+   ```
+
+   This creates:
+
+- ServiceAccount: `weka-vllm`
+- Deployment `decode`:
+  - 1 replica with 4 GPUs (tensor-parallel), 16 CPUs, port 8200
+  - InitContainers: `routing-proxy`, `create-cufile-on-node` (amg-utils)
+- Deployment `prefill`:
+  - 4 replicas, each with 1 GPU, 8 CPUs, port 8000
+  - InitContainers: `create-cufile-on-node` (amg-utils)
+
+#### Option 2: Host-Path Storage
+
+1. If WEKA is mounted at a different location than `/mnt/weka`, update the `path` in `./manifests/vllm/overlays/host/kustomization.yaml`:
+
+   ```yaml
+   patches:
+     - target:
+         kind: Deployment
+       patch: |-
+         - op: replace
+           path: /spec/template/spec/volumes/1
+           value:
+             name: weka-storage
+             hostPath:
+               path: /mnt/weka  # Replace with your WEKA mount path
+               type: Directory
+   ```
+
+2. Deploy both decode and prefill with host-path storage
+
+   ```bash
+   kubectl apply -k ./manifests/vllm/overlays/host
+   ```
+
+   This creates:
+   - ServiceAccount: `weka-vllm`
+   - Deployment `decode`: 1 replica with 4 GPUs (tensor-parallel), 16 CPUs, port 8200
+     - InitContainers: `routing-proxy`, `create-cufile-on-node` (amg-utils)
+   - Deployment `prefill`: 4 replicas, each with 1 GPU, 8 CPUs, port 8000
+     - InitContainers: `create-cufile-on-node` (amg-utils)
+
+### Deploy InferencePool
+
+Deploy the InferencePool and inference scheduler:
+
+**Note:** You can customize the InferencePool or EndpointPickerConfig by editing `./manifests/inferencepool.values.yaml`.
+
+```bash
+helm install weka-vllm \
+    -n ${NAMESPACE} \
+    -f ./manifests/inferencepool.values.yaml \
+    oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool --version v1.3.0
+```
+
+This creates:
+
+- InferencePool: `weka-vllm`
+- ServiceAccount: `weka-vllm-epp`
+- Deployment: `weka-vllm-epp` (runs `llm-d-inference-scheduler` image)
+- Service: `weka-vllm-epp`
+- ConfigMap: `weka-vllm-epp` (contains EndpointPickerConfig)
+- DestinationRule: `weka-vllm-epp` (controller traffic for connection limits and TLS for service `weka-vllm-epp`)
+- Role: `weka-vllm-epp`
+- RoleBinding: `weka-vllm-epp`
+
+### Deploy Gateway
+
+**Important:** Deploy the Gateway after the InferencePool, as the HTTPRoute references the InferencePool backend (`weka-vllm`).
+
+**Note:** By default, the Gateway service type is `LoadBalancer`. If you want to use `ClusterIP` instead, add the following patch to `./manifests/gateway/overlays/istio/kustomization.yaml` in the `patches:` section before deploying:
+
+```yaml
+  - target:
+      kind: Gateway
+      name: llm-d-inference-gateway
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          networking.istio.io/service-type: ClusterIP
+```
+
+Deploy the Gateway and HTTPRoute resources:
+
+```bash
+kubectl apply -k ./manifests/gateway/overlays/istio
+```
+
+This creates:
+
+- Gateway: `llm-d-inference-gateway`
+- HTTPRoute: `llm-d-route`
+- ConfigMap: `llm-d-inference-gateway`
+
+Alternatively, you can manually add the annotation after deployment to change to `ClusterIP`:
+
+```bash
+kubectl annotate gateway llm-d-inference-gateway \
+  -n ${NAMESPACE} \
+  networking.istio.io/service-type=ClusterIP
+```

--- a/guides/tiered-prefix-cache/weka/README.md
+++ b/guides/tiered-prefix-cache/weka/README.md
@@ -2,11 +2,16 @@
 
 This guide demonstrates how to deploy llm-d with WEKA storage using GPU
 Direct Storage (GDS) for high-performance data transfer between GPUs and
-storage. It covers both PVC and host-path storage configurations.
+storage. It supports both prefill/decode disaggregation and tiered prefix caching.
 
 ## Overview
 
 WEKA provides high-performance shared storage with GPU Direct Storage (GDS) support, enabling direct data transfer between GPUs and storage, bypassing CPU and system memory for reduced latency.
+
+This deployment uses a MultiConnector configuration that combines:
+
+1. **NIXL** - For prefill/decode disaggregation (KV transfer between pods over the network)
+2. **LMCache** - For tiered prefix caching (KV cache offloading to WEKA storage via GDS)
 
 The WEKA GDS integration includes:
 
@@ -17,11 +22,13 @@ The WEKA GDS integration includes:
 
 ## Architecture
 
-The manifests use a layered kustomize structure for Prefill/Decode disaggregation:
+The manifests use a layered kustomize structure with MultiConnector support:
 
 **Key features:**
 
-- **Prefill/Decode disaggregation**: Separate deployments optimized for each phase
+- **MultiConnector KV transfer**: Combines NIXL (network-based) and LMCache (storage-based) connectors
+- **Prefill/Decode disaggregation**: Separate deployments optimized for each phase via NIXL
+- **Tiered prefix caching**: KV cache offloading to WEKA storage via LMCache with GDS
 - **Decode** has routing-sidecar for coordinating with prefill instances
 - **Prefill** has no routing-sidecar, handles initial prompt processing
 - **Storage organized by type**: Choose `pvc/` or `host/` based on your storage setup

--- a/guides/tiered-prefix-cache/weka/README.md
+++ b/guides/tiered-prefix-cache/weka/README.md
@@ -15,10 +15,10 @@ This deployment uses a MultiConnector configuration that combines:
 
 The WEKA GDS integration includes:
 
-1. **InitContainers** - Automated setup that loads GDS kernel modules (`nvidia_fs` and `nvidia_peermem`) and creates cufile.json configuration
-2. **Volume Mounts** - Mounts cufile.json from `~/amg_stable/cufile.json` on the host to `/etc/cufile.json` in the container
+1. **cufile Configuration** - WEKA Operator provisions cufile.json (users can adjust the path via `subPath` if needed)
+2. **Volume Mounts** - Mounts cufile.json from WEKA storage to `/etc/cufile.json` into container
 3. **Storage Options** - Supports both PersistentVolumeClaim (PVC) and host-path storage configurations
-4. **Startup Probe** - Verifies GDS readiness (kernel modules loaded + cufile.json valid) before starting the container
+4. **GDS Requirements** - InitContainer loads kernel modules (`nvidia_fs` and `nvidia_peermem`) on host nodes
 
 ## Architecture
 
@@ -29,25 +29,25 @@ The manifests use a layered kustomize structure with MultiConnector support:
 - **MultiConnector KV transfer**: Combines NIXL (network-based) and LMCache (storage-based) connectors
 - **Prefill/Decode disaggregation**: Separate deployments optimized for each phase via NIXL
 - **Tiered prefix caching**: KV cache offloading to WEKA storage via LMCache with GDS
-- **Decode** has routing-sidecar for coordinating with prefill instances
-- **Prefill** has no routing-sidecar, handles initial prompt processing
 - **Storage organized by type**: Choose `pvc/` or `host/` based on your storage setup
 
 ## Prerequisites
 
 - Have the [proper client tools installed on your local system](../../prereq/client-setup/README.md) to use this guide
-- WEKA storage system configured with:
-  - WEKA CSI driver installed (for PVC storage option) - see [WEKA CSI Plugin documentation](https://docs.weka.io/appendices/weka-csi-plugin)
-  - WEKA filesystem mounted on nodes (for hostPath storage option)
-  - GPU Direct Storage (GDS) enabled:
-    - NVIDIA GPUs with GPUDirect Storage capability
-    - NVIDIA driver version 450.80.02 or later
-    - kernel modules: `nvidia-fs` and `nvidia_peermem` must be available on host
-    - WEKA client with GDS support installed
-    - **RHEL nodes only**: Install `nvidia-gds` package on the host (`dnf install nvidia-gds-12-9`)
-- AMG Utils for GDS configuration:
-  - The `amgctl` tool will be run via initContainer to create `~/amg_stable/cufile.json` on each node
-  - The file is then mounted into the container at `/etc/cufile.json`
+- **WEKA Operator**:
+  - Deploy the WEKA Operator to provision WEKA clients in your cluster
+  - Enable CSI in the operator (`csi.installationEnabled: true`) for PVC support
+  - WEKA Operator provisions cufile.json configuration for GPU Direct Storage
+  - See WEKA documentation for operator deployment instructions
+- **GPU Direct Storage (GDS)** requirements:
+  - NVIDIA GPUs with GPUDirect Storage capability
+  - NVIDIA driver version 450.80.02 or later
+  - Kernel modules: `nvidia-fs` and `nvidia_peermem` available on host nodes
+  - **RHEL nodes only**: Install `nvidia-gds` package on the host (`dnf install nvidia-gds-12-9`)
+- **Pod Configuration** for llm-d workloads (configured via manifests in this guide):
+  - **GDS kernel modules**: InitContainer (`enable-nvidia-gds`) loads required kernel modules
+  - **cufile mount**: cufile.json from WEKA storage mounted to `/etc/cufile.json`
+  - **Storage mount**: WEKA storage mounted for models, cache, and cufile.json (via PVC or hostPath)
 - Create Installation Namespace:
 
   ```bash
@@ -76,21 +76,15 @@ Choose either PVC or host-path storage based on your WEKA setup.
 
 Configure and deploy the WEKA CSI StorageClass following the [WEKA backend guide](../storage/manifests/backends/weka/README.md).
 
-Set your storage class name for use in the next step:
+##### 2. Create the PVC
+
+Create a PersistentVolumeClaim named `wekafs` with 100Gi storage:
+
+**Note:** Set `STORAGE_CLASS` to match the StorageClass name created in step 1.
 
 ```bash
 export STORAGE_CLASS=weka-csi-sc
-```
-
-##### 2. Create the PVC
-
-Create a PersistentVolumeClaim named `wekafs-amg` with 100Gi storage using the storage guide's PVC template:
-
-```bash
-envsubst < ../storage/manifests/pvc.yaml | \
-  sed -e 's/llm-d-kv-cache-storage/wekafs-amg/' \
-      -e 's/18000Gi/100Gi/' | \
-  kubectl apply -f - -n ${NAMESPACE}
+envsubst < ./manifests/vllm/overlays/pvc/pvc.yaml | kubectl apply -f - -n ${NAMESPACE}
 ```
 
 ##### 3. Deploy both decode and prefill with PVC storage
@@ -102,12 +96,12 @@ envsubst < ../storage/manifests/pvc.yaml | \
    This creates:
 
 - ServiceAccount: `weka-vllm`
-- Deployment `decode`:
-  - 1 replica with 4 GPUs (tensor-parallel), 16 CPUs, port 8200
-  - InitContainers: `routing-proxy`, `create-cufile-on-node` (amg-utils)
-- Deployment `prefill`:
-  - 4 replicas, each with 1 GPU, 8 CPUs, port 8000
-  - InitContainers: `create-cufile-on-node` (amg-utils)
+- Deployment `weka-decode`:
+  - 1 replica with 4 GPUs (tensor-parallel), 16 CPUs, 64Gi memory, port 8200
+  - InitContainers: `routing-proxy`, `enable-nvidia-gds`
+- Deployment `weka-prefill`:
+  - 4 replicas (each replica: 1 GPU, 8 CPUs, 64Gi memory), port 8000
+  - InitContainers: `enable-nvidia-gds`
 
 #### Option 2: Host-Path Storage
 
@@ -135,14 +129,14 @@ envsubst < ../storage/manifests/pvc.yaml | \
 
    This creates:
    - ServiceAccount: `weka-vllm`
-   - Deployment `decode`: 1 replica with 4 GPUs (tensor-parallel), 16 CPUs, port 8200
-     - InitContainers: `routing-proxy`, `create-cufile-on-node` (amg-utils)
-   - Deployment `prefill`: 4 replicas, each with 1 GPU, 8 CPUs, port 8000
-     - InitContainers: `create-cufile-on-node` (amg-utils)
+   - Deployment `weka-decode`: 1 replica with 4 GPUs (tensor-parallel), 16 CPUs, 64Gi memory, port 8200
+     - InitContainers: `routing-proxy`, `enable-nvidia-gds`
+   - Deployment `weka-prefill`: 4 replicas (each replica: 1 GPU, 8 CPUs, 64Gi memory), port 8000
+     - InitContainers: `enable-nvidia-gds`
 
 ### Deploy InferencePool
 
-Deploy the InferencePool and inference scheduler:
+Deploy the inference-scheduler and create the InferencePool CR:
 
 **Note:** You can customize the InferencePool or EndpointPickerConfig by editing `./manifests/inferencepool.values.yaml`.
 
@@ -150,7 +144,7 @@ Deploy the InferencePool and inference scheduler:
 helm install weka-vllm \
     -n ${NAMESPACE} \
     -f ./manifests/inferencepool.values.yaml \
-    oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool --version v1.3.0
+    oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool --version v1.4.0
 ```
 
 This creates:
@@ -166,7 +160,7 @@ This creates:
 
 ### Deploy Gateway
 
-**Important:** Deploy the Gateway after the InferencePool, as the HTTPRoute references the InferencePool backend (`weka-vllm`).
+Deploy the Gateway, HTTPRoute, and ConfigMap. The HTTPRoute references the InferencePool backend (`weka-vllm`).
 
 **Note:** By default, the Gateway service type is `LoadBalancer`. If you want to use `ClusterIP` instead, add the following patch to `./manifests/gateway/overlays/istio/kustomization.yaml` in the `patches:` section before deploying:
 
@@ -181,7 +175,7 @@ This creates:
           networking.istio.io/service-type: ClusterIP
 ```
 
-Deploy the Gateway and HTTPRoute resources:
+Deploy the resources:
 
 ```bash
 kubectl apply -k ./manifests/gateway/overlays/istio

--- a/guides/tiered-prefix-cache/weka/manifests/gateway/base/kustomization.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/gateway/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../../recipes/gateway/base

--- a/guides/tiered-prefix-cache/weka/manifests/gateway/overlays/istio/kustomization.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/gateway/overlays/istio/kustomization.yaml
@@ -1,0 +1,59 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: weka
+
+resources:
+  - ../../../../../../recipes/gateway/istio
+
+patches:
+  # Update HTTPRoute to add timeouts and reference InferencePool
+  - target:
+      kind: HTTPRoute
+    patch: |-
+      - op: add
+        path: /spec/rules/0/timeouts
+        value:
+          backendRequest: 0s
+          request: 0s
+      - op: replace
+        path: /spec/rules/0/backendRefs/0/name
+        value: weka-vllm
+
+  # Customize Istio proxy settings in ConfigMap
+  - target:
+      kind: ConfigMap
+      name: llm-d-inference-gateway
+    patch: |-
+      - op: replace
+        path: /data/deployment
+        value: |
+          spec:
+            template:
+              spec:
+                containers:
+                - name: istio-proxy
+                  args:
+                    - proxy
+                    - router
+                    - --domain
+                    - $(POD_NAMESPACE).svc.cluster.local
+                    - --proxyLogLevel
+                    - error
+                    - --proxyComponentLogLevel
+                    - misc:error
+                    - --log_output_level
+                    - default:error
+                  resources:
+                    limits:
+                      cpu: "4"
+                      memory: 4Gi
+                    requests:
+                      cpu: "1"
+                      memory: 1Gi
+
+labels:
+  - pairs:
+      app.kubernetes.io/instance: weka
+      app.kubernetes.io/gateway: llm-d-inference-gateway
+      app.kubernetes.io/component: inference-gateway

--- a/guides/tiered-prefix-cache/weka/manifests/gateway/overlays/istio/kustomization.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/gateway/overlays/istio/kustomization.yaml
@@ -55,5 +55,3 @@ patches:
 labels:
   - pairs:
       app.kubernetes.io/instance: weka
-      app.kubernetes.io/gateway: llm-d-inference-gateway
-      app.kubernetes.io/component: inference-gateway

--- a/guides/tiered-prefix-cache/weka/manifests/inferencepool.values.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/inferencepool.values.yaml
@@ -1,0 +1,68 @@
+inferenceExtension:
+  replicas: 1
+  image:
+    # upstream GIE epp image does NOT support PD, have to use `llm-d-inference-scheduler`
+    name: llm-d-inference-scheduler
+    hub: ghcr.io/llm-d
+    tag: v0.4.0
+    pullPolicy: Always
+  extProcPort: 9002
+  pluginsConfigFile: "pd-config.yaml"
+  pluginsCustomConfig:
+    pd-config.yaml: |
+      # ALWAYS DO PD IN THIS EXAMPLE (THRESHOLD 0)
+      apiVersion: inference.networking.x-k8s.io/v1alpha1
+      kind: EndpointPickerConfig
+      plugins:
+      - type: prefill-header-handler
+      - type: prefill-filter
+      - type: decode-filter
+      - type: max-score-picker
+      - type: queue-scorer
+        parameters:
+          hashBlockSize: 5
+          maxPrefixBlocksToMatch: 256
+          lruCapacityPerServer: 31250
+      - type: pd-profile-handler
+        parameters:
+          threshold: 0
+          hashBlockSize: 5
+      schedulingProfiles:
+      - name: prefill
+        plugins:
+        - pluginRef: prefill-filter
+        - pluginRef: queue-scorer
+          weight: 1.0
+        - pluginRef: max-score-picker
+      - name: decode
+        plugins:
+        - pluginRef: decode-filter
+        - pluginRef: queue-scorer
+          weight: 1.0
+        - pluginRef: max-score-picker
+
+inferencePool:
+  targetPortNumber: 8000
+  modelServerType: vllm
+  modelServers:
+    matchLabels:
+      llm-d.ai/inferenceServing: "true"
+
+provider:
+  name: istio
+  istio:
+    destinationRule:
+      trafficPolicy:
+        connectionPool:
+          http:
+            http1MaxPendingRequests: 256000
+            http2MaxRequests: 256000
+            idleTimeout: 900s
+            maxRequestsPerConnection: 256000
+          tcp:
+            connectTimeout: 900s
+            maxConnectionDuration: 1800s
+            maxConnections: 256000
+        tls:
+          insecureSkipVerify: true
+          mode: SIMPLE

--- a/guides/tiered-prefix-cache/weka/manifests/inferencepool.values.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/inferencepool.values.yaml
@@ -4,7 +4,7 @@ inferenceExtension:
     # upstream GIE epp image does NOT support PD, have to use `llm-d-inference-scheduler`
     name: llm-d-inference-scheduler
     hub: ghcr.io/llm-d
-    tag: v0.4.0
+    tag: v0.6.0
     pullPolicy: Always
   extProcPort: 9002
   pluginsConfigFile: "pd-config.yaml"
@@ -46,7 +46,7 @@ inferencePool:
   modelServerType: vllm
   modelServers:
     matchLabels:
-      llm-d.ai/inferenceServing: "true"
+      llm-d.ai/inference-serving: "true"
 
 provider:
   name: istio

--- a/guides/tiered-prefix-cache/weka/manifests/vllm/base/kustomization.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/vllm/base/kustomization.yaml
@@ -1,0 +1,263 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../../recipes/vllm/standard
+
+labels:
+  - pairs:
+      llm-d.ai/inferenceServing: "true"
+      llm-d.ai/model: Llama-33-70B-Instruct
+
+patches:
+  # Update image to latest llm-d
+  - target:
+      kind: Deployment
+      name: llm-d-model-server
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: "ghcr.io/llm-d/llm-d:latest"
+
+  # Update command and args for WEKA deployment
+  - target:
+      kind: Deployment
+      name: llm-d-model-server
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/command
+        value:
+          - "vllm"
+          - "serve"
+      - op: replace
+        path: /spec/template/spec/containers/0/args
+        value:
+          - "RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic"
+          - "--port"
+          - "8000"
+          - "--served-model-name"
+          - "RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic"
+          - "--block-size"
+          - "128"
+          - "--kv-transfer-config"
+          - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+          - "--disable-log-requests"
+          - "--disable-uvicorn-access-log"
+          - "--max-model-len"
+          - "32000"
+
+  # Remove HF_TOKEN from base recipe (not needed for WEKA deployment)
+  - target:
+      kind: Deployment
+      name: llm-d-model-server
+    patch: |-
+      - op: remove
+        path: /spec/template/spec/containers/0/env/0
+
+  # Add vLLM environment variables
+  - target:
+      kind: Deployment
+      name: llm-d-model-server
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: VLLM_NIXL_SIDE_CHANNEL_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: VLLM_LOGGING_LEVEL
+          value: "INFO"
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: NCCL_DEBUG
+          value: "INFO"
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: HF_HOME
+          value: "/mnt/weka/hf_cache"
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: NCCL_SOCKET_IFNAME
+          value: "=enp157s0np0,enp158s0np0"
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: NCCL_IB_HCA
+          value: "ibp"
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: UCX_NET_DEVICES
+          value: "ibp0:1,ibp1:1,ibp2:1,ibp3:1,ibp4:1,ibp5:1,ibp6:1,ibp7:1"
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: NVIDIA_GDRCOPY
+          value: "enabled"
+
+  # Update resources for WEKA deployment
+  - target:
+      kind: Deployment
+      name: llm-d-model-server
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/resources
+        value:
+          limits:
+            cpu: "8"
+            memory: 64Gi
+            nvidia.com/gpu: "1"
+            rdma/ib: 1
+          requests:
+            cpu: "8"
+            memory: 64Gi
+            nvidia.com/gpu: "1"
+            rdma/ib: 1
+
+  # Add initContainers for WEKA GDS setup
+  - target:
+      kind: Deployment
+      name: llm-d-model-server
+    patch: |-
+      - op: add
+        path: /spec/template/spec/initContainers
+        value:
+          - name: enable-nvidia-gds
+            image: "ghcr.io/llm-d/llm-d:latest"
+            command:
+              - /usr/local/bin/enable-nvidia-gds.sh
+            securityContext:
+              privileged: true
+          - name: create-cufile-on-node
+            image: quay.io/grpereir/amg-utils:latest
+            command:
+              - /usr/local/bin/entrypoint.sh
+            args:
+              - /bin/bash
+              - -lc
+              - "true"
+
+  # Replace startup probe with GDS-specific probe
+  - target:
+      kind: Deployment
+      name: llm-d-model-server
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/startupProbe
+        value:
+          exec:
+            command:
+              - "/usr/local/bin/gds-startup-probe.sh"
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          failureThreshold: 12
+
+  # Update readiness probe
+  - target:
+      kind: Deployment
+      name: llm-d-model-server
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/readinessProbe
+        value:
+          httpGet:
+            path: /v1/models
+            port: 8000
+          periodSeconds: 5
+          timeoutSeconds: 2
+          failureThreshold: 3
+
+  # Update liveness probe
+  - target:
+      kind: Deployment
+      name: llm-d-model-server
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/livenessProbe
+        value:
+          httpGet:
+            path: /health
+            port: 8000
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+
+  # Update service account
+  - target:
+      kind: Deployment
+      name: llm-d-model-server
+    patch: |-
+      - op: add
+        path: /spec/template/spec/serviceAccountName
+        value: weka-vllm
+
+  # Remove data volume from base (not needed for WEKA)
+  - target:
+      kind: Deployment
+      name: llm-d-model-server
+    patch: |-
+      - op: remove
+        path: /spec/template/spec/volumes/0
+
+  # Update shm volume to add sizeLimit
+  - target:
+      kind: Deployment
+      name: llm-d-model-server
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/volumes/0
+        value:
+          name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi
+
+  # Add WEKA storage volumes (will be patched by storage overlays)
+  - target:
+      kind: Deployment
+      name: llm-d-model-server
+    patch: |-
+      - op: add
+        path: /spec/template/spec/volumes/-
+        value:
+          name: weka-storage
+          # This will be patched by storage overlays (pvc or hostPath)
+      - op: add
+        path: /spec/template/spec/volumes/-
+        value:
+          name: host-node-cufile
+          hostPath:
+            path: ~/amg_stable/cufile.json
+            type: File
+
+  # Remove data volumeMount from base (not needed for WEKA)
+  - target:
+      kind: Deployment
+      name: llm-d-model-server
+    patch: |-
+      - op: remove
+        path: /spec/template/spec/containers/0/volumeMounts/0
+
+  # Add WEKA storage volume mounts
+  - target:
+      kind: Deployment
+      name: llm-d-model-server
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/volumeMounts/-
+        value:
+          name: weka-storage
+          mountPath: /mnt/weka
+      - op: add
+        path: /spec/template/spec/containers/0/volumeMounts/-
+        value:
+          name: host-node-cufile
+          mountPath: /etc/cufile.json
+          readOnly: true

--- a/guides/tiered-prefix-cache/weka/manifests/vllm/base/kustomization.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/vllm/base/kustomization.yaml
@@ -39,7 +39,7 @@ patches:
           - "--block-size"
           - "128"
           - "--kv-transfer-config"
-          - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+          - '{"kv_connector":"MultiConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"NixlConnector","kv_role":"kv_both"},{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}]}}'
           - "--disable-log-requests"
           - "--disable-uvicorn-access-log"
           - "--max-model-len"

--- a/guides/tiered-prefix-cache/weka/manifests/vllm/base/kustomization.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/vllm/base/kustomization.yaml
@@ -16,7 +16,7 @@ patches:
     patch: |-
       - op: replace
         path: /spec/template/spec/containers/0/image
-        value: "ghcr.io/llm-d/llm-d:latest"
+        value: "ghcr.io/llm-d/llm-d:v0.5.1"
 
   # Update command and args for WEKA deployment
   - target:
@@ -129,19 +129,11 @@ patches:
         path: /spec/template/spec/initContainers
         value:
           - name: enable-nvidia-gds
-            image: "ghcr.io/llm-d/llm-d:latest"
+            image: "ghcr.io/llm-d/llm-d:v0.5.1"
             command:
               - /usr/local/bin/enable-nvidia-gds.sh
             securityContext:
               privileged: true
-          - name: create-cufile-on-node
-            image: quay.io/grpereir/amg-utils:latest
-            command:
-              - /usr/local/bin/entrypoint.sh
-            args:
-              - /bin/bash
-              - -lc
-              - "true"
 
   # Replace startup probe with GDS-specific probe
   - target:
@@ -219,7 +211,7 @@ patches:
             medium: Memory
             sizeLimit: 16Gi
 
-  # Add WEKA storage volumes (will be patched by storage overlays)
+  # Add WEKA storage volume (will be patched by storage overlays)
   - target:
       kind: Deployment
       name: llm-d-model-server
@@ -229,13 +221,6 @@ patches:
         value:
           name: weka-storage
           # This will be patched by storage overlays (pvc or hostPath)
-      - op: add
-        path: /spec/template/spec/volumes/-
-        value:
-          name: host-node-cufile
-          hostPath:
-            path: ~/amg_stable/cufile.json
-            type: File
 
   # Remove data volumeMount from base (not needed for WEKA)
   - target:
@@ -258,6 +243,7 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/volumeMounts/-
         value:
-          name: host-node-cufile
+          name: weka-storage
           mountPath: /etc/cufile.json
+          subPath: cufile.json
           readOnly: true

--- a/guides/tiered-prefix-cache/weka/manifests/vllm/base/kustomization.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/vllm/base/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 
 labels:
   - pairs:
-      llm-d.ai/inferenceServing: "true"
+      llm-d.ai/inference-serving: "true"
       llm-d.ai/model: Llama-33-70B-Instruct
 
 patches:

--- a/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/decode/deployment-patch.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/decode/deployment-patch.yaml
@@ -51,7 +51,7 @@ spec:
             - --block-size
             - "128"
             - --kv-transfer-config
-            - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+            - '{"kv_connector":"MultiConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"NixlConnector","kv_role":"kv_both"},{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}]}}'
             - --disable-log-requests
             - --disable-uvicorn-access-log
             - --max-model-len

--- a/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/decode/deployment-patch.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/decode/deployment-patch.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm-d-model-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      llm-d.ai/role: decode
+  template:
+    metadata:
+      labels:
+        llm-d.ai/role: decode
+    spec:
+      serviceAccountName: weka-vllm
+      initContainers:
+        - name: routing-proxy
+          image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.5.0
+          imagePullPolicy: Always
+          args:
+            - --port=8000
+            - --vllm-port=8200
+            - --connector=nixlv2
+            - -v=1
+            - --secure-proxy=false
+          ports:
+            - containerPort: 8000
+          resources: {}
+          restartPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+        - name: create-cufile-on-node
+          image: quay.io/grpereir/amg-utils:latest
+          command:
+            - /usr/local/bin/entrypoint.sh
+          args:
+            - /bin/bash
+            - -lc
+            - "true"
+      containers:
+        - name: vllm
+          args:
+            - RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic
+            - --port
+            - "8200"
+            - --served-model-name
+            - RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic
+            - --tensor-parallel-size
+            - "4"
+            - --block-size
+            - "128"
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+            - --disable-log-requests
+            - --disable-uvicorn-access-log
+            - --max-model-len
+            - "32000"
+          readinessProbe:
+            httpGet:
+              path: /v1/models
+              port: 8200
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8200
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            limits:
+              cpu: "16"
+              memory: 64Gi
+              nvidia.com/gpu: "4"
+              rdma/ib: 1
+            requests:
+              cpu: "16"
+              memory: 64Gi
+              nvidia.com/gpu: "4"
+              rdma/ib: 1

--- a/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/decode/deployment-patch.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/decode/deployment-patch.yaml
@@ -30,14 +30,6 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
-        - name: create-cufile-on-node
-          image: quay.io/grpereir/amg-utils:latest
-          command:
-            - /usr/local/bin/entrypoint.sh
-          args:
-            - /bin/bash
-            - -lc
-            - "true"
       containers:
         - name: vllm
           args:

--- a/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/decode/deployment-patch.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/decode/deployment-patch.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: weka-vllm
       initContainers:
         - name: routing-proxy
-          image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.5.0
+          image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.6.0
           imagePullPolicy: Always
           args:
             - --port=8000

--- a/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/decode/kustomization.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/decode/kustomization.yaml
@@ -1,0 +1,32 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+
+patches:
+  # Apply strategic merge patch for decode configuration
+  - path: deployment-patch.yaml
+
+  # Rename deployment to "decode"
+  - target:
+      kind: Deployment
+      name: llm-d-model-server
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: decode
+
+  # Set ports for decode: 8200 (vLLM API) and 5600 (nixl side channel)
+  - target:
+      kind: Deployment
+      name: decode
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/ports
+        value:
+          - containerPort: 8200
+            name: metrics
+            protocol: TCP
+          - containerPort: 5600
+            name: nixl
+            protocol: TCP

--- a/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/decode/kustomization.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/decode/kustomization.yaml
@@ -7,19 +7,19 @@ patches:
   # Apply strategic merge patch for decode configuration
   - path: deployment-patch.yaml
 
-  # Rename deployment to "decode"
+  # Rename deployment to "weka-decode"
   - target:
       kind: Deployment
       name: llm-d-model-server
     patch: |-
       - op: replace
         path: /metadata/name
-        value: decode
+        value: weka-decode
 
   # Set ports for decode: 8200 (vLLM API) and 5600 (nixl side channel)
   - target:
       kind: Deployment
-      name: decode
+      name: weka-decode
     patch: |-
       - op: replace
         path: /spec/template/spec/containers/0/ports

--- a/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/host/kustomization.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/host/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: weka
+
+resources:
+  - serviceAccount.yaml
+  - ../decode
+  - ../prefill
+
+patches:
+  # Patch weka-storage volume to use hostPath for both decode and prefill
+  - target:
+      kind: Deployment
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/volumes/1
+        value:
+          name: weka-storage
+          hostPath:
+            path: /mnt/weka
+            type: Directory

--- a/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/host/serviceAccount.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/host/serviceAccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: weka-vllm
+  labels:
+    llm-d.ai/inferenceServing: "true"
+    llm-d.ai/model: Llama-33-70B-Instruct

--- a/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/host/serviceAccount.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/host/serviceAccount.yaml
@@ -3,5 +3,5 @@ kind: ServiceAccount
 metadata:
   name: weka-vllm
   labels:
-    llm-d.ai/inferenceServing: "true"
+    llm-d.ai/inference-serving: "true"
     llm-d.ai/model: Llama-33-70B-Instruct

--- a/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/prefill/deployment-patch.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/prefill/deployment-patch.yaml
@@ -24,7 +24,7 @@ spec:
             - --block-size
             - "128"
             - --kv-transfer-config
-            - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+            - '{"kv_connector":"MultiConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"NixlConnector","kv_role":"kv_both"},{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}]}}'
             - --disable-log-requests
             - --disable-uvicorn-access-log
             - --max-model-len

--- a/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/prefill/deployment-patch.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/prefill/deployment-patch.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm-d-model-server
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      llm-d.ai/role: prefill
+  template:
+    metadata:
+      labels:
+        llm-d.ai/role: prefill
+    spec:
+      serviceAccountName: weka-vllm
+      containers:
+        - name: vllm
+          args:
+            - RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic
+            - --port
+            - "8000"
+            - --served-model-name
+            - RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic
+            - --block-size
+            - "128"
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+            - --disable-log-requests
+            - --disable-uvicorn-access-log
+            - --max-model-len
+            - "32000"

--- a/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/prefill/kustomization.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/prefill/kustomization.yaml
@@ -1,0 +1,32 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+
+patches:
+  # Apply strategic merge patch for prefill configuration
+  - path: deployment-patch.yaml
+
+  # Rename deployment to "prefill"
+  - target:
+      kind: Deployment
+      name: llm-d-model-server
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: prefill
+
+  # Set ports for prefill: 8000 (vLLM API) and 5600 (nixl side channel)
+  - target:
+      kind: Deployment
+      name: prefill
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/ports
+        value:
+          - containerPort: 8000
+            name: http
+            protocol: TCP
+          - containerPort: 5600
+            name: nixl
+            protocol: TCP

--- a/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/prefill/kustomization.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/prefill/kustomization.yaml
@@ -7,19 +7,19 @@ patches:
   # Apply strategic merge patch for prefill configuration
   - path: deployment-patch.yaml
 
-  # Rename deployment to "prefill"
+  # Rename deployment to "weka-prefill"
   - target:
       kind: Deployment
       name: llm-d-model-server
     patch: |-
       - op: replace
         path: /metadata/name
-        value: prefill
+        value: weka-prefill
 
   # Set ports for prefill: 8000 (vLLM API) and 5600 (nixl side channel)
   - target:
       kind: Deployment
-      name: prefill
+      name: weka-prefill
     patch: |-
       - op: replace
         path: /spec/template/spec/containers/0/ports

--- a/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/pvc/kustomization.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/pvc/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: weka
+
+resources:
+  - serviceAccount.yaml
+  - ../decode
+  - ../prefill
+
+patches:
+  # Patch weka-storage volume to use PVC for both decode and prefill
+  - target:
+      kind: Deployment
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/volumes/1
+        value:
+          name: weka-storage
+          persistentVolumeClaim:
+            claimName: wekafs-amg

--- a/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/pvc/kustomization.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/pvc/kustomization.yaml
@@ -18,4 +18,4 @@ patches:
         value:
           name: weka-storage
           persistentVolumeClaim:
-            claimName: wekafs-amg
+            claimName: wekafs

--- a/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/pvc/pvc.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/pvc/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wekafs
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Gi
+  storageClassName: $STORAGE_CLASS

--- a/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/pvc/serviceAccount.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/pvc/serviceAccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: weka-vllm
+  labels:
+    llm-d.ai/inferenceServing: "true"
+    llm-d.ai/model: Llama-33-70B-Instruct

--- a/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/pvc/serviceAccount.yaml
+++ b/guides/tiered-prefix-cache/weka/manifests/vllm/overlays/pvc/serviceAccount.yaml
@@ -3,5 +3,5 @@ kind: ServiceAccount
 metadata:
   name: weka-vllm
   labels:
-    llm-d.ai/inferenceServing: "true"
+    llm-d.ai/inference-serving: "true"
     llm-d.ai/model: Llama-33-70B-Instruct


### PR DESCRIPTION
# Description
- add support to deploy weka backed storage by
1. ship a new probe script into final runtime image to do check on models loading and cufile.json existence
2. create another initConatiner in deployment to ensure nvidia models are loaded --this uses the same llm-d image which should not be wasting time to pull in to the cluster 
3. install extra packages during image build time
4. install new runtime package:  nvdia-gds(core which includes nvidia_fs gds-tools, libcufile etc) libibverbs libffi iproute infiniband-diags (for debug)
- add new guide for weka under "tiered-prefix-cache"
- use kustomize to deploy resources: Gateway, HTTPRoute, InferencePool, Deployment for decode and prefill
- support two overlays: host and pvc which require customization value.
- keep using Helm for InferencePool, DestinationRule and inference-scheduler deployment.
- update for the existing document

ref: https://issues.redhat.com/browse/INFERENG-3986

# Changes
creds to @Gregory-Pereira , cherry-pick his Draft:
- https://github.com/llm-d/llm-d/pull/208
- https://github.com/llm-d/llm-d/pull/246

# Note
this is a dupe of old PR https://github.com/llm-d/llm-d/pull/588