### PR TITLE
fix: Update helm toolchain versions for Helm 3.17.3 compatibility

### DIFF
--- a/guides/prereq/client-setup/install-deps.sh
+++ b/guides/prereq/client-setup/install-deps.sh
@@ -9,9 +9,9 @@ set -euo pipefail
 # Helm version
 HELM_VER="v3.19.0"
 # Helmdiff version
-HELMDIFF_VERSION="v3.13.0"
+HELMDIFF_VERSION="v3.14.0"
 # Helmfile version
-HELMFILE_VERSION="1.2.1"
+HELMFILE_VERSION="1.3.2"
 # chart-testing version
 CT_VERSION="3.14.0"
 
@@ -188,7 +188,7 @@ fi
 ########################################
 if ! helm plugin list | grep -q diff; then
   echo "📦 helm-diff plugin not found. Installing ${HELMDIFF_VERSION}..."
-  helm plugin install --version "${HELMDIFF_VERSION}" https://github.com/databus23/helm-diff
+  helm plugin install --version "${HELMDIFF_VERSION}" --verify=false https://github.com/databus23/helm-diff
 fi
 
 ########################################


### PR DESCRIPTION
Fixed https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/797

## Summary

Updates helm-diff and helmfile versions in the installation script to resolve compatibility issues with Helm 3.17.3.

## Problem

The deployment process was failing with the following errors when using Helm 3.17.3:

1. **helm-diff plugin error**:
   - Error: if any flags in the group [validate dry-run] are set none of the others can be; [dry-run validate] were all set
   - Error: plugin "diff" exited with error
   - Root cause: helm-diff v3.11.0 is incompatible with Helm 3.17.3's updated flag handling

2. **helmfile error**:
   - panic: error determining helm version: command "/opt/homebrew/bin/helm" exited with non-zero status
   - Error: unknown flag: --client
   - Root cause: helmfile 1.1.3 attempts to use the deprecated `--client` flag, which was removed in Helm 3.17+

3. **Plugin installation error**:
   - Error: plugin source does not support verification. Use --verify=false to skip verification

## Solution

Updated `guides/prereq/client-setup/install-deps.sh`:

1. **Upgraded helm-diff**: v3.11.0 → v3.14.0
   - v3.14.0 properly handles flag compatibility with Helm 3.17.3

2. **Upgraded helmfile**: 1.1.3 → 1.3.2
   - v1.3.2 removes usage of the deprecated `--client` flag

3. **Added verification skip flag**: Added `--verify=false` to helm plugin install command
   - Addresses plugin signature verification requirement

## Testing

`make deploy-wva-emulated-on-kind` succeeded base on https://github.com/llm-d/llm-d-workload-variant-autoscaler/tree/main/deploy/kind-emulator