### PR TITLE
docs: fix typos and spelling errors across docs, guides, and Dockerfile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ The first key step in testing a feature, or bugfix is to identify what layer of 
   * Check that your `InferencePool` exists (`kubectl get InferencePool.inference.networking.k8s.io`)
 * Upgrading Infra helmchart or anything affecting Gateway infrastructure
   * Check the `gateway` object (`kubectl get gateway -o yaml`)
-    * Check the `status` seciton, make sure it has an `address` and that there is a message saying `"Resource programmed, assigned to service(s) <gateway_service_address>"`
+    * Check the `status` section, make sure it has an `address` and that there is a message saying `"Resource programmed, assigned to service(s) <gateway_service_address>"`
     * Check the `parametersRef` for the `gateway` `infrastructure` exists (`kubectl get gateway wide-ep-inference-gateway -o yaml | yq .spec.infrastructure.parametersRef`, and then check to ensure that resource itself exists)
   * If using `istio` also check that your `DestinationRule` exists
 * Check the `httpRoute` object `status` section (`kubectl get httpRoute -o yaml | yq '.status.parents[]'`)
@@ -93,9 +93,9 @@ The first key step in testing a feature, or bugfix is to identify what layer of 
     * For `pplx` you can set both `prefill` and `decode` `VLLM_ALL2ALL_BACKEND` to `pplx`
       * This can be ran in any example
     * For testing the deepseek kernels, you can set `prefill`s backend to `deepep_high_throughput` and `decode` backend to `deepep_low_latency`
-      * This needs to be tested in either `pd-dissagregation` or better yet `wide-ep-lws`
+      * This needs to be tested in either `pd-disaggregation` or better yet `wide-ep-lws`
 * `UCX` + `NIXL` version bumps and changes
-  * This can be tested in `pd-dissagregation` or `wide-ep-lws`
+  * This can be tested in `pd-disaggregation` or `wide-ep-lws`
   * Currently we build `UCX` from source, and then build `NIXL` against our build of `NIXL`
 * `LMCache` version bumps and changes (coming soon)
   * Currently nothing uses the `LMCache` codepath directly, this will come as a subset of the KVCache offloading epic
@@ -132,11 +132,11 @@ EOF
 
 * [ ] `inference-scheduler` guide
 * [ ] `precise-kv-cache-aware` example
-* [ ] `pd-dissagregation` example (also covers deepseek kernels)
+* [ ] `pd-disaggregation` example (also covers deepseek kernels)
 * [ ] `wide-ep-lws` example (also covers deepseek kernels)
 * [ ] a `guidellm` benchmark to do a load test for performance regressions (any example)
 * [ ] run a guide with the `pplx` backend
-* [ ] run `pd-dissagregation` or `wide-ep-lws` with deepseek kernels (for `prefill`s set `VLLM_ALL2ALL_BACKEND` to `deepep_high_throughput` and set `decode` `VLLM_ALL2ALL_BACKEND` to `deepep_low_latency`)
+* [ ] run `pd-disaggregation` or `wide-ep-lws` with deepseek kernels (for `prefill`s set `VLLM_ALL2ALL_BACKEND` to `deepep_high_throughput` and set `decode` `VLLM_ALL2ALL_BACKEND` to `deepep_low_latency`)
 
 ### Code Review Requirements
 

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -332,7 +332,7 @@ ${LD_LIBRARY_PATH}" \
     CUDA_MAJOR=${CUDA_MAJOR} \
     CUDA_MINOR=${CUDA_MINOR}
 
-# LD_LIBRARY_PATH needs the torch path to apply proper linkers so as not to produce torch ABI missmatch
+# LD_LIBRARY_PATH needs the torch path to apply proper linkers so as not to produce torch ABI mismatch
 ENV LD_LIBRARY_PATH="/opt/vllm/lib64/python${PYTHON_VERSION}/site-packages/torch/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:/usr/local/lib:/usr/local/lib64:${NVSHMEM_DIR}/lib:${LD_LIBRARY_PATH}"
 
 # Install runtime dependencies
@@ -449,7 +449,7 @@ ARG SUPPRESS_PYTHON_OUTPUT
 
 # A script that starts if users exec into the image with bash. It warns that vLLM is built with precompiled by default,
 # and so if they change the vLLM version or use their fork, it may no longer work due to the precompiled shared libraries
-# pulled from teh vLLM wheel index.
+# pulled from the vLLM wheel index.
 COPY scripts/warn-vllm-precompiled.sh /opt/
 
 # Install cuda-python, nvshmem python bindings, xet
@@ -457,7 +457,7 @@ COPY scripts/warn-vllm-precompiled.sh /opt/
 # Installs vllm source. Supports three install modes:
     # 1) install vllm from source totally editably - dev option, supports fork and commit swapping
     # 3) install vllm from source with pulling precomiled binaries (shared libraries) from the vllm wheels index - less flexible dev option, may or may not work swapping shas but faster than full editable
-    # 2) install vllm from a wheel on the vllm wheels index - prod option, no flexbility
+    # 2) install vllm from a wheel on the vllm wheels index - prod option, no flexibility
 COPY docker/scripts/cuda/runtime/install-vllm.sh /tmp/install-vllm.sh
 RUN --mount=type=cache,target=/var/cache/git \
     /tmp/install-vllm.sh && \

--- a/docs/getting-started-inferencing.md
+++ b/docs/getting-started-inferencing.md
@@ -13,7 +13,7 @@ You are assumed to have deployed the llm-d inference stack from a guide, using t
 
 First we need to choose what strategy we are going to use to expose / interact with your gateway. It should be noted that this will be affected by the values you used when installing the `llm-d-infra` chart for your given guide. Select the tab that matches your environment.
 
