### PR TITLE
Only report on 404 broken links and not temp issues or scraper blocks

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -13,7 +13,8 @@ exclude = [
   "^https://github\\.com/.*/blob/.*#L[0-9]",
   # Local file references with line numbers cannot be verified by lychee
   "^file://.*:[0-9]",
-
+  # SSL certificate verification fails in GitHub CI runners (works fine locally)
+  "sky\\.cs\\.berkeley\\.edu",
 ]
 
 # Only fail on 404 (Not Found) — the only status code that definitively means


### PR DESCRIPTION
The URL link checker sometimes gets caught on non 404 issues from bot detection or other issues, so let's just focus on 404s because that's the main goal is to know when a URL we are linking to doesn't exist any more. 