### PR TITLE
update: update labels we use in guide and document label usages

### DIFF
--- a/guides/README.md
+++ b/guides/README.md
@@ -43,6 +43,36 @@ The following guides have been provided by the community but do not fully integr
 > [!NOTE]
 > New guides added to this list enable at least one of the core well-lit paths but may directly include prerequisite steps specific to new hardware or infrastructure providers without full abstraction. A guide added here is expected to eventually become part of an existing well-lit path.
 
+## Label Schema
+
+The llm-d guides use a standardized set of Kubernetes labels for resource identification, selection, and operational purposes.
+These core labels above are set via the `modelArtifacts.labels` section in the modelservice chart values.
+
+### Core Labels
+
+| Label | Purpose | Valid Values | Required |
+| ------- | --------- | -------------- | ---------- |
+| `llm-d.ai/inference-serving` | Identifies inference serving resources | `"true"` | Yes |
+| `llm-d.ai/guide` | Identifies which guide deployed the resource | `"inference-scheduling"`, `"pd-disaggregation"`, `"wide-ep-lws"`, `"precise-prefix-cache-aware"`, `"workload-autoscaling"`, `"simulated-accelerators"`, `"tiered-prefix-cache"` | Yes |
+| `llm-d.ai/accelerator-variant` | Hardware accelerator type | `"gpu"`, `"cpu"`, `"xpu"`, `"tpu"`, `"hpu"` | Yes |
+| `llm-d.ai/accelerator-vendor` | Hardware vendor | `"nvidia"`, `"intel"`, `"google"`, `"amd"` | Yes |
+| `llm-d.ai/model` | Model identifier | Model name (e.g., `"Qwen3-32B"`, `"Llama-3.1-8B-Instruct"`) | Yes |
+| `llm-d.ai/role` | Pod role in P/D disaggregated deployments. Only required when using Prefill/Decode (P/D) disaggregation | `"prefill"`, `"decode"` | No* |
+
+### Accelerator Variant Details
+
+* **`gpu`**: NVIDIA, AMD, or generic GPU accelerators
+* **`cpu`**: CPU-only inference (no accelerators)
+* **`xpu`**: Intel Data Center GPUs (Max series, Arc series)
+* **`tpu`**: Google Tensor Processing Units
+* **`hpu`**: Intel Gaudi Habana Processing Units
+
+### Additional Labels
+
+**Workload Variant Autoscaler:**
+
+* `inference.optimization/acceleratorName`: GPU model name (e.g., `"H100"`, `"L40S"`, `"A100"`) used for cost-based autoscaling decisions. This label is set via `va.accelerator` in the workload-variant-autoscaler chart values
+
 ## Known Issues
 
 * In Release v0.4.0, the `wide-ep-lws` will crash loop due to a deprecated logging flag on the `routing-proxy` sidecar. This is fixed in [commit 83dd587](https://github.com/llm-d/llm-d/commit/83dd587dd847498820314e8144aadb4fa90d451f).

--- a/guides/inference-scheduling/helmfile.yaml.gotmpl
+++ b/guides/inference-scheduling/helmfile.yaml.gotmpl
@@ -97,7 +97,7 @@ releases:
   - name: {{ printf "ms-%s" $rn | quote }}
     namespace: {{ $ns }}
     chart: llm-d-modelservice/llm-d-modelservice
-    version: v0.4.5
+    version: v0.4.6
     installed: true
     needs:
       {{- if ne .Environment.Name "standalone" }}

--- a/guides/inference-scheduling/ms-inference-scheduling/values-hpu.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values-hpu.yaml
@@ -21,11 +21,10 @@ modelArtifacts:
   labels:
     llm-d.ai/inference-serving: "true"
     llm-d.ai/guide: "inference-scheduling"
-    llm-d.ai/hardware-variant: "hpu"
+    llm-d.ai/accelerator-variant: "hpu"
     llm-d.ai/accelerator-vendor: "intel"
     llm-d.ai/model: "Llama-3.1-8B-Instruct"
 
-# Configure accelerator type for Intel Gaudi via DRA
 accelerator:
   type: intel-gaudi
   dra: true

--- a/guides/inference-scheduling/ms-inference-scheduling/values_cpu.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_cpu.yaml
@@ -9,7 +9,7 @@ modelArtifacts:
   labels:
     llm-d.ai/inference-serving: "true"
     llm-d.ai/guide: "inference-scheduling"
-    llm-d.ai/hardware-vairant: "cpu"
+    llm-d.ai/accelerator-variant: "cpu"
     llm-d.ai/model: "Llama-3.2-3B-Instruct"
 
 accelerator:

--- a/guides/inference-scheduling/ms-inference-scheduling/values_tpu.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_tpu.yaml
@@ -8,8 +8,8 @@ modelArtifacts:
   labels:
     llm-d.ai/inference-serving: "true"
     llm-d.ai/guide: "inference-scheduling"
-    llm-d.ai/hardware-vairant: "tpu"
-    llm-d.ai/hardware-vendor: "goolge"
+    llm-d.ai/accelerator-variant: "tpu"
+    llm-d.ai/accelerator-vendor: "google"
     llm-d.ai/model: Qwen3-Coder-480B-A35B-Instruct-FP8
 
 routing:

--- a/guides/inference-scheduling/ms-inference-scheduling/values_xpu.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_xpu.yaml
@@ -9,13 +9,13 @@ modelArtifacts:
   labels:
     llm-d.ai/inference-serving: "true"
     llm-d.ai/guide: "inference-scheduling"
-    llm-d.ai/hardware-variant: "xpu"
+    llm-d.ai/accelerator-variant: "xpu"
     llm-d.ai/accelerator-vendor: "intel"
     llm-d.ai/model: "Qwen3-0.6B"
 
 # Configure accelerator type for Intel XPU via DRA
 accelerator:
-  type: intel-i915
+  type: intel
   dra: true
 
 routing:

--- a/guides/pd-disaggregation/README.xpu.md
+++ b/guides/pd-disaggregation/README.xpu.md
@@ -140,25 +140,20 @@ helmfile apply -f istio.helmfile.yaml --selector kind=gateway-control-plane
 
 ## Step 5: Deploy Intel XPU PD Disaggregation
 
-⚠️ **Important - For Intel BMG GPU Users**: Before running `helmfile apply`, you must update the accelerator type in `ms-pd/values_xpu.yaml`:
+ℹ️ **Note**: Intel XPU configuration uses Dynamic Resource Allocation (DRA) with the unified `intel` resource claim template. The `ms-pd/values_xpu.yaml` file is already configured correctly with:
 
 ```yaml
-# Edit ms-pd/values_xpu.yaml
-# For Intel Data Center GPU Max 1550 (i915 driver):
 accelerator:
-  type: intel-i915
-  dra: true
-
-# For Intel BMG GPU (Battlemage G21, Xe driver):
-accelerator:
-  type: intel-xe
+  type: intel  # value 'intel' unifies 'intel-i915' and 'intel-xe'
   dra: true
 ```
 
-**Accelerator Type by GPU:**
+**DRA automatically handles both Intel GPU types:**
 
-* **Intel Data Center GPU Max 1550**: Use `type: intel-i915` (maps to `gpu.intel.com/i915`)
-* **Intel BMG GPU (Battlemage G21)**: Use `type: intel-xe` (maps to `gpu.intel.com/xe`)
+* **Intel Data Center GPU Max 1550** (i915 driver)
+* **Intel BMG GPU / Battlemage G21** (xe driver)
+
+No manual resource specification is required - DRA manages GPU allocation transparently.
 
 ```shell
 # Navigate to PD disaggregation guide directory

--- a/guides/pd-disaggregation/helmfile.yaml.gotmpl
+++ b/guides/pd-disaggregation/helmfile.yaml.gotmpl
@@ -90,7 +90,7 @@ releases:
   - name: {{ printf "ms-%s" $rn | quote }}
     namespace: {{ $ns }}
     chart: llm-d-modelservice/llm-d-modelservice
-    version: v0.4.5
+    version: v0.4.6
     installed: true
     needs:
       - {{ printf "infra-%s" $rn | quote }}

--- a/guides/pd-disaggregation/ms-pd/values.yaml
+++ b/guides/pd-disaggregation/ms-pd/values.yaml
@@ -8,7 +8,7 @@ modelArtifacts:
   labels:
     llm-d.ai/inference-serving: "true"
     llm-d.ai/guide: "pd-disaggregation"
-    llm-d.ai/hardware-vairant: "gpu"
+    llm-d.ai/accelerator-variant: "gpu"
     llm-d.ai/accelerator-vendor: "nvidia"
     llm-d.ai/model: "gpt-oss-120b"
 

--- a/guides/pd-disaggregation/ms-pd/values_tpu.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_tpu.yaml
@@ -12,8 +12,8 @@ modelArtifacts:
   labels:
     llm-d.ai/inference-serving: "true"
     llm-d.ai/guide: "pd-disaggregation"
-    llm-d.ai/hardware-vairant: "tpu"
-    llm-d.ai/hardware-vendor: "goolge"
+    llm-d.ai/accelerator-variant: "tpu"
+    llm-d.ai/accelerator-vendor: "google"
     llm-d.ai/model: "Llama-3.3-70B-Instruct"
 
 routing:

--- a/guides/pd-disaggregation/ms-pd/values_xpu.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_xpu.yaml
@@ -5,7 +5,7 @@ multinode: false
 
 # Configure accelerator type for Intel XPU via DRA
 accelerator:
-  type: intel-i915
+  type: intel
   dra: true
 
 modelArtifacts:
@@ -16,8 +16,8 @@ modelArtifacts:
   labels:
     llm-d.ai/inference-serving: "true"
     llm-d.ai/guide: "pd-disaggregation"
-    llm-d.ai/hardware-variant: "xpu"
-    llm-d.ai/hardware-vendor: "intel"
+    llm-d.ai/accelerator-variant: "xpu"
+    llm-d.ai/accelerator-vendor: "intel"
     llm-d.ai/model: "Qwen3-0.6B"
 
 routing:

--- a/guides/precise-prefix-cache-aware/helmfile.yaml.gotmpl
+++ b/guides/precise-prefix-cache-aware/helmfile.yaml.gotmpl
@@ -83,7 +83,7 @@ releases:
   - name: {{ printf "ms-%s" $rn | quote }}
     namespace: {{ $ns }}
     chart: llm-d-modelservice/llm-d-modelservice
-    version: v0.4.5
+    version: v0.4.6
     installed: true
     needs:
       - {{ printf "infra-%s" $rn | quote }}

--- a/guides/precise-prefix-cache-aware/ms-kv-events/values_xpu.yaml
+++ b/guides/precise-prefix-cache-aware/ms-kv-events/values_xpu.yaml
@@ -5,7 +5,7 @@ multinode: false
 
 # Configure accelerator type for Intel XPU via DRA
 accelerator:
-  type: intel-i915
+  type: intel
   dra: true
 
 modelArtifacts:

--- a/guides/precise-prefix-cache-aware/ms-kv-events/values_xpu_pod_discovery.yaml
+++ b/guides/precise-prefix-cache-aware/ms-kv-events/values_xpu_pod_discovery.yaml
@@ -5,7 +5,7 @@ multinode: false
 
 # Configure accelerator type for Intel XPU via DRA
 accelerator:
-  type: intel-i915
+  type: intel
   dra: true
 
 modelArtifacts:
@@ -122,4 +122,3 @@ decode:
 # Disable prefill for XPU example
 prefill:
   create: false
-

--- a/guides/recipes/vllm/standard/kustomization.yaml
+++ b/guides/recipes/vllm/standard/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
         template:
           metadata:
             labels:
-              llm-d.ai/hardware-variant: "gpu"
+              llm-d.ai/accelerator-variant: "gpu"
               llm-d.ai/accelerator-vendor: "nvidia"

--- a/guides/simulated-accelerators/helmfile.yaml.gotmpl
+++ b/guides/simulated-accelerators/helmfile.yaml.gotmpl
@@ -72,7 +72,7 @@ releases:
   - name: {{ printf "ms-%s" $rn | quote }}
     namespace: {{ $ns }}
     chart: llm-d-modelservice/llm-d-modelservice
-    version: v0.4.5
+    version: v0.4.6
     installed: true
     needs:
       - {{ printf "infra-%s" $rn | quote }}

--- a/guides/workload-autoscaling/helmfile.yaml.gotmpl
+++ b/guides/workload-autoscaling/helmfile.yaml.gotmpl
@@ -68,7 +68,7 @@ releases:
   - name: {{ printf "ms-%s" $rn | quote }}
     namespace: {{ $ns }}
     chart: llm-d-modelservice/llm-d-modelservice
-    version: v0.4.5
+    version: v0.4.6
     installed: true
     needs:
       - {{ printf "infra-%s" $rn | quote }}


### PR DESCRIPTION
# Description
- standardize accelerator labels: `hardware-variant `to `accelerator-variant `across all guides
- update modelservice to v0.4.6: Update Intel XPU docs to use unified DRA configuration
- document label usage for core and wva
- fix typo for google

# Ref 
- https://github.com/llm-d/llm-d/issues/698
- https://github.com/llm-d-incubation/llm-d-modelservice/pull/185
- Depends on PR https://github.com/llm-d-incubation/llm-d-modelservice/pull/191