### PR TITLE
fix: precise-prefix-cache-aware example error

### DIFF
--- a/guides/precise-prefix-cache-aware/helmfile.yaml.gotmpl
+++ b/guides/precise-prefix-cache-aware/helmfile.yaml.gotmpl
@@ -53,6 +53,45 @@ releases:
     values:
       {{- if eq $pd "true" }}
       - gaie-kv-events/values_pod_discovery.yaml
+      - inferenceExtension:
+          pluginsCustomConfig:
+            precise-prefix-cache-config.yaml: |
+              apiVersion: inference.networking.x-k8s.io/v1alpha1
+              kind: EndpointPickerConfig
+              plugins:
+                - type: single-profile-handler
+                - type: precise-prefix-cache-scorer
+                  parameters:
+                    tokenProcessorConfig:
+                      blockSize: 64
+                    indexerConfig:
+                      tokenizersPoolConfig:
+                        modelName: Qwen/Qwen3-32B
+                        local: null
+                        hf: null
+                        uds:
+                          socketFile: /tmp/tokenizer/tokenizer-uds.socket
+                    kvEventsConfig:
+                      topicFilter: "kv@"
+                      concurrency: 4
+                      discoverPods: true
+                      podDiscoveryConfig:
+                        labelSelector: "llm-d.ai/inference-serving=true,llm-d.ai/guide=precise-prefix-cache-aware"
+                        podNamespace: {{ $ns | quote }}
+                      zmqEndpoint: "tcp://*:5557"
+                - type: kv-cache-utilization-scorer
+                - type: queue-scorer
+                - type: max-score-picker
+              schedulingProfiles:
+                - name: default
+                  plugins:
+                    - pluginRef: precise-prefix-cache-scorer
+                      weight: 3.0
+                    - pluginRef: kv-cache-utilization-scorer
+                      weight: 2.0
+                    - pluginRef: queue-scorer
+                      weight: 2.0
+                    - pluginRef: max-score-picker
       {{- else }}
       - gaie-kv-events/values.yaml
       {{- end }}


### PR DESCRIPTION
According to the deployment method described in the official guide:
https://github.com/llm-d/llm-d/tree/main/guides/precise-prefix-cache-aware,
my testing shows that the score of the precise-prefix-cache-scorer consistently remains 0.
﻿
However, based on the implementation in the source code:
https://github.com/llm-d/llm-d-kv-cache/blob/main/pkg/kvevents/pool.go#L36,
the functionality works as expected only after enabling the pod-discovery configuration.
﻿
Therefore, it appears that the current guide is incomplete and should be updated to include the required pod-discovery setup.