### PR TITLE
build(efa): uplift version from 1.43.3 to 1.46.0

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -28,6 +28,8 @@ ARG USE_SCCACHE=true
 
 # Note: Components are listed in build order.
 
+ARG EFA_INSTALLER_VERSION="1.46.0"
+
 ARG GDRCOPY_REPO="https://github.com/NVIDIA/gdrcopy.git"
 ARG GDRCOPY_VERSION="v2.5.1"
 
@@ -142,18 +144,21 @@ ENV NVSHMEM_DIR="/opt/nvshmem-${NVSHMEM_VERSION}" \
     EFA_PREFIX="/opt/amazon/efa" \
     UCX_PREFIX="/opt/ucx" \
     NIXL_PREFIX="/opt/nixl"
-    
+
 ENV PATH="${NVSHMEM_DIR}/bin:${VIRTUAL_ENV}/bin:${PATH}" \
     LIBRARY_PATH="${EFA_PREFIX}/lib:${EFA_PREFIX}/lib64:${UCX_PREFIX}/lib:${UCX_PREFIX}/lib64:${NVSHMEM_DIR}/lib:${NVSHMEM_DIR}/lib64:${CUDA_HOME}/lib64:/usr/local/lib:/usr/local/lib64" \
     CPATH="${NVSHMEM_DIR}/include:/usr/include:/usr/local/include:${CUDA_HOME}/include:${CPATH}" \
     PKG_CONFIG_PATH="${UCX_PREFIX}/lib/pkgconfig:${UCX_PREFIX}/lib64/pkgconfig:${EFA_PREFIX}/lib/pkgconfig:${EFA_PREFIX}/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib/aarch64-linux-gnu/pkgconfig:/usr/lib64/pkgconfig:/usr/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/share/pkgconfig:${PKG_CONFIG_PATH}"
 
 # Install EFA
+ARG EFA_INSTALLER_VERSION
 COPY docker/scripts/cuda/common/package-utils.sh /tmp/package-utils.sh
 COPY docker/scripts/cuda/builder/install-efa.sh /tmp/install-efa.sh
 RUN --mount=type=secret,id=subman_org \
     --mount=type=secret,id=subman_activation_key \
-    TARGETOS=${TARGETOS} /tmp/install-efa.sh && \
+    TARGETOS=${TARGETOS} \
+    EFA_INSTALLER_VERSION=${EFA_INSTALLER_VERSION} \
+    /tmp/install-efa.sh && \
     rm -f /tmp/install-efa.sh /tmp/package-utils.sh
 
 # Build and install gdrcopy

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -320,19 +320,12 @@ RUN TARGETOS=${TARGETOS} /tmp/install-runtime-packages.sh && \
 COPY --from=builder /opt/amazon/efa /opt/amazon/efa/
 
 # Copy efa libs from builder (install-efa.sh)
+# Ubuntu does not build EFA, dummy empty folder
 COPY --from=builder /tmp/efa_libs /tmp/efa_libs
