### PR TITLE
🐛 Bump nightly pod_wait_timeout from 15m to 30m

### DIFF
--- a/.github/workflows/nightly-e2e-inference-scheduling-gke.yaml
+++ b/.github/workflows/nightly-e2e-inference-scheduling-gke.yaml
@@ -33,7 +33,7 @@ jobs:
       required_gpus: 2
       recommended_gpus: 4
       accelerator_type: L4
-      pod_wait_timeout: '15m'
+      pod_wait_timeout: '30m'
       pod_readiness_delay: 180
       httproute_file: httproute.gke.yaml
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}

--- a/.github/workflows/nightly-e2e-inference-scheduling.yaml
+++ b/.github/workflows/nightly-e2e-inference-scheduling.yaml
@@ -38,7 +38,7 @@ jobs:
       gateway_type: ${{ github.event.inputs.helmfile_env || 'istio' }}
       required_gpus: 2
       recommended_gpus: 4
-      pod_wait_timeout: '15m'
+      pod_wait_timeout: '30m'
       pod_readiness_delay: 180
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-pd-disaggregation-gke.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-gke.yaml
@@ -34,7 +34,7 @@ jobs:
       required_gpus: 2
       recommended_gpus: 4
       accelerator_type: L4
-      pod_wait_timeout: '15m'
+      pod_wait_timeout: '30m'
       pod_readiness_delay: 180
       httproute_file: httproute.gke.yaml
       # Slim transform: reduce model to Qwen3-0.6B, 1 GPU per pod, reduce memory

--- a/.github/workflows/nightly-e2e-pd-disaggregation.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation.yaml
@@ -39,7 +39,7 @@ jobs:
       gateway_type: ${{ github.event.inputs.helmfile_env || 'istio' }}
       required_gpus: 2
       recommended_gpus: 4
-      pod_wait_timeout: '15m'
+      pod_wait_timeout: '30m'
       pod_readiness_delay: 180
       # Slim transform: reduce model to Qwen3-0.6B, 1 GPU per pod, reduce memory
       pre_deploy_script: |

--- a/.github/workflows/nightly-e2e-precise-prefix-cache.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache.yaml
@@ -38,7 +38,7 @@ jobs:
       gateway_type: ${{ github.event.inputs.helmfile_env || 'istio' }}
       required_gpus: 2
       recommended_gpus: 4
-      pod_wait_timeout: '15m'
+      pod_wait_timeout: '30m'
       pod_readiness_delay: 180
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache.yaml
@@ -40,7 +40,7 @@ jobs:
       gateway_type: ${{ github.event.inputs.gateway_type || 'istio' }}
       required_gpus: 1
       recommended_gpus: 2
-      pod_wait_timeout: '15m'
+      pod_wait_timeout: '30m'
       pod_readiness_delay: 180
       httproute_file: ''
       # Slim transform: reduce Qwen3-32B to Qwen3-0.6B, 1 GPU, lower memory


### PR DESCRIPTION
## Summary
- Bumps `pod_wait_timeout` from 15m to 30m in 6 nightly caller workflows
- Large models (Qwen3-32B) need more than 15 minutes to download and load, causing false failures

## Changed workflows
- `nightly-e2e-inference-scheduling.yaml` (OCP)
- `nightly-e2e-inference-scheduling-gke.yaml` (GKE)
- `nightly-e2e-pd-disaggregation.yaml` (OCP)
- `nightly-e2e-pd-disaggregation-gke.yaml` (GKE)
- `nightly-e2e-precise-prefix-cache.yaml` (OCP)
- `nightly-e2e-tiered-prefix-cache.yaml` (OCP)

## Unchanged
- `nightly-e2e-simulated-accelerators.yaml` — 10m (no real model loading)
- `nightly-e2e-wide-ep-lws*.yaml` — already 20m/35m

## Test plan
- [x] Precise Prefix Cache (OCP) passed with 30m timeout (reusable default)
- [ ] After merge, re-trigger tiered-prefix-cache and GKE nightlies to verify