### PR TITLE
Remove pplx All2All backend

### DIFF
--- a/.github/workflows/typo-checker.md
+++ b/.github/workflows/typo-checker.md
@@ -90,7 +90,6 @@ The following are NOT typos — do not flag them:
 - OCI, GHCR, ghcr
 - Gaudi, HPU, XPU, TPU, ROCm
 - InfiniStore, infinistore
-- pplx, perplexity
 - kubectl, kubeconfig, kubecontext
 - ConfigMap, ServiceAccount, ClusterRole, RoleBinding
 - HTTPRoute, GRPCRoute, Gateway API

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,10 +88,9 @@ The first key step in testing a feature, or bugfix is to identify what layer of 
 
 ### Container Image Build Changes and Upgrades
 
-* Kernel upgrades and changes (`pplx`, `deepep`, `deepgemm`) - Ignore `flash-infer`
+* Kernel upgrades and changes (`deepep`, `deepgemm`) - Ignore `flash-infer`
   * To test these ensure you use the proper vLLM backend via the `VLLM_ALL2ALL_BACKEND` environment variable
-    * For `pplx` you can set both `prefill` and `decode` `VLLM_ALL2ALL_BACKEND` to `pplx`
-      * This can be ran in any example
+    * For single-node testing without extra dependencies, use `allgather_reducescatter` (the default)
     * For testing the deepseek kernels, you can set `prefill`s backend to `deepep_high_throughput` and `decode` backend to `deepep_low_latency`
       * This needs to be tested in either `pd-disaggregation` or better yet `wide-ep-lws`
 * `UCX` + `NIXL` version bumps and changes
@@ -135,7 +134,6 @@ EOF
 * [ ] `pd-disaggregation` example (also covers deepseek kernels)
 * [ ] `wide-ep-lws` example (also covers deepseek kernels)
 * [ ] a `guidellm` benchmark to do a load test for performance regressions (any example)
-* [ ] run a guide with the `pplx` backend
 * [ ] run `pd-disaggregation` or `wide-ep-lws` with deepseek kernels (for `prefill`s set `VLLM_ALL2ALL_BACKEND` to `deepep_high_throughput` and set `decode` `VLLM_ALL2ALL_BACKEND` to `deepep_low_latency`)
 
 ### Code Review Requirements

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -66,9 +66,6 @@ ARG DEEPEP_VERSION="fix/nvshmem-ibgda-multiple-definition"
 ARG DEEPGEMM_REPO="https://github.com/deepseek-ai/DeepGEMM"
 ARG DEEPGEMM_VERSION="v2.1.1.post3"
 
-ARG PPLX_KERNELS_REPO="https://github.com/perplexityai/pplx-kernels"
-ARG PPLX_KERNELS_VERSION="2bd6e30fab358829bd01d1c0907be8088ff9e5e1"
-
 ARG FLASHINFER_REPO="https://github.com/flashinfer-ai/flashinfer.git"
 ARG FLASHINFER_VERSION="v0.6.1"
 
@@ -284,8 +281,6 @@ ARG DEEPEP_REPO
 ARG DEEPEP_VERSION
 ARG DEEPGEMM_REPO
 ARG DEEPGEMM_VERSION
-ARG PPLX_KERNELS_REPO
-ARG PPLX_KERNELS_VERSION
 ARG FLASHINFER_REPO
 ARG FLASHINFER_VERSION
 COPY docker/scripts/cuda/builder/build-compiled-wheels.sh /tmp/build-compiled-wheels.sh
@@ -469,7 +464,7 @@ ARG SUPPRESS_PYTHON_OUTPUT
 COPY scripts/warn-vllm-precompiled.sh /opt/
 
 # Install cuda-python, nvshmem python bindings, xet
-# Install all compiled wheels (DeepEP, DeepGEMM, pplx-kernels, LMCache, nixl)
+# Install all compiled wheels (DeepEP, DeepGEMM, LMCache, nixl)
 # Installs vllm source. Supports three install modes:
     # 1) install vllm from source totally editably - dev option, supports fork and commit swapping
     # 3) install vllm from source with pulling precompiled binaries (shared libraries) from the vllm wheels index - less flexible dev option, may or may not work swapping shas but faster than full editable

