### PR TITLE
🐛 Build WVA image from main + prevent fork schedule runs

### DIFF
--- a/.github/workflows/e2e-accelerator-test.yaml
+++ b/.github/workflows/e2e-accelerator-test.yaml
@@ -31,8 +31,9 @@ permissions:
 jobs:
   setup:
     if: >
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'schedule'
+      github.repository == 'llm-d/llm-d' &&
+      (github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule')
     runs-on: ubuntu-latest
     outputs:
       instance_id: ${{ steps.launch.outputs.instance_id }}

--- a/.github/workflows/e2e-inference-scheduling-gke.yaml
+++ b/.github/workflows/e2e-inference-scheduling-gke.yaml
@@ -20,7 +20,8 @@ permissions:
 jobs:
   deploy_and_validate:
     if: >
-      github.event_name == 'schedule' ||
+      github.repository == 'llm-d/llm-d' &&
+      (github.event_name == 'schedule' ||
       github.event_name == 'pull_request' ||
       github.event_name == 'workflow_dispatch' ||
       (
@@ -34,7 +35,7 @@ jobs:
           github.event.comment.author_association == 'MEMBER' ||
           github.event.comment.author_association == 'COLLABORATOR'
         )
-      )
+      ))
     name: Test on ${{ matrix.accelerator.name }}
     runs-on: ubuntu-latest
 

--- a/.github/workflows/e2e-inference-scheduling-hpu.yaml
+++ b/.github/workflows/e2e-inference-scheduling-hpu.yaml
@@ -20,9 +20,10 @@ on:
 jobs:
   deploy_and_validate:
     if: >
-      github.event_name == 'workflow_dispatch' ||
+      github.repository == 'llm-d/llm-d' &&
+      (github.event_name == 'workflow_dispatch' ||
       github.event_name == 'pull_request' ||
-      github.event_name == 'schedule'
+      github.event_name == 'schedule')
     runs-on: hpu
     env:
       NAMESPACE: "llm-d-hpu-is"

--- a/.github/workflows/e2e-inference-scheduling-xpu.yaml
+++ b/.github/workflows/e2e-inference-scheduling-xpu.yaml
@@ -29,6 +29,7 @@ on:
         type: string
 jobs:
   deploy_and_validate:
+    if: github.repository == 'llm-d/llm-d'
     runs-on: xpu
     env:
       NAMESPACE: "llm-d-xpu-is"

--- a/.github/workflows/e2e-pd-disaggregation-accelerator-test.yaml
+++ b/.github/workflows/e2e-pd-disaggregation-accelerator-test.yaml
@@ -31,8 +31,9 @@ permissions:
 jobs:
   setup:
     if: >
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'schedule'
+      github.repository == 'llm-d/llm-d' &&
+      (github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule')
     runs-on: ubuntu-latest
     outputs:
       instance_id: ${{ steps.launch.outputs.instance_id }}

--- a/.github/workflows/e2e-pd-disaggregation-gke.yaml
+++ b/.github/workflows/e2e-pd-disaggregation-gke.yaml
@@ -20,7 +20,8 @@ permissions:
 jobs:
   deploy_and_validate:
     if: >
-      github.event_name == 'schedule' ||
+      github.repository == 'llm-d/llm-d' &&
+      (github.event_name == 'schedule' ||
       github.event_name == 'pull_request' ||
       github.event_name == 'workflow_dispatch' ||
       (
@@ -34,7 +35,7 @@ jobs:
           github.event.comment.author_association == 'MEMBER' ||
           github.event.comment.author_association == 'COLLABORATOR'
         )
-      )
+      ))
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/e2e-pd-gaudi.yaml
+++ b/.github/workflows/e2e-pd-gaudi.yaml
@@ -21,9 +21,10 @@ on:
 jobs:
   deploy_and_validate:
     if: >
-      github.event_name == 'workflow_dispatch' ||
+      github.repository == 'llm-d/llm-d' &&
+      (github.event_name == 'workflow_dispatch' ||
       github.event_name == 'pull_request' ||
-      github.event_name == 'schedule'
+      github.event_name == 'schedule')
     runs-on: hpu
     env:
       NAMESPACE: "llm-d-hpu-pd"

--- a/.github/workflows/e2e-pd-xpu.yaml
+++ b/.github/workflows/e2e-pd-xpu.yaml
@@ -30,6 +30,7 @@ on:
 
 jobs:
   deploy_and_validate:
+    if: github.repository == 'llm-d/llm-d'
     runs-on: xpu
     env:
       NAMESPACE: "llm-d-xpu-pd"

--- a/.github/workflows/e2e-prefix-cache-xpu.yaml
+++ b/.github/workflows/e2e-prefix-cache-xpu.yaml
@@ -30,6 +30,7 @@ on:
 
 jobs:
   deploy_and_validate:
+    if: github.repository == 'llm-d/llm-d'
     runs-on: xpu
     env:
       NAMESPACE: "llm-d-xpu-pc"

