### PR TITLE
feat: enable memory-backed /dev/shm for vLLM cpu tensor parallelism

### DIFF
--- a/guides/inference-scheduling/ms-inference-scheduling/values_cpu.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_cpu.yaml
@@ -63,6 +63,8 @@ decode:
           mountPath: /.config
         - name: torch-compile-cache
           mountPath: /.cache
+        - name: dshm
+          mountPath: /dev/shm
       startupProbe:
         httpGet:
           path: /v1/models
@@ -90,6 +92,10 @@ decode:
       emptyDir: {}
     - name: torch-compile-cache
       emptyDir: {}
+    - name: dshm
+      emptyDir:
+        medium: Memory
+        sizeLimit: 4Gi
 
 # Disable prefill for simple CPU example
 prefill:


### PR DESCRIPTION
This PR updates the values_cpu.yaml to include a memory-backed emptyDir volume mounted

### Reasoning for TP >= 2:
When running vLLM with Tensor Parallelism (TP) greater than 1, the engine spawns multiple processes that require Inter-Process Communication (IPC). These processes use shared memory to communicate and synchronize tensors across the parallel ranks.