### PR TITLE
✨ Add nightly E2E OpenShift workflows for 5 guides

### DIFF
--- a/.github/workflows/e2e-accelerator-test.yaml
+++ b/.github/workflows/e2e-accelerator-test.yaml
@@ -1,8 +1,8 @@
 name: E2E Accelerator EC2 Test
 
 on:
-  #  schedule: # TODO: enable once validated functional
-  #    - cron: '0 8 * * *'  # 4AM Eastern (08:00 UTC)
+  schedule:
+    - cron: '0 6 * * *'  # 6AM UTC daily
   workflow_dispatch:
     inputs:
       pr_or_branch:
@@ -31,7 +31,8 @@ permissions:
 jobs:
   setup:
     if: >
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule'
     runs-on: ubuntu-latest
     outputs:
       instance_id: ${{ steps.launch.outputs.instance_id }}

--- a/.github/workflows/e2e-inference-scheduling-gke.yaml
+++ b/.github/workflows/e2e-inference-scheduling-gke.yaml
@@ -4,7 +4,7 @@ on:
   # Runs with a PR comment /run-gke-inference-scheduling
   issue_comment:
     types: [created]
-  schedule:  # TODO: enable once validated functional
+  schedule:
     - cron: '0 10 * * *'  # 3AM PST (10:00 UTC)
   workflow_dispatch:
     inputs:

--- a/.github/workflows/e2e-inference-scheduling-hpu.yaml
+++ b/.github/workflows/e2e-inference-scheduling-hpu.yaml
@@ -1,6 +1,8 @@
 name: HPU Inference Scheduling Test
 
 on:
+  schedule:
+    - cron: '0 4 * * *'  # 4:00 AM UTC daily
   pull_request:
     paths:
       - 'guides/inference-scheduling/ms-inference-scheduling/values-hpu.yaml'
@@ -19,7 +21,8 @@ jobs:
   deploy_and_validate:
     if: >
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'pull_request'
+      github.event_name == 'pull_request' ||
+      github.event_name == 'schedule'
     runs-on: hpu
     env:
       NAMESPACE: "llm-d-hpu-is"

--- a/.github/workflows/e2e-pd-disaggregation-accelerator-test.yaml
+++ b/.github/workflows/e2e-pd-disaggregation-accelerator-test.yaml
@@ -1,6 +1,8 @@
 name: E2E PD-Disaggregation Test
 
 on:
+  schedule:
+    - cron: '30 6 * * *'  # 6:30 AM UTC daily
   workflow_dispatch:
     inputs:
       pr_or_branch:
@@ -29,7 +31,8 @@ permissions:
 jobs:
   setup:
     if: >
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule'
     runs-on: ubuntu-latest
     outputs:
       instance_id: ${{ steps.launch.outputs.instance_id }}

--- a/.github/workflows/e2e-pd-gaudi.yaml
+++ b/.github/workflows/e2e-pd-gaudi.yaml
@@ -1,6 +1,8 @@
 name: Gaudi PD Test
 
 on:
+  schedule:
+    - cron: '30 4 * * *'  # 4:30 AM UTC daily
   pull_request:
     paths:
       - 'guides/pd-disaggregation/ms-pd/values_hpu.yaml'
@@ -20,7 +22,8 @@ jobs:
   deploy_and_validate:
     if: >
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'pull_request'
+      github.event_name == 'pull_request' ||
+      github.event_name == 'schedule'
     runs-on: hpu
     env:
       NAMESPACE: "llm-d-hpu-pd"

--- a/.github/workflows/e2e-wide-ep-accelerator-gke.yaml
+++ b/.github/workflows/e2e-wide-ep-accelerator-gke.yaml
@@ -4,8 +4,8 @@ on:
   # Runs with a PR comment /run-gke-wide-ep
   issue_comment:
     types: [created]
-  schedule:  # TODO: enable once validated functional
-    - cron: '0 12 * * *'  # 5AM PST (11:00 UTC)
+  schedule:
+    - cron: '0 12 * * *'  # 5AM PST (12:00 UTC)
   workflow_dispatch:
     inputs:
       pr_or_branch:

--- a/.github/workflows/e2e-wide-ep-accelerator-test.yaml
+++ b/.github/workflows/e2e-wide-ep-accelerator-test.yaml
@@ -1,6 +1,8 @@
 name: E2E Wide EP Test
 
 on:
+  schedule:
+    - cron: '0 7 * * *'  # 7:00 AM UTC daily
   workflow_dispatch:
     inputs:
       pr_or_branch:
@@ -30,7 +32,8 @@ env:
 jobs:
   setup:
     if: >
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule'
     runs-on: ubuntu-latest
     outputs:
       instance_id: ${{ steps.launch.outputs.instance_id }}

