### PR TITLE
✨ feat: add caller_ref input to WVA nightly workflows

### DIFF
--- a/.github/workflows/nightly-e2e-wva-cks.yaml
+++ b/.github/workflows/nightly-e2e-wva-cks.yaml
@@ -40,6 +40,10 @@ on:
         description: 'HPA stabilization window in seconds'
         required: false
         default: '240'
+      caller_ref:
+        description: 'WVA repo ref to checkout for tests and image build (branch, tag, or SHA)'
+        required: false
+        default: 'main'
       skip_cleanup:
         description: 'Skip cleanup after tests (for debugging)'
         required: false
@@ -67,7 +71,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: llm-d/llm-d-workload-variant-autoscaler
-          ref: main
+          ref: ${{ github.event.inputs.caller_ref || 'main' }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -112,7 +116,7 @@ jobs:
       namespace: llm-d-nightly-wva
       deploy_wva: true
       caller_repo: llm-d/llm-d-workload-variant-autoscaler
-      caller_ref: main
+      caller_ref: ${{ github.event.inputs.caller_ref || 'main' }}
       model_id: ${{ github.event.inputs.model_id || 'unsloth/Meta-Llama-3.1-8B' }}
       accelerator_type: ${{ github.event.inputs.accelerator_type || 'H100' }}
       wva_image_tag: ${{ needs.build-wva-image.outputs.image_tag || github.event.inputs.image_tag }}

--- a/.github/workflows/nightly-e2e-wva-ocp.yaml
+++ b/.github/workflows/nightly-e2e-wva-ocp.yaml
@@ -40,6 +40,10 @@ on:
         description: 'HPA stabilization window in seconds'
         required: false
         default: '240'
+      caller_ref:
+        description: 'WVA repo ref to checkout for tests and image build (branch, tag, or SHA)'
+        required: false
+        default: 'main'
       skip_cleanup:
         description: 'Skip cleanup after tests (for debugging)'
         required: false
@@ -67,7 +71,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: llm-d/llm-d-workload-variant-autoscaler
-          ref: main
+          ref: ${{ github.event.inputs.caller_ref || 'main' }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -112,7 +116,7 @@ jobs:
       namespace: llm-d-nightly-wva
       deploy_wva: true
       caller_repo: llm-d/llm-d-workload-variant-autoscaler
-      caller_ref: main
+      caller_ref: ${{ github.event.inputs.caller_ref || 'main' }}
       model_id: ${{ github.event.inputs.model_id || 'unsloth/Meta-Llama-3.1-8B' }}
       accelerator_type: ${{ github.event.inputs.accelerator_type || 'A100' }}
       wva_image_tag: ${{ needs.build-wva-image.outputs.image_tag || github.event.inputs.image_tag }}


### PR DESCRIPTION
## Summary

Adds a `caller_ref` workflow_dispatch input to both WVA nightly workflows (OCP + CKS). This allows testing WVA branches in the nightly pipeline without merging to main first.

## Changes

- Added `caller_ref` input (default: `main`) to both `nightly-e2e-wva-ocp.yaml` and `nightly-e2e-wva-cks.yaml`
- Used in both the image build checkout step and the `caller_ref` passed to the reusable workflow
- **No behavior change for scheduled runs** — defaults to `main`

## Usage

```bash
gh workflow run nightly-e2e-wva-ocp.yaml --repo llm-d/llm-d -f caller_ref=fix/my-branch
```