### PR TITLE
🐛 fix: increase startup probe and pod wait timeouts for IS nightly E2E

### DIFF
--- a/.github/workflows/nightly-e2e-inference-scheduling-ocp.yaml
+++ b/.github/workflows/nightly-e2e-inference-scheduling-ocp.yaml
@@ -38,9 +38,9 @@ jobs:
       helmfile_env: ${{ github.event.inputs.helmfile_env || 'istio' }}
       gateway_type: ${{ github.event.inputs.helmfile_env || 'istio' }}
       accelerator_type: H100
-      required_gpus: 2
-      recommended_gpus: 4
-      pod_wait_timeout: '30m'
+      required_gpus: 16
+      recommended_gpus: 16
+      pod_wait_timeout: '60m'
       pod_readiness_delay: 180
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
       allow_gpu_preemption: true

--- a/guides/inference-scheduling/ms-inference-scheduling/values.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values.yaml
@@ -68,7 +68,7 @@ decode:
         initialDelaySeconds: 15
         periodSeconds: 30
         timeoutSeconds: 5
-        failureThreshold: 60
+        failureThreshold: 120
       livenessProbe:
         httpGet:
           path: /health


### PR DESCRIPTION
## Summary

The nightly E2E inference-scheduling workflow on OCP ([run #37](https://github.com/llm-d/llm-d/actions/runs/22422063961)) failed because 4 of 8 Qwen3-32B decode pods did not become ready within the 30m `pod_wait_timeout`.

**Root cause:** 8 pods concurrently downloading a ~60GB model from HuggingFace into ephemeral `emptyDir` volumes caused network contention. One pod on node `pokprod-b93r38s1` was killed by the startup probe (`failureThreshold=60 × periodSeconds=30 = 30min`) and restarted, making it impossible to finish within the wait window.

### Changes

- **startupProbe failureThreshold**: `60` → `120` (30min → 60min) to tolerate slow cold-cache model downloads under contention
- **pod_wait_timeout**: `30m` → `60m` to match the new startup probe window
- **required_gpus**: `2` → `16` and **recommended_gpus**: `4` → `16` to reflect the actual GPU demand (8 replicas × 2 GPUs each)

### Additional recommendation (not in this PR)

- **Cordon node `pokprod-b93r38s1`** — this node was consistently the slowest and is the only node where a pod was killed by the startup probe. It may have storage I/O or network bandwidth issues worth investigating.
- **Long-term:** Consider a shared PVC model cache to avoid 8 concurrent cold downloads of the same model every nightly run.

## Test plan

- [ ] Re-run nightly-e2e-inference-scheduling-ocp workflow manually and verify all 8 pods become ready within the new 60m window
- [ ] Confirm GPU availability check now correctly requires 16 GPUs before proceeding