--- a/docker/scripts/cuda/builder/build-compiled-wheels.sh
+++ b/docker/scripts/cuda/builder/build-compiled-wheels.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -Eeux
 
-# builds compiled extension wheels (FlashInfer, DeepEP, DeepGEMM, pplx-kernels)
+# builds compiled extension wheels (FlashInfer, DeepEP, DeepGEMM)
 #
 # Required environment variables:
 # - VIRTUAL_ENV: path to Python virtual environment
@@ -13,8 +13,6 @@ set -Eeux
 # - DEEPEP_VERSION: DeepEP version tag
 # - DEEPGEMM_REPO: DeepGEMM repository URL
 # - DEEPGEMM_VERSION: DeepGEMM version tag
-# - PPLX_KERNELS_REPO: pplx-kernels repository URL
-# - PPLX_KERNELS_VERSION: pplx-kernels commit SHA
 # - USE_SCCACHE: whether to use sccache (true/false)
 # - TARGETPLATFORM: Docker buildx platform (e.g., linux/amd64, linux/arm64)
 
@@ -27,7 +25,7 @@ cd /tmp
 . "${VIRTUAL_ENV}/bin/activate"
 . /usr/local/bin/setup-sccache
 
-# install build tools (cmake from pip provides 3.22+ needed by pplx-kernels)
+# install build tools
 uv pip install build cuda-python numpy setuptools-scm ninja cmake requests filelock tqdm
 # overwrite the TORCH_CUDA_ARCH_LIST for MoE kernels
 export TORCH_CUDA_ARCH_LIST="9.0a;10.0+PTX"
@@ -67,13 +65,6 @@ git submodule update --init --recursive
 uv build --wheel --no-build-isolation --out-dir /wheels
 cd ..
 rm -rf deepgemm
-
-git clone "${PPLX_KERNELS_REPO}" pplx-kernels
-cd pplx-kernels
-git checkout "${PPLX_KERNELS_VERSION}"
-uv build --wheel --no-build-isolation --out-dir /wheels
-cd ..
-rm -rf pplx-kernels
 
 if [ "${USE_SCCACHE}" = "true" ]; then
   echo "=== Compiled wheels build complete - sccache stats ==="

--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -22,7 +22,6 @@ Pinned in `docker/Dockerfile.cuda` (and variants):
 | **LMCache** | `v0.3.13` | tag | `docker/Dockerfile.cuda` line 51 | [LMCache/LMCache](https://github.com/LMCache/LMCache) |
 | **DeepEP** | `c66b1463601af5d127027fb459517fb97adab30d` | commit SHA (fork) | `docker/Dockerfile.cuda` line 57 | [smarterclayton/DeepEP](https://github.com/smarterclayton/DeepEP) (fork of [deepseek-ai/DeepEP](https://github.com/deepseek-ai/DeepEP)) |
 | **DeepGEMM** | `v2.1.0` | tag | `docker/Dockerfile.cuda` line 60 | [deepseek-ai/DeepGEMM](https://github.com/deepseek-ai/DeepGEMM) |
-| **pplx-kernels** | `2bd6e30fab358829bd01d1c0907be8088ff9e5e1` | commit SHA | `docker/Dockerfile.cuda` line 62 | [perplexityai/pplx-kernels](https://github.com/perplexityai/pplx-kernels) |
 | **FlashInfer** | `v0.5.3` | tag | `docker/Dockerfile.cuda` line 64 | [flashinfer-ai/flashinfer](https://github.com/flashinfer-ai/flashinfer) |
 | **PyTorch** | `2.9.1` | version | `docker/constraints.txt` line 1 | [pytorch/pytorch](https://github.com/pytorch/pytorch) |
 


### PR DESCRIPTION
Remove the pplx all2all backend from the llm-d image and documentation as the kernels have been has been deprecated in favor of https://github.com/perplexityai/pplx-garden, and the all2all backend has been removed from vLLM in https://github.com/vllm-project/vllm/pull/33724.