### PR TITLE
docs: Clarify WideEP network requirements

### DIFF
--- a/guides/wide-ep-lws/README.md
+++ b/guides/wide-ep-lws/README.md
@@ -24,7 +24,8 @@ This guide requires 32 Nvidia H200 or B200 GPUs and InfiniBand or RoCE RDMA netw
 * Have the [proper client tools installed on your local system](../prereq/client-setup/README.md) to use this guide.
 * Ensure your cluster infrastructure is sufficient to [deploy high scale inference](../prereq/infrastructure/README.md)
   * You must have high speed inter-accelerator networking
-  * The pods leveraging inter-node EP must be deployed within the same networking domain
+  * The pods leveraging inter-node EP must be deployed in a cluster environment with full mesh network connectivity.
+    * **_NOTE:_** The DeepEP backend used in WideEP requires All-to-All RDMA connectivity. Every NIC on a host must be able to communicate with every NIC on all other hosts. Networks restricted to communicating only between matching NIC IDs (rail-only connectivity) will fail.
   * You have deployed the [LeaderWorkerSet optional controller](../prereq/infrastructure/README.md#optional-install-leaderworkerset-for-multi-host-inference)
 * Configure and deploy your [Gateway control plane](../prereq/gateway-provider/README.md).
 * Have the [Monitoring stack](../../docs/monitoring/README.md) installed on your system.


### PR DESCRIPTION
This PR aims to clarify a common issue when users try to deploy WideEP. Many HPC clusters have NICs on "rail-aligned" subnets without routing across subnets. Deploying WideEP in a set-up like this can lead to confusing error messages during NVSHMEM bootstrapping.

