### PR TITLE
fix(GHA): ignore lint for markdown file with line number + build for XPU and CPU with "docker/build-push-action"

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -11,8 +11,10 @@ exclude = [
   "^https://platform\\.openai\\.com/docs/api-reference/",
   # Google Docs headings/fragments are dynamically generated and not reliably checkable
   "^https://docs\\.google\\.com/document/.*#",
-  # GitHub blob line anchors (#L123 / #L123-L130) aren’t reliably checkable by lychee (HTML-only anchors)
+  # GitHub blob line anchors (#L123 / #L123-L130) aren't reliably checkable by lychee (HTML-only anchors)
   "^https://github\\.com/.*/blob/.*#L[0-9]",
+  # Local file references with line numbers cannot be verified by lychee
+  "^file://.*:[0-9]",
 ]
 
 # Accept status codes like 200 (OK), 204 (No Content), etc.

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -474,6 +474,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to Container Registry
         uses: docker/login-action@v3
         with:
@@ -500,8 +503,8 @@ jobs:
           platforms: linux/amd64
           push: true
           provenance: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=xpu-dev
+          cache-to: type=gha,mode=max,scope=xpu-dev,oci-mediatypes=true,compression=zstd
           tags: |
             ${{ env.REGISTRY }}/${{ github.repository }}-xpu-dev:${{ steps.set-tag.outputs.tag }}
             ${{ steps.set-tag.outputs.pr_tag != '' && format('{0}/{1}-xpu-dev:{2}', env.REGISTRY, github.repository, steps.set-tag.outputs.pr_tag) || '' }}
@@ -554,6 +557,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to Container Registry
         uses: docker/login-action@v3
         with:
@@ -580,8 +586,8 @@ jobs:
           platforms: linux/amd64
           push: true
           provenance: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=cpu-dev
+          cache-to: type=gha,mode=max,scope=cpu-dev,oci-mediatypes=true,compression=zstd
           tags: |
             ${{ env.REGISTRY }}/${{ github.repository }}-cpu-dev:${{ steps.set-tag.outputs.tag }}
             ${{ steps.set-tag.outputs.pr_tag != '' && format('{0}/{1}-cpu-dev:{2}', env.REGISTRY, github.repository, steps.set-tag.outputs.pr_tag) || '' }}

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -90,7 +90,7 @@ jobs:
             matrix.platform == 'linux/arm64' && 'arm64' || 'amd64' }}
           cache-to: >-
             type=gha,mode=max,scope=cuda-${{ matrix.os }}-${{
-            matrix.platform == 'linux/arm64' && 'arm64' || 'amd64' }}
+            matrix.platform == 'linux/arm64' && 'arm64' || 'amd64' }},oci-mediatypes=true,compression=zstd
           labels: ${{ steps.meta.outputs.labels }}
           outputs: >-
             type=image,name=${{ env.REGISTRY }}/${{ github.repository }}-cuda${{ matrix.image_suffix }},
@@ -262,8 +262,8 @@ jobs:
           platforms: linux/amd64
           push: true
           provenance: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=aws
+          cache-to: type=gha,mode=max,scope=aws,oci-mediatypes=true,compression=zstd
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           github-token: ${{ secrets.GHCR_TOKEN }}
@@ -331,8 +331,8 @@ jobs:
           platforms: linux/amd64
           push: true
           provenance: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=cpu
+          cache-to: type=gha,mode=max,scope=cpu,oci-mediatypes=true,compression=zstd
           tags: |
             ${{ env.REGISTRY }}/${{ github.repository }}-cpu:${{ env.TAG }}
             ${{ env.REGISTRY }}/${{ github.repository }}-cpu:latest
@@ -401,8 +401,8 @@ jobs:
           platforms: linux/amd64
           push: true
           provenance: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=xpu
+          cache-to: type=gha,mode=max,scope=xpu,oci-mediatypes=true,compression=zstd
           tags: |
             ${{ env.REGISTRY }}/${{ github.repository }}-xpu:${{ env.TAG }}
             ${{ env.REGISTRY }}/${{ github.repository }}-xpu:latest


### PR DESCRIPTION
# Description
When made change in [PR](https://github.com/llm-d/llm-d/pull/568), there is a bug which blocked build image for XPU and CPU. This was found when test [PR ](https://github.com/llm-d/llm-d/pull/611)
see: https://github.com/llm-d/llm-d/actions/runs/21134003416/job/60771639084
and lint is failing because of file line number is used
see: https://github.com/llm-d/llm-d/actions/runs/21133599789/job/60770296742

# Changes
This PR is to address above two issues, by
- fix github action for both build-images and ci-release
- ignore checks on the line in lychee

