### PR TITLE
🐛 Fix WVA nightlies to use consolidated test suite

### DIFF
--- a/.github/workflows/nightly-e2e-wva-cks.yaml
+++ b/.github/workflows/nightly-e2e-wva-cks.yaml
@@ -125,5 +125,5 @@ jobs:
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
       required_gpus: 2
       recommended_gpus: 4
-      test_target: test-e2e-openshift
+      test_target: test-e2e-full
     secrets: inherit

--- a/.github/workflows/nightly-e2e-wva-ocp.yaml
+++ b/.github/workflows/nightly-e2e-wva-ocp.yaml
@@ -126,5 +126,5 @@ jobs:
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
       required_gpus: 2
       recommended_gpus: 4
-      test_target: test-e2e-openshift
+      test_target: test-e2e-full
     secrets: inherit


### PR DESCRIPTION
## Summary
- Switch `test_target` from deprecated `test-e2e-openshift` to `test-e2e-full` in both:
  - `nightly-e2e-wva-cks.yaml`
  - `nightly-e2e-wva-ocp.yaml`
- The old `test/e2e-openshift/` suite was removed in llm-d/llm-d-workload-variant-autoscaler#787
- `test-e2e-full` runs the consolidated `test/e2e/` suite which supports all platforms

## Context
The deprecated Makefile target `test-e2e-openshift` now points to a deleted test directory after the legacy suites were removed from WVA.

Companion PR: llm-d/llm-d-workload-variant-autoscaler#TBD (fixes the nightly in the WVA repo itself)

## Test plan
- [ ] Next nightly runs pass with `test-e2e-full` target