### PR TITLE
build(cpu): optimize docker build

### DIFF
--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -1,35 +1,28 @@
-FROM ubuntu:22.04 AS base-common
+FROM ubuntu:24.04 AS base-common
 
 ARG PYTHON_VERSION=3.12
 ARG PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu"
+# This should be set to a proper vllm release tag
+ARG VLLM_COMMIT=c5f10cc139ec87e217f2bb56a677dd57394729f5
+ARG TARGETARCH
+# Support for building with non-AVX512 vLLM
+ARG VLLM_CPU_DISABLE_AVX512=0
+# Support for building with AVX512BF16 ISA
+ARG VLLM_CPU_AVX512BF16=0
+# Support for building with AVX512VNNI ISA
+ARG VLLM_CPU_AVX512VNNI=0
 
-RUN apt clean && apt-get update -y && \
-    apt-get install -y --no-install-recommends --fix-missing \
-    curl \
-    git \
-    wget \
-    vim 
-
-RUN apt-get install -y ca-certificates && update-ca-certificates && \
-    git config --global http.sslVerify false
-
-
-# Clone vLLM and build for CPU
-WORKDIR /workspace
-RUN --mount=type=cache,target=/var/cache/git \
-    git clone https://github.com/vllm-project/vllm.git && \
-    cd vllm && \
-    git checkout c5f10cc139ec87e217f2bb56a677dd57394729f5
-
-
-WORKDIR /workspace/vllm
-
-# Install minimal dependencies and uv
+# Install system dependencies and uv
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update -y \
-    && apt-get install -y --no-install-recommends sudo ccache git curl wget ca-certificates \
-        gcc-12 g++-12 libtcmalloc-minimal4 libnuma-dev ffmpeg libsm6 libxext6 libgl1 jq lsof \
+    && apt-get install -y --no-install-recommends \
+        sudo curl git wget vim ca-certificates \
+        gcc-12 g++-12 ccache \
+        libtcmalloc-minimal4 libnuma-dev \
+        ffmpeg libsm6 libxext6 libgl1 jq lsof \
+    && update-ca-certificates \
+    && git config --global http.sslVerify false \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 10 --slave /usr/bin/g++ g++ /usr/bin/g++-12 \
     && curl -LsSf https://astral.sh/uv/install.sh | sh
 
@@ -40,21 +33,35 @@ ENV PATH="/root/.local/bin:$PATH"
 ENV VIRTUAL_ENV="/opt/venv"
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 RUN uv venv --python ${PYTHON_VERSION} --seed ${VIRTUAL_ENV}
+
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-ENV UV_HTTP_TIMEOUT=500
+# Clone vLLM source code
+WORKDIR /workspace
+RUN --mount=type=cache,target=/var/cache/git \
+    git clone https://github.com/vllm-project/vllm.git && \
+    cd vllm && \
+    git checkout ${VLLM_COMMIT}
 
 # Install Python dependencies
+WORKDIR /workspace/vllm
 ENV PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL}
 ENV UV_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL}
 ENV UV_INDEX_STRATEGY="unsafe-best-match"
 ENV UV_LINK_MODE="copy"
+ENV UV_HTTP_TIMEOUT=500
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --upgrade pip && \
     uv pip install -r requirements/cpu.txt
 
-ARG TARGETARCH
+RUN echo 'ulimit -c 0' >> ~/.bashrc
+
 ENV TARGETARCH=${TARGETARCH}
+
+# Only for runtime consistency
+ENV VLLM_CPU_DISABLE_AVX512=${VLLM_CPU_DISABLE_AVX512}
+ENV VLLM_CPU_AVX512BF16=${VLLM_CPU_AVX512BF16}
+ENV VLLM_CPU_AVX512VNNI=${VLLM_CPU_AVX512VNNI}
 
 ######################### x86_64 BASE IMAGE #########################
 FROM base-common AS base-amd64
@@ -66,42 +73,25 @@ FROM base-common AS base-arm64
 
 ENV LD_PRELOAD="/usr/lib/aarch64-linux-gnu/libtcmalloc_minimal.so.4"
 
-######################### BASE IMAGE #########################
-FROM base-${TARGETARCH} AS base
-
-RUN echo 'ulimit -c 0' >> ~/.bashrc
-
 ######################### BUILD IMAGE #########################
-FROM base AS vllm-build
+# Build vLLM wheel from source
+###############################################################
+FROM base-${TARGETARCH} AS vllm-build
 
 ARG max_jobs=32
-ENV MAX_JOBS=${max_jobs}
-
-ARG GIT_REPO_CHECK=0
-# Support for building with non-AVX512 vLLM: docker build --build-arg VLLM_CPU_DISABLE_AVX512="true" ...
-ARG VLLM_CPU_DISABLE_AVX512=0
-ENV VLLM_CPU_DISABLE_AVX512=${VLLM_CPU_DISABLE_AVX512}
-# Support for building with AVX512BF16 ISA: docker build --build-arg VLLM_CPU_AVX512BF16="true" ...
-ARG VLLM_CPU_AVX512BF16=0
-ENV VLLM_CPU_AVX512BF16=${VLLM_CPU_AVX512BF16}
-# Support for building with AVX512VNNI ISA: docker build --build-arg VLLM_CPU_AVX512VNNI="true" ...
-ARG VLLM_CPU_AVX512VNNI=0
-ENV VLLM_CPU_AVX512VNNI=${VLLM_CPU_AVX512VNNI}
 
 WORKDIR /workspace/vllm
 
 RUN --mount=type=cache,target=/root/.cache/uv \
    uv pip install -r requirements/cpu-build.txt
 
-
 RUN --mount=type=cache,target=/root/.cache/uv \