--- a/.github/workflows/nightly-e2e-inference-scheduling-gke.yaml
+++ b/.github/workflows/nightly-e2e-inference-scheduling-gke.yaml
@@ -1,0 +1,40 @@
+name: Nightly - Inference Scheduling E2E (GKE)
+
+# Nightly regression test for the inference-scheduling guide on GKE.
+# Deploys via helmfile (gke env) and validates with e2e-validate.sh.
+
+on:
+  schedule:
+    - cron: '0 10 * * *'  # 10:00 UTC daily (staggered from OCP nightlies)
+  workflow_dispatch:
+    inputs:
+      skip_cleanup:
+        description: 'Skip cleanup after tests (for debugging)'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-e2e-inference-scheduling-gke
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml@main
+    with:
+      guide_name: inference-scheduling
+      namespace: llm-d-nightly-inference-gke
+      helmfile_env: gke
+      gateway_type: gke
+      gke_cluster_name: llm-d-e2e-us-east5
+      gke_cluster_zone: us-east5
+      required_gpus: 2
+      recommended_gpus: 4
+      accelerator_type: L4
+      pod_wait_timeout: '15m'
+      pod_readiness_delay: 180
+      httproute_file: httproute.gke.yaml
+      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+    secrets: inherit

--- a/.github/workflows/nightly-e2e-inference-scheduling.yaml
+++ b/.github/workflows/nightly-e2e-inference-scheduling.yaml
@@ -1,0 +1,44 @@
+name: Nightly - Inference Scheduling E2E (OpenShift)
+
+# Nightly regression test for the inference-scheduling guide on OpenShift.
+# Deploys via helmfile and validates with e2e-validate.sh.
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Midnight UTC daily
+  workflow_dispatch:
+    inputs:
+      helmfile_env:
+        description: 'Helmfile environment'
+        required: false
+        default: 'istio'
+        type: choice
+        options:
+          - istio
+          - kgateway
+      skip_cleanup:
+        description: 'Skip cleanup after tests (for debugging)'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-e2e-inference-scheduling
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml@main
+    with:
+      guide_name: inference-scheduling
+      namespace: llm-d-nightly-inference
+      helmfile_env: ${{ github.event.inputs.helmfile_env || 'istio' }}
+      gateway_type: ${{ github.event.inputs.helmfile_env || 'istio' }}
+      required_gpus: 2
+      recommended_gpus: 4
+      pod_wait_timeout: '15m'
+      pod_readiness_delay: 180
+      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+    secrets: inherit

--- a/.github/workflows/nightly-e2e-pd-disaggregation-gke.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-gke.yaml
@@ -1,0 +1,69 @@
+name: Nightly - PD Disaggregation E2E (GKE)
+
+# Nightly regression test for the pd-disaggregation guide on GKE.
+# Deploys via helmfile (gke env) and validates with e2e-validate.sh.
+# Uses a slim model transformation to reduce GPU requirements.
+
+on:
+  schedule:
+    - cron: '30 10 * * *'  # 10:30 UTC daily (staggered)
+  workflow_dispatch:
+    inputs:
+      skip_cleanup:
+        description: 'Skip cleanup after tests (for debugging)'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-e2e-pd-disaggregation-gke
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml@main
+    with:
+      guide_name: pd-disaggregation
+      namespace: llm-d-nightly-pd-gke
+      helmfile_env: gke
+      gateway_type: gke
+      gke_cluster_name: llm-d-e2e-us-east5
+      gke_cluster_zone: us-east5
+      required_gpus: 2
+      recommended_gpus: 4
+      accelerator_type: L4
+      pod_wait_timeout: '15m'
+      pod_readiness_delay: 180
+      httproute_file: httproute.gke.yaml
+      # Slim transform: reduce model to Qwen3-0.6B, 1 GPU per pod, reduce memory
+      pre_deploy_script: |
+        echo "Applying pd-disaggregation slim transforms..."
+        cd guides/pd-disaggregation
+        yq e '.modelArtifacts.uri = "hf://Qwen/Qwen3-0.6B"' -i ms-pd/values.yaml
+        yq e '.routing.modelName = "Qwen/Qwen3-0.6B"' -i ms-pd/values.yaml
+        yq e 'del(.decode.containers[0].args[] | select(. == "--tensor-parallel-size" or . == "4"))' -i ms-pd/values.yaml
+        yq e 'del(.decode.containers[0].args[] | select(. == "--max-model-len" or . == "32000"))' -i ms-pd/values.yaml
+        yq e 'del(.prefill.containers[0].args[] | select(. == "--max-model-len" or . == "32000"))' -i ms-pd/values.yaml
+        yq e 'del(.decode.containers[0].resources.limits.memory)' -i ms-pd/values.yaml
+        yq e 'del(.decode.containers[0].resources.requests.memory)' -i ms-pd/values.yaml
+        yq e 'del(.decode.containers[0].resources.limits.cpu)' -i ms-pd/values.yaml
+        yq e 'del(.decode.containers[0].resources.requests.cpu)' -i ms-pd/values.yaml
+        yq e 'del(.decode.containers[0].resources.limits."rdma/ib")' -i ms-pd/values.yaml
+        yq e 'del(.decode.containers[0].resources.requests."rdma/ib")' -i ms-pd/values.yaml
+        yq e 'del(.prefill.containers[0].resources.limits.memory)' -i ms-pd/values.yaml
+        yq e 'del(.prefill.containers[0].resources.requests.memory)' -i ms-pd/values.yaml
+        yq e 'del(.prefill.containers[0].resources.limits.cpu)' -i ms-pd/values.yaml
+        yq e 'del(.prefill.containers[0].resources.requests.cpu)' -i ms-pd/values.yaml
+        yq e 'del(.prefill.containers[0].resources.limits."rdma/ib")' -i ms-pd/values.yaml
+        yq e 'del(.prefill.containers[0].resources.requests."rdma/ib")' -i ms-pd/values.yaml
+        yq e '.decode.containers[0].resources.limits["nvidia.com/gpu"] = "1"' -i ms-pd/values.yaml
+        yq e '.decode.containers[0].resources.requests["nvidia.com/gpu"] = "1"' -i ms-pd/values.yaml
+        yq e '.prefill.replicas = 1' -i ms-pd/values.yaml
+        yq e '.decode.volumes[1].emptyDir.sizeLimit = "2Gi"' -i ms-pd/values.yaml
+        yq e '.prefill.volumes[1].emptyDir.sizeLimit = "2Gi"' -i ms-pd/values.yaml
+        echo "Slim transform applied — model: Qwen3-0.6B, 1 GPU decode, 1 prefill replica"
+        cd "$GITHUB_WORKSPACE"
+      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+    secrets: inherit

