### PR TITLE
docs: update container image link in PROJECT.md

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -74,7 +74,7 @@ Published to the website [https://llm-d.github.io/](https://llm-d.github.io/).
 
 ### Container Images
 
-Images are published to [ghcr.io/llm-d](https://github.com/llm-d/llm-d/pkgs/container/llm-d).
+Images are published to [ghcr.io/llm-d](https://github.com/orgs/llm-d/packages).
 
 ### Project Automation
 


### PR DESCRIPTION
Changed the link for published container images from the broken link to a better more project general link