### PR TITLE
🐛 Fix PD disaggregation nightly decode tensor parallelism

### DIFF
--- a/.github/workflows/nightly-e2e-pd-disaggregation-gke.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-gke.yaml
@@ -43,7 +43,6 @@ jobs:
         cd guides/pd-disaggregation
         yq e '.modelArtifacts.uri = "hf://Qwen/Qwen3-0.6B"' -i ms-pd/values.yaml
         yq e '.routing.modelName = "Qwen/Qwen3-0.6B"' -i ms-pd/values.yaml
-        yq e 'del(.decode.containers[0].args[] | select(. == "--tensor-parallel-size" or . == "4"))' -i ms-pd/values.yaml
         yq e 'del(.decode.containers[0].args[] | select(. == "--max-model-len" or . == "32000"))' -i ms-pd/values.yaml
         yq e 'del(.prefill.containers[0].args[] | select(. == "--max-model-len" or . == "32000"))' -i ms-pd/values.yaml
         yq e 'del(.decode.containers[0].resources.limits.memory)' -i ms-pd/values.yaml
@@ -60,6 +59,7 @@ jobs:
         yq e 'del(.prefill.containers[0].resources.requests."rdma/ib")' -i ms-pd/values.yaml
         yq e '.decode.containers[0].resources.limits["nvidia.com/gpu"] = "1"' -i ms-pd/values.yaml
         yq e '.decode.containers[0].resources.requests["nvidia.com/gpu"] = "1"' -i ms-pd/values.yaml
+        yq e '.decode.parallelism.tensor = 1' -i ms-pd/values.yaml
         yq e '.prefill.replicas = 1' -i ms-pd/values.yaml
         yq e '.decode.volumes[1].emptyDir.sizeLimit = "2Gi"' -i ms-pd/values.yaml
         yq e '.prefill.volumes[1].emptyDir.sizeLimit = "2Gi"' -i ms-pd/values.yaml

--- a/.github/workflows/nightly-e2e-pd-disaggregation.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation.yaml
@@ -47,7 +47,6 @@ jobs:
         cd guides/pd-disaggregation
         yq e '.modelArtifacts.uri = "hf://Qwen/Qwen3-0.6B"' -i ms-pd/values.yaml
         yq e '.routing.modelName = "Qwen/Qwen3-0.6B"' -i ms-pd/values.yaml
-        yq e 'del(.decode.containers[0].args[] | select(. == "--tensor-parallel-size" or . == "4"))' -i ms-pd/values.yaml
         yq e 'del(.decode.containers[0].args[] | select(. == "--max-model-len" or . == "32000"))' -i ms-pd/values.yaml
         yq e 'del(.prefill.containers[0].args[] | select(. == "--max-model-len" or . == "32000"))' -i ms-pd/values.yaml
         yq e 'del(.decode.containers[0].resources.limits.memory)' -i ms-pd/values.yaml
@@ -64,6 +63,7 @@ jobs:
         yq e 'del(.prefill.containers[0].resources.requests."rdma/ib")' -i ms-pd/values.yaml
         yq e '.decode.containers[0].resources.limits["nvidia.com/gpu"] = "1"' -i ms-pd/values.yaml
         yq e '.decode.containers[0].resources.requests["nvidia.com/gpu"] = "1"' -i ms-pd/values.yaml
+        yq e '.decode.parallelism.tensor = 1' -i ms-pd/values.yaml
         yq e '.prefill.replicas = 1' -i ms-pd/values.yaml
         yq e '.decode.volumes[1].emptyDir.sizeLimit = "2Gi"' -i ms-pd/values.yaml
         yq e '.prefill.volumes[1].emptyDir.sizeLimit = "2Gi"' -i ms-pd/values.yaml


### PR DESCRIPTION
## Summary
- Both PD disaggregation nightly workflows (OCP + GKE) crash because the slim transform reduces GPU resources to 1 but doesn't override `decode.parallelism.tensor` (still 4)
- The Helm chart uses `parallelism.tensor` to set both `--tensor-parallel-size` in vLLM args AND GPU count in the pod spec, so decode pods crash with: `World size (4) is larger than the number of available GPUs (1)`
- Adds `yq e '.decode.parallelism.tensor = 1'` to both workflow slim transforms
- Removes no-op `del()` for `--tensor-parallel-size` args (these aren't in the values.yaml args list; the chart injects them from the parallelism field)

## Root Cause
```
decode:
  parallelism:
    tensor: 4  # <-- This was NOT changed by slim transforms
```

The chart generates `--tensor-parallel-size 4` and requests 4 GPUs from this field. The existing slim transform tried to delete `--tensor-parallel-size` from the container args array, but it's not there — the chart injects it.

## Test Plan
- [ ] Re-trigger PD Disaggregation (OCP) nightly — decode pods should start successfully with 1 GPU
- [ ] Re-trigger PD Disaggregation (GKE) nightly — same verification
- [ ] Verify slim transform output shows `decode.parallelism.tensor: 1` in the modified values.yaml