### PR TITLE
 Add debug variant support for llm-d images across CUDA, CPU, and XPU

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -18,6 +18,73 @@ env:
   TAG: ${{ github.event.release.tag_name != '' && github.event.release.tag_name || github.ref_name }}
 
 jobs:
+  release-cuda-llm-d-debug:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: vllm-runner
+            os: rhel
+            base_image_suffix: ubi9
+            image_suffix: "-debug"
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TAG }}
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.GHCR_USER }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}-cuda${{ matrix.image_suffix }}
+          tags: |
+            type=raw,value=${{ github.event.release.tag_name }},enable=${{ github.event_name == 'release' && github.event.action == 'published' }}
+            type=raw,value=${{ github.ref_name }},enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=latest,enable=true
+
+      - name: Build and push debug image
+        id: build-debug
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/Dockerfile.cuda
+          platforms: ${{ matrix.platform }}
+          push: true
+          build-args: |
+            BUILD_DEBUG=true
+            TARGETOS=${{ matrix.os }}
+            TARGETPLATFORM=${{ matrix.platform }}
+            BUILD_BASE_IMAGE_SUFFIX=${{ matrix.os == 'ubuntu' && 'ubuntu20.04' || matrix.base_image_suffix }}
+            FINAL_BASE_IMAGE_SUFFIX=${{ matrix.base_image_suffix }}
+            CACHE_BUSTER=${{ github.ref_name }}-${{ github.run_id }}
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ github.repository }}-cuda${{ matrix.image_suffix }}:${{ env.TAG }}
+            ${{ env.REGISTRY }}/${{ github.repository }}-cuda${{ matrix.image_suffix }}:latest
+          github-token: ${{ secrets.GHCR_TOKEN }}
+          secrets: |
+            aws_access_key_id=${{ secrets.AWS_ACCESS_KEY_ID_S3_BUCKET_ONLY }}
+            aws_secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY_S3_BUCKET_ONLY }}
+            subman_org=${{ secrets.SUBMAN_ORG }}
+            subman_activation_key=${{ secrets.SUBMAN_ACTIVATION_KEY }}
+        env:
+          DOCKER_BUILDKIT: "1"
+          BUILDKIT_PROGRESS: "plain"
+
   release-cuda-llm-d:
     strategy:
       fail-fast: false

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,12 @@ ifeq ($(BUILD_TYPE), dev)
 	IMAGE_BASE := $(IMAGE_BASE)-dev
 endif
 
+# BUILD_DEBUG, options ['true', 'false']
+BUILD_DEBUG ?= false
+ifeq ($(BUILD_DEBUG), true)
+	IMAGE_BASE := $(IMAGE_BASE)-debug
+endif
+
 IMG := $(IMAGE_BASE):$(VERSION)
 
 CONTAINER_TOOL := $(shell (command -v docker >/dev/null 2>&1 && echo docker) || (command -v podman >/dev/null 2>&1 && echo podman) || echo "")
@@ -38,12 +44,14 @@ SUPPRESS_PYTHON_OUTPUT ?=
 .PHONY: help
 help: ## Print help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
-	@printf "\n\033[1mXPU Build Examples:\033[0m\n"
-	@printf "  \033[36mmake image-build DEVICE=xpu\033[0m                    # Build Intel XPU Docker image\n"
-	@printf "  \033[36mmake image-build DEVICE=xpu VERSION=v0.2.0\033[0m     # Build with specific version\n"
-	@printf "  \033[36mmake image-push DEVICE=xpu\033[0m                     # Push Intel XPU Docker image\n"
-	@printf "  \033[36mmake image-retag DEVICE=xpu NEW_TAG=test\033[0m                     # Re-Tag Intel XPU Docker image\n"
-	@printf "  \033[36mmake env DEVICE=xpu\033[0m                            # Show XPU environment variables\n"
+	@printf "\n\033[1mBuild Examples:\033[0m\n"
+	@printf "  \033[36mmake image-build DEVICE=cuda\033[0m                            # Build CUDA Docker image (default)\n"
+	@printf "  \033[36mmake image-build DEVICE=cuda BUILD_DEBUG=true\033[0m           # Build CUDA Docker image with debug symbols\n"
+	@printf "  \033[36mmake image-build DEVICE=xpu\033[0m                             # Build Intel XPU Docker image\n"
+	@printf "  \033[36mmake image-build DEVICE=xpu VERSION=v0.2.0\033[0m              # Build with specific version\n"
+	@printf "  \033[36mmake image-push DEVICE=xpu\033[0m                              # Push Intel XPU Docker image\n"
+	@printf "  \033[36mmake image-retag DEVICE=xpu NEW_TAG=test\033[0m                # Re-Tag Intel XPU Docker image\n"
+	@printf "  \033[36mmake env DEVICE=xpu\033[0m                                     # Show XPU environment variables\n"
 
 ##@ Development
 
