### PR TITLE
feat: add support to build for CPU on AMX

### DIFF
--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -18,6 +18,8 @@ ARG VLLM_CPU_DISABLE_AVX512=0
 ARG VLLM_CPU_AVX512BF16=0
 # Support for building with AVX512VNNI ISA
 ARG VLLM_CPU_AVX512VNNI=0
+# Support for building with AMXBF16 ISA
+ARG VLLM_CPU_AMXBF16=1
 
 # Install system dependencies and uv
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -69,6 +71,7 @@ ENV TARGETARCH=${TARGETARCH}
 ENV VLLM_CPU_DISABLE_AVX512=${VLLM_CPU_DISABLE_AVX512}
 ENV VLLM_CPU_AVX512BF16=${VLLM_CPU_AVX512BF16}
 ENV VLLM_CPU_AVX512VNNI=${VLLM_CPU_AVX512VNNI}
+ENV VLLM_CPU_AMXBF16=${VLLM_CPU_AMXBF16}
 
 ######################### x86_64 BASE IMAGE #########################
 FROM base-common AS base-amd64


### PR DESCRIPTION
# Description
- AVX2 is old one for Intel, we already have support for AVX512 the new version
- this change is only to add more support on AMX alongwith AVX512

# Ref
- original support in vllm in https://github.com/vllm-project/vllm/pull/27954
- request in https://issues.redhat.com/browse/RHAIRFE-28