### PR TITLE
✨ Add wide-ep and benchmark CKS nightly callers

### DIFF
--- a/.github/workflows/nightly-benchmark-cks.yaml
+++ b/.github/workflows/nightly-benchmark-cks.yaml
@@ -1,0 +1,51 @@
+name: Nightly - Benchmark (CKS)
+
+# Triggers the CKS benchmark nightly in llm-d/llm-d-benchmark.
+# The actual benchmark workflow (ci-nighly-benchmark-cks.yaml) runs on
+# self-hosted runners with GPU access on the waldorf CKS cluster.
+#
+# This caller exists so all nightly schedules for CKS are visible from
+# the llm-d/llm-d repo alongside the IS, PD, and wide-ep nightlies.
+
+on:
+  schedule:
+    - cron: '0 8 * * *'  # 08:00 UTC daily (staggered from wide-ep CKS at 07:00)
+  workflow_dispatch:
+    inputs:
+      input_dir:
+        description: 'Input directory for benchmark results'
+        required: false
+        default: '/tmp/cicd/analysis'
+      output_dir:
+        description: 'Output directory name (S3 prefix and artifact name)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-benchmark-cks
+  cancel-in-progress: true
+
+jobs:
+  trigger-benchmark:
+    name: Trigger CKS Benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger benchmark workflow in llm-d-benchmark
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GHCR_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'llm-d',
+              repo: 'llm-d-benchmark',
+              workflow_id: 'ci-nighly-benchmark-cks.yaml',
+              ref: 'main',
+              inputs: {
+                input_dir: '${{ github.event.inputs.input_dir || '/tmp/cicd/analysis' }}',
+                output_dir: '${{ github.event.inputs.output_dir || '' }}'
+              }
+            })
+            console.log('Triggered CKS benchmark workflow in llm-d/llm-d-benchmark')