--- a/.github/workflows/nightly-e2e-pd-disaggregation.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation.yaml
@@ -1,0 +1,73 @@
+name: Nightly - PD Disaggregation E2E (OpenShift)
+
+# Nightly regression test for the pd-disaggregation guide on OpenShift.
+# Deploys via helmfile and validates with e2e-validate.sh.
+# Uses a slim model transformation to reduce GPU requirements.
+
+on:
+  schedule:
+    - cron: '30 0 * * *'  # 00:30 UTC daily (staggered from inference-scheduling)
+  workflow_dispatch:
+    inputs:
+      helmfile_env:
+        description: 'Helmfile environment'
+        required: false
+        default: 'istio'
+        type: choice
+        options:
+          - istio
+          - kgateway
+      skip_cleanup:
+        description: 'Skip cleanup after tests (for debugging)'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-e2e-pd-disaggregation
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml@main
+    with:
+      guide_name: pd-disaggregation
+      namespace: llm-d-nightly-pd
+      helmfile_env: ${{ github.event.inputs.helmfile_env || 'istio' }}
+      gateway_type: ${{ github.event.inputs.helmfile_env || 'istio' }}
+      required_gpus: 2
+      recommended_gpus: 4
+      pod_wait_timeout: '15m'
+      pod_readiness_delay: 180
+      # Slim transform: reduce model to Qwen3-0.6B, 1 GPU per pod, reduce memory
+      pre_deploy_script: |
+        echo "Applying pd-disaggregation slim transforms..."
+        cd guides/pd-disaggregation
+        yq e '.modelArtifacts.uri = "hf://Qwen/Qwen3-0.6B"' -i ms-pd/values.yaml
+        yq e '.routing.modelName = "Qwen/Qwen3-0.6B"' -i ms-pd/values.yaml
+        yq e 'del(.decode.containers[0].args[] | select(. == "--tensor-parallel-size" or . == "4"))' -i ms-pd/values.yaml
+        yq e 'del(.decode.containers[0].args[] | select(. == "--max-model-len" or . == "32000"))' -i ms-pd/values.yaml
+        yq e 'del(.prefill.containers[0].args[] | select(. == "--max-model-len" or . == "32000"))' -i ms-pd/values.yaml
+        yq e 'del(.decode.containers[0].resources.limits.memory)' -i ms-pd/values.yaml
+        yq e 'del(.decode.containers[0].resources.requests.memory)' -i ms-pd/values.yaml
+        yq e 'del(.decode.containers[0].resources.limits.cpu)' -i ms-pd/values.yaml
+        yq e 'del(.decode.containers[0].resources.requests.cpu)' -i ms-pd/values.yaml
+        yq e 'del(.decode.containers[0].resources.limits."rdma/ib")' -i ms-pd/values.yaml
+        yq e 'del(.decode.containers[0].resources.requests."rdma/ib")' -i ms-pd/values.yaml
+        yq e 'del(.prefill.containers[0].resources.limits.memory)' -i ms-pd/values.yaml
+        yq e 'del(.prefill.containers[0].resources.requests.memory)' -i ms-pd/values.yaml
+        yq e 'del(.prefill.containers[0].resources.limits.cpu)' -i ms-pd/values.yaml
+        yq e 'del(.prefill.containers[0].resources.requests.cpu)' -i ms-pd/values.yaml
+        yq e 'del(.prefill.containers[0].resources.limits."rdma/ib")' -i ms-pd/values.yaml
+        yq e 'del(.prefill.containers[0].resources.requests."rdma/ib")' -i ms-pd/values.yaml
+        yq e '.decode.containers[0].resources.limits["nvidia.com/gpu"] = "1"' -i ms-pd/values.yaml
+        yq e '.decode.containers[0].resources.requests["nvidia.com/gpu"] = "1"' -i ms-pd/values.yaml
+        yq e '.prefill.replicas = 1' -i ms-pd/values.yaml
+        yq e '.decode.volumes[1].emptyDir.sizeLimit = "2Gi"' -i ms-pd/values.yaml
+        yq e '.prefill.volumes[1].emptyDir.sizeLimit = "2Gi"' -i ms-pd/values.yaml
+        echo "Slim transform applied — model: Qwen3-0.6B, 1 GPU decode, 1 prefill replica"
+        cd "$GITHUB_WORKSPACE"
+      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+    secrets: inherit

