### PR TITLE
fix: DestinationRule creation from Helm for wideEP

### DIFF
--- a/guides/wide-ep-lws/manifests/inferencepool.values.yaml
+++ b/guides/wide-ep-lws/manifests/inferencepool.values.yaml
@@ -24,7 +24,7 @@ inferenceExtension:
   pluginsCustomConfig:
     custom-plugins.yaml: |
       # ALWAYS DO PD IN THIS EXAMPLE (THRESHOLD 0)
-      # This example uses random routing 
+      # This example uses random routing
       # since it's not yet possible to route to individual DP ranks
       apiVersion: inference.networking.x-k8s.io/v1alpha1
       kind: EndpointPickerConfig
@@ -54,21 +54,23 @@ inferencePool:
     matchLabels:
       llm-d.ai/inferenceServing: "true"
       llm-d.ai/model: DeepSeek-R1-0528
-  provider:
-    istio:
-      destinationRule:
-        host: deepseek-r1-epp
-        trafficPolicy:
-          tls:
-            mode: SIMPLE
-            insecureSkipVerify: true
-          connectionPool:
-            http:
-              http1MaxPendingRequests: 256000
-              maxRequestsPerConnection: 256000
-              http2MaxRequests: 256000
-              idleTimeout: "900s"
-            tcp:
-              maxConnections: 256000
-              maxConnectionDuration: "1800s"
-              connectTimeout: "900s"
+
+provider:
+  name: istio
+  istio:
+    destinationRule:
+      host: llm-d-infpool-epp
+      trafficPolicy:
+        tls:
+          mode: SIMPLE
+          insecureSkipVerify: true
+        connectionPool:
+          http:
+            http1MaxPendingRequests: 256000
+            maxRequestsPerConnection: 256000
+            http2MaxRequests: 256000
+            idleTimeout: "900s"
+          tcp:
+            maxConnections: 256000
+            maxConnectionDuration: "1800s"
+            connectTimeout: "900s"


### PR DESCRIPTION
# Description
Fix https://github.com/llm-d/llm-d/issues/615


# Changes 
- wrong nested providers for istio to enable creation
- fix wrong host value, there is no deepseek-r1-epp, the name is generated by helm release name or can leave it unset to generate FQDN

# Test
`>helm upgrade llm-d-infpool   -n llm-d-wide-ep   -f ./manifests/inferencepool.values.yaml   --set "provider.name=istio"   --set "inferenceExtension.monitoring.prometheus.enable=true"   oci://us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/charts/inferencepool   --version v1.2.0`
```
>k get dr -n llm-d-wide-ep
NAME                HOST                AGE
llm-d-infpool-epp   llm-d-infpool-epp   40m
>k get svc -n llm-d-wide-ep
NAME                TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
llm-d-infpool-epp   ClusterIP   172.30.216.230   <none>        9002/TCP,9090/TCP   40m
```