### PR TITLE
feat: add support to build for CPU on AMX

### DIFF
--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -18,6 +18,8 @@ ARG VLLM_CPU_DISABLE_AVX512=0
 ARG VLLM_CPU_AVX512BF16=0
 # Support for building with AVX512VNNI ISA
 ARG VLLM_CPU_AVX512VNNI=0
+# Support for building with AMXBF16 ISA
+ARG VLLM_CPU_AMXBF16=1
 
 RUN apt clean && apt-get update -y && \
     apt-get install -y --no-install-recommends --fix-missing \
@@ -82,6 +84,7 @@ ENV TARGETARCH=${TARGETARCH}
 ENV VLLM_CPU_DISABLE_AVX512=${VLLM_CPU_DISABLE_AVX512}
 ENV VLLM_CPU_AVX512BF16=${VLLM_CPU_AVX512BF16}
 ENV VLLM_CPU_AVX512VNNI=${VLLM_CPU_AVX512VNNI}
+ENV VLLM_CPU_AMXBF16=${VLLM_CPU_AMXBF16}
 
 ######################### x86_64 BASE IMAGE #########################
 FROM base-common AS base-amd64


### PR DESCRIPTION
- AVX2 is old one for Intel, we already have support for AVX512 the new version
- this change is only to add more support on AMX alongwith AVX512

# Notes
origin PR in https://github.com/llm-d/llm-d/pull/684


