### PR TITLE
fix: adding cuda compat driver lib into runtime image which will work with old driver version

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -416,8 +416,8 @@ RUN export UV_INSTALL_DIR=/usr/local/bin && \
     ln -s /opt/vllm/bin/pip /usr/bin/pip && \
     uv pip install --no-cache -U wheel
 
-# Ensure CUDA compatibility library is loaded
-RUN echo "/usr/local/cuda-${CUDA_MAJOR}.${CUDA_MINOR}/compat/" > /etc/ld.so.conf.d/00-cuda-compat.conf && ldconfig
+# Ensure CUDA compatibility library is loaded (enables forward compatibility with older drivers)
+RUN echo "${CUDA_HOME}/compat/" > /etc/ld.so.conf.d/00-cuda-compat.conf && ldconfig
 
 # Copy compiled wheels
 COPY --from=builder /wheels/*.whl /tmp/wheels/


### PR DESCRIPTION
# Description 
- in env with older driver, without this fix, it wont work. as cuda 12.9 wont be supported + /usr/local/cuda-12.9/compat cannot be foudn without ldconfig register it
- in env with new drive 575+, without this fix, it should work.
- as stated by [Nividia](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html) `The /usr/local/cuda symbolic link points to the location where the CUDA Toolkit was installed. This link allows projects to use the latest CUDA Toolkit without any configuration file update.`  this is different from what vllm is doing(see ref below)

# Ref
vllm image: https://github.com/vllm-project/vllm/blob/main/docker/Dockerfile#L563