### PR TITLE
[fix]: disable monitoring by default in guides to prevent deployment failures

### DIFF
--- a/guides/inference-scheduling/README.md
+++ b/guides/inference-scheduling/README.md
@@ -24,7 +24,7 @@ This example out of the box uses 16 GPUs (8 replicas x 2 GPUs each) of any suppo
 
 - Have the [proper client tools installed on your local system](../prereq/client-setup/README.md) to use this guide.
 - Ensure your cluster infrastructure is sufficient to [deploy high scale inference](../prereq/infrastructure)
-- Have the [Monitoring stack](../../docs/monitoring/README.md) installed on your system.
+- (Optional) Have the [Monitoring stack](../../docs/monitoring/README.md) installed on your system for metrics collection. If monitoring is installed, enable it by setting `monitoring.prometheus.enabled: true` in `gaie-inference-scheduling/values.yaml` and `decode.monitoring.podmonitor.enabled: true` in the appropriate modelservice values file for your hardware backend (e.g., `ms-inference-scheduling/values.yaml` for the default GPU deployment, or the corresponding `values_*.yaml` such as `values_amd.yaml`, `values_cpu.yaml`, `values_xpu.yaml`, or `values_tpu.yaml` when deploying with `-e amd`, `-e cpu`, `-e xpu`, or `-e gke_tpu`).
 - Create a namespace for installation.
 
   ```bash

--- a/guides/inference-scheduling/gaie-inference-scheduling/values.yaml
+++ b/guides/inference-scheduling/gaie-inference-scheduling/values.yaml
@@ -24,7 +24,7 @@ inferenceExtension:
     secret:
       name: inference-scheduling-gateway-sa-metrics-reader-secret
     prometheus:
-      enabled: true
+      enabled: false  # Set to true if Prometheus Operator (ServiceMonitor CRD) is installed on your cluster
       auth:
         # To allow unauthenticated /metrics access (e.g., for debugging with curl), set to false
         enabled: true

--- a/guides/inference-scheduling/ms-inference-scheduling/values.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values.yaml
@@ -28,7 +28,7 @@ decode:
   replicas: 8
   monitoring:
     podmonitor:
-      enabled: true
+      enabled: false  # Set to true if Prometheus Operator (PodMonitor CRD) is installed on your cluster
       portName: "vllm"  # decode vLLM service port (from routing.proxy.targetPort)
       path: "/metrics"
       interval: "30s"

--- a/guides/inference-scheduling/ms-inference-scheduling/values_amd.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_amd.yaml
@@ -28,7 +28,7 @@ decode:
   replicas: 8
   monitoring:
     podmonitor:
-      enabled: true
+      enabled: false  # Set to true if Prometheus Operator (PodMonitor CRD) is installed on your cluster
       portName: "vllm"  # decode vLLM service port (from routing.proxy.targetPort)
       path: "/metrics"
       interval: "30s"

--- a/guides/inference-scheduling/ms-inference-scheduling/values_cpu.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_cpu.yaml
@@ -26,7 +26,7 @@ decode:
   replicas: 2
   monitoring:
     podmonitor:
-      enabled: true
+      enabled: false  # Set to true if Prometheus Operator (PodMonitor CRD) is installed on your cluster
       portName: "vllm"
       path: "/metrics"
       interval: "30s"

--- a/guides/inference-scheduling/ms-inference-scheduling/values_tpu.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_tpu.yaml
@@ -31,7 +31,7 @@ decode:
       cloud.google.com/gke-tpu-accelerator: "tpu7x"
   monitoring:
     podmonitor:
-      enabled: true
+      enabled: false  # Set to true if Prometheus Operator (PodMonitor CRD) is installed on your cluster
       portName: "vllm"  # decode vLLM service port (from routing.proxy.targetPort)
       path: "/metrics"
       interval: "30s"

--- a/guides/inference-scheduling/ms-inference-scheduling/values_xpu.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_xpu.yaml
@@ -28,7 +28,7 @@ decode:
   replicas: 2
   monitoring:
     podmonitor:
-      enabled: true
+      enabled: false  # Set to true if Prometheus Operator (PodMonitor CRD) is installed on your cluster
       portName: "vllm"
       path: "/metrics"
       interval: "30s"

--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -50,7 +50,7 @@ For Intel HPU deployments:
 * Have the [proper client tools installed on your local system](../prereq/client-setup/README.md) to use this guide.
 * Ensure your cluster infrastructure is sufficient to [deploy high scale inference](../prereq/infrastructure)
 * Configure and deploy your [Gateway control plane](../prereq/gateway-provider/README.md).
-* Have the [Monitoring stack](../../docs/monitoring/README.md) installed on your system.
+* (Optional) Have the [Monitoring stack](../../docs/monitoring/README.md) installed on your system for metrics collection. If monitoring is installed, enable it by setting `monitoring.prometheus.enabled: true` in the GAIE values file and `decode.monitoring.podmonitor.enabled: true` / `prefill.monitoring.podmonitor.enabled: true` in the model service values file.
 * Create a namespace for installation.
 
   ```bash

