### PR TITLE
Fix broken kgateway link

### DIFF
--- a/guides/QUICKSTART.md
+++ b/guides/QUICKSTART.md
@@ -42,7 +42,7 @@ llm-d integrates with the [Kubernetes Gateway API](https://gateway-api.sigs.k8s.
 You must select an [appropriate Gateway implementation for your infrastructure and deploy the Gateway control plane and its prerequisite CRDs](./prereq/gateway-provider/README.md).
 
 > [!IMPORTANT]
-> We recommend selecting a Gateway implementation provided by your infrastructure, if available. If not, we test and verify our guides with both [kgateway](https://kgateway.dev/docs/main/quickstart/) and [istio](https://istio.io/latest/docs/setup/getting-started/).
+> We recommend selecting a Gateway implementation provided by your infrastructure, if available. If not, we test and verify our guides with both [kgateway](https://kgateway.dev/docs/envoy/latest/quickstart/) and [istio](https://istio.io/latest/docs/setup/getting-started/).
 
 ## Deployment
 


### PR DESCRIPTION
This link was broken - should be https://kgateway.dev/docs/envoy/latest/quickstart/