### PR TITLE
build(efa): uplift version from 1.43.3 to 1.46

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -28,6 +28,8 @@ ARG USE_SCCACHE=true
 
 # Note: Components are listed in build order.
 
+ARG EFA_INSTALLER_VERSION="1.46.0"
+
 ARG GDRCOPY_REPO="https://github.com/NVIDIA/gdrcopy.git"
 ARG GDRCOPY_VERSION="v2.5.1"
 
@@ -142,18 +144,21 @@ ENV NVSHMEM_DIR="/opt/nvshmem-${NVSHMEM_VERSION}" \
     EFA_PREFIX="/opt/amazon/efa" \
     UCX_PREFIX="/opt/ucx" \
     NIXL_PREFIX="/opt/nixl"
-    
+
 ENV PATH="${NVSHMEM_DIR}/bin:${VIRTUAL_ENV}/bin:${PATH}" \
     LIBRARY_PATH="${EFA_PREFIX}/lib:${EFA_PREFIX}/lib64:${UCX_PREFIX}/lib:${UCX_PREFIX}/lib64:${NVSHMEM_DIR}/lib:${NVSHMEM_DIR}/lib64:${CUDA_HOME}/lib64:/usr/local/lib:/usr/local/lib64" \
     CPATH="${NVSHMEM_DIR}/include:/usr/include:/usr/local/include:${CUDA_HOME}/include:${CPATH}" \
     PKG_CONFIG_PATH="${UCX_PREFIX}/lib/pkgconfig:${UCX_PREFIX}/lib64/pkgconfig:${EFA_PREFIX}/lib/pkgconfig:${EFA_PREFIX}/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib/aarch64-linux-gnu/pkgconfig:/usr/lib64/pkgconfig:/usr/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/share/pkgconfig:${PKG_CONFIG_PATH}"
 
 # Install EFA
+ARG EFA_INSTALLER_VERSION
 COPY docker/scripts/cuda/common/package-utils.sh /tmp/package-utils.sh
 COPY docker/scripts/cuda/builder/install-efa.sh /tmp/install-efa.sh
 RUN --mount=type=secret,id=subman_org \
     --mount=type=secret,id=subman_activation_key \
-    TARGETOS=${TARGETOS} /tmp/install-efa.sh && \
+    TARGETOS=${TARGETOS} \
+    EFA_INSTALLER_VERSION=${EFA_INSTALLER_VERSION} \
+    /tmp/install-efa.sh && \
     rm -f /tmp/install-efa.sh /tmp/package-utils.sh
 
 # Build and install gdrcopy


### PR DESCRIPTION
# Description

- Update EFA version to 1.46.0 as we need libfabric to build UCX and NVSHMEM

# Changes
- set version in Dockerfile.cuda
- simplify downloading and installation steps
- fix lint in shell



# Ref
- all available EFA release https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-changelog.html
- EFA installation guide https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html
- ref https://github.com/llm-d/llm-d/issues/589


