### PR TITLE
fix(gateway): Add tmp volume to Envoy gateway for readOnlyRootFilesystem

### DIFF
--- a/guides/prereq/gateway-provider/common-configurations/kgateway.yaml
+++ b/guides/prereq/gateway-provider/common-configurations/kgateway.yaml
@@ -1,2 +1,12 @@
 gateway:
   gatewayClassName: kgateway
+  gatewayParameters:
+    kube:
+      envoyContainer:
+        extraVolumeMounts:
+          - name: tmp
+            mountPath: /tmp
+      podTemplate:
+        extraVolumes:
+          - name: tmp
+            emptyDir: {}


### PR DESCRIPTION
Signed-off-by: Guangya Liu <gyliu513@gmail.com>

Fixed https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/801

Envoy proxy was crashing with 'Failed to create temporary file' error due to readOnlyRootFilesystem=true without a writable /tmp volume.

Added emptyDir volume for /tmp in GatewayParameters to fix the issue while maintaining security posture.