### PR TITLE
adding required packages for LMCache runtime

### DIFF
--- a/docker/packages/common/runtime-packages.json
+++ b/docker/packages/common/runtime-packages.json
@@ -10,7 +10,9 @@
     "git": "git",
     "curl": "curl",
     "libatomic": "libatomic1",
-    "libaio": null
+    "libaio": null,
+    "libxcb":"libxcb1",
+    "libxcb-devel":"libxcb1-dev"
   },
   "ubuntu_only": [
     "gcc",


### PR DESCRIPTION
cc @liu-cong @Sneha-at @maugustosilva

When Marcio ran the v0.5 image he got the following bug:

```
k logs -f facebook-28bb2887-opt-125m-decode-65f9c58c46-kqqz5
Defaulted container "vllm" out of: vllm, routing-proxy (init)
(APIServer pid=1) INFO 02-04 21:34:43 [api_server.py:1272] vLLM API server version 0.14.1
(APIServer pid=1) INFO 02-04 21:34:43 [utils.py:263] non-default args: {'model_tag': '/model-cache/models/facebook/opt-125m', 'port': 8200, 'model': '/model-cache/models/facebook/opt-125m', 'max_model_len': 16384,
 'served_model_name': ['facebook/opt-125m']}
(APIServer pid=1) INFO 02-04 21:34:53 [model.py:530] Resolved architecture: OPTForCausalLM
(APIServer pid=1) WARNING 02-04 21:34:53 [model.py:2020] User-specified max_model_len (16384) is greater than the derived max_model_len (max_position_embeddings=2048.0 or model_max_length=None in model's config.js
on). VLLM_ALLOW_LONG_MAX_MODEL_LEN must be used with extreme caution. If the model uses relative position encoding (RoPE), positions exceeding derived_max_model_len lead to nan. If the model uses absolute position
 encoding, positions exceeding derived_max_model_len will cause a CUDA array out-of-bounds error.
(APIServer pid=1) INFO 02-04 21:34:53 [model.py:1545] Using max model len 16384
(APIServer pid=1) INFO 02-04 21:34:54 [scheduler.py:229] Chunked prefill is enabled with max_num_batched_tokens=8192.
(APIServer pid=1) INFO 02-04 21:34:54 [vllm.py:630] Asynchronous scheduling is enabled.
(APIServer pid=1) INFO 02-04 21:34:54 [vllm.py:637] Disabling NCCL for DP synchronization when using async scheduling.
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib64/python3.12/multiprocessing/spawn.py", line 122, in spawn_main
    exitcode = _main(fd, parent_sentinel)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/multiprocessing/spawn.py", line 131, in _main
    prepare(preparation_data)
  File "/usr/lib64/python3.12/multiprocessing/spawn.py", line 246, in prepare
    _fixup_main_from_path(data['init_main_from_path'])
  File "/usr/lib64/python3.12/multiprocessing/spawn.py", line 297, in _fixup_main_from_path  
    main_content = runpy.run_path(main_path,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen runpy>", line 280, in run_path
  File "/usr/lib64/python3.12/pkgutil.py", line 170, in <module>
    iter_importer_modules.register(
  File "/usr/lib64/python3.12/functools.py", line 895, in register
    if _is_union_type(cls):
       ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/functools.py", line 845, in _is_union_type
    from typing import get_origin, Union
  File "/opt/vllm/lib/python3.12/site-packages/cv2/typing/__init__.py", line 62, in <module>
    import cv2.mat_wrapper
ImportError: libxcb.so.1: cannot open shared object file: No such file or directory
(APIServer pid=1) Traceback (most recent call last):
(APIServer pid=1)   File "/opt/vllm/bin/vllm", line 10, in <module>
(APIServer pid=1)     sys.exit(main())
(APIServer pid=1)              ^^^^^^
(APIServer pid=1)   File "/opt/vllm-source/vllm/entrypoints/cli/main.py", line 73, in main
(APIServer pid=1)     args.dispatch_function(args)
(APIServer pid=1)   File "/opt/vllm-source/vllm/entrypoints/cli/serve.py", line 60, in cmd
(APIServer pid=1)     uvloop.run(run_server(args))
(APIServer pid=1)   File "/opt/vllm/lib64/python3.12/site-packages/uvloop/__init__.py", line 96, in run
(APIServer pid=1)     return __asyncio.run(
(APIServer pid=1)            ^^^^^^^^^^^^^^
(APIServer pid=1)   File "/usr/lib64/python3.12/asyncio/runners.py", line 195, in run
(APIServer pid=1)     return runner.run(main)
(APIServer pid=1)            ^^^^^^^^^^^^^^^^
(APIServer pid=1)   File "/usr/lib64/python3.12/asyncio/runners.py", line 118, in run
(APIServer pid=1)     return self._loop.run_until_complete(task)
(APIServer pid=1)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=1)   File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
(APIServer pid=1)   File "/opt/vllm/lib64/python3.12/site-packages/uvloop/__init__.py", line 48, in wrapper
(APIServer pid=1)     return await main
(APIServer pid=1)            ^^^^^^^^^^
(APIServer pid=1)   File "/opt/vllm-source/vllm/entrypoints/openai/api_server.py", line 1319, in run_server
(APIServer pid=1)     await run_server_worker(listen_address, sock, args, **uvicorn_kwargs)
(APIServer pid=1)   File "/opt/vllm-source/vllm/entrypoints/openai/api_server.py", line 1338, in run_server_worker
(APIServer pid=1)     async with build_async_engine_client(
(APIServer pid=1)                ^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=1)   File "/usr/lib64/python3.12/contextlib.py", line 210, in __aenter__
(APIServer pid=1)     return await anext(self.gen)
(APIServer pid=1)            ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=1)   File "/opt/vllm-source/vllm/entrypoints/openai/api_server.py", line 173, in build_async_engine_client
(APIServer pid=1)     async with build_async_engine_client_from_engine_args(
(APIServer pid=1)                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=1)   File "/usr/lib64/python3.12/contextlib.py", line 210, in __aenter__
(APIServer pid=1)     return await anext(self.gen)
(APIServer pid=1)            ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=1)   File "/opt/vllm-source/vllm/entrypoints/openai/api_server.py", line 214, in build_async_engine_client_from_engine_args
(APIServer pid=1)     async_llm = AsyncLLM.from_vllm_config(
(APIServer pid=1)                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=1)   File "/opt/vllm-source/vllm/v1/engine/async_llm.py", line 205, in from_vllm_config
(APIServer pid=1)     return cls(
(APIServer pid=1)            ^^^^
(APIServer pid=1)   File "/opt/vllm-source/vllm/v1/engine/async_llm.py", line 132, in __init__
(APIServer pid=1)     self.engine_core = EngineCoreClient.make_async_mp_client(
(APIServer pid=1)                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=1)   File "/opt/vllm-source/vllm/v1/engine/core_client.py", line 122, in make_async_mp_client
(APIServer pid=1)     return AsyncMPClient(*client_args)
(APIServer pid=1)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=1)   File "/opt/vllm-source/vllm/v1/engine/core_client.py", line 824, in __init__
(APIServer pid=1)     super().__init__(
(APIServer pid=1)   File "/opt/vllm-source/vllm/v1/engine/core_client.py", line 479, in __init__
(APIServer pid=1)     with launch_core_engines(vllm_config, executor_class, log_stats) as (
(APIServer pid=1)          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=1)   File "/usr/lib64/python3.12/contextlib.py", line 144, in __exit__
(APIServer pid=1)     next(self.gen)
(APIServer pid=1)   File "/opt/vllm-source/vllm/v1/engine/utils.py", line 921, in launch_core_engines
(APIServer pid=1)     wait_for_engine_startup(
(APIServer pid=1)   File "/opt/vllm-source/vllm/v1/engine/utils.py", line 980, in wait_for_engine_startup
(APIServer pid=1)     raise RuntimeError(
(APIServer pid=1) RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {'EngineCore_DP0': 1}
```

This seemed to line up with: https://github.com/LMCache/LMCache/issues/2452. So we apply a similar fix and will test: https://github.com/LMCache/LMCache/pull/2451 Seems this was introduced in https://github.com/vllm-project/vllm/pull/30864 which released in v0.14.0 so it makes sense we hit this.