### PR TITLE
chore: update bug report issue template with current versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -30,13 +30,14 @@ body:
       label: Version
       description: What version of our software are you running?
       options:
-        - v0.2.0
-        - v0.2.1
-        - v0.2.2
-        - v0.3.0
-        - v0.3.1
+        - v0.5.0
         - v0.4.0
-      default: v0.3.0
+        - v0.3.1
+        - v0.3.0
+        - v0.2.2
+        - v0.2.1
+        - v0.2.0
+      default: 0
     validations:
       required: true
   - type: textarea
@@ -44,3 +45,4 @@ body:
     attributes:
       label: Relevant log output
       description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell


### PR DESCRIPTION
## What

Updates the bug report issue template ([.github/ISSUE_TEMPLATE/bug.yml](cci:7://file:///d:/llm-d/.github/ISSUE_TEMPLATE/bug.yml:0:0-0:0)) to reflect current project state.

## Changes

- **Added `v0.5.0`** to the version dropdown (was missing — template only listed up to `v0.4.0`)
- **Reordered versions** newest-first for better UX (users are most likely reporting on recent versions)
- **Updated default** from `v0.3.0` to `v0.5.0`
- **Added `render: shell`** to the log output textarea so pasted logs are automatically formatted as code blocks

## Why

The template was last updated when `v0.4.0` was the latest release and defaulted to `v0.3.0`. With `v0.5.0` released, this was outdated and could confuse users filing bugs.
