### PR TITLE
🐛 Fix typo in CKS benchmark caller workflow dispatch

### DIFF
--- a/.github/workflows/nightly-benchmark-cks.yaml
+++ b/.github/workflows/nightly-benchmark-cks.yaml
@@ -1,7 +1,7 @@
 name: Nightly - Benchmark (CKS)
 
 # Triggers the CKS benchmark nightly in llm-d/llm-d-benchmark.
-# The actual benchmark workflow (ci-nighly-benchmark-cks.yaml) runs on
+# The actual benchmark workflow (ci-nightly-benchmark-cks.yaml) runs on
 # self-hosted runners with GPU access on the waldorf CKS cluster.
 #
 # This caller exists so all nightly schedules for CKS are visible from
@@ -41,7 +41,7 @@ jobs:
             await github.rest.actions.createWorkflowDispatch({
               owner: 'llm-d',
               repo: 'llm-d-benchmark',
-              workflow_id: 'ci-nighly-benchmark-cks.yaml',
+              workflow_id: 'ci-nightly-benchmark-cks.yaml',
               ref: 'main',
               inputs: {
                 input_dir: '${{ github.event.inputs.input_dir || '/tmp/cicd/analysis' }}',


### PR DESCRIPTION
## Summary
- Fixed `workflow_id` from `ci-nighly-benchmark-cks.yaml` (missing 't') to `ci-nightly-benchmark-cks.yaml`
- The dispatch was silently failing because the target workflow didn't exist with that name

## Test plan
- [ ] Trigger `nightly-benchmark-cks.yaml` manually
- [ ] Verify it successfully dispatches to `llm-d/llm-d-benchmark`