### PR TITLE
Fixing wide ep decode port name

### DIFF
--- a/guides/wide-ep-lws/manifests/modelserver/base/decode.yaml
+++ b/guides/wide-ep-lws/manifests/modelserver/base/decode.yaml
@@ -168,7 +168,7 @@ spec:
             name: vllm
             protocol: TCP
           - containerPort: 5557
-            name: vllm
+            name: nixl
             protocol: TCP
           startupProbe:
             httpGet:


### PR DESCRIPTION
Current Decode yaml in the Wide-EP yaml is broken since the port name is duplicate. Changed to match the port name in the prefill yaml