### PR TITLE
🐛 Fix uds-tokenizer image tag in PPC guide (v0.5.0-rc1 → v0.5.1-rc1)

### DIFF
--- a/guides/precise-prefix-cache-aware/gaie-kv-events/values.yaml
+++ b/guides/precise-prefix-cache-aware/gaie-kv-events/values.yaml
@@ -37,7 +37,7 @@ inferenceExtension:
           key: HF_TOKEN
   sidecar:
     enabled: true
-    image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.5.0-rc1
+    image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.5.1-rc1
     imagePullPolicy: IfNotPresent
     name: tokenizer-uds
     # Both HF_HOME and TOKENIZERS_DIR are required to point to the same mounted directory

--- a/guides/precise-prefix-cache-aware/gaie-kv-events/values_pod_discovery.yaml
+++ b/guides/precise-prefix-cache-aware/gaie-kv-events/values_pod_discovery.yaml
@@ -17,7 +17,7 @@ inferenceExtension:
           key: HF_TOKEN
   sidecar:
     enabled: true
-    image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.5.0-rc1
+    image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.5.1-rc1
     imagePullPolicy: IfNotPresent
     name: tokenizer-uds
     # Both HF_HOME and TOKENIZERS_DIR are required to point to the same mounted directory


### PR DESCRIPTION
## Summary
- The `llm-d-uds-tokenizer:v0.5.0-rc1` image tag does not exist in ghcr.io (manifest unknown)
- This causes `ImagePullBackOff` on the tokenizer-uds sidecar, which cascades to `CrashLoopBackOff` on the EPP container (depends on tokenizer via UDS socket)
- The entire PPC (precise-prefix-cache-aware) nightly E2E fails at "Wait for pods to be ready"

## Changes
- `guides/precise-prefix-cache-aware/gaie-kv-events/values.yaml`: `v0.5.0-rc1` → `v0.5.1-rc1`
- `guides/precise-prefix-cache-aware/gaie-kv-events/values_pod_discovery.yaml`: `v0.5.0-rc1` → `v0.5.1-rc1`

Available tags in ghcr.io/llm-d/llm-d-uds-tokenizer: `v0.5.0`, `v0.5.1-rc1`, `latest`

## Test plan
- [ ] Re-run PPC OCP nightly after merge to verify EPP pod starts successfully