### PR TITLE
⚠️ Revert: Fix tiered-prefix-cache CrashLoopBackOff (#768)

### DIFF
--- a/.github/workflows/nightly-e2e-tiered-prefix-cache.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache.yaml
@@ -53,7 +53,7 @@ jobs:
           value: |-
             exec vllm serve \
               Qwen/Qwen3-0.6B \
-              --kv-transfer-config '{"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"cpu_bytes_to_use":10737418240}}' \
+              --kv-transfer-config '{"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"num_cpu_blocks":4000}}' \
               --port 8000 \
               --max-num-seq 64
         - op: replace

--- a/guides/tiered-prefix-cache/cpu/README.md
+++ b/guides/tiered-prefix-cache/cpu/README.md
@@ -197,7 +197,7 @@ The following benchmark results demonstrate the performance improvements of usin
 * **vLLM Configuration:**
   * `gpu_memory_utilization` was set to `0.65` to reduce the pressure on the benchmark tool. In
     production configuration this is typically set to a higher value such as 0.9.
-  * CPU offloading was enabled with `cpu_bytes_to_use` set to `107374182400` (100GB) of CPU cache.
+  * CPU offloading was enabled with `num_cpu_blocks` set to `41000`, which provides approximately 100GB of CPU cache.
 * **LMCache Configuration:**
   * For LMCache setup, `LMCACHE_MAX_LOCAL_CPU_SIZE` is set to 100 GB.
 

--- a/guides/tiered-prefix-cache/cpu/manifests/vllm/offloading-connector/kustomization.yaml
+++ b/guides/tiered-prefix-cache/cpu/manifests/vllm/offloading-connector/kustomization.yaml
@@ -13,7 +13,7 @@ patches:
           exec vllm serve \
             Qwen/Qwen3-32B \
             --tensor-parallel-size 2 \
-            --kv-transfer-config '{"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"cpu_bytes_to_use":107374182400}}' \
+            --kv-transfer-config '{"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"num_cpu_blocks":41000}}' \
             --port 8000 \
             --max-num-seq 1024
   - target:


### PR DESCRIPTION
## Summary

Reverts #768 — merged prematurely.

The original fix updated `num_cpu_blocks` → `cpu_bytes_to_use` for the vLLM OffloadingConnector in the tiered-prefix-cache guide and nightly workflow.