### PR TITLE
[xpu] Use DRA for inference scheduling

### DIFF
--- a/guides/inference-scheduling/ms-inference-scheduling/values_xpu.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_xpu.yaml
@@ -28,7 +28,7 @@ decode:
   containers:
     - name: "vllm"
       # Use Intel latest published xpu image
-      image: ghcr.io/llm-d/llm-d-xpu:v0.4.0
+      image: ghcr.io/llm-d/llm-d-xpu-dev:pr-592
       modelCommand: "vllmServe"
       args:
         - "--dtype"
@@ -49,11 +49,9 @@ decode:
         limits:
           cpu: "8"
           memory: 24Gi
-          gpu.intel.com/i915: "1"
         requests:
           cpu: "4"
           memory: 12Gi
-          gpu.intel.com/i915: "1"
       mountModelVolume: true
       volumeMounts:
         - name: metrics-volume


### PR DESCRIPTION
We would like to use DRA for all Intel accelerators. For some reason, this was left out. If possible, can we get this one to 0.5?