### PR TITLE
fixing KV transfer ports and relevant env vars in PD

### DIFF
--- a/guides/pd-disaggregation/ms-pd/values_tpu.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_tpu.yaml
@@ -34,7 +34,7 @@ decode:
       interval: "30s"
   containers:
     - name: "vllm"
-      image: vllm/vllm-tpu:v0.11.1
+      image: vllm/vllm-tpu:v0.13.2
       modelCommand: vllmServe
       args:
         # Keep tensor-parallelism as the first set of arguments
@@ -50,14 +50,19 @@ decode:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        - name: VLLM_LOGGING_LEVEL
-          value: DEBUG
+        - name: TPU_SIDE_CHANNEL_PORT # data plane port for PD coordination
+          value: "9600" # default for TPU
+        - name: TPU_KV_TRANSFER_PORT # Port where the KV transfer actually happens
+          value: "9100" # default for TPU
       ports:
-        - containerPort: 8200
+        - containerPort: 8000
           name: vllm
           protocol: TCP
-        - containerPort: 5600
-          name: nixl
+        - containerPort: 9100
+          name: tpu-kv-transfer
+          protocol: TCP
+        - containerPort: 9600
+          name: tpu-pd-coordination
           protocol: TCP
       resources:
         limits:
@@ -120,12 +125,12 @@ prefill:
   monitoring:
     podmonitor:
       enabled: true
-      portName: "metrics"  # prefill vLLM service port (from routing.servicePort)
+      portName: "vllm"  # prefill vLLM service port (from routing.servicePort)
       path: "/metrics"
       interval: "30s"
   containers:
     - name: "vllm"
-      image: vllm/vllm-tpu:v0.11.1
+      image: vllm/vllm-tpu:v0.13.2
       modelCommand: vllmServe
       args:
         - "--tensor-parallel-size"
@@ -140,14 +145,19 @@ prefill:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        - name: VLLM_LOGGING_LEVEL
-          value: DEBUG
+        - name: TPU_SIDE_CHANNEL_PORT # data plane port for PD coordination
+          value: "9600" # default for TPU
+        - name: TPU_KV_TRANSFER_PORT # Port where the KV transfer actually happens
+          value: "9100" # default for TPU
       ports:
         - containerPort: 8000
-          name: metrics
+          name: vllm
           protocol: TCP
-        - containerPort: 5600
-          name: nixl
+        - containerPort: 9100
+          name: tpu-kv-transfer
+          protocol: TCP
+        - containerPort: 9600
+          name: tpu-pd-coordination
           protocol: TCP
       resources:
         limits:

--- a/guides/pd-disaggregation/ms-pd/values_xpu.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_xpu.yaml
@@ -52,6 +52,10 @@ decode:
       env:
         - name: UCX_TLS
           value: "tcp"
+        - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
       ports:
         - containerPort: 8200
           name: vllm
@@ -109,6 +113,10 @@ prefill:
       env:
         - name: UCX_TLS
           value: "tcp"
+        - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
       ports:
         - containerPort: 8000
           name: vllm


### PR DESCRIPTION
Changes:
- bumped TPU image to 0.13.2 stable
- port 5600 should be default for NIXL
- TPU actually uses 2 port values for kv transfer, routing is done from pod ip in kvconector