### PR TITLE
🌱 OCP H100 nodeSelector + CKS GPU preemption for nightly E2E

### DIFF
--- a/.github/workflows/nightly-e2e-inference-scheduling-cks.yaml
+++ b/.github/workflows/nightly-e2e-inference-scheduling-cks.yaml
@@ -42,5 +42,6 @@ jobs:
       pod_wait_timeout: '30m'
       pod_readiness_delay: 180
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
+      allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-inference-scheduling-ocp.yaml
+++ b/.github/workflows/nightly-e2e-inference-scheduling-ocp.yaml
@@ -43,4 +43,9 @@ jobs:
       pod_readiness_delay: 180
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pre_deploy_script: |
+        echo "Adding H100 nodeSelector for OCP deployment..."
+        yq e '.decode.extraConfig.nodeSelector["nvidia.com/gpu.product"] = "NVIDIA-H100-80GB-HBM3"' -i "${GUIDE_PATH}/ms-inference-scheduling/values.yaml"
+        echo "Updated values.yaml with H100 nodeSelector"
+        yq e '.decode.extraConfig.nodeSelector' "${GUIDE_PATH}/ms-inference-scheduling/values.yaml"
     secrets: inherit

--- a/.github/workflows/nightly-e2e-pd-disaggregation-cks.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-cks.yaml
@@ -71,5 +71,6 @@ jobs:
         echo "Slim transform applied — model: Qwen3-0.6B, 1 GPU decode, 1 prefill replica"
         cd "$GITHUB_WORKSPACE"
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
+      allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-precise-prefix-cache-ocp.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-ocp.yaml
@@ -43,4 +43,9 @@ jobs:
       pod_readiness_delay: 180
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pre_deploy_script: |
+        echo "Adding H100 nodeSelector for OCP deployment..."
+        yq e '.decode.extraConfig.nodeSelector["nvidia.com/gpu.product"] = "NVIDIA-H100-80GB-HBM3"' -i "${GUIDE_PATH}/ms-kv-events/values.yaml"
+        echo "Updated values.yaml with H100 nodeSelector"
+        yq e '.decode.extraConfig.nodeSelector' "${GUIDE_PATH}/ms-kv-events/values.yaml"
     secrets: inherit

--- a/.github/workflows/nightly-e2e-wide-ep-lws-cks.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-cks.yaml
@@ -276,5 +276,6 @@ jobs:
 
         echo "Deployment complete"
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
+      allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-wva-cks.yaml
+++ b/.github/workflows/nightly-e2e-wva-cks.yaml
@@ -66,6 +66,7 @@ jobs:
       max_num_seqs: ${{ github.event.inputs.max_num_seqs || '1' }}
       hpa_stabilization_seconds: ${{ github.event.inputs.hpa_stabilization_seconds || '240' }}
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
+      allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
       required_gpus: 2
       recommended_gpus: 4


### PR DESCRIPTION
## Summary
- **OCP callers**: Adds H100 nodeSelector (`nvidia.com/gpu.product=NVIDIA-H100-80GB-HBM3`) to inference-scheduling and precise-prefix-cache OCP nightlies via `pre_deploy_script`
- **CKS callers**: Enables `allow_gpu_preemption: true` on all 4 CKS nightlies (IS, PD, WVA, wide-ep-lws) so they can proceed when `hpc-verification` (priority -1) is consuming GPUs

## Context
**OCP**: pok-prod cluster has H100 nodes. Without explicit nodeSelector, pods may land on nodes without the expected GPU type.

**CKS**: `hpc-verification` runs every hour for ~59 minutes at priority -1, consuming all 64 GPUs. Our nightly pods (default priority 0) can preempt these, but the GPU check hard-fails before pods are created. With `allow_gpu_preemption=true` + llm-d-infra PR #31 (merged), the check only proceeds if blocking pods have negative priority.

## Test plan
- [ ] Trigger IS-OCP or PPC-OCP nightly — verify nodeSelector appears in deployed values
- [ ] Trigger any CKS nightly while hpc-verification runs — verify it proceeds with preemption warning