--- a/.github/workflows/nightly-e2e-precise-prefix-cache.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache.yaml
@@ -1,0 +1,44 @@
+name: Nightly - Precise Prefix Cache E2E (OpenShift)
+
+# Nightly regression test for the precise-prefix-cache-aware guide on OpenShift.
+# Deploys via helmfile and validates with e2e-validate.sh.
+
+on:
+  schedule:
+    - cron: '0 1 * * *'  # 01:00 UTC daily (staggered)
+  workflow_dispatch:
+    inputs:
+      helmfile_env:
+        description: 'Helmfile environment'
+        required: false
+        default: 'istio'
+        type: choice
+        options:
+          - istio
+          - kgateway
+      skip_cleanup:
+        description: 'Skip cleanup after tests (for debugging)'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-e2e-precise-prefix-cache
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml@main
+    with:
+      guide_name: precise-prefix-cache-aware
+      namespace: llm-d-nightly-prefix-cache
+      helmfile_env: ${{ github.event.inputs.helmfile_env || 'istio' }}
+      gateway_type: ${{ github.event.inputs.helmfile_env || 'istio' }}
+      required_gpus: 2
+      recommended_gpus: 4
+      pod_wait_timeout: '15m'
+      pod_readiness_delay: 180
+      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+    secrets: inherit