@@ -113,6 +121,7 @@ image-build: check-container-tool ## Build Docker image using $(CONTAINER_TOOL)
 	@printf "\033[33;1m==== Building Docker image $(IMG) ====\033[0m\n"
 	$(CONTAINER_TOOL) build --progress=plain --platform $(PLATFORMS) \
 		$(if $(SUPPRESS_PYTHON_OUTPUT),--build-arg SUPPRESS_PYTHON_OUTPUT=$(SUPPRESS_PYTHON_OUTPUT)) \
+		--build-arg BUILD_DEBUG=$(BUILD_DEBUG) \
 		-t $(IMG) -f $(DOCKERFILE_DIR)/$(DOCKERFILE) .
 
 .PHONY: image-push

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -18,6 +18,8 @@ ARG VLLM_CPU_DISABLE_AVX512=0
 ARG VLLM_CPU_AVX512BF16=0
 # Support for building with AVX512VNNI ISA
 ARG VLLM_CPU_AVX512VNNI=0
+# Support for debug builds with debug symbols
+ARG BUILD_DEBUG=false
 
 RUN apt clean && apt-get update -y && \
     apt-get install -y --no-install-recommends --fix-missing \
@@ -124,6 +126,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 #################################################################
 FROM vllm-build
 
+ARG BUILD_DEBUG
+
 ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/lib:${LD_LIBRARY_PATH}"
 
 RUN --mount=type=bind,from=vllm-build,src=/workspace/vllm/dist,target=dist \
@@ -143,8 +147,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends pkg-config \
 # Copy install_nixl.py script
 COPY docker/scripts/cpu/install_nixl.py /workspace/install_nixl.py
 
-# Install nixl + UCX
-RUN python3 /workspace/install_nixl.py
+# Install nixl + UCX with debug support if enabled
+RUN BUILD_DEBUG=${BUILD_DEBUG} python3 /workspace/install_nixl.py
 
 WORKDIR /workspace
 ENTRYPOINT ["python", "-m", "vllm.entrypoints.openai.api_server"]

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -23,6 +23,7 @@ ARG BASE_IMAGE_SUFFIX=ubi9
 ARG PYTHON_VERSION=3.12
 
 ARG USE_SCCACHE=true
+ARG BUILD_DEBUG=false
 
 ######################## COMPONENT VERSIONS ########################
 
@@ -90,6 +91,7 @@ ARG PYTHON_VERSION
 ARG NVSHMEM_VERSION
 
 ARG USE_SCCACHE
+ARG BUILD_DEBUG
 
 WORKDIR /workspace
 
@@ -199,7 +201,7 @@ COPY docker/scripts/cuda/builder/build-ucx.sh /tmp/build-ucx.sh
 RUN --mount=type=cache,target=/var/cache/git \
     --mount=type=secret,id=aws_access_key_id \
     --mount=type=secret,id=aws_secret_access_key \
-    /tmp/build-ucx.sh && \
+    BUILD_DEBUG=${BUILD_DEBUG} /tmp/build-ucx.sh && \
     rm -f /tmp/build-ucx.sh
 
 # Build NVSHMEM
@@ -211,7 +213,7 @@ COPY docker/scripts/cuda/builder/build-nvshmem.sh /tmp/build-nvshmem.sh
 RUN --mount=type=cache,target=/var/cache/git \
     --mount=type=secret,id=aws_access_key_id \
     --mount=type=secret,id=aws_secret_access_key \
-    /tmp/build-nvshmem.sh && \
+    BUILD_DEBUG=${BUILD_DEBUG} /tmp/build-nvshmem.sh && \
     rm -f /tmp/build-nvshmem.sh
 
 

--- a/docker/Dockerfile.xpu
+++ b/docker/Dockerfile.xpu
@@ -1,6 +1,7 @@
 ARG ONEAPI_VERSION=2025.2.2-0
 ARG VLLM_REPO="https://github.com/vllm-project/vllm.git"
 ARG VLLM_COMMIT_SHA="d7de043d55d1dd629554467e23874097e1c48993"
+ARG BUILD_DEBUG=false
 
 FROM intel/deep-learning-essentials:${ONEAPI_VERSION}-devel-ubuntu24.04 AS vllm-base
 