--- a/.github/workflows/e2e-wide-ep-accelerator-gke.yaml
+++ b/.github/workflows/e2e-wide-ep-accelerator-gke.yaml
@@ -20,7 +20,8 @@ permissions:
 jobs:
   deploy_and_validate:
     if: >
-      github.event_name == 'schedule' ||
+      github.repository == 'llm-d/llm-d' &&
+      (github.event_name == 'schedule' ||
       github.event_name == 'pull_request' ||
       github.event_name == 'workflow_dispatch' ||
       (
@@ -34,7 +35,7 @@ jobs:
           github.event.comment.author_association == 'MEMBER' ||
           github.event.comment.author_association == 'COLLABORATOR'
         )
-      )
+      ))
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/e2e-wide-ep-accelerator-test.yaml
+++ b/.github/workflows/e2e-wide-ep-accelerator-test.yaml
@@ -32,8 +32,9 @@ env:
 jobs:
   setup:
     if: >
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'schedule'
+      github.repository == 'llm-d/llm-d' &&
+      (github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule')
     runs-on: ubuntu-latest
     outputs:
       instance_id: ${{ steps.launch.outputs.instance_id }}

--- a/.github/workflows/nightly-benchmark-cks.yaml
+++ b/.github/workflows/nightly-benchmark-cks.yaml
@@ -30,6 +30,7 @@ concurrency:
 
 jobs:
   trigger-benchmark:
+    if: github.repository == 'llm-d/llm-d'
     name: Trigger CKS Benchmark
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nightly-build-image.yaml
+++ b/.github/workflows/nightly-build-image.yaml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository == 'llm-d/llm-d'
     uses: ./.github/workflows/build-image.yml
     with:
       force_build: true

--- a/.github/workflows/nightly-e2e-inference-scheduling-cks.yaml
+++ b/.github/workflows/nightly-e2e-inference-scheduling-cks.yaml
@@ -30,6 +30,7 @@ concurrency:
 
 jobs:
   nightly:
+    if: github.repository == 'llm-d/llm-d'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml@main
     with:
       guide_name: inference-scheduling

--- a/.github/workflows/nightly-e2e-inference-scheduling-gke.yaml
+++ b/.github/workflows/nightly-e2e-inference-scheduling-gke.yaml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   nightly:
+    if: github.repository == 'llm-d/llm-d'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml@main
     with:
       guide_name: inference-scheduling

--- a/.github/workflows/nightly-e2e-inference-scheduling-ocp.yaml
+++ b/.github/workflows/nightly-e2e-inference-scheduling-ocp.yaml
@@ -30,6 +30,7 @@ concurrency:
 
 jobs:
   nightly:
+    if: github.repository == 'llm-d/llm-d'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml@main
     with:
       guide_name: inference-scheduling

--- a/.github/workflows/nightly-e2e-pd-disaggregation-cks.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-cks.yaml
@@ -31,6 +31,7 @@ concurrency:
 
 jobs:
   nightly:
+    if: github.repository == 'llm-d/llm-d'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml@main
     with:
       guide_name: pd-disaggregation

--- a/.github/workflows/nightly-e2e-pd-disaggregation-gke.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-gke.yaml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   nightly:
+    if: github.repository == 'llm-d/llm-d'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml@main
     with:
       guide_name: pd-disaggregation

--- a/.github/workflows/nightly-e2e-pd-disaggregation-ocp.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-ocp.yaml
@@ -31,6 +31,7 @@ concurrency:
 
 jobs:
   nightly:
+    if: github.repository == 'llm-d/llm-d'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml@main
     with:
       guide_name: pd-disaggregation

--- a/.github/workflows/nightly-e2e-precise-prefix-cache-ocp.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-ocp.yaml
@@ -30,6 +30,7 @@ concurrency:
 
 jobs:
   nightly:
+    if: github.repository == 'llm-d/llm-d'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml@main
     with:
       guide_name: precise-prefix-cache-aware

--- a/.github/workflows/nightly-e2e-simulated-accelerators.yaml
+++ b/.github/workflows/nightly-e2e-simulated-accelerators.yaml
@@ -31,6 +31,7 @@ concurrency:
 
 jobs:
   nightly:
+    if: github.repository == 'llm-d/llm-d'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml@main
     with:
       guide_name: simulated-accelerators

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-ocp.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-ocp.yaml
@@ -31,6 +31,7 @@ concurrency:
 
 jobs:
   nightly:
+    if: github.repository == 'llm-d/llm-d'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml@main
     with:
       guide_name: tiered-prefix-cache

--- a/.github/workflows/nightly-e2e-wide-ep-lws-cks.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-cks.yaml
@@ -32,6 +32,7 @@ concurrency:
 
 jobs:
   nightly:
+    if: github.repository == 'llm-d/llm-d'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml@main
     with:
       guide_name: wide-ep-lws

--- a/.github/workflows/nightly-e2e-wide-ep-lws-gke.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-gke.yaml
@@ -25,6 +25,7 @@ concurrency:
 
 jobs:
   nightly:
+    if: github.repository == 'llm-d/llm-d'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke-helmfile.yaml@main
     with:
       guide_name: wide-ep-lws

--- a/.github/workflows/nightly-e2e-wide-ep-lws-ocp.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-ocp.yaml
@@ -32,6 +32,7 @@ concurrency:
 
 jobs:
   nightly:
+    if: github.repository == 'llm-d/llm-d'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml@main
     with:
       guide_name: wide-ep-lws

--- a/.github/workflows/nightly-e2e-wva-cks.yaml
+++ b/.github/workflows/nightly-e2e-wva-cks.yaml
@@ -51,6 +51,7 @@ concurrency:
 
 jobs:
   nightly:
+    if: github.repository == 'llm-d/llm-d'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml@main
     with:
       guide_name: workload-autoscaling

--- a/.github/workflows/nightly-e2e-wva-ocp.yaml
+++ b/.github/workflows/nightly-e2e-wva-ocp.yaml
@@ -3,6 +3,9 @@ name: Nightly - WVA E2E (OpenShift)
 # Nightly regression test for WVA (Workload Variant Autoscaler) on OpenShift.
 # Deploys the workload-autoscaling guide stack via the consolidated helmfile
 # reusable workflow and runs the WVA e2e test suite from the WVA repo.
+#
+# Builds the WVA controller image from main before testing, since the helm
+# chart on main may require features not yet in a tagged release image.
 
 on:
   schedule:
@@ -18,9 +21,9 @@ on:
         required: false
         default: 'A100'
       image_tag:
-        description: 'WVA image tag — "latest" auto-resolves to newest release'
+        description: 'WVA image tag (leave empty to build from main)'
         required: false
-        default: 'latest'
+        default: ''
       request_rate:
         description: 'Request rate (req/s)'
         required: false
@@ -44,13 +47,54 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 concurrency:
   group: nightly-e2e-wva-ocp
   cancel-in-progress: true
 
 jobs:
+  # Build the WVA controller image from main so the chart and binary match.
+  # The chart on main may include flags (e.g. --config-file) that only exist
+  # in the latest code, not in the last tagged release.
+  build-wva-image:
+    if: github.repository == 'llm-d/llm-d' && github.event.inputs.image_tag == ''
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.build.outputs.image_tag }}
+    steps:
+      - name: Checkout WVA source
+        uses: actions/checkout@v4
+        with:
+          repository: llm-d/llm-d-workload-variant-autoscaler
+          ref: main
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USER }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Build and push image
+        id: build
+        run: |
+          SHA=$(git rev-parse --short=8 HEAD)
+          IMAGE_TAG="nightly-${SHA}"
+          FULL_IMAGE="ghcr.io/llm-d/llm-d-workload-variant-autoscaler:${IMAGE_TAG}"
+          echo "Building WVA controller from main: $FULL_IMAGE"
+          make docker-build IMG="$FULL_IMAGE"
+          make docker-push IMG="$FULL_IMAGE"
+          echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+
   nightly:
