### PR TITLE
temporarily disable EFA

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -28,7 +28,7 @@ ARG USE_SCCACHE=true
 
 # Note: Components are listed in build order.
 
-# ARG EFA_INSTALLER_VERSION="1.46.0"
+# ARG EFA_INSTALLER_VERSION="1.46.0" # temporarily remove EFA
 
 ARG GDRCOPY_REPO="https://github.com/NVIDIA/gdrcopy.git"
 ARG GDRCOPY_VERSION="v2.5.1"
@@ -141,7 +141,7 @@ RUN export UV_INSTALL_DIR=/usr/local/bin && \
     uv pip install --no-cache -U wheel meson-python ninja pybind11 build
 
 ENV NVSHMEM_DIR="/opt/nvshmem-${NVSHMEM_VERSION}" \
-    # EFA_PREFIX="/opt/amazon/efa" \ # Tempo
+    # EFA_PREFIX="/opt/amazon/efa" \ # temporarily remove EFA
     UCX_PREFIX="/opt/ucx" \
     NIXL_PREFIX="/opt/nixl"
 

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -28,7 +28,7 @@ ARG USE_SCCACHE=true
 
 # Note: Components are listed in build order.
 
-ARG EFA_INSTALLER_VERSION="1.46.0"
+# ARG EFA_INSTALLER_VERSION="1.46.0"
 
 ARG GDRCOPY_REPO="https://github.com/NVIDIA/gdrcopy.git"
 ARG GDRCOPY_VERSION="v2.5.1"
@@ -141,12 +141,13 @@ RUN export UV_INSTALL_DIR=/usr/local/bin && \
     uv pip install --no-cache -U wheel meson-python ninja pybind11 build
 
 ENV NVSHMEM_DIR="/opt/nvshmem-${NVSHMEM_VERSION}" \
-    EFA_PREFIX="/opt/amazon/efa" \
+    # EFA_PREFIX="/opt/amazon/efa" \ # Tempo
     UCX_PREFIX="/opt/ucx" \
     NIXL_PREFIX="/opt/nixl"
 
 ENV PATH="${NVSHMEM_DIR}/bin:${VIRTUAL_ENV}/bin:${PATH}" \
-    LIBRARY_PATH="${EFA_PREFIX}/lib:${EFA_PREFIX}/lib64:\
+    # LIBRARY_PATH="${EFA_PREFIX}/lib:${EFA_PREFIX}/lib64:\
+    LIBRARY_PATH="\
 ${UCX_PREFIX}/lib:${UCX_PREFIX}/lib64:\
 ${NVSHMEM_DIR}/lib:${NVSHMEM_DIR}/lib64:\
 ${CUDA_HOME}/lib64/stubs:${CUDA_HOME}/lib64:\
@@ -158,7 +159,7 @@ ${CUDA_HOME}/include:\
 /usr/include:\
 ${CPATH}" \
     PKG_CONFIG_PATH="${UCX_PREFIX}/lib/pkgconfig:${UCX_PREFIX}/lib64/pkgconfig:\
-${EFA_PREFIX}/lib/pkgconfig:${EFA_PREFIX}/lib64/pkgconfig:\
+# ${EFA_PREFIX}/lib/pkgconfig:${EFA_PREFIX}/lib64/pkgconfig:\
 /usr/local/lib/pkgconfig:\
 /usr/local/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib/aarch64-linux-gnu/pkgconfig:\
 /usr/lib64/pkgconfig:/usr/lib/pkgconfig:\
@@ -166,16 +167,16 @@ ${EFA_PREFIX}/lib/pkgconfig:${EFA_PREFIX}/lib64/pkgconfig:\
 /usr/share/pkgconfig:\
 ${PKG_CONFIG_PATH}"
 