--- a/.github/workflows/nightly-e2e-simulated-accelerators.yaml
+++ b/.github/workflows/nightly-e2e-simulated-accelerators.yaml
@@ -1,0 +1,45 @@
+name: Nightly - Simulated Accelerators E2E (OpenShift)
+
+# Nightly regression test for the simulated-accelerators guide on OpenShift.
+# No real GPUs required — uses simulated model backends.
+# Deploys via helmfile and validates with e2e-validate.sh.
+
+on:
+  schedule:
+    - cron: '30 1 * * *'  # 01:30 UTC daily (staggered)
+  workflow_dispatch:
+    inputs:
+      helmfile_env:
+        description: 'Helmfile environment'
+        required: false
+        default: 'istio'
+        type: choice
+        options:
+          - istio
+          - kgateway
+      skip_cleanup:
+        description: 'Skip cleanup after tests (for debugging)'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-e2e-simulated-accelerators
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml@main
+    with:
+      guide_name: simulated-accelerators
+      namespace: llm-d-nightly-sim
+      helmfile_env: ${{ github.event.inputs.helmfile_env || 'istio' }}
+      gateway_type: ${{ github.event.inputs.helmfile_env || 'istio' }}
+      required_gpus: 0
+      recommended_gpus: 0
+      pod_wait_timeout: '10m'
+      pod_readiness_delay: 0
+      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+    secrets: inherit

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache.yaml
@@ -1,0 +1,94 @@
+name: Nightly - Tiered Prefix Cache E2E (OpenShift)
+
+# Nightly regression test for the tiered-prefix-cache/cpu guide on OpenShift.
+# Uses kustomize for model server + helm for InferencePool + gateway recipe.
+# Slim transform reduces Qwen3-32B to Qwen3-0.6B with 1 GPU.
+
+on:
+  schedule:
+    - cron: '0 2 * * *'  # 02:00 UTC daily (staggered)
+  workflow_dispatch:
+    inputs:
+      gateway_type:
+        description: 'Gateway provider type'
+        required: false
+        default: 'istio'
+        type: choice
+        options:
+          - istio
+          - kgateway
+      skip_cleanup:
+        description: 'Skip cleanup after tests (for debugging)'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-e2e-tiered-prefix-cache
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml@main
+    with:
+      guide_name: tiered-prefix-cache
+      guide_path: guides/tiered-prefix-cache/cpu
+      namespace: llm-d-nightly-pfc-cpu
+      helmfile_env: ${{ github.event.inputs.gateway_type || 'istio' }}
+      gateway_type: ${{ github.event.inputs.gateway_type || 'istio' }}
+      required_gpus: 1
+      recommended_gpus: 2
+      pod_wait_timeout: '15m'
+      pod_readiness_delay: 180
+      httproute_file: ''
+      # Slim transform: reduce Qwen3-32B to Qwen3-0.6B, 1 GPU, lower memory
+      pre_deploy_script: |
+        echo "Applying tiered-prefix-cache slim transforms..."
+        KUSTOMIZE_DIR="guides/tiered-prefix-cache/cpu/manifests/vllm/offloading-connector"
+        cat > "${KUSTOMIZE_DIR}/nightly-slim-patch.yaml" <<'PATCH'
+        - op: replace
+          path: /spec/template/spec/containers/0/args/0
+          value: |-
+            exec vllm serve \
+              Qwen/Qwen3-0.6B \
+              --kv-transfer-config '{"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"num_cpu_blocks":4000}}' \
+              --port 8000 \
+              --max-num-seq 64
+        - op: replace
+          path: /spec/template/spec/containers/0/resources
+          value:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              nvidia.com/gpu: "1"
+        PATCH
+        yq e '.patches += [{"target": {"kind": "Deployment", "name": "llm-d-model-server"}, "path": "nightly-slim-patch.yaml"}]' -i "${KUSTOMIZE_DIR}/kustomization.yaml"
+        echo "Slim transform applied — model: Qwen3-0.6B, 1 GPU, reduced memory"
+      # Custom deploy: kustomize + helm + gateway recipe (not helmfile)
+      custom_deploy_script: |
+        NAMESPACE="llm-d-nightly-pfc-cpu"
+        GATEWAY_TYPE="${GATEWAY_TYPE:-istio}"
+        echo "Deploying tiered-prefix-cache/cpu via kustomize + helm..."
+
+        # 1. Deploy gateway recipe
+        echo "Deploying gateway recipe ($GATEWAY_TYPE)..."
+        kubectl apply -k "guides/recipes/gateway/${GATEWAY_TYPE}" -n "$NAMESPACE"
+
+        # 2. Deploy model server via kustomize
+        echo "Deploying model server (offloading-connector)..."
+        kubectl apply -k guides/tiered-prefix-cache/cpu/manifests/vllm/offloading-connector -n "$NAMESPACE"
+
+        # 3. Deploy InferencePool via helm
+        echo "Deploying InferencePool..."
+        helm install llm-d-infpool \
+          -n "$NAMESPACE" \
+          -f guides/tiered-prefix-cache/cpu/manifests/inferencepool/values.yaml \
+          --set "provider.name=${GATEWAY_TYPE}" \
+          oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool \
+          --version v1.3.0
+
+        echo "Deployment complete"
+      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+    secrets: inherit

--- a/.github/workflows/nightly-e2e-wide-ep-lws-gke.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-gke.yaml
@@ -1,0 +1,87 @@
+name: Nightly - Wide EP LWS E2E (GKE)
+
+# Nightly regression test for the wide-ep-lws guide on GKE.
+# Uses LeaderWorkerSet for P/D disaggregation with kustomize + helm.
+# Uses the existing GKE kustomize overlay (manifests/modelserver/gke).
+# Tests: LWS CRD, P/D routing sidecar, InferencePool PD plugins.
+# Reference: e2e-wide-ep-accelerator-gke.yaml (existing GKE wide-ep CI test)
+
+on:
+  schedule:
+    - cron: '0 11 * * *'  # 11:00 UTC daily (staggered)
+  workflow_dispatch:
+    inputs:
+      skip_cleanup:
+        description: 'Skip cleanup after tests (for debugging)'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-e2e-wide-ep-lws-gke
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml@main
+    with:
+      guide_name: wide-ep-lws
+      guide_path: guides/wide-ep-lws
+      namespace: llm-d-nightly-wide-ep-gke
+      helmfile_env: gke
+      gateway_type: gke
+      gke_cluster_name: llm-d-e2e-us-south1-2
+      gke_cluster_zone: us-south1
+      required_gpus: 2
+      recommended_gpus: 2
+      accelerator_type: L4
+      pod_wait_timeout: '35m'
+      pod_readiness_delay: 480
+      httproute_file: ''
+      # Install LWS CRD before deployment
+      pre_deploy_script: |
+        echo "Installing LeaderWorkerSet for wide-ep-lws..."
+        if ! kubectl get crd leaderworkersets.leaderworkerset.x-k8s.io &>/dev/null; then
+          echo "Installing LeaderWorkerSet via helm..."
+          helm install lws oci://registry.k8s.io/lws/charts/lws \
+            --version=0.7.0 \
+            --namespace lws-system \
+            --create-namespace \
+            --wait --timeout 300s
+          kubectl wait deploy/lws-controller-manager -n lws-system \
+            --for=condition=available --timeout=120s || true
+        else
+          echo "LeaderWorkerSet CRD already installed"
+        fi
+      # Custom deploy: kustomize (GKE overlay) + helm + gateway recipe
+      # Mirrors the existing e2e-wide-ep-accelerator-gke.yaml deploy pattern
+      custom_deploy_script: |
+        NAMESPACE="llm-d-nightly-wide-ep-gke"
+        echo "Deploying wide-ep-lws on GKE via kustomize + helm..."
+
+        # 1. Deploy model server via kustomize (GKE overlay)
+        echo "Deploying model server (LeaderWorkerSets, GKE overlay)..."
+        kubectl apply -k guides/wide-ep-lws/manifests/modelserver/gke -n "$NAMESPACE"
+
+        # 2. Deploy InferencePool via helm
+        echo "Deploying InferencePool..."
+        helm install llm-d-infpool \
+          -n "$NAMESPACE" \
+          --set "provider.name=gke" \
+          --set "inferencePool.apiVersion=inference.networking.k8s.io/v1" \
+          --set "inferenceExtension.monitoring.prometheus.enabled=true" \
+          -f guides/wide-ep-lws/manifests/inferencepool.values.yaml \
+          oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool \
+          --version v1.3.0
+
+        # 3. Deploy gateway recipe (GKE L7 regional external managed)
+        echo "Deploying Gateway and HTTPRoute..."
+        kubectl apply -k guides/recipes/gateway/gke-l7-regional-external-managed -n "$NAMESPACE"
+
+        echo "Deployment complete"
+      # Wide-EP-specific validation: check prefill + decode pods
+      e2e_validate_args: '-v'
+      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+    secrets: inherit

