### PR TITLE
[logs] Show model download progress feedback

### DIFF
--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -134,4 +134,8 @@ COPY docker/scripts/cpu/install_nixl.py /workspace/install_nixl.py
 RUN python3 /workspace/install_nixl.py
 
 WORKDIR /workspace
+
+ENV HF_HUB_DISABLE_PROGRESS_BARS=0 \
+    PYTHONUNBUFFERED=1
+
 ENTRYPOINT ["python", "-m", "vllm.entrypoints.openai.api_server"]

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -476,7 +476,8 @@ RUN umask 002 && \
 
 # default opinionated env var for HF_HOME, over-writeable
 ENV LLM_D_MODELS_DIR=/var/lib/llm-d/models \
-    HF_HOME=/var/lib/llm-d/.hf
+    HF_HOME=/var/lib/llm-d/.hf \
+    HF_HUB_DISABLE_PROGRESS_BARS=0
 
 # creates default models directory and makes path writeable for both root and default user, with symlink for convenience
 # find command keeps group=0 on all new subdirs created later
@@ -488,6 +489,7 @@ RUN mkdir -p "$LLM_D_MODELS_DIR" "$HF_HOME" && \
 
 ENV PATH="${VIRTUAL_ENV}/bin:/usr/local/nvidia/bin:${PATH}" \
     HOME=/home/vllm \
+    PYTHONUNBUFFERED=1 \
     VLLM_USAGE_SOURCE=production-docker-image \
     VLLM_WORKER_MULTIPROC_METHOD=fork \
     OUTLINES_CACHE_DIR=/tmp/outlines \

--- a/docker/Dockerfile.xpu
+++ b/docker/Dockerfile.xpu
@@ -79,6 +79,9 @@ CMD ["/bin/bash"]
 
 FROM vllm-base AS runtime
 
+ENV HF_HUB_DISABLE_PROGRESS_BARS=0 \
+    PYTHONUNBUFFERED=1
+
 ARG CACHE_BUSTER
 RUN if [ -n "${CACHE_BUSTER}" ]; then \
         echo "$CACHE_BUSTER" > /tmp/builder-buster; \
@@ -87,7 +90,12 @@ RUN if [ -n "${CACHE_BUSTER}" ]; then \
 # install additional dependencies for openai api server
 # hadolint ignore=DL3013
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install accelerate hf_transfer pytest pytest_asyncio lm_eval[api] modelscope
+    pip install accelerate pytest pytest_asyncio lm_eval[api] modelscope
+
+# install OTEL packages to enable tracing
+COPY docker/packages/common/runtime-otel-package-requirements.txt /tmp/runtime-otel-package-requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install -r /tmp/runtime-otel-package-requirements.txt
 
 # install OTEL packages to enable tracing
 COPY docker/packages/common/runtime-otel-package-requirements.txt /tmp/runtime-otel-package-requirements.txt


### PR DESCRIPTION
- Add `HF_HUB_DISABLE_PROGRESS_BARS=0` to enable HuggingFace progress bars
- Add `PYTHONUNBUFFERED=1` to flush Python output immediately to logs
- Remove deprecated `hf_transfer` from XPU Dockerfile

Fixes: #484