### PR TITLE
🌱 Enable GPU preemption for all CKS nightly E2E workflows

### DIFF
--- a/.github/workflows/nightly-e2e-inference-scheduling-cks.yaml
+++ b/.github/workflows/nightly-e2e-inference-scheduling-cks.yaml
@@ -42,5 +42,6 @@ jobs:
       pod_wait_timeout: '30m'
       pod_readiness_delay: 180
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
+      allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-pd-disaggregation-cks.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-cks.yaml
@@ -71,5 +71,6 @@ jobs:
         echo "Slim transform applied — model: Qwen3-0.6B, 1 GPU decode, 1 prefill replica"
         cd "$GITHUB_WORKSPACE"
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
+      allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-wide-ep-lws-cks.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-cks.yaml
@@ -276,5 +276,6 @@ jobs:
 
         echo "Deployment complete"
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
+      allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-wva-cks.yaml
+++ b/.github/workflows/nightly-e2e-wva-cks.yaml
@@ -66,6 +66,7 @@ jobs:
       max_num_seqs: ${{ github.event.inputs.max_num_seqs || '1' }}
       hpa_stabilization_seconds: ${{ github.event.inputs.hpa_stabilization_seconds || '240' }}
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
+      allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
       required_gpus: 2
       recommended_gpus: 4


### PR DESCRIPTION
## Summary
- Adds `allow_gpu_preemption: true` to all 4 CKS nightly caller workflows (IS, PD, WVA, wide-ep-lws)
- Companion to llm-d/llm-d-infra PR #30 (merged) which added the `allow_gpu_preemption` input to the CKS reusable workflow

## Context
CKS cluster runs `hpc-verification` (NHC) every hour for ~59 minutes, consuming all 64 GPUs at priority -1. Our nightly pods run at default priority 0 and **can** preempt these, but the GPU availability check in the reusable workflow hard-fails with `exit 1` before pods are ever created — preventing Kubernetes scheduler from doing preemption.

With `allow_gpu_preemption: true`, the check warns instead of failing, allowing pods to be created in Pending state where the Kubernetes scheduler can evict the lower-priority hpc-verification pods.

## Test plan
- [ ] Trigger any CKS nightly while hpc-verification is running
- [ ] Verify workflow proceeds past GPU check with warning
- [ ] Verify nightly pods preempt hpc-verification pods and become Ready