--- a/.github/workflows/nightly-e2e-wide-ep-lws.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws.yaml
@@ -1,0 +1,272 @@
+name: Nightly - Wide EP LWS E2E (OpenShift)
+
+# Nightly regression test for the wide-ep-lws guide on OpenShift.
+# Uses LeaderWorkerSet for P/D disaggregation with kustomize + helm.
+# Slim transform reduces DeepSeek-R1-0528 to Qwen3-0.6B with 1 GPU per role.
+# Tests: LWS CRD, P/D routing sidecar, InferencePool PD plugins.
+
+on:
+  schedule:
+    - cron: '30 2 * * *'  # 02:30 UTC daily (staggered)
+  workflow_dispatch:
+    inputs:
+      gateway_type:
+        description: 'Gateway provider type'
+        required: false
+        default: 'istio'
+        type: choice
+        options:
+          - istio
+          - kgateway
+      skip_cleanup:
+        description: 'Skip cleanup after tests (for debugging)'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-e2e-wide-ep-lws
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml@main
+    with:
+      guide_name: wide-ep-lws
+      guide_path: guides/wide-ep-lws
+      namespace: llm-d-nightly-wide-ep
+      helmfile_env: ${{ github.event.inputs.gateway_type || 'istio' }}
+      gateway_type: ${{ github.event.inputs.gateway_type || 'istio' }}
+      required_gpus: 2
+      recommended_gpus: 2
+      pod_wait_timeout: '20m'
+      pod_readiness_delay: 180
+      httproute_file: ''
+      # Slim transform: replace DeepSeek-R1-0528 with Qwen3-0.6B, 1 GPU per role,
+      # remove expert parallelism / RDMA / multi-node, keep LWS + P/D + routing sidecar.
+      # Based on .github/scripts/e2e/wide-ep-transform.sh and e2e-wide-ep-accelerator-gke.yaml.
+      pre_deploy_script: |
+        echo "Applying wide-ep-lws slim transforms..."
+
+        # Install LeaderWorkerSet via helm (matching existing CI approach)
+        if ! kubectl get crd leaderworkersets.leaderworkerset.x-k8s.io &>/dev/null; then
+          echo "Installing LeaderWorkerSet via helm..."
+          helm install lws oci://registry.k8s.io/lws/charts/lws \
+            --version=0.7.0 \
+            --namespace lws-system \
+            --create-namespace \
+            --wait --timeout 300s
+          kubectl wait deploy/lws-controller-manager -n lws-system \
+            --for=condition=available --timeout=120s || true
+        else
+          echo "LeaderWorkerSet CRD already installed"
+        fi
+
+        NIGHTLY_DIR="guides/wide-ep-lws/manifests/modelserver/nightly"
+        mkdir -p "$NIGHTLY_DIR"
+
+        # --- Slim prefill manifest ---
+        cat > "${NIGHTLY_DIR}/prefill.yaml" <<'PREFILL_EOF'
+        apiVersion: leaderworkerset.x-k8s.io/v1
+        kind: LeaderWorkerSet
+        metadata:
+          name: wide-ep-llm-d-prefill
+          labels:
+            llm-d.ai/inference-serving: "true"
+            llm-d.ai/guide: "wide-ep-lws"
+            llm-d.ai/model: DeepSeek-R1-0528
+            llm-d.ai/role: prefill
+        spec:
+          replicas: 1
+          leaderWorkerTemplate:
+            size: 1
+            workerTemplate:
+              metadata:
+                labels:
+                  llm-d.ai/inference-serving: "true"
+                  llm-d.ai/guide: "wide-ep-lws"
+                  llm-d.ai/model: DeepSeek-R1-0528
+                  llm-d.ai/role: prefill
+              spec:
+                serviceAccountName: deepseek-r1
+                volumes:
+                  - name: dshm
+                    emptyDir:
+                      medium: Memory
+                      sizeLimit: 256Mi
+                containers:
+                  - name: vllm
+                    image: ghcr.io/llm-d/llm-d-cuda:v0.5.0
+                    imagePullPolicy: Always
+                    command: ["/bin/bash", "-c"]
+                    args:
+                      - |
+                        exec vllm serve \
+                          Qwen/Qwen3-0.6B \
+                          --port 8000 \
+                          --max-num-seq 64 \
+                          --max-model-len 4096 \
+                          --enforce-eager
+                    env:
+                      - name: VLLM_LOGGING_LEVEL
+                        value: INFO
+                      - name: HF_HUB_CACHE
+                        value: /var/cache/huggingface
+                    ports:
+                      - containerPort: 8000
+                        name: vllm
+                        protocol: TCP
+                    startupProbe:
+                      httpGet:
+                        path: /health
+                        port: vllm
+                      periodSeconds: 1
+                      failureThreshold: 600
+                    readinessProbe:
+                      httpGet:
+                        path: /v1/models
+                        port: vllm
+                      periodSeconds: 10
+                      failureThreshold: 3
+                    resources:
+                      limits:
+                        nvidia.com/gpu: "1"
+                      requests:
+                        nvidia.com/gpu: "1"
+                    volumeMounts:
+                      - name: dshm
+                        mountPath: /dev/shm
+        PREFILL_EOF
+
+        # --- Slim decode manifest (with routing sidecar) ---
+        cat > "${NIGHTLY_DIR}/decode.yaml" <<'DECODE_EOF'
+        apiVersion: leaderworkerset.x-k8s.io/v1
+        kind: LeaderWorkerSet
+        metadata:
+          name: wide-ep-llm-d-decode
+          labels:
+            llm-d.ai/inference-serving: "true"
+            llm-d.ai/guide: "wide-ep-lws"
+            llm-d.ai/model: DeepSeek-R1-0528
+            llm-d.ai/role: decode
+        spec:
+          replicas: 1
+          leaderWorkerTemplate:
+            size: 1
+            workerTemplate:
+              metadata:
+                labels:
+                  llm-d.ai/inference-serving: "true"
+                  llm-d.ai/guide: "wide-ep-lws"
+                  llm-d.ai/model: DeepSeek-R1-0528
+                  llm-d.ai/role: decode
+              spec:
+                serviceAccountName: deepseek-r1
+                initContainers:
+                  - name: routing-proxy
+                    args:
+                      - --port=8000
+                      - --vllm-port=8200
+                      - --connector=nixlv2
+                      - --zap-log-level=1
+                      - --secure-proxy=false
+                      - --enable-prefiller-sampling
+                    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.5.0
+                    imagePullPolicy: Always
+                    ports:
+                      - containerPort: 8000
+                        name: sidecar
+                        protocol: TCP
+                    resources: {}
+                    restartPolicy: Always
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      runAsNonRoot: true
+                volumes:
+                  - name: dshm
+                    emptyDir:
+                      medium: Memory
+                      sizeLimit: 256Mi
+                containers:
+                  - name: vllm
+                    image: ghcr.io/llm-d/llm-d-cuda:v0.5.0
+                    imagePullPolicy: Always
+                    command: ["/bin/bash", "-c"]
+                    args:
+                      - |
+                        exec vllm serve \
+                          Qwen/Qwen3-0.6B \
+                          --port 8200 \
+                          --max-num-seq 64 \
+                          --max-model-len 4096 \
+                          --enforce-eager
+                    env:
+                      - name: VLLM_LOGGING_LEVEL
+                        value: INFO
+                      - name: HF_HUB_CACHE
+                        value: /var/cache/huggingface
+                    ports:
+                      - containerPort: 8200
+                        name: vllm
+                        protocol: TCP
+                    startupProbe:
+                      httpGet:
+                        path: /health
+                        port: vllm
+                      periodSeconds: 1
+                      failureThreshold: 600
+                    readinessProbe:
+                      httpGet:
+                        path: /v1/models
+                        port: vllm
+                      periodSeconds: 10
+                      failureThreshold: 3
+                    resources:
+                      limits:
+                        nvidia.com/gpu: "1"
+                      requests:
+                        nvidia.com/gpu: "1"
+                    volumeMounts:
+                      - name: dshm
+                        mountPath: /dev/shm
+        DECODE_EOF
+
+        # --- Kustomization for nightly overlay ---
+        cat > "${NIGHTLY_DIR}/kustomization.yaml" <<'KUSTOM_EOF'
+        apiVersion: kustomize.config.k8s.io/v1beta1
+        kind: Kustomization
+        resources:
+          - prefill.yaml
+          - decode.yaml
+          - ../base/serviceAccount.yaml
+        KUSTOM_EOF
+
+        echo "Slim transform applied — model: Qwen3-0.6B, 1 GPU per role, LWS size 1"
+      # Custom deploy: kustomize + helm + gateway recipe (not helmfile)
+      custom_deploy_script: |
+        NAMESPACE="llm-d-nightly-wide-ep"
+        GATEWAY_TYPE="${GATEWAY_TYPE:-istio}"
+        echo "Deploying wide-ep-lws via kustomize + helm..."
+
+        # 1. Deploy gateway recipe
+        echo "Deploying gateway recipe ($GATEWAY_TYPE)..."
+        kubectl apply -k "guides/recipes/gateway/${GATEWAY_TYPE}" -n "$NAMESPACE"
+
+        # 2. Deploy model server via kustomize (nightly slim overlay)
+        echo "Deploying model server (LeaderWorkerSets)..."
+        kubectl apply -k guides/wide-ep-lws/manifests/modelserver/nightly -n "$NAMESPACE"
+
+        # 3. Deploy InferencePool via helm
+        echo "Deploying InferencePool..."
+        helm install llm-d-infpool \
+          -n "$NAMESPACE" \
+          -f guides/wide-ep-lws/manifests/inferencepool.values.yaml \
+          --set "provider.name=${GATEWAY_TYPE}" \
+          oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool \
+          --version v1.3.0
+
+        echo "Deployment complete"
+      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

