### PR TITLE
Partial enablement of CICD for GKE

### DIFF
--- a/.github/workflows/nightly-e2e-inference-scheduling-gke.yaml
+++ b/.github/workflows/nightly-e2e-inference-scheduling-gke.yaml
@@ -33,7 +33,7 @@ jobs:
       gke_cluster_zone: us-east5
       required_gpus: 2
       recommended_gpus: 4
-      accelerator_type: L4
+      accelerator_type: H100
       pod_wait_timeout: '30m'
       pod_readiness_delay: 180
       httproute_file: httproute.gke.yaml

--- a/.github/workflows/nightly-e2e-pd-disaggregation-gke.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-gke.yaml
@@ -34,7 +34,7 @@ jobs:
       gke_cluster_zone: us-east5
       required_gpus: 2
       recommended_gpus: 4
-      accelerator_type: L4
+      accelerator_type: H100
       pod_wait_timeout: '30m'
       pod_readiness_delay: 180
       httproute_file: httproute.gke.yaml


### PR DESCRIPTION
The GKE cluster has now 16 Nvidia H100 accelerator. Let's use this PR as a "pipe cleaner" before enabling the rest.