### PR TITLE
ci: add link checker workflow

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,29 @@
+name: Link Check
+
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+  schedule:
+    # Run weekly on Mondays at 08:00 UTC to catch external link rot
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --config .github/lychee.toml
+            --no-progress
+            './**/*.md'
+          fail: true


### PR DESCRIPTION
Add GitHub Actions workflow to check markdown links using lychee.

Runs on:
- PRs that modify markdown files
- Weekly schedule (Mondays 08:00 UTC)
- Manual trigger

Uses existing lychee.toml configuration.