### PR TITLE
🐛 Fix CKS WVA test target: use test-e2e-openshift (no kind dependency)

### DIFF
--- a/.github/workflows/nightly-e2e-wva-cks.yaml
+++ b/.github/workflows/nightly-e2e-wva-cks.yaml
@@ -71,5 +71,5 @@ jobs:
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
       required_gpus: 2
       recommended_gpus: 4
-      test_target: test-e2e
+      test_target: test-e2e-openshift
     secrets: inherit


### PR DESCRIPTION
## Summary
- The CKS WVA nightly caller was using `test_target: test-e2e`, which requires `kind` to be installed on the runner
- CKS runners (CoreWeave) don't have `kind` — tests fail immediately with "Kind is not installed"
- Switch to `test_target: test-e2e-openshift` which runs the same e2e saturation tests on real clusters without the kind dependency

## Context
This is the last fix needed to get WVA nightly E2E passing on CKS. Prior fixes (llm-d/llm-d-infra PRs #38, #39) resolved:
- prometheus node-exporter DaemonSet timeout on GPU nodes
- HTTPRoute overwrite when `deploy_wva: true`
- Stale monitoring namespace cleanup

## Test plan
- [ ] Trigger `Nightly - WVA E2E (CKS)` workflow dispatch
- [ ] Verify test step runs `make test-e2e-openshift` instead of `make test-e2e`
- [ ] Verify full pipeline passes end-to-end on CKS