### PR TITLE
Fix broken slack links in documentation

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -25,7 +25,7 @@ The purpose of this policy is to ensure a smooth on-boarding and off-boarding pr
 
 ### 2.3. Getting Help
 
-- The organization's maintainers are here to help contributors be efficient and confident in their collaboration effort. If you need help you can reach out to the maintainers on slack at the [llm-d-dev channel](https://llm-d.slack.com/archives/C08SH9K8JGK).
+- The organization's maintainers are here to help contributors be efficient and confident in their collaboration effort. If you need help you can reach out to the maintainers on slack in the #llm-d-dev channel (llm-d Slack workspace: https://llm-d.ai/slack).
 - Be sure to join the [llm-d-dev Google Group](https://groups.google.com/g/llm-d-contributors) to get access to important artifacts like proposals, diagrams, and meeting invitations.
 
 ### 2.4. Orientation

--- a/SIGS.md
+++ b/SIGS.md
@@ -71,7 +71,7 @@ SIGs operate within the broader llm-d project governance framework defined in [P
 
 **💬 Communication**:
 
-- **Slack Channel**: [#sig-inference-scheduler](https://llm-d.slack.com/archives/C08SBNRRSBD)
+- **Slack Channel**: #sig-inference-scheduler (llm-d Slack workspace: https://llm-d.ai/slack)
 - **Meeting Recordings and Docs**: [Public Google Drive](https://drive.google.com/drive/folders/1aKTJru43krjHP2ORayEEp4JP-N7dJL8S)
 - **GitHub Issues**: [github.com/llm-d/llm-d-inference-scheduler](https://github.com/llm-d/llm-d-inference-scheduler/issues)
 
@@ -93,7 +93,7 @@ SIGs operate within the broader llm-d project governance framework defined in [P
 
 **💬 Communication**:
 
-- **Slack Channel**: [#sig-benchmarking](https://llm-d.slack.com/archives/C08TSFYMSCQ)
+- **Slack Channel**: #sig-benchmarking (llm-d Slack workspace: https://llm-d.ai/slack)
 - **Meeting Recordings and Docs**: [Public Google Drive](https://drive.google.com/drive/folders/1Hd-rCRLDbucl-LD0RlQwOCLqERWF-obT)
 - **GitHub Issues**: [github.com/llm-d/llm-d-benchmark](https://github.com/llm-d/llm-d-benchmark/issues)
 
@@ -115,7 +115,7 @@ SIGs operate within the broader llm-d project governance framework defined in [P
 
 **💬 Communication**:
 
-- **Slack Channel**: [#sig-pd-disaggregation](https://llm-d.slack.com/archives/C08T1E128PK)
+- **Slack Channel**: #sig-pd-disaggregation (llm-d Slack workspace: https://llm-d.ai/slack)
 - **Meeting Recordings and Docs**: [Public Google Drive](https://drive.google.com/drive/folders/1jk7wtojsWNbYQVf7BY8BEvIg8FMRZV0q)
 - **GitHub Issues**: [github.com/llm-d/llm-d-routing-sidecar](https://github.com/llm-d/llm-d-routing-sidecar/issues)
 
@@ -137,7 +137,7 @@ SIGs operate within the broader llm-d project governance framework defined in [P
 
 **💬 Communication**:
 
-- **Slack Channel**: [#sig-kv-disaggregation](https://llm-d.slack.com/archives/C08TB7ZDV7S)
+- **Slack Channel**: #sig-kv-disaggregation (llm-d Slack workspace: https://llm-d.ai/slack)
 - **Meeting Recordings and Docs**: [Public Google Drive](https://drive.google.com/drive/folders/1mFbzwEWL2-LvD21owgxlKRcQD0eSmcz6)
 - **GitHub Issues**: [github.com/llm-d/llm-d-kv-cache](https://github.com/llm-d/llm-d-kv-cache/issues)
 
@@ -159,7 +159,7 @@ SIGs operate within the broader llm-d project governance framework defined in [P
 
 **💬 Communication**:
 
-- **Slack Channel**: [#sig-installation](https://llm-d.slack.com/archives/C08SLBGKBEZ)
+- **Slack Channel**: #sig-installation (llm-d Slack workspace: https://llm-d.ai/slack)
 - **Meeting Recordings and Docs**: [Public Google Drive](https://drive.google.com/drive/folders/1H-0Y8fXepzrYpcaUOBfuphn1Cl-gU0xr)
 - **GitHub Issues**: [github.com/llm-d-incubation/llm-d-modelservice](https://github.com/llm-d-incubation/llm-d-modelservice/issues) | [github.com/llm-d-incubation/llm-d-infra](https://github.com/llm-d-incubation/llm-d-infra/issues)
 
@@ -181,7 +181,7 @@ SIGs operate within the broader llm-d project governance framework defined in [P
 
 **💬 Communication**:
 
-- **Slack Channel**: [#sig-autoscaling](https://llm-d.slack.com/archives/C08T899332A)
+- **Slack Channel**: #sig-autoscaling (llm-d Slack workspace: https://llm-d.ai/slack)
 - **Meeting Recordings and Docs**: [Public Google Drive](https://drive.google.com/drive/folders/1iDlTgpFPOrSQn7dWR3uCQLtqhz86HTAi)
 - **GitHub Issues**: [github.com/llm-d-incubation/workload-variant-autoscaler](https://github.com/llm-d-incubation/workload-variant-autoscaler/issues)
 
@@ -203,7 +203,7 @@ SIGs operate within the broader llm-d project governance framework defined in [P
 
 **💬 Communication**:
 
-- **Slack Channel**: [#sig-observability](https://llm-d.slack.com/archives/C09305NHZ45)
+- **Slack Channel**: #sig-observability (llm-d Slack workspace: https://llm-d.ai/slack)
 - **Meeting Recordings and Docs**: [Public Google Drive](https://drive.google.com/drive/folders/1H-TVTCKYVxUn4fER7xuTPmscNttZCutN)
 
 ## Getting Involved


### PR DESCRIPTION
Replace direct Slack archive links with the general workspace link to avoid Lychee link checker rate limiting (429 Too Many Requests).