### PR TITLE
✨ Enable GPU preemption on all nightly E2E workflows

### DIFF
--- a/.github/workflows/nightly-e2e-inference-scheduling-gke.yaml
+++ b/.github/workflows/nightly-e2e-inference-scheduling-gke.yaml
@@ -38,5 +38,6 @@ jobs:
       pod_readiness_delay: 180
       httproute_file: httproute.gke.yaml
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
+      allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-inference-scheduling-ocp.yaml
+++ b/.github/workflows/nightly-e2e-inference-scheduling-ocp.yaml
@@ -43,6 +43,7 @@ jobs:
       pod_wait_timeout: '30m'
       pod_readiness_delay: 180
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
+      allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
       pre_deploy_script: |
         echo "Adding H100 nodeSelector for OCP deployment..."

--- a/.github/workflows/nightly-e2e-pd-disaggregation-gke.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-gke.yaml
@@ -67,5 +67,6 @@ jobs:
         echo "Slim transform applied — model: Qwen3-0.6B, 1 GPU decode, 1 prefill replica"
         cd "$GITHUB_WORKSPACE"
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
+      allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-pd-disaggregation-ocp.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-ocp.yaml
@@ -72,5 +72,6 @@ jobs:
         echo "Slim transform applied — model: Qwen3-0.6B, 1 GPU decode, 1 prefill replica"
         cd "$GITHUB_WORKSPACE"
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
+      allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-precise-prefix-cache-ocp.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-ocp.yaml
@@ -43,6 +43,7 @@ jobs:
       pod_wait_timeout: '30m'
       pod_readiness_delay: 180
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
+      allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
       pre_deploy_script: |
         echo "Adding H100 nodeSelector for OCP deployment..."

--- a/.github/workflows/nightly-e2e-simulated-accelerators.yaml
+++ b/.github/workflows/nightly-e2e-simulated-accelerators.yaml
@@ -43,5 +43,6 @@ jobs:
       pod_wait_timeout: '10m'
       pod_readiness_delay: 0
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
+      allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-ocp.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-ocp.yaml
@@ -100,5 +100,6 @@ jobs:
 
         echo "Deployment complete"
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
+      allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-wide-ep-lws-gke.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-gke.yaml
@@ -92,5 +92,6 @@ jobs:
       # Wide-EP-specific validation: check prefill + decode pods
       e2e_validate_args: '-v'
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
+      allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-wide-ep-lws-ocp.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-ocp.yaml
@@ -278,5 +278,6 @@ jobs:
 
         echo "Deployment complete"
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
+      allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-wva-ocp.yaml
+++ b/.github/workflows/nightly-e2e-wva-ocp.yaml
@@ -121,6 +121,7 @@ jobs:
       max_num_seqs: ${{ github.event.inputs.max_num_seqs || '1' }}
       hpa_stabilization_seconds: ${{ github.event.inputs.hpa_stabilization_seconds || '240' }}
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
+      allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
       required_gpus: 2
       recommended_gpus: 4


### PR DESCRIPTION
## Summary
- Adds `allow_gpu_preemption: true` to all 10 nightly caller workflows that were missing it (4 CKS callers already had it)
- When GPUs are scarce, nightly tests will preempt default-priority (priority <= 0) GPU workloads instead of failing with GPU starvation
- Deploys nightly workloads with `nightly-gpu-critical` PriorityClass (value: 1000000) so Kubernetes scheduler handles preemption automatically

## How it works
1. **GPU check** — if free GPUs < required, counts preemptable GPU capacity (pods at priority <= 0)
2. **PriorityClass** — creates `nightly-gpu-critical` (value 1000000) before deployment
3. **Workload patching** — after helmfile deploy, patches GPU-consuming Deployments/StatefulSets/LeaderWorkerSets with `priorityClassName: nightly-gpu-critical`
4. **Kubernetes preemption** — scheduler evicts lower-priority pods to free GPUs for nightly workloads

## Dependencies
- **Requires** [llm-d/llm-d-infra#40](https://github.com/llm-d/llm-d-infra/pull/40) — adds `allow_gpu_preemption` support to OCP and GKE reusable workflows (CKS already had the input, now enhanced with PriorityClass + patching)

## Files changed (10 caller workflows)
| Workflow | Platform |
|----------|----------|
| `nightly-e2e-inference-scheduling-ocp.yaml` | OCP |
| `nightly-e2e-inference-scheduling-gke.yaml` | GKE |
| `nightly-e2e-pd-disaggregation-ocp.yaml` | OCP |
| `nightly-e2e-pd-disaggregation-gke.yaml` | GKE |
| `nightly-e2e-precise-prefix-cache-ocp.yaml` | OCP |
| `nightly-e2e-tiered-prefix-cache-ocp.yaml` | OCP |
| `nightly-e2e-wide-ep-lws-ocp.yaml` | OCP |
| `nightly-e2e-wide-ep-lws-gke.yaml` | GKE |
| `nightly-e2e-wva-ocp.yaml` | OCP |
| `nightly-e2e-simulated-accelerators.yaml` | OCP |

## Test plan
- [ ] Merge llm-d-infra#40 first
- [ ] Trigger nightly workflows on OCP — verify PriorityClass created and workloads patched
- [ ] Trigger nightly workflows on GKE — same verification
- [ ] Confirm preemption works when GPUs are scarce (pods at priority 0 get evicted)