--- a/.github/workflows/nightly-e2e-wide-ep-lws-cks.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-cks.yaml
@@ -1,0 +1,272 @@
+name: Nightly - Wide EP LWS E2E (CKS)
+
+# Nightly regression test for the wide-ep-lws guide on CoreWeave (CKS).
+# Uses LeaderWorkerSet for P/D disaggregation with kustomize + helm.
+# Slim transform reduces DeepSeek-R1-0528 to Qwen3-0.6B with 1 GPU per role.
+# Tests: LWS CRD, P/D routing sidecar, InferencePool PD plugins.
+
+on:
+  schedule:
+    - cron: '0 7 * * *'  # 07:00 UTC daily (staggered from IS/PD CKS)
+  workflow_dispatch:
+    inputs:
+      gateway_type:
+        description: 'Gateway provider type'
+        required: false
+        default: 'istio'
+        type: choice
+        options:
+          - istio
+          - kgateway
+      skip_cleanup:
+        description: 'Skip cleanup after tests (for debugging)'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-e2e-wide-ep-lws-cks
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml@main
+    with:
+      guide_name: wide-ep-lws
+      guide_path: guides/wide-ep-lws
+      namespace: llm-d-nightly-wide-ep-cks
+      helmfile_env: ${{ github.event.inputs.gateway_type || 'istio' }}
+      gateway_type: ${{ github.event.inputs.gateway_type || 'istio' }}
+      accelerator_type: H100
+      required_gpus: 2
+      recommended_gpus: 2
+      pod_wait_timeout: '20m'
+      pod_readiness_delay: 180
+      httproute_file: ''
+      # Slim transform: replace DeepSeek-R1-0528 with Qwen3-0.6B, 1 GPU per role,
+      # remove expert parallelism / RDMA / multi-node, keep LWS + P/D + routing sidecar.
+      pre_deploy_script: |
+        echo "Applying wide-ep-lws slim transforms..."
+
+        # Install LeaderWorkerSet via helm (matching existing CI approach)
+        if ! kubectl get crd leaderworkersets.leaderworkerset.x-k8s.io &>/dev/null; then
+          echo "Installing LeaderWorkerSet via helm..."
+          helm install lws oci://registry.k8s.io/lws/charts/lws \
+            --version=0.7.0 \
+            --namespace lws-system \
+            --create-namespace \
+            --wait --timeout 300s
+          kubectl wait deploy/lws-controller-manager -n lws-system \
+            --for=condition=available --timeout=120s || true
+        else
+          echo "LeaderWorkerSet CRD already installed"
+        fi
+
+        NIGHTLY_DIR="guides/wide-ep-lws/manifests/modelserver/nightly"
+        mkdir -p "$NIGHTLY_DIR"
+
+        # --- Slim prefill manifest ---
+        cat > "${NIGHTLY_DIR}/prefill.yaml" <<'PREFILL_EOF'
+        apiVersion: leaderworkerset.x-k8s.io/v1
+        kind: LeaderWorkerSet
+        metadata:
+          name: wide-ep-llm-d-prefill
+          labels:
+            llm-d.ai/inference-serving: "true"
+            llm-d.ai/guide: "wide-ep-lws"
+            llm-d.ai/model: DeepSeek-R1-0528
+            llm-d.ai/role: prefill
+        spec:
+          replicas: 1
+          leaderWorkerTemplate:
+            size: 1
+            workerTemplate:
+              metadata:
+                labels:
+                  llm-d.ai/inference-serving: "true"
+                  llm-d.ai/guide: "wide-ep-lws"
+                  llm-d.ai/model: DeepSeek-R1-0528
+                  llm-d.ai/role: prefill
+              spec:
+                serviceAccountName: deepseek-r1
+                volumes:
+                  - name: dshm
+                    emptyDir:
+                      medium: Memory
+                      sizeLimit: 256Mi
+                containers:
+                  - name: vllm
+                    image: ghcr.io/llm-d/llm-d-cuda:v0.5.0
+                    imagePullPolicy: Always
+                    command: ["/bin/bash", "-c"]
+                    args:
+                      - |
+                        exec vllm serve \
+                          Qwen/Qwen3-0.6B \
+                          --port 8000 \
+                          --max-num-seq 64 \
+                          --max-model-len 4096 \
+                          --enforce-eager
+                    env:
+                      - name: VLLM_LOGGING_LEVEL
+                        value: INFO
+                      - name: HF_HUB_CACHE
+                        value: /var/cache/huggingface
+                    ports:
+                      - containerPort: 8000
+                        name: vllm
+                        protocol: TCP
+                    startupProbe:
+                      httpGet:
+                        path: /health
+                        port: vllm
+                      periodSeconds: 1
+                      failureThreshold: 600
+                    readinessProbe:
+                      httpGet:
+                        path: /v1/models
+                        port: vllm
+                      periodSeconds: 10
+                      failureThreshold: 3
+                    resources:
+                      limits:
+                        nvidia.com/gpu: "1"
+                      requests:
+                        nvidia.com/gpu: "1"
+                    volumeMounts:
+                      - name: dshm
+                        mountPath: /dev/shm
+        PREFILL_EOF
+
+        # --- Slim decode manifest (with routing sidecar) ---
+        cat > "${NIGHTLY_DIR}/decode.yaml" <<'DECODE_EOF'
+        apiVersion: leaderworkerset.x-k8s.io/v1
+        kind: LeaderWorkerSet
+        metadata:
+          name: wide-ep-llm-d-decode
+          labels:
+            llm-d.ai/inference-serving: "true"
+            llm-d.ai/guide: "wide-ep-lws"
+            llm-d.ai/model: DeepSeek-R1-0528
+            llm-d.ai/role: decode
+        spec:
+          replicas: 1
+          leaderWorkerTemplate:
+            size: 1
+            workerTemplate:
+              metadata:
+                labels:
+                  llm-d.ai/inference-serving: "true"
+                  llm-d.ai/guide: "wide-ep-lws"
+                  llm-d.ai/model: DeepSeek-R1-0528
+                  llm-d.ai/role: decode
+              spec:
+                serviceAccountName: deepseek-r1
+                initContainers:
+                  - name: routing-proxy
+                    args:
+                      - --port=8000
+                      - --vllm-port=8200
+                      - --connector=nixlv2
+                      - --zap-log-level=1
+                      - --secure-proxy=false
+                      - --enable-prefiller-sampling
+                    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.5.0
+                    imagePullPolicy: Always
+                    ports:
+                      - containerPort: 8000
+                        name: sidecar
+                        protocol: TCP
+                    resources: {}
+                    restartPolicy: Always
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      runAsNonRoot: true
+                volumes:
+                  - name: dshm
+                    emptyDir:
+                      medium: Memory
+                      sizeLimit: 256Mi
+                containers:
+                  - name: vllm
+                    image: ghcr.io/llm-d/llm-d-cuda:v0.5.0
+                    imagePullPolicy: Always
+                    command: ["/bin/bash", "-c"]
+                    args:
+                      - |
+                        exec vllm serve \
+                          Qwen/Qwen3-0.6B \
+                          --port 8200 \
+                          --max-num-seq 64 \
+                          --max-model-len 4096 \
+                          --enforce-eager
+                    env:
+                      - name: VLLM_LOGGING_LEVEL
+                        value: INFO
+                      - name: HF_HUB_CACHE
+                        value: /var/cache/huggingface
+                    ports:
+                      - containerPort: 8200
+                        name: vllm
+                        protocol: TCP
+                    startupProbe:
+                      httpGet:
+                        path: /health
+                        port: vllm
+                      periodSeconds: 1
+                      failureThreshold: 600
+                    readinessProbe:
+                      httpGet:
+                        path: /v1/models
+                        port: vllm
+                      periodSeconds: 10
+                      failureThreshold: 3
+                    resources:
+                      limits:
+                        nvidia.com/gpu: "1"
+                      requests:
+                        nvidia.com/gpu: "1"
+                    volumeMounts:
+                      - name: dshm
+                        mountPath: /dev/shm
+        DECODE_EOF
+
+        # --- Kustomization for nightly overlay ---
+        cat > "${NIGHTLY_DIR}/kustomization.yaml" <<'KUSTOM_EOF'
+        apiVersion: kustomize.config.k8s.io/v1beta1
+        kind: Kustomization
+        resources:
+          - prefill.yaml
+          - decode.yaml
+          - ../base/serviceAccount.yaml
+        KUSTOM_EOF
+
+        echo "Slim transform applied — model: Qwen3-0.6B, 1 GPU per role, LWS size 1"
+      # Custom deploy: kustomize + helm + gateway recipe (not helmfile)
+      custom_deploy_script: |
+        NAMESPACE="llm-d-nightly-wide-ep-cks"
+        GATEWAY_TYPE="${GATEWAY_TYPE:-istio}"
+        echo "Deploying wide-ep-lws via kustomize + helm..."
+
+        # 1. Deploy gateway recipe
+        echo "Deploying gateway recipe ($GATEWAY_TYPE)..."
+        kubectl apply -k "guides/recipes/gateway/${GATEWAY_TYPE}" -n "$NAMESPACE"
+
+        # 2. Deploy model server via kustomize (nightly slim overlay)
+        echo "Deploying model server (LeaderWorkerSets)..."
+        kubectl apply -k guides/wide-ep-lws/manifests/modelserver/nightly -n "$NAMESPACE"
+
+        # 3. Deploy InferencePool via helm
+        echo "Deploying InferencePool..."
+        helm install llm-d-infpool \
+          -n "$NAMESPACE" \
+          -f guides/wide-ep-lws/manifests/inferencepool.values.yaml \
+          --set "provider.name=${GATEWAY_TYPE}" \
+          oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool \
+          --version v1.3.0
+
+        echo "Deployment complete"
+      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Adds `nightly-e2e-wide-ep-lws-cks.yaml` — Wide EP LWS nightly on CKS/waldorf using slim transforms (Qwen3-0.6B, 1 GPU per role, LWS size 1). Scheduled at 07:00 UTC.
- Adds `nightly-benchmark-cks.yaml` — Trigger workflow that dispatches the CKS benchmark nightly in `llm-d/llm-d-benchmark`. Scheduled at 08:00 UTC.

Follows up on #780 (IS + PD CKS callers, merged).

### CKS nightly schedule (all staggered)
| Time (UTC) | Workflow |
|------------|----------|
| 06:00 | inference-scheduling |
| 06:30 | pd-disaggregation |
| 07:00 | wide-ep-lws |
| 08:00 | benchmark (dispatched to llm-d-benchmark) |

## Test plan
- [ ] Verify wide-ep workflow YAML is valid (triggers on schedule + workflow_dispatch)
- [ ] Verify benchmark trigger dispatches correctly to llm-d-benchmark
- [ ] Manually trigger wide-ep workflow and confirm it uses CKS reusable workflow
- [ ] Confirm no conflicts with existing OCP/GKE nightlies