--- a/guides/pd-disaggregation/gaie-pd/values.yaml
+++ b/guides/pd-disaggregation/gaie-pd/values.yaml
@@ -45,7 +45,7 @@ inferenceExtension:
     secret:
       name: pd-gateway-sa-metrics-reader-secret
     prometheus:
-      enabled: true
+      enabled: false  # Set to true if Prometheus Operator (ServiceMonitor CRD) is installed on your cluster
       auth:
         # To allow unauthenticated /metrics access (e.g., for debugging with curl), set to false
         enabled: true

--- a/guides/pd-disaggregation/ms-pd/values.yaml
+++ b/guides/pd-disaggregation/ms-pd/values.yaml
@@ -26,7 +26,7 @@ decode:
   replicas: 1
   monitoring:
     podmonitor:
-      enabled: true
+      enabled: false  # Set to true if Prometheus Operator (PodMonitor CRD) is installed on your cluster
       portName: "vllm"  # decode vLLM service port (from routing.proxy.targetPort)
       path: "/metrics"
       interval: "30s"
@@ -112,7 +112,7 @@ prefill:
   replicas: 4
   monitoring:
     podmonitor:
-      enabled: true
+      enabled: false  # Set to true if Prometheus Operator (PodMonitor CRD) is installed on your cluster
       portName: "vllm"  # prefill vLLM service port (from routing.servicePort)
       path: "/metrics"
       interval: "30s"

--- a/guides/pd-disaggregation/ms-pd/values_hpu.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_hpu.yaml
@@ -31,7 +31,7 @@ decode:
   replicas: 1
   monitoring:
     podmonitor:
-      enabled: true
+      enabled: false  # Set to true if Prometheus Operator (PodMonitor CRD) is installed on your cluster
       portName: "vllm"
       path: "/metrics"
       interval: "30s"
@@ -129,7 +129,7 @@ prefill:
   replicas: 4
   monitoring:
     podmonitor:
-      enabled: true
+      enabled: false  # Set to true if Prometheus Operator (PodMonitor CRD) is installed on your cluster
       portName: "vllm"
       path: "/metrics"
       interval: "30s"

--- a/guides/pd-disaggregation/ms-pd/values_tpu.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_tpu.yaml
@@ -34,7 +34,7 @@ decode:
       cloud.google.com/gke-tpu-accelerator: "tpu-v6e-slice"
   monitoring:
     podmonitor:
-      enabled: true
+      enabled: false  # Set to true if Prometheus Operator (PodMonitor CRD) is installed on your cluster
       portName: "vllm"  # decode vLLM service port (from routing.proxy.targetPort)
       path: "/metrics"
       interval: "30s"
@@ -130,7 +130,7 @@ prefill:
       cloud.google.com/gke-tpu-accelerator: "tpu-v6e-slice"
   monitoring:
     podmonitor:
-      enabled: true
+      enabled: false  # Set to true if Prometheus Operator (PodMonitor CRD) is installed on your cluster
       portName: "vllm"  # prefill vLLM service port (from routing.servicePort)
       path: "/metrics"
       interval: "30s"

--- a/guides/pd-disaggregation/ms-pd/values_xpu.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_xpu.yaml
@@ -34,7 +34,7 @@ decode:
   replicas: 1
   monitoring:
     podmonitor:
-      enabled: true
+      enabled: false  # Set to true if Prometheus Operator (PodMonitor CRD) is installed on your cluster
       portName: "vllm"  # decode vLLM service port (from routing.proxy.targetPort)
       path: "/metrics"
       interval: "30s"
@@ -134,7 +134,7 @@ prefill:
   replicas: 3
   monitoring:
     podmonitor:
-      enabled: true
+      enabled: false  # Set to true if Prometheus Operator (PodMonitor CRD) is installed on your cluster
       portName: "vllm"  # prefill vLLM service port (from routing.servicePort)
       path: "/metrics"
       interval: "30s"