-# Install EFA
-ARG EFA_INSTALLER_VERSION
-COPY docker/scripts/cuda/common/package-utils.sh /tmp/package-utils.sh
-COPY docker/scripts/cuda/builder/install-efa.sh /tmp/install-efa.sh
-RUN --mount=type=secret,id=subman_org \
-    --mount=type=secret,id=subman_activation_key \
-    TARGETOS=${TARGETOS} \
-    EFA_INSTALLER_VERSION=${EFA_INSTALLER_VERSION} \
-    /tmp/install-efa.sh && \
-    rm -f /tmp/install-efa.sh /tmp/package-utils.sh
+# Install EFA - temporarily disabled
+# ARG EFA_INSTALLER_VERSION
+# COPY docker/scripts/cuda/common/package-utils.sh /tmp/package-utils.sh
+# COPY docker/scripts/cuda/builder/install-efa.sh /tmp/install-efa.sh
+# RUN --mount=type=secret,id=subman_org \
+#     --mount=type=secret,id=subman_activation_key \
+#     TARGETOS=${TARGETOS} \
+#     EFA_INSTALLER_VERSION=${EFA_INSTALLER_VERSION} \
+#     /tmp/install-efa.sh && \
+#     rm -f /tmp/install-efa.sh /tmp/package-utils.sh
 
 # Build and install gdrcopy
 ARG GDRCOPY_REPO
@@ -307,11 +308,12 @@ ENV LANG="C.UTF-8" \
     UV_CONSTRAINT="/tmp/constraints.txt" \
     VIRTUAL_ENV="/opt/vllm" \
     NVSHMEM_DIR="/opt/nvshmem-${NVSHMEM_VERSION}" \
-    EFA_PREFIX="/opt/amazon/efa" \
+    # EFA_PREFIX="/opt/amazon/efa" \
     UCX_PREFIX="/opt/ucx" \
     CUDA_HOME="/usr/local/cuda"
 
-ENV LD_LIBRARY_PATH="${EFA_PREFIX}/lib:${EFA_PREFIX}/lib64:\
+# ENV LD_LIBRARY_PATH="${EFA_PREFIX}/lib:${EFA_PREFIX}/lib64:\
+ENV LD_LIBRARY_PATH="\
 ${UCX_PREFIX}/lib:${UCX_PREFIX}/lib64:\
 /opt/vllm/lib64/python${PYTHON_VERSION}/site-packages/torch/lib:\
 /usr/local/nvidia/lib:/usr/local/nvidia/lib64:${CUDA_HOME}/lib64:${CUDA_HOME}/compat:\
@@ -337,16 +339,16 @@ RUN TARGETOS=${TARGETOS} /tmp/install-runtime-packages.sh && \
     rm -f /tmp/install-runtime-packages.sh /tmp/package-utils.sh && \
     rm -rf /tmp/packages
 
-# Copy in efa
-COPY --from=builder /opt/amazon/efa /opt/amazon/efa/
+# Copy in efa - temporarily removed
+# COPY --from=builder /opt/amazon/efa /opt/amazon/efa/
 
-# Copy efa libs from builder (install-efa.sh)
+# Copy efa libs from builder (install-efa.sh) - temporarily remove
 # Ubuntu does not build EFA
