### PR TITLE
fix: add missing check-buildah target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,6 +295,12 @@ check-builder:
 		echo "✅ Using builder: $(BUILDER)"; \
 	fi
 
+.PHONY: check-buildah
+check-buildah:
+	@command -v buildah >/dev/null 2>&1 || { \
+	  echo "⚠️  buildah is not installed. You can install it with:"; \
+	  echo "🔧 sudo apt install buildah  OR  brew install buildah"; exit 1; }
+
 .PHONY: check-podman
 check-podman:
 	@command -v podman >/dev/null 2>&1 || { \


### PR DESCRIPTION
The check-tools target lists check-buildah as a dependency, but the target was never defined, causing `make check-tools` to fail with "No rule to make target 'check-buildah'" on any system.

This has been present since the initial commit (c9f73a4, 2025-04-29) but was never caught, likely because most contributors either skip `make check-tools` or already have buildah installed.