### PR TITLE
fix: add accelerator type so it can set proper env variable for vllm container to use intel xpu

### DIFF
--- a/guides/pd-disaggregation/ms-pd/values_xpu.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_xpu.yaml
@@ -8,6 +8,9 @@ dra:
   enabled: true
   type: intel
 
+accelerator:
+  type: intel-i915
+
 modelArtifacts:
   uri: "hf://deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
   size: 10Gi  # Smaller model size for Intel XPU
@@ -29,49 +32,49 @@ decode:
   monitoring:
     podmonitor:
       enabled: true
-      portName: "vllm" # decode vLLM service port (from routing.proxy.targetPort)
+      portName: "vllm"  # decode vLLM service port (from routing.proxy.targetPort)
       path: "/metrics"
       interval: "30s"
   containers:
-  - name: "vllm"
-    image: ghcr.io/llm-d/llm-d-xpu-dev:pr-592
-    modelCommand: vllmServe
-    args:
-      - "--block-size"
-      - "128"
-      - "--kv-transfer-config"
-      - '{"kv_connector":"NixlConnector", "kv_role":"kv_both", "kv_buffer_device":"cpu"}'
-      - "--disable-log-requests"
-      - "--disable-uvicorn-access-log"
-      - "--max-model-len"
-      - "32000"
-    securityContext:
-      fsGroup: 107
-      supplementalGroups:
-        - 107
-    env:
-      - name: UCX_TLS
-        value: "tcp"
-    ports:
-      - containerPort: 8200
-        name: vllm
-        protocol: TCP
-      - containerPort: 5557
-        name: nixl
-        protocol: TCP
-    resources:
-      limits:
-        memory: 64Gi
-        cpu: "16"
-        # note: XPU resources get controlled by parallelism + accelerators above
-      requests:
-        memory: 64Gi
-        cpu: "16"
-        # note: XPU resources get controlled by parallelism + accelerators above
-    mountModelVolume: true
-    volumeMounts:
-      - name: dshm
-        mountPath: /dev/shm
+    - name: "vllm"
+      image: ghcr.io/llm-d/llm-d-xpu-dev:pr-592
+      modelCommand: vllmServe
+      args:
+        - "--block-size"
+        - "128"
+        - "--kv-transfer-config"
+        - '{"kv_connector":"NixlConnector", "kv_role":"kv_both", "kv_buffer_device":"cpu"}'
+        - "--disable-log-requests"
+        - "--disable-uvicorn-access-log"
+        - "--max-model-len"
+        - "32000"
+      securityContext:
+        fsGroup: 107
+        supplementalGroups:
+          - 107
+      env:
+        - name: UCX_TLS
+          value: "tcp"
+      ports:
+        - containerPort: 8200
+          name: vllm
+          protocol: TCP
+        - containerPort: 5557
+          name: nixl
+          protocol: TCP
+      resources:
+        limits:
+          memory: 64Gi
+          cpu: "16"
+          # note: XPU resources get controlled by parallelism + accelerators above
+        requests:
+          memory: 64Gi
+          cpu: "16"
+          # note: XPU resources get controlled by parallelism + accelerators above
+      mountModelVolume: true
+      volumeMounts:
+        - name: dshm
+          mountPath: /dev/shm
   volumes:
     - name: dshm
       emptyDir:
@@ -86,49 +89,49 @@ prefill:
   monitoring:
     podmonitor:
       enabled: true
-      portName: "vllm" # prefill vLLM service port (from routing.servicePort)
+      portName: "vllm"  # prefill vLLM service port (from routing.servicePort)
       path: "/metrics"
       interval: "30s"
   containers:
-  - name: "vllm"
-    image: ghcr.io/llm-d/llm-d-xpu-dev:pr-592
-    modelCommand: vllmServe
-    args:
-      - "--block-size"
-      - "128"
-      - "--kv-transfer-config"
-      - '{"kv_connector":"NixlConnector", "kv_role":"kv_both", "kv_buffer_device":"cpu"}'
-      - "--disable-log-requests"
-      - "--disable-uvicorn-access-log"
-      - "--max-model-len"
-      - "32000"
-    securityContext:
-      fsGroup: 107
-      supplementalGroups:
-        - 107
-    env:
-      - name: UCX_TLS
-        value: "tcp"
-    ports:
-      - containerPort: 8000
-        name: vllm
-        protocol: TCP
-      - containerPort: 5557
-        name: nixl
-        protocol: TCP
-    resources:
-      limits:
-        memory: 64Gi
-        cpu: "8"
-        # note: XPU resources get controlled by parallelism + dra above
-      requests:
-        memory: 64Gi
-        cpu: "8"
-        # note: XPU resources get controlled by parallelism + dra above
-    mountModelVolume: true
-    volumeMounts:
-      - name: dshm
-        mountPath: /dev/shm
+    - name: "vllm"
+      image: ghcr.io/llm-d/llm-d-xpu-dev:pr-592
+      modelCommand: vllmServe
+      args:
+        - "--block-size"
+        - "128"
+        - "--kv-transfer-config"
+        - '{"kv_connector":"NixlConnector", "kv_role":"kv_both", "kv_buffer_device":"cpu"}'
+        - "--disable-log-requests"
+        - "--disable-uvicorn-access-log"
+        - "--max-model-len"
+        - "32000"
+      securityContext:
+        fsGroup: 107
+        supplementalGroups:
+          - 107
+      env:
+        - name: UCX_TLS
+          value: "tcp"
+      ports:
+        - containerPort: 8000
+          name: vllm
+          protocol: TCP
+        - containerPort: 5557
+          name: nixl
+          protocol: TCP
+      resources:
+        limits:
+          memory: 64Gi
+          cpu: "8"
+          # note: XPU resources get controlled by parallelism + dra above
+        requests:
+          memory: 64Gi
+          cpu: "8"
+          # note: XPU resources get controlled by parallelism + dra above
+      mountModelVolume: true
+      volumeMounts:
+        - name: dshm
+          mountPath: /dev/shm
   volumes:
     - name: dshm
       emptyDir:


### PR DESCRIPTION
# Description

part of the issue https://github.com/llm-d/llm-d/issues/620 has been resolved by PR https://github.com/llm-d/llm-d/pull/518 when enable dra in values_xpu.yaml
there are left part for the accelerator need to config.
According to [helpers.tpl](https://github.com/llm-d-incubation/llm-d-modelservice/blob/llm-d-modelservice-v0.3.17/charts/llm-d-modelservice/templates/_helpers.tpl#L249) if do not set accelerator.type to "cpu" then  it fall back to use `nvidia` as type but then it wont set [env](https://github.com/llm-d-incubation/llm-d-modelservice/blob/llm-d-modelservice-v0.3.17/charts/llm-d-modelservice/values.yaml#L63) for `VLLM_USE_V1` `TORCH_LLḾ_ALLREDUCE` `VLLM_WORKER_MULTIPROC_METHOD` in vllm container


# Changes
- DRA has been enabled in xpu but still missing accelerator type which set the gpu.intel.com:1 in `ResourceClaimTemplate` but not the env variables needed for vLLM. this change is to add accelerator.type in value
- also fix lint on the yaml file