Add nightly E2E regression testing across multiple platforms for llm-d guides.

### OpenShift nightly callers (6 guides via reusable workflow)
| Guide | Cron (UTC) | GPUs | Deploy |
|-------|-----------|------|--------|
| inference-scheduling | 00:00 | 2+ | helmfile |
| pd-disaggregation | 00:30 | 2+ | helmfile + slim transform |
| precise-prefix-cache-aware | 01:00 | 2+ | helmfile |
| simulated-accelerators | 01:30 | 0 | helmfile |
| tiered-prefix-cache/cpu | 02:00 | 1 | kustomize+helm |
| wide-ep-lws | 02:30 | 2 | kustomize+helm+LWS |

### GKE nightly callers (3 guides via reusable workflow)
| Guide | Cron (UTC) | Cluster | Deploy |
|-------|-----------|---------|--------|
| inference-scheduling | 10:00 | llm-d-e2e-us-east5 | helmfile (gke env) |
| pd-disaggregation | 10:30 | llm-d-e2e-us-east5 | helmfile (gke env) + slim |
| wide-ep-lws | 11:00 | llm-d-e2e-us-south1-2 | kustomize+helm (GKE overlay) |

### EC2 nightly schedules enabled (3 existing workflows)
| Workflow | Cron (UTC) | Instance |
|----------|-----------|----------|
| e2e-accelerator-test | 06:00 | g6.12xlarge |
| e2e-pd-disaggregation-accelerator-test | 06:30 | g6.12xlarge |
| e2e-wide-ep-accelerator-test | 07:00 | g6.12xlarge |

### Intel HPU nightly schedules added (2 existing workflows)
| Workflow | Cron (UTC) | Runner |
|----------|-----------|--------|
| e2e-inference-scheduling-hpu | 04:00 | hpu |
| e2e-pd-gaudi | 04:30 | hpu |

### Existing GKE schedule TODOs removed
- e2e-inference-scheduling-gke (10:00 UTC) — schedule was enabled but had TODO comment
- e2e-wide-ep-accelerator-gke (12:00 UTC) — same

### Reusable workflows (in llm-d-infra)
- OpenShift: [llm-d/llm-d-infra#8](https://github.com/llm-d/llm-d-infra/pull/8)
- GKE: [llm-d/llm-d-infra#8](https://github.com/llm-d/llm-d-infra/pull/8)

## Test plan
- [ ] Trigger each nightly workflow manually via workflow_dispatch
- [ ] Verify OpenShift: GPU check -> deploy -> e2e-validate.sh -> cleanup
- [ ] Verify GKE: auth -> GPU check -> deploy -> e2e-validate.sh -> cleanup
- [ ] Verify EC2: launch -> deploy -> test -> terminate
- [ ] Verify HPU: deploy -> test -> cleanup
- [ ] Let crons fire for 3-5 days and monitor for flakes