--- a/guides/precise-prefix-cache-aware/README.md
+++ b/guides/precise-prefix-cache-aware/README.md
@@ -17,7 +17,7 @@ This example out of the box uses 16 GPUs (8 replicas x 2 GPUs each) of any suppo
 
 - Have the [proper client tools installed on your local system](../prereq/client-setup/README.md) to use this guide.
 - Configure and deploy your [Gateway control plane](../prereq/gateway-provider/README.md).
-- Have the [Monitoring stack](../../docs/monitoring/README.md) installed on your system.
+- (Optional) Have the [Monitoring stack](../../docs/monitoring/README.md) installed on your system for metrics collection. If monitoring is installed, enable it by setting `monitoring.prometheus.enabled: true` in the GAIE values file and `decode.monitoring.podmonitor.enabled: true` in the model service values file.
 - Create a namespace for installation.
 
   ```bash

--- a/guides/precise-prefix-cache-aware/gaie-kv-events/values.yaml
+++ b/guides/precise-prefix-cache-aware/gaie-kv-events/values.yaml
@@ -104,7 +104,7 @@ inferenceExtension:
     interval: "10s"
     # Prometheus ServiceMonitor will be created when enabled for EPP metrics collection
     prometheus:
-      enabled: true
+      enabled: false  # Set to true if Prometheus Operator (ServiceMonitor CRD) is installed on your cluster
       auth:
         # To allow unauthenticated /metrics access (e.g., for debugging with curl), set to false
         enabled: true

--- a/guides/precise-prefix-cache-aware/ms-kv-events/values.yaml
+++ b/guides/precise-prefix-cache-aware/ms-kv-events/values.yaml
@@ -28,7 +28,7 @@ decode:
   replicas: 8
   monitoring:
     podmonitor:
-      enabled: true
+      enabled: false  # Set to true if Prometheus Operator (PodMonitor CRD) is installed on your cluster
       portName: "vllm"  # decode vLLM service port (from routing.proxy.targetPort)
       path: "/metrics"
       interval: "30s"

--- a/guides/precise-prefix-cache-aware/ms-kv-events/values_pod_discovery.yaml
+++ b/guides/precise-prefix-cache-aware/ms-kv-events/values_pod_discovery.yaml
@@ -27,7 +27,7 @@ decode:
   replicas: 8
   monitoring:
     podmonitor:
-      enabled: true
+      enabled: false  # Set to true if Prometheus Operator (PodMonitor CRD) is installed on your cluster
       portName: "vllm"
       path: "/metrics"
       interval: "30s"

--- a/guides/precise-prefix-cache-aware/ms-kv-events/values_xpu.yaml
+++ b/guides/precise-prefix-cache-aware/ms-kv-events/values_xpu.yaml
@@ -29,7 +29,7 @@ decode:
   replicas: 2
   monitoring:
     podmonitor:
-      enabled: true
+      enabled: false  # Set to true if Prometheus Operator (PodMonitor CRD) is installed on your cluster
       portName: "vllm"
       path: "/metrics"
       interval: "30s"

--- a/guides/precise-prefix-cache-aware/ms-kv-events/values_xpu_pod_discovery.yaml
+++ b/guides/precise-prefix-cache-aware/ms-kv-events/values_xpu_pod_discovery.yaml
@@ -29,7 +29,7 @@ decode:
   replicas: 2
   monitoring:
     podmonitor:
-      enabled: true
+      enabled: false  # Set to true if Prometheus Operator (PodMonitor CRD) is installed on your cluster
       portName: "vllm"
       path: "/metrics"
       interval: "30s"

--- a/guides/simulated-accelerators/README.md
+++ b/guides/simulated-accelerators/README.md
@@ -10,7 +10,7 @@ This guide demonstrates how to deploy the simulator `ghcr.io/llm-d/llm-d-inferen
 
 - Have the [proper client tools installed on your local system](../prereq/client-setup/README.md) to use this guide.
 - Configure and deploy your [Gateway control plane](../prereq/gateway-provider/README.md).
