### PR TITLE
🐛 Add docker build retry for WVA nightly E2E workflows

### DIFF
--- a/.github/workflows/nightly-e2e-wva-cks.yaml
+++ b/.github/workflows/nightly-e2e-wva-cks.yaml
@@ -88,7 +88,18 @@ jobs:
           IMAGE_TAG="nightly-${SHA}"
           FULL_IMAGE="ghcr.io/llm-d/llm-d-workload-variant-autoscaler:${IMAGE_TAG}"
           echo "Building WVA controller from main: $FULL_IMAGE"
-          make docker-build IMG="$FULL_IMAGE"
+          for attempt in 1 2 3; do
+            echo "Build attempt $attempt/3"
+            if make docker-build IMG="$FULL_IMAGE"; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "Build failed after 3 attempts"
+              exit 1
+            fi
+            echo "Build failed (likely transient registry error), retrying in 30s..."
+            sleep 30
+          done
           make docker-push IMG="$FULL_IMAGE"
           echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/nightly-e2e-wva-ocp.yaml
+++ b/.github/workflows/nightly-e2e-wva-ocp.yaml
@@ -88,7 +88,18 @@ jobs:
           IMAGE_TAG="nightly-${SHA}"
           FULL_IMAGE="ghcr.io/llm-d/llm-d-workload-variant-autoscaler:${IMAGE_TAG}"
           echo "Building WVA controller from main: $FULL_IMAGE"
-          make docker-build IMG="$FULL_IMAGE"
+          for attempt in 1 2 3; do
+            echo "Build attempt $attempt/3"
+            if make docker-build IMG="$FULL_IMAGE"; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "Build failed after 3 attempts"
+              exit 1
+            fi
+            echo "Build failed (likely transient registry error), retrying in 30s..."
+            sleep 30
+          done
           make docker-push IMG="$FULL_IMAGE"
           echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary

- Add 3-attempt retry with 30s delay to `make docker-build` in both WVA nightly E2E callers
- Handles intermittent quay.io HTTP 500 errors from the `quay.io/projectquay/golang:1.24` base image

## Problem

The WVA controller `Dockerfile` uses `FROM quay.io/projectquay/golang:1.24`, and quay.io intermittently returns 500 Internal Server Error during `docker build`. This causes the `build-wva-image` job to fail, which cascades to skip the entire nightly E2E test run.

Multiple CKS and OCP runs failed from this in the past 24 hours.

## Test plan

- [ ] Trigger WVA nightly on CKS — build should retry on transient failures
- [ ] Trigger WVA nightly on OCP — build should retry on transient failures