-RUN if [ -d /tmp/efa_libs ]; then \
-        if [ "${TARGETOS:-rhel}" = "ubuntu" ]; then \
-            if [ "${TARGETPLATFORM:-linux/amd64}" = "linux/arm64" ]; then \
-                cp -a /tmp/efa_libs/* /usr/lib/aarch64-linux-gnu/ || true; \
-            else \
-                cp -a /tmp/efa_libs/* /usr/lib/x86_64-linux-gnu/ || true; \
-            fi; \
-        else \
-            cp -a /tmp/efa_libs/* /usr/lib64/ || true; \
-        fi; \
-        rm -rf /tmp/efa_libs; \
-    fi
+RUN if [ "${TARGETOS:-rhel}" = "rhel" ] && [ -d /tmp/efa_libs ]; then \
+        cp -a /tmp/efa_libs/* /usr/lib64/ || true; \
+    fi && \
+    rm -rf /tmp/efa_libs
 
 # Copy gdrcopy libraries from builder
 # Install to /usr/local/lib (always present) and multiarch lib dir

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -320,7 +320,7 @@ RUN TARGETOS=${TARGETOS} /tmp/install-runtime-packages.sh && \
 COPY --from=builder /opt/amazon/efa /opt/amazon/efa/
 
 # Copy efa libs from builder (install-efa.sh)
-# Ubuntu does not build EFA, dummy empty folder
+# Ubuntu does not build EFA
 COPY --from=builder /tmp/efa_libs /tmp/efa_libs
 RUN if [ "${TARGETOS:-rhel}" = "rhel" ] && [ -d /tmp/efa_libs ]; then \
         cp -a /tmp/efa_libs/* /usr/lib64/ || true; \

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -319,6 +319,21 @@ RUN TARGETOS=${TARGETOS} /tmp/install-runtime-packages.sh && \
 # Copy in efa
 COPY --from=builder /opt/amazon/efa /opt/amazon/efa/
 
+# Copy efa libs from builder (install-efa.sh)
+COPY --from=builder /tmp/efa_libs /tmp/efa_libs
+RUN if [ -d /tmp/efa_libs ]; then \
+        if [ "${TARGETOS:-rhel}" = "ubuntu" ]; then \
+            if [ "${TARGETPLATFORM:-linux/amd64}" = "linux/arm64" ]; then \
+                cp -a /tmp/efa_libs/* /usr/lib/aarch64-linux-gnu/ || true; \
+            else \
+                cp -a /tmp/efa_libs/* /usr/lib/x86_64-linux-gnu/ || true; \
+            fi; \
+        else \
+            cp -a /tmp/efa_libs/* /usr/lib64/ || true; \
+        fi; \
+        rm -rf /tmp/efa_libs; \
+    fi
+
 # Copy gdrcopy libraries from builder
 # Install to /usr/local/lib (always present) and multiarch lib dir
 COPY --from=builder /usr/local/lib/libgdrapi.so* /usr/local/lib/

--- a/docker/scripts/cuda/builder/install-efa.sh
+++ b/docker/scripts/cuda/builder/install-efa.sh
@@ -14,7 +14,7 @@ set -Eeu
 
 if [ "$TARGETOS" = "ubuntu" ]; then
     echo "Ubuntu image needs to be built against Ubuntu 20.04 and EFA only supports 22.04 and 24.04."
-    mkdir -p "${EFA_PREFIX}"
+    mkdir -p "${EFA_PREFIX}" /tmp/efa_libs
     exit 0
 fi
 
@@ -53,27 +53,10 @@ ldconfig
 rm -rf "${EFA_WORKDIR}"
 
 # new EFA installer puts libefa.so.1 in different locations depending on OS:
-# - RHEL/UBI: /usr/lib64
-# - Ubuntu: /usr/lib/x86_64-linux-gnu or /usr/lib/aarch64-linux-gnu
+# - RHEL/UBI: /lib64
 mkdir -p /tmp/efa_libs
-if [ "$TARGETOS" = "ubuntu" ]; then
-    if [ "${TARGETPLATFORM:-linux/amd64}" = "linux/arm64" ]; then
-        if [ -f /usr/lib/aarch64-linux-gnu/libefa.so.1 ]; then
-            cp -a /usr/lib/aarch64-linux-gnu/libefa.so* /tmp/efa_libs/ || true
-        fi
-    else
-        if [ -f /usr/lib/x86_64-linux-gnu/libefa.so.1 ]; then
-            cp -a /usr/lib/x86_64-linux-gnu/libefa.so* /tmp/efa_libs/ || true
-        fi
-    fi
-    cleanup_packages ubuntu
-elif [ "$TARGETOS" = "rhel" ]; then
-    if [ -f /lib64/libefa.so.1 ]; then
-        cp -a /lib64/libefa.so* /tmp/efa_libs/ || true
-    fi
-    cleanup_packages rhel
-    ensure_unregistered
-else
-    echo "ERROR: Unsupported TARGETOS='$TARGETOS'. Must be 'ubuntu' or 'rhel'." >&2
-    exit 1
+if [ -f /lib64/libefa.so.1 ]; then
+    cp -a /lib64/libefa.so* /tmp/efa_libs/ || true
 fi
+cleanup_packages rhel
+ensure_unregistered

--- a/docker/scripts/cuda/builder/install-efa.sh
+++ b/docker/scripts/cuda/builder/install-efa.sh
@@ -52,9 +52,25 @@ cd "${EFA_WORKDIR}/aws-efa-installer" && ./efa_installer.sh --skip-kmod --no-ver
 ldconfig
 rm -rf "${EFA_WORKDIR}"
 
+# new EFA installer puts libefa.so.1 in different locations depending on OS:
+# - RHEL/UBI: /usr/lib64
+# - Ubuntu: /usr/lib/x86_64-linux-gnu or /usr/lib/aarch64-linux-gnu
+mkdir -p /tmp/efa_libs
 if [ "$TARGETOS" = "ubuntu" ]; then
+    if [ "${TARGETPLATFORM:-linux/amd64}" = "linux/arm64" ]; then
+        if [ -f /usr/lib/aarch64-linux-gnu/libefa.so.1 ]; then
+            cp -a /usr/lib/aarch64-linux-gnu/libefa.so* /tmp/efa_libs/ || true
+        fi
+    else
+        if [ -f /usr/lib/x86_64-linux-gnu/libefa.so.1 ]; then
+            cp -a /usr/lib/x86_64-linux-gnu/libefa.so* /tmp/efa_libs/ || true
+        fi
+    fi
     cleanup_packages ubuntu
 elif [ "$TARGETOS" = "rhel" ]; then
+    if [ -f /lib64/libefa.so.1 ]; then
+        cp -a /lib64/libefa.so* /tmp/efa_libs/ || true
+    fi
     cleanup_packages rhel
     ensure_unregistered
 else

--- a/docker/scripts/cuda/builder/install-efa.sh
+++ b/docker/scripts/cuda/builder/install-efa.sh
@@ -14,6 +14,7 @@ set -Eeu
 
 if [ "$TARGETOS" = "ubuntu" ]; then
     echo "Ubuntu image needs to be built against Ubuntu 20.04 and EFA only supports 22.04 and 24.04."
+    # Create empty folder so Dockerfile COPY don't fail on Ubuntu
     mkdir -p "${EFA_PREFIX}" /tmp/efa_libs
     exit 0
 fi
@@ -52,11 +53,16 @@ cd "${EFA_WORKDIR}/aws-efa-installer" && ./efa_installer.sh --skip-kmod --no-ver
 ldconfig
 rm -rf "${EFA_WORKDIR}"
 
-# new EFA installer puts libefa.so.1 in different locations depending on OS:
-# - RHEL/UBI: /lib64
+# Copy all EFA-installed libs to runtime
+# - libefa.so*
+# - libibverbs.so*
+# - librdmacm.so*
 mkdir -p /tmp/efa_libs
-if [ -f /lib64/libefa.so.1 ]; then
-    cp -a /lib64/libefa.so* /tmp/efa_libs/ || true
-fi
+for efalib in libefa libibverbs librdmacm; do
+    if ls /lib64/${efalib}.so* >/dev/null 2>&1; then
+        cp -a /lib64/${efalib}.so* /tmp/efa_libs/ || true
+    fi
+done
+
 cleanup_packages rhel
 ensure_unregistered


### PR DESCRIPTION
# Description

- Update EFA version to 1.46.0 as we need libfabric to build UCX and NVSHMEM
- copy libefa.so.1 from builder to runtime

# Changes
- set version in Dockerfile.cuda
- simplify downloading and installation steps
- fix lint in shell

# Build
https://github.com/llm-d/llm-d/pkgs/container/llm-d-cuda-dev/645085300?tag=pr-607

# Test
using image ghcr.io/llm-d/llm-d-cuda-dev:pr-607@ from above CI build (new build from )
```
>podman run -it --rm   --ipc=host   --entrypoint /bin/bash  ghcr.io/llm-d/llm-d-cuda:sha-8f12238
bash-5.1$ export NIXL_LOG_LEVEL=debug
python3 - <<'EOF'
from nixl._api import nixl_agent, nixl_agent_config
agent_config = nixl_agent_config(backends=["LIBFABRIC"])
nixl_agent1 = nixl_agent("target", agent_config)
EOF
2026-01-21 06:15:57 NIXL INFO    logging.py:82 Log level set to DEBUG from NIXL_LOG_LEVEL environment variable
I0121 06:15:57.751350       3 nixl_agent.cpp:122] NIXL ETCD is excluded
I0121 06:15:57.751441       3 nixl_plugin_manager.cpp:206] Loading plugins from: /opt/vllm/lib64/python3.12/site-packages/nixl_cu12/../.nixl_cu12.mesonpy.libs/plugins
I0121 06:15:57.751652       3 nixl_plugin_manager.cpp:316] Discovered and loaded plugin: GDS
I0121 06:15:57.751839       3 nixl_plugin_manager.cpp:316] Discovered and loaded plugin: GDS_MT
I0121 06:15:57.752585       3 nixl_plugin_manager.cpp:316] Discovered and loaded plugin: LIBFABRIC
I0121 06:15:57.752748       3 nixl_plugin_manager.cpp:316] Discovered and loaded plugin: POSIX
I0121 06:15:57.754708       3 nixl_plugin_manager.cpp:316] Discovered and loaded plugin: UCX
I0121 06:15:57.754745       3 libfabric_rail_manager.cpp:41] Creating rail manager with striping threshold: 131072 bytes
I0121 06:15:58.033739       3 libfabric_topology.cpp:124] Discovered 1 socket devices (TCP fallback)
I0121 06:15:58.033767       3 libfabric_topology.cpp:96] Using simplified topology for sockets devices (no topology mapping needed)
I0121 06:15:58.033769       3 libfabric_topology.cpp:104] TCP devices available globally - no GPU-specific mapping required
I0121 06:15:58.033774       3 libfabric_rail_manager.cpp:51] Got 1 network devices from topology for provider=sockets
I0121 06:15:58.033800       3 libfabric_rail.cpp:48] InitializeBasePool - Rail 0 completed. Total requests: 1024 Free requests: 1024
I0121 06:15:58.033825       3 libfabric_rail.cpp:48] InitializeBasePool - Rail 0 completed. Total requests: 1024 Free requests: 1024
I0121 06:15:58.033833       3 libfabric_rail.cpp:438] No provider found with FI_HMEM capability for rail 0, retrying without FI_HMEM
I0121 06:15:58.033979       3 libfabric_rail.cpp:452] Using provider without FI_HMEM support for rail 0
I0121 06:15:58.033997       3 libfabric_rail.cpp:465] fabric_attr->name 192.168.0.0/24
W0121 06:15:58.034107       3 libfabric_rail.cpp:544] fi_setopt FI_OPT_SHARED_MEMORY_PERMITTED failed for rail 0: Protocol not available - continuing anyway
I0121 06:15:58.034127       3 libfabric_rail.cpp:210] CreateBufferChunk on Rail 0 successfully created buffer chunk: buffer=0x7f60fd7a1010 size=8388608 mr=0x557cdc4f7490 mr_key=18446744073709551615
I0121 06:15:58.034134       3 libfabric_rail.cpp:244] InitializeWithBuffers on Rail 0 successfully initialized with 1 buffer chunks
I0121 06:15:58.039378       3 libfabric_rail_manager.cpp:97] Created data rail 0 (device=wlp9s0f0, provider=sockets)
I0121 06:15:58.039413       3 libfabric_rail.cpp:48] InitializeBasePool - Rail 0 completed. Total requests: 1024 Free requests: 1024
I0121 06:15:58.039439       3 libfabric_rail.cpp:48] InitializeBasePool - Rail 0 completed. Total requests: 1024 Free requests: 1024
I0121 06:15:58.039458       3 libfabric_rail.cpp:438] No provider found with FI_HMEM capability for rail 0, retrying without FI_HMEM
I0121 06:15:58.039649       3 libfabric_rail.cpp:452] Using provider without FI_HMEM support for rail 0
I0121 06:15:58.039668       3 libfabric_rail.cpp:465] fabric_attr->name 192.168.0.0/24
W0121 06:15:58.039743       3 libfabric_rail.cpp:544] fi_setopt FI_OPT_SHARED_MEMORY_PERMITTED failed for rail 0: Protocol not available - continuing anyway
I0121 06:15:58.039755       3 libfabric_rail.cpp:210] CreateBufferChunk on Rail 0 successfully created buffer chunk: buffer=0x7f60f77ff010 size=8388608 mr=0x557cdc8202a0 mr_key=18446744073709551615
I0121 06:15:58.039762       3 libfabric_rail.cpp:244] InitializeWithBuffers on Rail 0 successfully initialized with 1 buffer chunks
I0121 06:15:58.045409       3 libfabric_rail_manager.cpp:123] Created control rail 0 (device=wlp9s0f0, provider=sockets)
I0121 06:15:58.045418       3 libfabric_rail_manager.cpp:67] Successfully created 1 data rails and 1 control rails using provider=sockets
I0121 06:15:58.045421       3 libfabric_backend.cpp:233] Initializing Libfabric Backend with GPU Support
I0121 06:15:58.045424       3 libfabric_backend.cpp:244] CUDA address workaround enabled
I0121 06:15:58.045426       3 libfabric_backend.cpp:262] Using default striping threshold: 131072 bytes
I0121 06:15:58.045427       3 libfabric_backend.cpp:267] Rail Manager created with 1 data rails and 1 control rails
I0121 06:15:58.045429       3 libfabric_backend.cpp:272] Set notification processor for control rail 0
I0121 06:15:58.045430       3 libfabric_backend.cpp:279] Set connection state processor for CM rail 0
I0121 06:15:58.045432       3 libfabric_backend.cpp:297] Setting up XFER_ID tracking callbacks for 1 data rails
I0121 06:15:58.045434       3 libfabric_backend.cpp:306] Set XFER_ID callback for data rail 0
I0121 06:15:58.045437       3 libfabric_backend.cpp:543] Creating connection for agent: target
I0121 06:15:58.045462       3 libfabric_rail_manager.cpp:514] Processed data rail 0 (fi_addr=0)
I0121 06:15:58.045465       3 libfabric_rail_manager.cpp:523] Successfully processed 1 data rails
I0121 06:15:58.045482       3 libfabric_rail_manager.cpp:514] Processed control rail 0 (fi_addr=0)
I0121 06:15:58.045484       3 libfabric_rail_manager.cpp:523] Successfully processed 1 control rails
I0121 06:15:58.045485       3 libfabric_backend.cpp:593] Index 0: target
I0121 06:15:58.045488       3 libfabric_backend.cpp:601] Successfully created connection for agent: target on 1 data rails and 1 control rails
I0121 06:15:58.045491       3 libfabric_backend.cpp:335] Created self-connection for agent: target on 1 data rails and 1 control rails
I0121 06:15:58.045492       3 libfabric_backend.cpp:341] Starting CM thread
I0121 06:15:58.045527       3 libfabric_backend.cpp:347] ConnectionManagement thread started successfully
I0121 06:15:58.045529       3 libfabric_backend.cpp:351] Starting Progress thread for data rails with delay: 0 microseconds
I0121 06:15:58.045546       3 libfabric_backend.cpp:360] Progress thread started successfully
I0121 06:15:58.045549       3 libfabric_backend.cpp:416] Retrieving local endpoint addresses for all 1 rails
I0121 06:15:58.045558       3 libfabric_rail_manager.cpp:819] Serialized 1 data rail endpoints
I0121 06:15:58.045561       3 libfabric_rail_manager.cpp:819] Serialized 1 control rail endpoints
I0121 06:15:58.045563       3 libfabric_rail_manager.cpp:765] Connection info serialized with prefix dest, size=210
I0121 06:15:58.045565       3 libfabric_backend.cpp:426] Rail Manager serialized connection info for 1 rails, 1 control rails, total size=210
I0121 06:15:58.045569       3 libfabric_backend.cpp:477] Connecting to agent: target, connections_ size=1
I0121 06:15:58.045571       3 libfabric_backend.cpp:489] Connection exists but not established, triggering establishConnection for target
I0121 06:15:58.045573       3 libfabric_backend.cpp:633] Establishing connections_ on control rails and data rails for agent: target
I0121 06:15:58.045575       3 libfabric_backend.cpp:639] Using connection info with 1 data rails and 1 control rails
I0121 06:15:58.045577       3 libfabric_backend.cpp:642] Data rail 0: 02 00 8a 15 c0 a8 00 1f 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
I0121 06:15:58.045584       3 libfabric_backend.cpp:646] Control rail 0: 02 00 b0 49 c0 a8 00 1f 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
I0121 06:15:58.045588       3 libfabric_backend.cpp:649] Agent index: 0
I0121 06:15:58.045591       3 libfabric_rail_manager.cpp:819] Serialized 1 data rail endpoints
I0121 06:15:58.045593       3 libfabric_rail_manager.cpp:819] Serialized 1 control rail endpoints
I0121 06:15:58.045594       3 libfabric_rail_manager.cpp:765] Connection info serialized with prefix src, size=208
I0121 06:15:58.045599       3 libfabric_rail_manager.cpp:609] Sending control message type 0 agent_idx=0 XFER_ID=3 imm_data=12288
I0121 06:15:58.045557      28 libfabric_backend.cpp:1290] PT: Thread started successfully for data rails only
I0121 06:15:58.045544      27 libfabric_backend.cpp:1262] CM: Thread started successfully


bash-5.1$ /opt/amazon/efa/bin/fi_info --version
/opt/amazon/efa/bin/fi_info: 2.3.1amzn4.0
libfabric: 2.3.1amzn4.0
libfabric api: 2.3


```


# Ref
- all available EFA release https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-changelog.html
- EFA installation guide https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html
- ref https://github.com/llm-d/llm-d/issues/589