@@ -84,6 +85,8 @@ RUN if [ -n "${CACHE_BUSTER}" ]; then \
         echo "$CACHE_BUSTER" > /tmp/builder-buster; \
     fi;
 
+ARG BUILD_DEBUG
+
 # install additional dependencies for openai api server
 # hadolint ignore=DL3013
 RUN --mount=type=cache,target=/root/.cache/pip \
@@ -103,7 +106,7 @@ COPY docker/scripts/xpu/install_nixl_from_source_ubuntu.py /tmp/install_nixl_fro
 # vLLM XPU runtime; the installer script can fetch the latest version if this is unset,
 # but we intentionally use a fixed, tested version here.
 ENV NIXL_VERSION=0.7.0
-RUN python3 /tmp/install_nixl_from_source_ubuntu.py
+RUN BUILD_DEBUG=${BUILD_DEBUG} python3 /tmp/install_nixl_from_source_ubuntu.py
 
 # PyJWT-2.7.0 will influence some wheel behaviors, remove its dist-info to avoid conflicts
 RUN rm /usr/lib/python3/dist-packages/PyJWT-2.7.0.dist-info/ -rf

--- a/docker/scripts/cpu/install_nixl.py
+++ b/docker/scripts/cpu/install_nixl.py
@@ -104,21 +104,35 @@ def build_and_install_prerequisites(args):
     ucx_source_path = os.path.abspath(UCX_DIR)
     run_command(['git', 'checkout', 'v1.19.x'], cwd=ucx_source_path)
     run_command(['./autogen.sh'], cwd=ucx_source_path)
+
+    # Check for debug build mode
+    build_debug = os.environ.get('BUILD_DEBUG', 'false').lower() == 'true'
+    if build_debug:
+        print("=== Building UCX with debug symbols enabled ===", flush=True)
+        configure_script = './contrib/configure-devel'
+        make_install_target = 'install'
+    else:
+        print("=== Building UCX in release mode ===", flush=True)
+        configure_script = './configure'
+        make_install_target = 'install-strip'
+
     configure_command = [
-        './configure',
+        configure_script,
         f'--prefix={ucx_install_path}',
         '--enable-shared',
         '--disable-static',
         '--disable-doxygen-doc',
-        '--enable-optimizations',
         '--enable-cma',
         '--enable-devel-headers',
         '--with-verbs',
         '--enable-mt',
     ]
+    if not build_debug:
+        configure_command.append('--enable-optimizations')
+
     run_command(configure_command, cwd=ucx_source_path)
     run_command(['make', '-j', str(os.cpu_count() or 1)], cwd=ucx_source_path)
-    run_command(['make', 'install'], cwd=ucx_source_path)
+    run_command(['make', make_install_target], cwd=ucx_source_path)
     print("--- UCX build and install complete ---", flush=True)
 
     # -- Step 2: Build NIXL wheel from source --

--- a/docker/scripts/cuda/builder/build-nvshmem.sh
+++ b/docker/scripts/cuda/builder/build-nvshmem.sh
@@ -19,6 +19,7 @@ set -Eeux
 # - VIRTUAL_ENV: Path to the virtual environment from which python will be pulled
 # - USE_SCCACHE: whether to use sccache (true/false)
 # - PYTHON_VERSION: Python version (e.g., 3.12)
+# - BUILD_DEBUG: whether to build with debug symbols and logging (true/false) - defaults to false
 
 cd /tmp
 
@@ -57,6 +58,19 @@ if [ "$TARGETOS" = "rhel" ] && [ -n "${EFA_PREFIX}" ]; then
     )
 fi
 
+# Configure debug build options
+DEBUG_FLAGS=("")
+: "${BUILD_DEBUG:=false}"
+if [ "${BUILD_DEBUG}" = "true" ]; then
+    echo "=== Building NVSHMEM with debug symbols and logging enabled ==="
+    DEBUG_FLAGS=(
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        -DNVSHMEM_DEVEL=ON
+    )
+else
+    echo "=== Building NVSHMEM in release mode ==="
+fi
+
 cmake \
     -G Ninja \
     -DNVSHMEM_PREFIX="${NVSHMEM_DIR}" \
@@ -75,6 +89,7 @@ cmake \
     -DNVSHMEM_USE_NCCL=0 \
     -DNVSHMEM_BUILD_TESTS=0 \
     -DNVSHMEM_BUILD_EXAMPLES=0 \
+    ${DEBUG_FLAGS[@]} \
     ${EFA_FLAGS[@]} \
     ..
 

