### PR TITLE
build: reduce cuda runtime image size by switch base image

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -287,7 +287,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # ============================================================================
 # RUNTIME STAGE - Minimal runtime image
 # ============================================================================
-FROM nvcr.io/nvidia/cuda:${CUDA_MAJOR}.${CUDA_MINOR}.${CUDA_PATCH}-devel-${FINAL_BASE_IMAGE_SUFFIX} AS runtime
+FROM nvcr.io/nvidia/cuda:${CUDA_MAJOR}.${CUDA_MINOR}.${CUDA_PATCH}-runtime-${FINAL_BASE_IMAGE_SUFFIX} AS runtime
 
 ARG CACHE_BUSTER
 RUN if [ -n "${CACHE_BUSTER}" ]; then \

--- a/docker/packages/cuda/runtime-packages.json
+++ b/docker/packages/cuda/runtime-packages.json
@@ -1,13 +1,12 @@
 {
   "rhel_to_ubuntu": {
     "cuda-nvcc-${CUDA_MAJOR}-${CUDA_MINOR}": "cuda-nvcc-${CUDA_MAJOR}-${CUDA_MINOR}",
-    "cuda-cuobjdump-${CUDA_MAJOR}-${CUDA_MINOR}": "cuda-cuobjdump-${CUDA_MAJOR}-${CUDA_MINOR}",
     "cuda-nvrtc-${CUDA_MAJOR}-${CUDA_MINOR}": "cuda-nvrtc-${CUDA_MAJOR}-${CUDA_MINOR}",
+    "cuda-cudart-devel-${CUDA_MAJOR}-${CUDA_MINOR}": "cuda-cudart-dev-${CUDA_MAJOR}-${CUDA_MINOR}",
     "python${PYTHON_VERSION}": "python${PYTHON_VERSION}",
     "python${PYTHON_VERSION}-pip": "python${PYTHON_VERSION}-venv",
     "python${PYTHON_VERSION}-devel": "python${PYTHON_VERSION}-dev",
     "numactl-libs": "libnuma1",
-    "pciutils": "pciutils",
     "procps-ng": "procps",
     "git": "git",
     "libatomic": "libatomic1",
@@ -16,7 +15,6 @@
     "libxcb-devel":"libxcb1-dev"
   },
   "ubuntu_only": [
-    "gcc",
     "hwloc",
     "libhwloc15",
     "curl"


### PR DESCRIPTION
# Description
- change to use cuda runtime than devel as runtime base image
- remove unnecessary runtime packages: gcc git cuda-cuobjdump pcituil
- add cuda-cudart-dev which is in the old devel [image](https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/12.9.1/ubi9/devel/Dockerfile?ref_type=heads#L51) 

Ref: https://github.com/llm-d/llm-d/issues/301

# Build
https://github.com/llm-d/llm-d/pkgs/container/llm-d-cuda-dev/645358748?tag=pr-606
https://github.com/llm-d/llm-d/pkgs/container/llm-d-cuda-dev-ubuntu/645358787?tag=pr-606

# Detail
in 0.4.0 nvcr.io/nvidia/cuda:12.9.1-devel-ubi9 is of size 4.17G
by switch to nvcr.io/nvidia/cuda:12.9.1-devel-ubi9 is 1.3G
the rest of the packages removed + added aint taken much space