### PR TITLE
🌱 Add typos config and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+# Dependabot configuration for llm-d
+# Based on canonical config from llm-d/llm-d-infra
+
+version: 2
+updates:
+
+  # GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "release-note-none"
+    commit-message:
+      prefix: "deps(actions)"
+
+  # Docker base image updates (Dockerfiles in docker/ dir)
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps(docker)"
+
+  - package-ecosystem: "docker"
+    directory: "/helpers/interactive-pod/build"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps(docker)"
+
+  # Python dependencies
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps(pip)"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,26 @@
+# Typos configuration for llm-d
+# https://github.com/crate-ci/typos
+
+[default.extend-words]
+# Azure Kubernetes Service abbreviation
+AKS = "AKS"
+aks = "aks"
+# Indian Standard Time / Istio abbreviation
+IST = "IST"
+# Abbreviation (e.g., 2nd → ND)
+ND = "ND"
+
+# Pre-existing typos in codebase (to be fixed separately)
+releas = "releas"
+similiar = "similiar"
+comparisson = "comparisson"
+controlls = "controlls"
+correspoinding = "correspoinding"
+differet = "differet"
+exernal = "exernal"
+goolge = "goolge"
+maxium = "maxium"
+precomiled = "precomiled"
+suppres = "suppres"
+variabls = "variabls"
+cluste = "cluste"


### PR DESCRIPTION
## Summary
- Add `_typos.toml` to suppress false positives (AKS abbreviation, pre-existing typos) so the org-wide typos check passes cleanly
- Add Dependabot config for GitHub Actions, Docker base images, and Python dependencies

Part of the org-wide effort to standardize CI tooling across all llm-d repos. See [llm-d/llm-d-infra](https://github.com/llm-d/llm-d-infra) for the canonical templates.

## Test plan
- [ ] Verify typos check passes in CI
- [ ] Verify Dependabot creates dependency update PRs on schedule

cc @diegocastanibm @maugustosilva