+    needs: build-wva-image
+    if: github.repository == 'llm-d/llm-d' && always() && (needs.build-wva-image.result == 'success' || needs.build-wva-image.result == 'skipped')
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml@main
     with:
       guide_name: workload-autoscaling
@@ -60,7 +104,7 @@ jobs:
       caller_ref: main
       model_id: ${{ github.event.inputs.model_id || 'unsloth/Meta-Llama-3.1-8B' }}
       accelerator_type: ${{ github.event.inputs.accelerator_type || 'A100' }}
-      wva_image_tag: ${{ github.event.inputs.image_tag || 'latest' }}
+      wva_image_tag: ${{ needs.build-wva-image.outputs.image_tag || github.event.inputs.image_tag }}
       request_rate: ${{ github.event.inputs.request_rate || '20' }}
       num_prompts: ${{ github.event.inputs.num_prompts || '3000' }}
       max_num_seqs: ${{ github.event.inputs.max_num_seqs || '1' }}


### PR DESCRIPTION
## Summary

Two fixes:

1. **WVA nightly E2E**: Build the WVA controller image from `main` before testing. The helm chart on `main` now passes `--config-file` (added by Viper PR llm-d/llm-d-workload-variant-autoscaler#711) which only exists in the latest code, not in the last tagged release image. Without this, the controller crashes with `unknown flag: --config-file`. Uses `GITHUB_TOKEN` with `packages:write` for GHCR auth.

2. **Fork guard**: Add `if: github.repository == 'llm-d/llm-d'` to the first job of all 27 scheduled workflows. GitHub Actions `schedule` triggers fire on every fork that has the workflow on its default branch, wasting compute resources on forks that lack the required secrets and infrastructure.

### Files changed (27)
- `nightly-e2e-wva-ocp.yaml` — build WVA from main + GHCR auth fix + fork guard
- 26 other scheduled workflow files — fork guard only

## Test plan
- [x] Trigger WVA nightly from branch to verify build + E2E passes
- [ ] Verify forks no longer run scheduled workflows after merge