-**_NOTE:_** If you're unsure which to use—start with a ClusterIP gateway service type and port-forward as it's the most reliable and easiest. Use LoadBalancer if your provider supports it and you just need raw L4 access. Use Nodeport if you want an externally accessible gateway but your k8s provider does not support LoadBalancer integration and you have a functioning load balancer ctronller in your cluster, such as MetalLB.
+**_NOTE:_** If you're unsure which to use—start with a ClusterIP gateway service type and port-forward as it's the most reliable and easiest. Use LoadBalancer if your provider supports it and you just need raw L4 access. Use Nodeport if you want an externally accessible gateway but your k8s provider does not support LoadBalancer integration and you have a functioning load balancer controller in your cluster, such as MetalLB.
 
 <!-- TABS:START -->
 
@@ -144,7 +144,7 @@ Expected output:
 
 ### /v1/completions
 
-Now lets try hitting the `/v1/completions` endpoint (this is model dependent, ensure your model matches what the server returns for the `v1/models` curl).
+Now let's try hitting the `/v1/completions` endpoint (this is model dependent, ensure your model matches what the server returns for the `v1/models` curl).
 
 ```bash
 curl -X POST ${ENDPOINT}/v1/completions \

--- a/guides/README.md
+++ b/guides/README.md
@@ -41,7 +41,7 @@ The following guides have been provided by the community but do not fully integr
 * Coming Soon!
 
 > [!NOTE]
-> New guides added to this list enable at least one of the core well-lit paths but may directly include prerequisite steps specific to new hardware or infrastructure providers without full abstraction. A guide added here is expected to eventually become path of an existing well-lit path.
+> New guides added to this list enable at least one of the core well-lit paths but may directly include prerequisite steps specific to new hardware or infrastructure providers without full abstraction. A guide added here is expected to eventually become part of an existing well-lit path.
 
 ## Known Issues
 

--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -154,7 +154,7 @@ For instructions on getting started making inference requests see [our docs](../
 
 ## Tuning Selective PD
 
-Selective PD is a feature in the `inference-scheduler` within the context of prefill-decode dissagregation, although it is disabled by default. This features enables routing to just decode even with the P/D deployed. To enable it, you will need to set `threshold` value for the `pd-profile-handler` plugin, in the [GAIE values file](./gaie-pd/values.yaml). You can see the value of this here:
+Selective PD is a feature in the `inference-scheduler` within the context of prefill-decode disaggregation, although it is disabled by default. This feature enables routing to just decode even with the P/D deployed. To enable it, you will need to set `threshold` value for the `pd-profile-handler` plugin, in the [GAIE values file](./gaie-pd/values.yaml). You can see the value of this here:
 
 ```bash
 cat gaie-pd/values.yaml | yq '.inferenceExtension.pluginsCustomConfig."pd-config.yaml"' | yq '.plugins[] | select(.type == "pd-profile-handler")'

--- a/guides/pd-disaggregation/README.tpu.md
+++ b/guides/pd-disaggregation/README.tpu.md
@@ -149,7 +149,7 @@ infra-pd-inference-gateway   gke-l7-regional-external-managed   123.123.123.123 
     }
     ```
 
-1. Now lets try hitting the `/v1/completions` endpoint (this is model dependent, ensure your model matches what the server returns for the `v1/models` curl).
+1. Now let's try hitting the `/v1/completions` endpoint (this is model dependent, ensure your model matches what the server returns for the `v1/models` curl).
 
     ```bash
     curl -X POST ${ENDPOINT}/v1/completions \
@@ -204,7 +204,7 @@ For more information see [our docs](../../docs/getting-started-inferencing.md)
 
 ## Tuning Selective PD
 
-Selective PD is a feature in the `inference-scheduler` within the context of prefill-decode dissagregation, although it is disabled by default. This features enables routing to just decode even with the P/D deployed.
+Selective PD is a feature in the `inference-scheduler` within the context of prefill-decode disaggregation, although it is disabled by default. This feature enables routing to just decode even with the P/D deployed.
 
 For information on this plugin, see our [`pd-profile-handler` docs in the inference-scheduler](https://github.com/llm-d/llm-d-inference-scheduler/blob/v0.5.0/docs/architecture.md?plain=1#L205-L210)
 


### PR DESCRIPTION
## What

Fixes 14 typos and spelling errors found across 6 files in docs, guides, and the CUDA Dockerfile.

## Changes

| File | Fix |
|------|-----|
| [CONTRIBUTING.md](cci:7://file:///d:/llm-d/CONTRIBUTING.md:0:0-0:0) | `dissagregation` → `disaggregation` (4×), `seciton` → `section` |
| [docker/Dockerfile.cuda](cci:7://file:///d:/llm-d/docker/Dockerfile.cuda:0:0-0:0) | `missmatch` → `mismatch`, `teh` → `the`, `flexbility` → `flexibility` |
| [docs/getting-started-inferencing.md](cci:7://file:///d:/llm-d/docs/getting-started-inferencing.md:0:0-0:0) | `ctronller` → `controller`, `lets` → `let's` |
| [guides/pd-disaggregation/README.md](cci:7://file:///d:/llm-d/guides/pd-disaggregation/README.md:0:0-0:0) | `dissagregation` → `disaggregation`, `This features` → `This feature` |
| [guides/pd-disaggregation/README.tpu.md](cci:7://file:///d:/llm-d/guides/pd-disaggregation/README.tpu.md:0:0-0:0) | `dissagregation` → `disaggregation`, `This features` → `This feature`, `lets` → `let's` |
| [guides/README.md](cci:7://file:///d:/llm-d/guides/README.md:0:0-0:0) | `path of` → `part of` |

## Why

These typos appear in contributor-facing and user-facing documentation. Fixing them improves readability and professionalism of the project docs.
