### PR TITLE
PD disaggregation guide fix: add missing VLLM_NIXL_SIDE_CHANNEL_HOST env var

### DIFF
--- a/guides/pd-disaggregation/ms-pd/values.yaml
+++ b/guides/pd-disaggregation/ms-pd/values.yaml
@@ -36,6 +36,11 @@ decode:
         - "--disable-uvicorn-access-log"
         - "--max-model-len"
         - "32000"
+      env:
+        - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
       ports:
         - containerPort: 8200
           name: vllm
@@ -114,6 +119,11 @@ prefill:
         - "--disable-uvicorn-access-log"
         - "--max-model-len"
         - "32000"
+      env:
+        - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
       ports:
         - containerPort: 8000
           name: vllm


### PR DESCRIPTION
Adds the missing `VLLM_NIXL_SIDE_CHANNEL_HOST` environment variable to the `pd-disaggregation` guide.

When I deployed the `pd-disaggregation` example on GKE, the following errors were observed causing Pod crashes:
```
KeyError: '604f3f68-909c-43e0-bb3a-e96850fca226'
...
AsyncLLM output_handler failed.
...
{decoderURL: http://localhost:8200, error: dial tcp 127.0.0.1:8200: connect: connection refused, 
level: error, logger: proxy server on port 8000, msg: failed to connect to vLLM decoder, 
stacktrace: github.com/llm-d/llm-d-inference-scheduler/pkg/sidecar/proxy.(*Server).createRoutes...}
```
Adding back the env `VLLM_NIXL_SIDE_CHANNEL_HOST` fixed the issue. It was removed in #548