### PR TITLE
⚠️ Skip gateway provider install on OCP nightly E2Es

### DIFF
--- a/.github/workflows/nightly-e2e-inference-scheduling-ocp.yaml
+++ b/.github/workflows/nightly-e2e-inference-scheduling-ocp.yaml
@@ -44,6 +44,7 @@ jobs:
       pod_readiness_delay: 180
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
       allow_gpu_preemption: true
+      install_gateway_provider: false
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
       pre_deploy_script: |
         echo "Adding H100 nodeSelector for OCP deployment..."

--- a/.github/workflows/nightly-e2e-pd-disaggregation-ocp.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-ocp.yaml
@@ -73,5 +73,6 @@ jobs:
         cd "$GITHUB_WORKSPACE"
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
       allow_gpu_preemption: true
+      install_gateway_provider: false
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-precise-prefix-cache-ocp.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-ocp.yaml
@@ -44,6 +44,7 @@ jobs:
       pod_readiness_delay: 180
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
       allow_gpu_preemption: true
+      install_gateway_provider: false
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
       pre_deploy_script: |
         echo "Adding H100 nodeSelector for OCP deployment..."

--- a/.github/workflows/nightly-e2e-simulated-accelerators.yaml
+++ b/.github/workflows/nightly-e2e-simulated-accelerators.yaml
@@ -44,5 +44,6 @@ jobs:
       pod_readiness_delay: 0
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
       allow_gpu_preemption: true
+      install_gateway_provider: false
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-ocp.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-ocp.yaml
@@ -101,5 +101,6 @@ jobs:
         echo "Deployment complete"
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
       allow_gpu_preemption: true
+      install_gateway_provider: false
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-wide-ep-lws-ocp.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-ocp.yaml
@@ -283,5 +283,6 @@ jobs:
         echo "Deployment complete"
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
       allow_gpu_preemption: true
+      install_gateway_provider: false
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-wva-ocp.yaml
+++ b/.github/workflows/nightly-e2e-wva-ocp.yaml
@@ -122,6 +122,7 @@ jobs:
       hpa_stabilization_seconds: ${{ github.event.inputs.hpa_stabilization_seconds || '240' }}
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
       allow_gpu_preemption: true
+      install_gateway_provider: false
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
       required_gpus: 2
       recommended_gpus: 4


### PR DESCRIPTION
## Summary

On **pok-prod-sa**, Istio and Gateway API CRDs are already installed and managed by the OpenShift Ingress Operator. The OCP nightly workflows were reinstalling them on every run (`install_gateway_provider` defaults to `true`), which destabilized the Istio control plane and caused gateway pods to **CrashLoopBackOff**.

This was the root cause of the SA and TPC OCP nightly failures on 2026-02-23:
- `infra-sim-inference-gateway-istio` pod crashed with 7+ restarts
- OpenShift's `ValidatingAdmissionPolicy` blocks external modification of Gateway API CRDs

### Changes

Adds `install_gateway_provider: false` to all 6 OCP nightly caller workflows:
- `nightly-e2e-inference-scheduling-ocp.yaml`
- `nightly-e2e-pd-disaggregation-ocp.yaml`
- `nightly-e2e-precise-prefix-cache-ocp.yaml`
- `nightly-e2e-tiered-prefix-cache-ocp.yaml`
- `nightly-e2e-wide-ep-lws-ocp.yaml`
- `nightly-e2e-wva-ocp.yaml`

## Test plan

- [ ] Trigger a manual run of one OCP nightly (e.g., IS) and verify it skips gateway installation
- [ ] Verify the deployed pods come up without Istio gateway CrashLoopBackOff
- [ ] Wait for next scheduled nightly cycle and confirm all 6 pass