### PR TITLE
Fix: rename std to std_dev in inference-perf benchmark configs

### DIFF
--- a/guides/benchmark/inference_scheduling_template.yaml
+++ b/guides/benchmark/inference_scheduling_template.yaml
@@ -50,13 +50,13 @@ workload:                         # yaml configuration for harness workload(s)
         min: 10             # min length of the synthetic prompts
         max: 100            # max length of the synthetic prompts
         mean: 50            # mean length of the synthetic prompts
-        std: 10             # standard deviation of the length of the synthetic prompts
+        std_dev: 10         # standard deviation of the length of the synthetic prompts
         total_count: 100    # total number of prompts to generate to fit the above mentioned distribution constraints
       output_distribution:
         min: 10             # min length of the output to be generated
         max: 100            # max length of the output to be generated
         mean: 50            # mean length of the output to be generated
-        std: 10             # standard deviation of the length of the output to be generated
+        std_dev: 10         # standard deviation of the length of the output to be generated
         total_count: 100    # total number of output lengths to generate to fit the above mentioned distribution constraints
     report:
       request_lifecycle:

--- a/guides/benchmark/pd_template.yaml
+++ b/guides/benchmark/pd_template.yaml
@@ -60,12 +60,12 @@ workload:                         # yaml configuration for harness workload(s)
         min: 1000
         max: 1000
         mean: 1000
-        std: 0
+        std_dev: 0
       output_distribution:
         min: 1000
         max: 1000
         mean: 1000
-        std: 0
+        std_dev: 0
     report:
       request_lifecycle:
         summary: true

--- a/guides/benchmark/precise_template.yaml
+++ b/guides/benchmark/precise_template.yaml
@@ -50,13 +50,13 @@ workload:  # yaml configuration for harness workload(s)
         min: 10             # min length of the synthetic prompts
         max: 100            # max length of the synthetic prompts
         mean: 50            # mean length of the synthetic prompts
-        std: 10             # standard deviation of the length of the synthetic prompts
+        std_dev: 10         # standard deviation of the length of the synthetic prompts
         total_count: 100    # total number of prompts to generate to fit the above mentioned distribution constraints
       output_distribution:
         min: 10             # min length of the output to be generated
         max: 100            # max length of the output to be generated
         mean: 50            # mean length of the output to be generated
-        std: 10             # standard deviation of the length of the output to be generated
+        std_dev: 10         # standard deviation of the length of the output to be generated
         total_count: 100    # total number of output lengths to generate to fit the above mentioned distribution constraints
     report:
       request_lifecycle:


### PR DESCRIPTION
## The issue
The inference-perf distribution prompt lengths uses [std_dev as its field name (with a default of 200)](https://github.com/kubernetes-sigs/inference-perf/blob/2747298/inference_perf/config.py#L66), but the benchmark workload templates all use std instead. Since Pydantic silently ignores unknown fields, the std values in the YAML are quietly dropped at parse time and the default std_dev: 200 is used regardless of what's configured.

This issue can be confirmed by running any workload with std: 0 and checking the saved scenario config.yaml in the PVC: it will show std_dev: 200.0, not 0.

## What this PR does
Renames std: → std_dev: in the 3 benchmark workload templates.

## Test
Tested by running the benchmark again and check the config.yaml written in the PVC.

Testing running benchmarks with a modified `guides/benchmark/precise_template.yaml`
```yaml
...
data:
  type: random
  input_distribution:
    min: 2423                # min length of the synthetic prompts
    max: 2423                # max length of the synthetic prompts
    mean: 2423               # mean length of the synthetic prompts
    std_dev: 0               # standard deviation of the length of the synthetic prompts
    total_count: 3600        # total number of prompts to generate to fit the above mentioned distribution constraints
...
```

Before the fix:
```yaml
...
data:
  type: random
  path: null
  input_distribution:
    min: 2423
    max: 2423
    mean: 2423.0
    std_dev: 200.0
    total_count: 3600
...
```

After the fix:
```yaml
...
data:
  type: random
  path: null
  input_distribution:
    min: 2423
    max: 2423
    mean: 2423.0
    std_dev: 0.0
    total_count: 3600
...
```