-    VLLM_TARGET_DEVICE=cpu python3 setup.py bdist_wheel --dist-dir=dist --py-limited-api=cp38
+    MAX_JOBS=${max_jobs} VLLM_TARGET_DEVICE=cpu \
+    python3 setup.py bdist_wheel --dist-dir=dist --py-limited-api=cp38
 
-CMD ["/bin/bash"]
-
-# ============================================================
-# Step 2: Build vllm-cpu-env with nixl + UCX
-# ============================================================
+######################### RUNTIME IMAGE #########################
+# Final runtime image with install vLLM wheel + NIXL + UCX
+#################################################################
 FROM vllm-build
 
 ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/lib:${LD_LIBRARY_PATH}"
@@ -110,8 +100,7 @@ RUN --mount=type=bind,from=vllm-build,src=/workspace/vllm/dist,target=dist \
     pip install dist/*.whl
 
 # Install pkg-config
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    pkg-config \
+RUN apt-get update && apt-get install -y --no-install-recommends pkg-config \
  && rm -rf /var/lib/apt/lists/*
 
 # Copy install_nixl.py script
@@ -121,5 +110,4 @@ COPY docker/scripts/cpu/install_nixl.py /workspace/install_nixl.py
 RUN python3 /workspace/install_nixl.py
 
 WORKDIR /workspace
-ENTRYPOINT ["/bin/bash"]
-
+ENTRYPOINT ["python", "-m", "vllm.entrypoints.openai.api_server"]


### PR DESCRIPTION
# Changes
- uplift base image to Ubuntu 24 which has python 3.12 preinstalled
- remove duplicated apt-get packages
- reduce final image layers and intermediate build stages
- change to use ENTRYPOINT than CMD to align with cuda image

# Breaking changes
take llama 3.2 as example
- pre this PR with `CMD ["/bin/bash"] `
>docker run -it ghcr.io/llm-d/llm-d-cpu-dev:old python -m vllm.entrypoints.openai.api_server --model meta-llama/Llama-3.2-3B
- after this PR with `ENTRYPOINT ["python", "-m", "vllm.entrypoints.openai.api_server"]`
>docker run -it ghcr.io/llm-d/llm-d-cpu-dev:new --model meta-llama/Llama-3.2-3B

# Build
```
>make image-build DEVICE=cpu VERSION=revert-back-22.04 BUILD_TYPE=dev PLATFORMS=linux/amd64
==== Building Docker image quay.io/wenzhou/llm-d/llm-d-cpu-dev:revert-back-22.04 ====
podman build --progress=plain --platform linux/amd64 -t quay.io/wenzhou/llm-d/llm-d-cpu-dev:revert-back-22.04 -f docker/Dockerfile.cpu .
...
```

# Test
```
>podman run --rm --entrypoint bash "quay.io/wenzhou/llm-d/llm-d-cpu-dev:revert-back-22.04" -c "pip list | grep -E 'vllm|torch|nixl' | head -20"
facebook/opt-125m --max-model-len 2048
intel_extension_for_pytorch       2.8.0
nixl                              0.6.1
torch                             2.8.0+cpu
torchaudio                        2.8.0+cpu
torchvision                       0.23.0+cpu
vllm                              0.11.1rc7.dev71+gc5f10cc13.cpu
```
```
>podman run --rm --entrypoint python "quay.io/wenzhou/llm-d/llm-d-cpu-dev:revert-back-22.04" -c "import os; print(...)"
VLLM_CPU_DISABLE_AVX512: 0
VLLM_CPU_AVX512BF16: 0
VLLM_CPU_AVX512VNNI: 0
```

`>podman run -d --rm -p 18080:8000 --ipc=host "quay.io/wenzhou/llm-d/llm-d-cpu-dev:revert-back-22.04" --model facebook/opt-125m --max-model-len 2048`
```
>podman logs d62890576354
...
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
(EngineCore_DP0 pid=93) INFO 01-19 09:20:42 [parallel_state.py:1325] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
(EngineCore_DP0 pid=93) INFO 01-19 09:20:42 [cpu_model_runner.py:55] Starting to load model facebook/opt-125m...
```
```
>curl -s http://127.0.0.1:18080/v1/models
{"object":"list","data":[{"id":"facebook/opt-125m","object":"model","created":1768814506,"owned_by":"vllm","root":"facebook/opt-125m","parent":null,"max_model_len":2048,"permission":[{"id":"modelperm-28d11ae461f64f93b29bb418200541d0","object":"model_permission","created":1768814506,"allow_create_engine":false,"allow_sampling":true,"allow_logprobs":true,"allow_search_indices":false,"allow_view":t
```
```
>curl -s http://127.0.0.1:18080/v1/completions -H "Content-Type: application/json" \
        -d '{
            "model": "facebook/opt-125m",
            "prompt": "San Francisco is a",
            "max_tokens": 1000
        }'
{"id":"cmpl-b2e851195d324a9db96b76a64ed5cd19","object":"text_completion","created":1768815106,"model":"facebook/opt-125m","choices":[{"index":0,"text":" mix builder town and US destination. I hope there are not many fancy techs here. The streets seem pretty upmarket, and I am not sure that there is enough variety of apartments and bakeries to have what you are looking for. :)  Mind if I ask how many people own a business in SFO and if so, where?\nJust to play around, I don't own a business, seems to rest the shelves on a rather large scale right off of the search box. Unearthed is also located in SFO, but I've heard of more newcomers understood to have a MetroFone, although I haven't heard much about that one either. I highly recommend both of them. :)\n> I don't own a business  then you haven't payed attention to what you've posted on other subs then have a 10 minute conversation with an unknown name :D","logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null,"prompt_logprobs":null,"prompt_token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":5,"total_tokens":185,"completion_tokens":180,"prompt_tokens_details":null},"kv_t
```

