### PR TITLE
Add RDMA tools container image for RoCE/InfiniBand validation

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -83,6 +83,7 @@ jobs:
       xpu: ${{ steps.force.outputs.xpu || steps.filter.outputs.xpu || steps.dispatch.outputs.xpu }}
       cpu: ${{ steps.force.outputs.cpu || steps.filter.outputs.cpu || steps.dispatch.outputs.cpu }}
       hpu: ${{ steps.force.outputs.hpu || steps.filter.outputs.hpu || steps.dispatch.outputs.hpu }}
+      rdma-tools: ${{ steps.filter.outputs.rdma-tools }}
     steps:
       - name: Force all platforms
         if: inputs.force_build == true
@@ -133,6 +134,8 @@ jobs:
               - 'docker/scripts/cpu/**'
             hpu:
               - 'docker/Dockerfile.hpu'
+            rdma-tools:
+              - 'docker/Dockerfile.rdma-tools'
       # shim to convert comma-separated platforms input into same boolean outputs as path filter
       - name: Parse dispatch platforms
         if: github.event_name == 'workflow_dispatch'
@@ -961,6 +964,81 @@ jobs:
 
       - name: Display vulnerability summary
         if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
+        run: |
+          echo "=== Vulnerability Scan Summary ==="
+          if [ -f trivy-results.sarif ]; then
+            echo "Scan completed. Check the Security tab for detailed results."
+          else
+            echo "No vulnerabilities found or scan failed."
+          fi
+
+  rdma-tools-build-llm-d:
+    needs: [detect-changes]
+    if: ${{ needs.detect-changes.outputs.rdma-tools == 'true' }}
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --oci-worker-gc
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.GHCR_USER }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}-rdma-tools-dev
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build & Push
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile.rdma-tools
+          platforms: linux/amd64
+          push: true
+          provenance: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          github-token: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ github.repository }}-rdma-tools-dev@${{ steps.build-and-push.outputs.digest }}
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH,MEDIUM"
+          scanners: vuln
+          timeout: 30m
+        env:
+          TRIVY_USERNAME: ${{ secrets.GHCR_USER }}
+          TRIVY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "trivy-results.sarif"
+
+      - name: Display vulnerability summary
         run: |
           echo "=== Vulnerability Scan Summary ==="
           if [ -f trivy-results.sarif ]; then

