### PR TITLE
[BUG] sourcing docker/vllm-version in ci-release

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -51,6 +51,16 @@ jobs:
           ref: ${{ env.TAG }}
           fetch-depth: 0
 
+      - name: Load vLLM version from file
+        id: vllm-version
+        run: |
+          source docker/vllm-version
+          echo "repo=${VLLM_REPO}" >> $GITHUB_OUTPUT
+          echo "commit_sha=${VLLM_COMMIT_SHA}" >> $GITHUB_OUTPUT
+          echo "precompiled_wheel_commit=${VLLM_PRECOMPILED_WHEEL_COMMIT}" >> $GITHUB_OUTPUT
+          echo "prebuilt=${VLLM_PREBUILT}" >> $GITHUB_OUTPUT
+          echo "use_precompiled=${VLLM_USE_PRECOMPILED}" >> $GITHUB_OUTPUT
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -117,6 +127,11 @@ jobs:
             BUILD_BASE_IMAGE_SUFFIX=${{ matrix.os == 'ubuntu' && 'ubuntu20.04' || matrix.base_image_suffix }}
             FINAL_BASE_IMAGE_SUFFIX=${{ matrix.base_image_suffix }}
             CACHE_BUSTER=${{ github.ref_name }}-${{ github.run_id }}
+            VLLM_REPO=${{ steps.vllm-version.outputs.repo }}
+            VLLM_COMMIT_SHA=${{ steps.vllm-version.outputs.commit_sha }}
+            VLLM_PRECOMPILED_WHEEL_COMMIT=${{ steps.vllm-version.outputs.precompiled_wheel_commit }}
+            VLLM_PREBUILT=${{ steps.vllm-version.outputs.prebuilt }}
+            VLLM_USE_PRECOMPILED=${{ steps.vllm-version.outputs.use_precompiled }}
           # disabling cache from cache to temporarily to prevent building issues
           # cache-from: >-
           #   type=gha,scope=cuda-${{ matrix.os }}-${{
@@ -369,6 +384,16 @@ jobs:
           ref: ${{ env.TAG }}
           fetch-depth: 0
 
+      - name: Load vLLM version from file
+        id: vllm-version
+        run: |
+          source docker/vllm-version
+          echo "repo=${VLLM_REPO}" >> $GITHUB_OUTPUT
+          echo "commit_sha=${VLLM_COMMIT_SHA}" >> $GITHUB_OUTPUT
+          echo "precompiled_wheel_commit=${VLLM_PRECOMPILED_WHEEL_COMMIT}" >> $GITHUB_OUTPUT
+          echo "prebuilt=${VLLM_PREBUILT}" >> $GITHUB_OUTPUT
+          echo "use_precompiled=${VLLM_USE_PRECOMPILED}" >> $GITHUB_OUTPUT
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -430,6 +455,11 @@ jobs:
             FINAL_BASE_IMAGE_SUFFIX=${{ matrix.base_image_suffix }}
             CACHE_BUSTER=${{ github.ref_name }}-${{ github.run_id }}
             ENABLE_EFA=true
+            VLLM_REPO=${{ steps.vllm-version.outputs.repo }}
+            VLLM_COMMIT_SHA=${{ steps.vllm-version.outputs.commit_sha }}
+            VLLM_PRECOMPILED_WHEEL_COMMIT=${{ steps.vllm-version.outputs.precompiled_wheel_commit }}
+            VLLM_PREBUILT=${{ steps.vllm-version.outputs.prebuilt }}
+            VLLM_USE_PRECOMPILED=${{ steps.vllm-version.outputs.use_precompiled }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: >-
             type=image,name=${{ env.REGISTRY }}/${{ github.repository }}-aws${{ matrix.image_suffix }},


### PR DESCRIPTION
To fix issue with:
```
#14 [base-common  9/12] RUN --mount=type=cache,target=/var/cache/git     git clone "${VLLM_REPO}" /workspace/vllm &&     git -C /workspace/vllm config --system --add safe.directory /workspace/vllm &&     git -C /workspace/vllm fetch --depth=1 origin "${VLLM_COMMIT_SHA}" || true &&     git -C /workspace/vllm checkout -q "${VLLM_COMMIT_SHA}"
#14 0.055 fatal: repository '' does not exist
#14 0.057 fatal: not a git repository (or any of the parent directories): .git
#14 ERROR: process "/bin/sh -c git clone \"${VLLM_REPO}\" /workspace/vllm &&     git -C /workspace/vllm config --system --add safe.directory /workspace/vllm &&     git -C /workspace/vllm fetch --depth=1 origin \"${VLLM_COMMIT_SHA}\" || true &&     git -C /workspace/vllm checkout -q \"${VLLM_COMMIT_SHA}\"" did not complete successfully: exit code: 128
------
 > [base-common  9/12] RUN --mount=type=cache,target=/var/cache/git     git clone "${VLLM_REPO}" /workspace/vllm &&     git -C /workspace/vllm config --system --add safe.directory /workspace/vllm &&     git -C /workspace/vllm fetch --depth=1 origin "${VLLM_COMMIT_SHA}" || true &&     git -C /workspace/vllm checkout -q "${VLLM_COMMIT_SHA}":
0.055 fatal: repository '' does not exist
0.057 fatal: not a git repository (or any of the parent directories): .git
------

 1 warning found (use docker --debug to expand):
 - UndefinedVar: Usage of undefined variable '$LD_LIBRARY_PATH' (line 133)
Dockerfile.cpu:64
--------------------
  63 |     WORKDIR /workspace
  64 | >>> RUN --mount=type=cache,target=/var/cache/git \
  65 | >>>     git clone "${VLLM_REPO}" /workspace/vllm && \
  66 | >>>     git -C /workspace/vllm config --system --add safe.directory /workspace/vllm && \
  67 | >>>     git -C /workspace/vllm fetch --depth=1 origin "${VLLM_COMMIT_SHA}" || true && \
  68 | >>>     git -C /workspace/vllm checkout -q "${VLLM_COMMIT_SHA}"
  69 |     
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c git clone \"${VLLM_REPO}\" /workspace/vllm &&     git -C /workspace/vllm config --system --add safe.directory /workspace/vllm &&     git -C /workspace/vllm fetch --depth=1 origin \"${VLLM_COMMIT_SHA}\" || true &&     git -C /workspace/vllm checkout -q \"${VLLM_COMMIT_SHA}\"" did not complete successfully: exit code: 128
Reference
Check build summary support
Error: buildx failed with: ERROR: failed to build: failed to solve: process "/bin/sh -c git clone \"${VLLM_REPO}\" /workspace/vllm &&     git -C /workspace/vllm config --system --add safe.directory /workspace/vllm &&     git -C /workspace/vllm fetch --depth=1 origin \"${VLLM_COMMIT_SHA}\" || true &&     git -C /workspace/vllm checkout -q \"${VLLM_COMMIT_SHA}\"" did not complete successfully: exit code: 128
```
More info: https://github.com/llm-d/llm-d/actions/runs/22239933508