-- Have the [Monitoring stack](../../docs/monitoring/README.md) installed on your system.
+- (Optional) Have the [Monitoring stack](../../docs/monitoring/README.md) installed on your system for metrics collection. If monitoring is installed, enable it by setting `monitoring.prometheus.enabled: true` in the GAIE values file and `decode.monitoring.podmonitor.enabled: true` / `prefill.monitoring.podmonitor.enabled: true` in the model service values file.
 - Create a namespace for installation.
 
   ```bash

--- a/guides/simulated-accelerators/gaie-sim/values.yaml
+++ b/guides/simulated-accelerators/gaie-sim/values.yaml
@@ -26,7 +26,7 @@ inferenceExtension:
     secret:
       name: sim-gateway-sa-metrics-reader-secret
     prometheus:
-      enabled: true
+      enabled: false  # Set to true if Prometheus Operator (ServiceMonitor CRD) is installed on your cluster
       auth:
         # To allow unauthenticated /metrics access (e.g., for debugging with curl), set to false
         enabled: true

--- a/guides/simulated-accelerators/ms-sim/values.yaml
+++ b/guides/simulated-accelerators/ms-sim/values.yaml
@@ -22,7 +22,7 @@ decode:
   replicas: 3
   monitoring:
     podmonitor:
-      enabled: true
+      enabled: false  # Set to true if Prometheus Operator (PodMonitor CRD) is installed on your cluster
       portName: "vllm"  # decode vLLM service port (from routing.proxy.targetPort)
       path: "/metrics"
       interval: "30s"
@@ -69,7 +69,7 @@ prefill:
   replicas: 1
   monitoring:
     podmonitor:
-      enabled: true
+      enabled: false  # Set to true if Prometheus Operator (PodMonitor CRD) is installed on your cluster
       portName: "vllm"  # prefill vLLM service port (from routing.servicePort)
       path: "/metrics"
       interval: "30s"

--- a/guides/wide-ep-lws/README.md
+++ b/guides/wide-ep-lws/README.md
@@ -28,7 +28,7 @@ This guide requires 32 Nvidia H200 or B200 GPUs and InfiniBand or RoCE RDMA netw
     * **_NOTE:_** The DeepEP backend used in WideEP requires All-to-All RDMA connectivity. Every NIC on a host must be able to communicate with every NIC on all other hosts. Networks restricted to communicating only between matching NIC IDs (rail-only connectivity) will fail.
   * You have deployed the [LeaderWorkerSet optional controller](../prereq/infrastructure/README.md#optional-install-leaderworkerset-for-multi-host-inference)
 * Configure and deploy your [Gateway control plane](../prereq/gateway-provider/README.md).
-* Have the [Monitoring stack](../../docs/monitoring/README.md) installed on your system.
+* (Optional) Have the [Monitoring stack](../../docs/monitoring/README.md) installed on your system for metrics collection. If monitoring is installed, enable it by setting `monitoring.prometheus.enabled: true` in the GAIE values file and `decode.monitoring.podmonitor.enabled: true` / `prefill.monitoring.podmonitor.enabled: true` in the model service values file.
 * Create a namespace for installation.
 
   ```bash

--- a/guides/wide-ep-lws/manifests/inferencepool.values.yaml
+++ b/guides/wide-ep-lws/manifests/inferencepool.values.yaml
@@ -17,7 +17,7 @@ inferenceExtension:
       name: wide-ep-gateway-sa-metrics-reader-secret
     # Prometheus ServiceMonitor will be created when enabled for EPP metrics collection
     prometheus:
-      enabled: true
+      enabled: false  # Set to true if Prometheus Operator (ServiceMonitor CRD) is installed on your cluster
   pluginsConfigFile: "custom-plugins.yaml"
   pluginsCustomConfig:
     custom-plugins.yaml: |


### PR DESCRIPTION
## Summary

Fixes #800

All user guides fail to deploy when Prometheus Operator CRDs (`ServiceMonitor`, `PodMonitor`) are not installed on the cluster, because monitoring is enabled by default in the guide values files.

### Changes

Across all affected guides (**inference-scheduling**, **simulated-accelerators**, **pd-disaggregation**, **precise-prefix-cache-aware**):

- Disabled `monitoring.prometheus.enabled` in GAIE values files (ServiceMonitor)
- Disabled `decode.monitoring.podmonitor.enabled` (and `prefill.monitoring.podmonitor.enabled` where applicable) in model service values files (PodMonitor)
- Changed monitoring from a required prerequisite to optional in each guide's README, with instructions on how to re-enable

### Root Cause

The helmfiles create `ServiceMonitor` and `PodMonitor` resources that require the `monitoring.coreos.com/v1` CRDs from Prometheus Operator. Without these CRDs, `helmfile apply` fails with:
```
no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
no matches for kind "PodMonitor" in version "monitoring.coreos.com/v1"
```

### Test Plan
- [ ] Deploy inference-scheduling guide without Prometheus Operator — should succeed
- [ ] Deploy with Prometheus Operator and monitoring re-enabled — should succeed
- [ ] Verify all 4 guide READMEs clearly document how to enable monitoring

Signed-off-by: Junqi Zhang <jz3424@columbia.edu>