### PR TITLE
🐛 Build WVA controller image from main for CKS nightly

### DIFF
--- a/.github/workflows/nightly-e2e-wva-cks.yaml
+++ b/.github/workflows/nightly-e2e-wva-cks.yaml
@@ -3,6 +3,9 @@ name: Nightly - WVA E2E (CKS)
 # Nightly regression test for WVA (Workload Variant Autoscaler) on CoreWeave
 # Kubernetes (CKS). Deploys the workload-autoscaling guide stack via the
 # consolidated helmfile reusable workflow and runs the WVA e2e test suite.
+#
+# Builds the WVA controller image from main before testing, since the helm
+# chart on main may require features not yet in a tagged release image.
 
 on:
   schedule:
@@ -18,9 +21,9 @@ on:
         required: false
         default: 'H100'
       image_tag:
-        description: 'WVA image tag — "latest" auto-resolves to newest release'
+        description: 'WVA image tag (leave empty to build from main)'
         required: false
-        default: 'latest'
+        default: ''
       request_rate:
         description: 'Request rate (req/s)'
         required: false
@@ -44,14 +47,54 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 concurrency:
   group: nightly-e2e-wva-cks
   cancel-in-progress: true
 
 jobs:
+  # Build the WVA controller image from main so the chart and binary match.
+  # The chart on main may include flags (e.g. --config-file) that only exist
+  # in the latest code, not in the last tagged release.
+  build-wva-image:
+    if: github.repository == 'llm-d/llm-d' && github.event.inputs.image_tag == ''
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.build.outputs.image_tag }}
+    steps:
+      - name: Checkout WVA source
+        uses: actions/checkout@v4
+        with:
+          repository: llm-d/llm-d-workload-variant-autoscaler
+          ref: main
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USER }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Build and push image
+        id: build
+        run: |
+          SHA=$(git rev-parse --short=8 HEAD)
+          IMAGE_TAG="nightly-${SHA}"
+          FULL_IMAGE="ghcr.io/llm-d/llm-d-workload-variant-autoscaler:${IMAGE_TAG}"
+          echo "Building WVA controller from main: $FULL_IMAGE"
+          make docker-build IMG="$FULL_IMAGE"
+          make docker-push IMG="$FULL_IMAGE"
+          echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+
   nightly:
-    if: github.repository == 'llm-d/llm-d'
+    needs: build-wva-image
+    if: github.repository == 'llm-d/llm-d' && always() && (needs.build-wva-image.result == 'success' || needs.build-wva-image.result == 'skipped')
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-cks-helmfile.yaml@main
     with:
       guide_name: workload-autoscaling
@@ -61,7 +104,7 @@ jobs:
       caller_ref: main
       model_id: ${{ github.event.inputs.model_id || 'unsloth/Meta-Llama-3.1-8B' }}
       accelerator_type: ${{ github.event.inputs.accelerator_type || 'H100' }}
-      wva_image_tag: ${{ github.event.inputs.image_tag || 'latest' }}
+      wva_image_tag: ${{ needs.build-wva-image.outputs.image_tag || github.event.inputs.image_tag }}
       request_rate: ${{ github.event.inputs.request_rate || '20' }}
       num_prompts: ${{ github.event.inputs.num_prompts || '3000' }}
       max_num_seqs: ${{ github.event.inputs.max_num_seqs || '1' }}


### PR DESCRIPTION
## Summary
- The CKS WVA nightly was using `wva_image_tag: latest` which resolves to the v0.5.0 release binary
- The chart on main now passes `--config-file` to the controller (added in PR llm-d/llm-d-workload-variant-autoscaler#713), but v0.5.0 doesn't support that flag → CrashLoopBackOff
- Add a `build-wva-image` job (matching the existing OCP caller pattern) that builds the WVA controller image from main before testing

## Changes
- Add `build-wva-image` job: checks out WVA repo at main, builds image, tags `nightly-<sha>`, pushes to GHCR
- Change `image_tag` default from `latest` to `''` (empty = build from main)
- Add `packages: write` permission for GHCR push
- Wire build output to `wva_image_tag` input on the reusable workflow
- Identical pattern to the OCP caller (`nightly-e2e-wva-ocp.yaml`)

## Test plan
- [ ] Trigger `Nightly - WVA E2E (CKS)` workflow dispatch from this branch
- [ ] Verify `build-wva-image` job builds and pushes successfully
- [ ] Verify WVA controller pods start without CrashLoopBackOff
- [ ] Verify full e2e test pipeline passes