--- a/docker/scripts/cuda/builder/build-ucx.sh
+++ b/docker/scripts/cuda/builder/build-ucx.sh
@@ -17,6 +17,7 @@ set -Eeux
 # - UCX_PREFIX: prefix dir that contains installation path
 # - USE_SCCACHE: whether to use sccache (true/false)
 # - TARGETOS: OS type (ubuntu or rhel)
+# - BUILD_DEBUG: whether to build with debug symbols and logging (true/false) - defaults to false
 
 cd /tmp
 
@@ -35,8 +36,20 @@ if [ "$TARGETOS" = "rhel" ] && [ -n "${EFA_PREFIX}" ]; then
     EFA_FLAG="--with-efa"
 fi
 
+# Choose configure script based on debug mode
+: "${BUILD_DEBUG:=false}"
+if [ "${BUILD_DEBUG}" = "true" ]; then
+    echo "=== Building UCX with debug symbols enabled ==="
+    CONFIGURE_SCRIPT="./contrib/configure-devel"
+    INSTALL_TARGET="install"
+else
+    echo "=== Building UCX in release mode ==="
+    CONFIGURE_SCRIPT="./contrib/configure-release"
+    INSTALL_TARGET="install-strip"
+fi
+
 ./autogen.sh
-./contrib/configure-release \
+${CONFIGURE_SCRIPT} \
     --prefix="${UCX_PREFIX}" \
     --enable-shared \
     --disable-static \
@@ -51,7 +64,7 @@ fi
     --enable-mt
 
 make -j$(nproc)
-make install-strip
+make ${INSTALL_TARGET}
 ldconfig
 
 cd /tmp && rm -rf /tmp/ucx

--- a/docker/scripts/xpu/install_nixl_from_source_ubuntu.py
+++ b/docker/scripts/xpu/install_nixl_from_source_ubuntu.py
@@ -141,22 +141,36 @@ def build_and_install_prerequisites(args):
 
     run_command(["git", "checkout", "v1.19.x"], cwd=ucx_source_path)
     run_command(["./autogen.sh"], cwd=ucx_source_path)
+
+    # Check for debug build mode
+    build_debug = os.environ.get("BUILD_DEBUG", "false").lower() == "true"
+    if build_debug:
+        print("=== Building UCX with debug symbols enabled ===", flush=True)
+        configure_script = "./contrib/configure-devel"
+        make_install_target = "install"
+    else:
+        print("=== Building UCX in release mode ===", flush=True)
+        configure_script = "./configure"
+        make_install_target = "install-strip"
+
     configure_command = [
-        "./configure",
+        configure_script,
         f"--prefix={ucx_install_path}",
         "--enable-shared",
         "--disable-static",
         "--disable-doxygen-doc",
-        "--enable-optimizations",
         "--enable-cma",
         "--enable-devel-headers",
         "--with-verbs",
         "--enable-mt",
         "--with-ze=no",
     ]
+    if not build_debug:
+        configure_command.append("--enable-optimizations")
+
     run_command(configure_command, cwd=ucx_source_path)
     run_command(["make", "-j", str(os.cpu_count() or 1)], cwd=ucx_source_path)
-    run_command(["make", "install"], cwd=ucx_source_path)
+    run_command(["make", make_install_target], cwd=ucx_source_path)
     print("--- UCX build and install complete ---", flush=True)
 
     # -- Step 2: Build NIXL wheel from source --


### PR DESCRIPTION
  **Overview**

  This PR introduces debug variant support for llm-d images, enabling debug-level logging and symbols for NVSHMEM, UCX, and NIXL to facilitate low-level debugging of networking and communication issues.

  **Motivation**

  Currently, NVSHMEM and UCX are built with optimizations enabled and debug logging disabled, making it difficult to diagnose low-level networking issues. This PR publishes debug variants alongside existing non-debug versions to be easily consumable for debugging low-level issues without requiring custom builds.
  
  **Usage**

  Local builds:
```
  make image-build DEVICE=cuda BUILD_DEBUG=true
  make image-build DEVICE=cpu BUILD_DEBUG=true
  make image-build DEVICE=xpu BUILD_DEBUG=true
```

  Pull pre-built images:
`  docker pull ghcr.io/llm-d/llm-d-cuda-debug:latest`

  Image naming convention:
```
  - Regular: ghcr.io/llm-d/llm-d-{device}[-dev]:version
  - Debug: ghcr.io/llm-d/llm-d-{device}[-dev]-debug:version
```