### PR TITLE
Update intellegent inference scheduling well lit path and values.yaml

### DIFF
--- a/guides/inference-scheduling/README.md
+++ b/guides/inference-scheduling/README.md
@@ -8,7 +8,7 @@ This profile defaults to the approximate prefix cache aware scorer, which only o
 
 ## Hardware Requirements
 
-This example out of the box uses 20 GPUs (10 replicas x 2 GPUs each) of any supported kind, though fewer can be used so long as `values.yaml` is also updated accordingly:
+This example out of the box uses 16 GPUs (8 replicas x 2 GPUs each) of any supported kind, though fewer can be used so long as `values.yaml` is also updated accordingly:
 
 - **NVIDIA GPUs**: Any NVIDIA GPU (support determined by the inferencing image used)
 - **Intel XPU/GPUs**: Intel Data Center GPU Max 1550 or compatible Intel XPU device

--- a/guides/inference-scheduling/ms-inference-scheduling/values.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values.yaml
@@ -16,7 +16,7 @@ accelerator: # controlls specialized hardware Type
 
 decode:
   create: true
-  replicas: 10
+  replicas: 8
   monitoring:
     podmonitor:
       enabled: true
@@ -30,19 +30,6 @@ decode:
     args:
       - "--disable-uvicorn-access-log"
       - "--tensor-parallel-size=2"
-    env:
-      - name: CUDA_VISIBLE_DEVICES
-        value: "0"
-      - name: UCX_TLS
-        value: "cuda_ipc,cuda_copy,tcp"
-      - name: VLLM_NIXL_SIDE_CHANNEL_HOST
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      - name: VLLM_NIXL_SIDE_CHANNEL_PORT
-        value: "5557"
-      - name: VLLM_LOGGING_LEVEL
-        value: INFO
     ports:
       - containerPort: 8000
         name: vllm


### PR DESCRIPTION
This PR updates the Intelligent Inference Scheduling guide and deployment configuration to replicate the setup described in the Predicted Latency Aware Scheduling blog post.

  ## Changes
   - Deployment config (`values.yaml`):
     - Updated the model from Qwen/Qwen3-0.6B to Qwen/Qwen3-32B to match the blog post's hardware profile.
     - Scaled the deployment to 10 replicas.
     - Replica to use 2 GPUs with tensor parallelism enabled (--tensor-parallel-size=2), for 2x H100 per server
   - Updated inference scheduling `README.md`