--- a/docker/Dockerfile.rdma-tools
+++ b/docker/Dockerfile.rdma-tools
@@ -1,0 +1,124 @@
+ARG CUDA_MAJOR=12
+ARG CUDA_MINOR=9
+ARG CUDA_PATCH=1
+
+# Tool versions (pinned for reproducibility)
+ARG IPERF_VERSION=3.20
+ARG TCPDUMP_VERSION=tcpdump-4.99.6
+ARG PCIUTILS_VERSION=v3.14.0
+ARG PERFTEST_VERSION=25.10.0-0.128
+ARG GDRCOPY_VERSION=v2.5.1
+ARG NCCL_TESTS_VERSION=v2.17.8
+
+# ============================================================================
+# Builder Stage: Build all tools from source
+# ============================================================================
+FROM nvcr.io/nvidia/cuda:${CUDA_MAJOR}.${CUDA_MINOR}.${CUDA_PATCH}-devel-ubi9 AS builder
+
+ARG IPERF_VERSION
+ARG TCPDUMP_VERSION
+ARG PCIUTILS_VERSION
+ARG PERFTEST_VERSION
+ARG GDRCOPY_VERSION
+ARG NCCL_TESTS_VERSION
+
+# Install build dependencies in one layer
+RUN dnf install -y \
+    git gcc gcc-c++ make autoconf automake libtool diffutils \
+    libpcap libpcap-devel \
+    rdma-core-devel libibverbs-devel librdmacm-devel libibumad-devel \
+    && dnf clean all
+
+# Build iperf3
+RUN git clone --branch ${IPERF_VERSION} --depth 1 https://github.com/esnet/iperf.git /tmp/iperf && \
+    cd /tmp/iperf && \
+    ./configure --prefix=/usr --libdir=/usr/lib && \
+    make -j$(nproc) && \
+    make install DESTDIR=/install
+# Build tcpdump
+RUN git clone --branch ${TCPDUMP_VERSION} --depth 1 https://github.com/the-tcpdump-group/tcpdump.git /tmp/tcpdump && \
+    cd /tmp/tcpdump && \
+    ./autogen.sh && \
+    ./configure --prefix=/usr && \
+    make -j$(nproc) && \
+    make install DESTDIR=/install
+
+# Build pciutils (must be before perftest - provides pci/pci.h)
+RUN git clone --branch ${PCIUTILS_VERSION} --depth 1 https://github.com/pciutils/pciutils.git /tmp/pciutils && \
+    cd /tmp/pciutils && \
+    make SHARED=yes && \
+    make install-lib PREFIX=/usr DESTDIR=/install && \
+    # Create symlinks - version number from tag
+    cd /install/usr/lib && \
+    ln -sf libpci.so.*.*.* libpci.so.3 && \
+    ln -sf libpci.so.3 libpci.so && \
+    # Also install to system for perftest build
+    cd /tmp/pciutils && \
+    make install-lib PREFIX=/usr && \
+    ln -sf /usr/lib/libpci.so.*.*.* /usr/lib/libpci.so.3 && \
+    ln -sf /usr/lib/libpci.so.3 /usr/lib/libpci.so && \
+    ldconfig
+
+# Build perftest with CUDA support
+RUN git clone --branch ${PERFTEST_VERSION} --depth 1 https://github.com/linux-rdma/perftest.git /tmp/perftest && \
+    cd /tmp/perftest && \
+    ./autogen.sh && \
+    CUDA_H_PATH=/usr/local/cuda/include ./configure --prefix=/usr --enable-cudart && \
+    make -j$(nproc) && \
+    make install DESTDIR=/install
+
+# Build GDRCopy
+RUN git clone --branch ${GDRCOPY_VERSION} --depth 1 https://github.com/NVIDIA/gdrcopy.git /tmp/gdrcopy && \
+    cd /tmp/gdrcopy && \
+    make lib exes && \
+    make DESTDIR=/install PREFIX=/usr/local install
+
+# Build NCCL tests
+RUN git clone --branch ${NCCL_TESTS_VERSION} --depth 1 https://github.com/NVIDIA/nccl-tests.git /tmp/nccl-tests && \
+    cd /tmp/nccl-tests && \
+    make MPI=0 CUDA_HOME=/usr/local/cuda NCCL_HOME=/usr/local/cuda \
+         NVCC_GENCODE="\
+         -gencode=arch=compute_70,code=sm_70 \
+         -gencode=arch=compute_75,code=sm_75 \
+         -gencode=arch=compute_80,code=sm_80 \
+         -gencode=arch=compute_86,code=sm_86 \
+         -gencode=arch=compute_89,code=sm_89 \
+         -gencode=arch=compute_90,code=sm_90" && \
+    chmod +x build/*_perf
+
+# Consolidate libraries into /install/usr/local/lib for easy copying
+RUN mkdir -p /install/usr/local/lib && \
+    cp -a /install/usr/lib/libpci* /install/usr/local/lib/ && \
+    cp -a /install/usr/lib/libiperf* /install/usr/local/lib/
+
+
+# ============================================================================
+# Final Stage: Compact runtime image
+# ============================================================================
+ARG CUDA_MAJOR CUDA_MINOR CUDA_PATCH
+FROM nvcr.io/nvidia/cuda:${CUDA_MAJOR}.${CUDA_MINOR}.${CUDA_PATCH}-runtime-ubi9
+
+WORKDIR /root
+
+# Install runtime utilities
+RUN dnf install -y \
+    wget procps-ng jq bc iputils ethtool net-tools \
+    numactl kmod systemd-udev libpcap python3 hostname \
+    && dnf clean all
+
+# Install RDMA libraries from UBI (matches what perftest was compiled against)
+RUN dnf install -y libibverbs libibumad librdmacm && dnf clean all
+
+# Copy all built artifacts from builder
+COPY --from=builder /install/usr/bin/* /usr/local/bin/
+COPY --from=builder /install/usr/local/bin/* /usr/local/bin/
+COPY --from=builder /install/usr/local/lib/* /usr/local/lib/
+COPY --from=builder /tmp/nccl-tests /opt/nccl-tests
+
+# Configure library paths
+RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/usrlocal.conf && ldconfig
+
+# Create results directory
+RUN mkdir -p /results
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
This PR introduces a container image for validating / troubleshooting RDMA and GPU network for llm-d workloads, consolidating tools from multiple contributors projects into one "official" tools image. The idea is that this will be built along with the llm-d image, and have the tools we need to verify that a cluster is ready (functional and performant) to run llm-d P/D and WideEP deployments.

This is based off of:
- https://github.com/rajkiranjoshi/networking-debug-container/blob/main/Dockerfile
- https://github.com/natoscott/gpu-tools/blob/main/Containerfile
- https://github.com/bbenshab/Infrabric-deployer/blob/main/manifests/99-network-perf-tests/dockerfile/Dockerfile
- https://github.com/schmaustech/nvidia-tools-image/blob/main/dockerfile.tools
- https://github.com/llm-d-incubation/hermes/tree/main

### Tools Included
#### RDMA Performance Testing:
- perftest with CUDA/GPUDirect support (ib_write_bw, ib_read_bw, ib_send_bw, ib_write_lat, etc.)

#### Network Tools:
- iperf3 - TCP/UDP bandwidth testing
- tcpdump - packet capture

#### GPU Tools:

- gdrcopy - GPU Direct RDMA copy utilities (copybw, copylat)
- nccl-tests - Multi-GPU collective communication benchmarks

#### Utilities:
- iputils, ethtool, net-tools, numactl... etc

### Not Included (Potential Extensions)
- nixlbench
  - Not yet integrated
- libibverbs-utils (ibv_devinfo, ibv_devices)
  - Not in UBI repos. Alternatives: read sysfs or use [hermes](https://github.com/llm-d-incubation/hermes/tree/main).
- infiniband-diags (ibstat, ibstatus)
  - Not in UBI repos. Alternatives: sysfs 