-COPY --from=builder /tmp/efa_libs /tmp/efa_libs
-RUN if [ "${TARGETOS:-rhel}" = "rhel" ] && [ -d /tmp/efa_libs ]; then \
-        cp -a /tmp/efa_libs/* /usr/lib64/ || true; \
-    fi && \
-    rm -rf /tmp/efa_libs
+# COPY --from=builder /tmp/efa_libs /tmp/efa_libs
+# RUN if [ "${TARGETOS:-rhel}" = "rhel" ] && [ -d /tmp/efa_libs ]; then \
+#         cp -a /tmp/efa_libs/* /usr/lib64/ || true; \
+#     fi && \
+#     rm -rf /tmp/efa_libs
 
 # Copy gdrcopy libraries from builder
 # Install to /usr/local/lib (always present) and multiarch lib dir

--- a/docker/scripts/cuda/builder/build-compiled-wheels.sh
+++ b/docker/scripts/cuda/builder/build-compiled-wheels.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -Eeu
+set -Eeux
 
 # builds compiled extension wheels (FlashInfer, DeepEP, DeepGEMM, pplx-kernels)
 #

--- a/docker/scripts/cuda/builder/build-gdrcopy.sh
+++ b/docker/scripts/cuda/builder/build-gdrcopy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -Eeu
+set -Eeux
 
 # builds and installs gdrcopy from source
 #

--- a/docker/scripts/cuda/builder/build-lmcache.sh
+++ b/docker/scripts/cuda/builder/build-lmcache.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -Eeu
+set -Eeux
 
 # builds and installs LMCache and Infinistore from source
 #

--- a/docker/scripts/cuda/builder/build-nixl.sh
+++ b/docker/scripts/cuda/builder/build-nixl.sh
@@ -33,7 +33,7 @@ fi
 
 # Ubuntu image needs to be built against Ubuntu 20.04 and EFA only supports 22.04 and 24.04.
 EFA_FLAG=""
-if [ "$TARGETOS" = "rhel" ]; then
+if [ "$TARGETOS" = "rhel" ] && [ -n "${EFA_PREFIX}" ]; then
     EFA_FLAG="-Dlibfabric_path=${EFA_PREFIX}"
 fi
 

--- a/docker/scripts/cuda/builder/build-nixl.sh
+++ b/docker/scripts/cuda/builder/build-nixl.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
-set -Eex
+set -Eeux
 
 # purpose: builds NIXL from source, gated by `BUILD_NIXL_FROM_SOURCE`
 #
+# Optional environment variables:
+# - EFA_PREFIX: Path to Libfabric installation
+: "${EFA_PREFIX:=}"
 # Required environment variables:
 # - BUILD_NIXL_FROM_SOURCE: if nixl should be installed by vLLM or has been built from source in the builder stages
 # - NIXL_REPO: Git repo to use for NIXL
 # - NIXL_VERSION: Git ref to use for NIXL
 # - NIXL_PREFIX: Path to install NIXL to
-# - EFA_PREFIX: Path to Libfabric installation
 # - UCX_PREFIX: Path to UCX installation
 # - VIRTUAL_ENV: Path to the virtual environment
 # - USE_SCCACHE: whether to use sccache (true/false)

--- a/docker/scripts/cuda/builder/build-nixl.sh
+++ b/docker/scripts/cuda/builder/build-nixl.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -Eeu
+set -Eex
 
 # purpose: builds NIXL from source, gated by `BUILD_NIXL_FROM_SOURCE`
 #

--- a/docker/scripts/cuda/builder/build-nvshmem.sh
+++ b/docker/scripts/cuda/builder/build-nvshmem.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
-set -Eex
+set -Eeux
 
 # builds and installs NVSHMEM from source with coreweave patch
 #
+# Optional environment variables:
+# - EFA_PREFIX: Path to EFA installation
+: "${EFA_PREFIX:=}"
 # Required environment variables:
 # - TARGETOS: OS type (ubuntu or rhel)
 # - CUDA_MAJOR: CUDA major version (e.g., 12)
@@ -12,7 +15,6 @@ set -Eex
 # - NVSHMEM_VERSION: NVSHMEM version to build (e.g., 3.3.20, or git ref if NVSHMEM_USE_GIT=true)
 # - NVSHMEM_DIR: NVSHMEM installation directory
 # - NVSHMEM_CUDA_ARCHITECTURES: CUDA architectures to build for
-# - EFA_PREFIX: Path to EFA installation
 # - UCX_PREFIX: Path to UCX installation
 # - VIRTUAL_ENV: Path to the virtual environment from which python will be pulled
 # - USE_SCCACHE: whether to use sccache (true/false)

--- a/docker/scripts/cuda/builder/build-nvshmem.sh
+++ b/docker/scripts/cuda/builder/build-nvshmem.sh
@@ -48,7 +48,7 @@ mkdir -p build && cd build
 
 # Ubuntu image needs to be built against Ubuntu 20.04 and EFA only supports 22.04 and 24.04.
 EFA_FLAGS=("")
-if [ "$TARGETOS" = "rhel" ]; then
+if [ "$TARGETOS" = "rhel" ] && [ -n "${EFA_PREFIX}" ]; then
     EFA_FLAGS=(
         -DNVSHMEM_LIBFABRIC_SUPPORT=1
         -DLIBFABRIC_HOME="${EFA_PREFIX}"

--- a/docker/scripts/cuda/builder/build-nvshmem.sh
+++ b/docker/scripts/cuda/builder/build-nvshmem.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -Eeux
+set -Eex
 
 # builds and installs NVSHMEM from source with coreweave patch
 #

--- a/docker/scripts/cuda/builder/build-ucx.sh
+++ b/docker/scripts/cuda/builder/build-ucx.sh
@@ -28,7 +28,7 @@ fi
 
 # Ubuntu image needs to be built against Ubuntu 20.04 and EFA only supports 22.04 and 24.04.
 EFA_FLAG=""
-if [ "$TARGETOS" = "rhel" ]; then
+if [ "$TARGETOS" = "rhel" ] && [ -n "${EFA_PREFIX}" ]; then
     EFA_FLAG="--with-efa"
 fi
 

--- a/docker/scripts/cuda/builder/build-ucx.sh
+++ b/docker/scripts/cuda/builder/build-ucx.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -Ee
+set -Eeux
 
 # purpose: builds and installs UCX from source
 # --------------------------------------------
@@ -7,6 +7,9 @@ set -Ee
 # - /run/secrets/aws_access_key_id: AWS access key ID for role that can only interact with SCCache S3 Bucket
 # - /run/secrets/aws_secret_access_key: AWS secret access key for role that can only interact with SCCache S3 Bucket
 # --------------------------------------------
+# Optional environment variables:
+# - EFA_PREFIX: Path to EFA installation
+: "${EFA_PREFIX:=}"
 # Required environment variables:
 # - CUDA_HOME: Cuda runtime path to install UCX against
 # - UCX_REPO: git remote to build UCX from

--- a/docker/scripts/cuda/builder/build-ucx.sh
+++ b/docker/scripts/cuda/builder/build-ucx.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -Eeu
+set -Ee
 
 # purpose: builds and installs UCX from source
 # --------------------------------------------

--- a/docker/scripts/cuda/builder/install-base-packages.sh
+++ b/docker/scripts/cuda/builder/install-base-packages.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -Eeu
+set -Eeux
 
 # installs base packages, EPEL/universe repos, and CUDA repository
 #

--- a/docker/scripts/cuda/builder/install-cmake.sh
+++ b/docker/scripts/cuda/builder/install-cmake.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -Eeu
+set -Eeux
 
 # purpose: install cmake 3.22.0 as a workaround for building nvshmem from source
 # CMAKE version is locked here because the url changes when downloading from github based on the version

--- a/docker/scripts/cuda/builder/install-efa.sh
+++ b/docker/scripts/cuda/builder/install-efa.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -Eex
+set -Eeux
 
 # purpose: Install EFA
 # -------------------------------
@@ -7,12 +7,16 @@ set -Eex
 # - /run/secrets/subman_org: Subscription Manager Organization - used if on a ubi based image for entitlement
 # - /run/secrets/subman_activation_key: Subscription Manager Activation key - used if on a ubi based image for entitlement
 # -------------------------------
+# Optional environment variables:
+# - EFA_PREFIX: Path to include ld linkers to ensure that UCX and NVSHMEM can build against EFA and Libfacbric successfully. When empty will not run script.
+# - EFA_INSTALLER_VERSION: Version of AWS EFA installer to download (default: 1.46.0 is the current latest release). When empty will not run script.
+: "${EFA_PREFIX:=}"
+: "${EFA_INSTALLER_VERSION:=}"
 # Required environment variables:
 # - TARGETOS: Target OS - either 'ubuntu' or 'rhel' (default: rhel)
-# - EFA_PREFIX: Path to include ld linkers to ensure that UCX and NVSHMEM can build against EFA and Libfacbric successfully
-# - EFA_INSTALLER_VERSION: Version of AWS EFA installer to download (default: 1.46.0 is the current latest release)
 
-if [ "$TARGETOS" = "ubuntu" ] || [ -z "${EFA_PREFIX}" ] ; then
+
+if [ "$TARGETOS" = "ubuntu" ] || [ -z "${EFA_PREFIX}" ]  || [ -z "${EFA_INSTALLER_VERSION}" ] ; then
     echo "Ubuntu image needs to be built against Ubuntu 20.04 and EFA only supports 22.04 and 24.04."
     # Create empty folder so Dockerfile COPY don't fail on Ubuntu
     mkdir -p "${EFA_PREFIX}" /tmp/efa_libs

--- a/docker/scripts/cuda/builder/install-efa.sh
+++ b/docker/scripts/cuda/builder/install-efa.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -Eeux
+set -Eeu
+# special logging exception - do not use high level logging with EFA installer + entitlement
 
 # purpose: Install EFA
 # -------------------------------

--- a/docker/scripts/cuda/builder/install-efa.sh
+++ b/docker/scripts/cuda/builder/install-efa.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -Eeu
+set -Eex
 
 # purpose: Install EFA
 # -------------------------------
@@ -12,7 +12,7 @@ set -Eeu
 # - EFA_PREFIX: Path to include ld linkers to ensure that UCX and NVSHMEM can build against EFA and Libfacbric successfully
 # - EFA_INSTALLER_VERSION: Version of AWS EFA installer to download (default: 1.46.0 is the current latest release)
 
-if [ "$TARGETOS" = "ubuntu" ]; then
+if [ "$TARGETOS" = "ubuntu" ] || [ -z "${EFA_PREFIX}" ] ; then
     echo "Ubuntu image needs to be built against Ubuntu 20.04 and EFA only supports 22.04 and 24.04."
     # Create empty folder so Dockerfile COPY don't fail on Ubuntu
     mkdir -p "${EFA_PREFIX}" /tmp/efa_libs

--- a/docker/scripts/cuda/builder/install-sccache.sh
+++ b/docker/scripts/cuda/builder/install-sccache.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -Eeu
+set -Eeux
 
 # installs sccache binary from github releases and verifies connectivity
 #

--- a/guides/wide-ep-lws/manifests/modelserver/base/decode.yaml
+++ b/guides/wide-ep-lws/manifests/modelserver/base/decode.yaml
@@ -49,7 +49,7 @@ spec:
             emptyDir: {}
         containers:
           - name: vllm
-            image: ghcr.io/llm-d/llm-d-cuda:v0.4.0
+            image: ghcr.io/llm-d/llm-d-cuda-dev:sha-24f07f2
             securityContext:
               capabilities:
                 add:

--- a/guides/wide-ep-lws/manifests/modelserver/base/prefill.yaml
+++ b/guides/wide-ep-lws/manifests/modelserver/base/prefill.yaml
@@ -29,7 +29,7 @@ spec:
             emptyDir: {}
         containers:
           - name: vllm
-            image: ghcr.io/llm-d/llm-d-cuda:v0.4.0
+            image: ghcr.io/llm-d/llm-d-cuda-dev:sha-24f07f2
             securityContext:
               capabilities:
                 add:


### PR DESCRIPTION
Relates to nvshmem initialization issue:

The failure:
```bash
wide-ep-llm-d-prefill-0 vllm 
wide-ep-llm-d-prefill-0 vllm /tmp/nvshmem_src/src/host/init/init.cu:1034: non-zero status: 28 nvshmem detect topo failed 
wide-ep-llm-d-prefill-0 vllm 
wide-ep-llm-d-prefill-0 vllm /tmp/nvshmem_src/src/host/init/init.cu:1034: non-zero status: 28 nvshmem detect topo failed 
wide-ep-llm-d-prefill-0 vllm 
wide-ep-llm-d-prefill-0 vllm /tmp/nvshmem_src/src/host/init/init.cu:1034: non-zero status: 28 nvshmem detect topo failed 
wide-ep-llm-d-prefill-0 vllm 
wide-ep-llm-d-prefill-0 vllm /tmp/nvshmem_src/src/host/init/init.cu:1034: non-zero status: 28 nvshmem detect topo failed 
wide-ep-llm-d-prefill-0 vllm 
wide-ep-llm-d-prefill-0 vllm /tmp/nvshmem_src/src/host/init/init.cu:1034: non-zero status: 28 nvshmem detect topo failed 
wide-ep-llm-d-prefill-0 vllm 
...
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m Traceback (most recent call last):
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m   File "/opt/vllm/bin/vllm", line 10, in <module>
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m     sys.exit(main())
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m              ^^^^^^
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m   File "/opt/vllm-source/vllm/entrypoints/cli/main.py", line 73, in main
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m     args.dispatch_function(args)
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m   File "/opt/vllm-source/vllm/entrypoints/cli/serve.py", line 60, in cmd
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m     uvloop.run(run_server(args))
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m   File "/opt/vllm/lib64/python3.12/site-packages/uvloop/__init__.py", line 96, in run
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m     return __asyncio.run(
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m            ^^^^^^^^^^^^^^
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m   File "/usr/lib64/python3.12/asyncio/runners.py", line 195, in run
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m     return runner.run(main)
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m            ^^^^^^^^^^^^^^^^
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m   File "/usr/lib64/python3.12/asyncio/runners.py", line 118, in run
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m     return self._loop.run_until_complete(task)
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m   File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m   File "/opt/vllm/lib64/python3.12/site-packages/uvloop/__init__.py", line 48, in wrapper
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m     return await main
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m            ^^^^^^^^^^
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m   File "/opt/vllm-source/vllm/entrypoints/openai/api_server.py", line 1319, in run_server
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m     await run_server_worker(listen_address, sock, args, **uvicorn_kwargs)
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m   File "/opt/vllm-source/vllm/entrypoints/openai/api_server.py", line 1338, in run_server_worker
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m     async with build_async_engine_client(
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m                ^^^^^^^^^^^^^^^^^^^^^^^^^^
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m   File "/usr/lib64/python3.12/contextlib.py", line 210, in __aenter__
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m     return await anext(self.gen)
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m            ^^^^^^^^^^^^^^^^^^^^^
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m   File "/opt/vllm-source/vllm/entrypoints/openai/api_server.py", line 173, in build_async_engine_client
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m     async with build_async_engine_client_from_engine_args(
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m   File "/usr/lib64/python3.12/contextlib.py", line 210, in __aenter__
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m     return await anext(self.gen)
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m            ^^^^^^^^^^^^^^^^^^^^^
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m   File "/opt/vllm-source/vllm/entrypoints/openai/api_server.py", line 214, in build_async_engine_client_from_engine_args
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m     async_llm = AsyncLLM.from_vllm_config(
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m   File "/opt/vllm-source/vllm/v1/engine/async_llm.py", line 205, in from_vllm_config
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m     return cls(
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m            ^^^^
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m   File "/opt/vllm-source/vllm/v1/engine/async_llm.py", line 132, in __init__
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m     self.engine_core = EngineCoreClient.make_async_mp_client(
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m   File "/opt/vllm-source/vllm/v1/engine/core_client.py", line 121, in make_async_mp_client
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m     return DPLBAsyncMPClient(*client_args)
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m   File "/opt/vllm-source/vllm/v1/engine/core_client.py", line 1196, in __init__
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m     super().__init__(
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m   File "/opt/vllm-source/vllm/v1/engine/core_client.py", line 1037, in __init__
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m     super().__init__(
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m   File "/opt/vllm-source/vllm/v1/engine/core_client.py", line 824, in __init__
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m     super().__init__(
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m   File "/opt/vllm-source/vllm/v1/engine/core_client.py", line 479, in __init__
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m     with launch_core_engines(vllm_config, executor_class, log_stats) as (
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m   File "/usr/lib64/python3.12/contextlib.py", line 144, in __exit__
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m     next(self.gen)
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m   File "/opt/vllm-source/vllm/v1/engine/utils.py", line 921, in launch_core_engines
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m     wait_for_engine_startup(
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m   File "/opt/vllm-source/vllm/v1/engine/utils.py", line 980, in wait_for_engine_startup
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m     raise RuntimeError(
wide-ep-llm-d-prefill-0-1 vllm [0;36m(APIServer pid=1)[0;0m RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
```

What is the bug: nvshmem intialization fails over RDMA because of conflicting libiverbs versions

Why does this happen: First we install Base packages, in which rdma-core and libiverbs versions ~ 56 and 57 are available. Then we install EFA which explicitly brings versions 59 and 60. This causes those package version conflicts and missmatch.

Solutions:
    1. Split EFA and non efa image again
    2. Let base packages controll userspace rdma-core packages
        - Maybe EFA doesnt work
    3. Let EFA controll userspace rdma-core pacakges
        - bound to EFA release cycle - not scalable, but might be doable as a 1 off with more time
    4. Downgrade to EFA installer v1.43.3 - Same problem in reverse - it detected issues with the RDMA path and fell back to TCP (not 100% sure but I seem to remember this), meaning we can use libfabric but performance was bad)
    5. Split the images
    
Long term this makes sense to split the images now. We didn't want to do this for convenience but the ownership / what is a first class citizen quesetions get resolved by doing so, so im in favor. Lets look into some dockerfile + multi-stage build  techniques that will help reduce code drift but deal with this