### PR TITLE
feat: add lifecycle hooks and graceful termination to wide-ep-lws manifests

### DIFF
--- a/guides/wide-ep-lws/manifests/modelserver/base/decode.yaml
+++ b/guides/wide-ep-lws/manifests/modelserver/base/decode.yaml
@@ -23,6 +23,7 @@ spec:
           llm-d.ai/model: DeepSeek-R1-0528
           llm-d.ai/role: decode
       spec:
+        terminationGracePeriodSeconds: 130
         serviceAccountName: deepseek-r1
         initContainers:
           - name: routing-proxy
@@ -175,6 +176,10 @@ spec:
               - containerPort: 5600
                 name: nixl
                 protocol: TCP
+            lifecycle:
+              preStop:
+                sleep:
+                  seconds: 30
             startupProbe:
               httpGet:
                 path: /health

--- a/guides/wide-ep-lws/manifests/modelserver/base/prefill.yaml
+++ b/guides/wide-ep-lws/manifests/modelserver/base/prefill.yaml
@@ -23,6 +23,7 @@ spec:
           llm-d.ai/model: DeepSeek-R1-0528
           llm-d.ai/role: prefill
       spec:
+        terminationGracePeriodSeconds: 130
         serviceAccountName: deepseek-r1
         volumes:
           - name: dshm
@@ -147,6 +148,10 @@ spec:
               - containerPort: 5600
                 name: nixl
                 protocol: TCP
+            lifecycle:
+              preStop:
+                sleep:
+                  seconds: 30
             startupProbe:
               httpGet:
                 path: /health


### PR DESCRIPTION
**Summary**
  Add best practice graceful termination configuration to wide-ep-lws decode and prefill manifests, per the recommended setup in
  [kubernetes-sigs/gateway-api-inference-extension](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/bfd979d7576acf3f121efeae01920cb09d09cbe8/config/manifests/vllm/gpu-deployment.yaml#L56).

  - `lifecycle.preStop.sleep` (30s) — lets the gateway remove the pod from rotation before termination
  - `terminationGracePeriodSeconds` (130s) — sufficient buffer for connection draining

  Complements #330 (probes) and aligns with `recipes/vllm/base/deployment.yaml` which already has these fields.

  **Note:** Helm chart values.yaml updates require `llm-d-modelservice` to support `lifecycle` and `terminationGracePeriodSeconds` passthrough first — tracked as follow-up.

  Partially addresses #284.