### PR TITLE
Move routing-proxy from initContainers to standard containers

### DIFF
--- a/guides/wide-ep-lws/manifests/modelserver/base/decode.yaml
+++ b/guides/wide-ep-lws/manifests/modelserver/base/decode.yaml
@@ -24,7 +24,16 @@ spec:
           llm-d.ai/role: decode
       spec:
         serviceAccountName: deepseek-r1
-        initContainers:
+        volumes:
+          - name: dshm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 2Gi  # roughly 32MB per local DP plus scratch space
+          - name: hf-cache
+            emptyDir: {}
+          - name: jit-cache
+            emptyDir: {}
+        containers:
           - name: routing-proxy
             args:
               - --port=8000
@@ -40,20 +49,9 @@ spec:
                 name: sidecar
                 protocol: TCP
             resources: {}
-            restartPolicy: Always
             securityContext:
               allowPrivilegeEscalation: false
               runAsNonRoot: true
-        volumes:
-          - name: dshm
-            emptyDir:
-              medium: Memory
-              sizeLimit: 2Gi  # roughly 32MB per local DP plus scratch space
-          - name: hf-cache
-            emptyDir: {}
-          - name: jit-cache
-            emptyDir: {}
-        containers:
           - name: vllm
             image: ghcr.io/llm-d/llm-d-cuda:v0.5.0
             securityContext:


### PR DESCRIPTION
The routing-proxy container must coexist with the main decode container throughout the pod's lifecycle, not just during initialization.

Additionally, because it is a regular container, Kubernetes can run Liveness and Readiness probes on the proxy. If the proxy hangs but the vLLM engine is fine, Kubernetes knows the pod is no longer "Ready" to serve traffic. initContainers do not support these continuous health checks. We can add it in future releases.
