### PR TITLE
Image verification workflow

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -902,6 +902,7 @@ jobs:
           fi
 
   release-hpu-llm-d:
+
     strategy:
       fail-fast: false
     runs-on: vllm-runner
@@ -960,3 +961,62 @@ jobs:
           else
             echo "No vulnerabilities found or scan failed."
           fi
+
+  verify-release-images:
+    name: Verify all release images exist
+    needs:
+      - release-cuda-manifest
+      - release-aws-manifest
+      - release-cpu-llm-d
+      - release-rocm-llm-d
+      - release-xpu-llm-d
+      - release-hpu-llm-d
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.GHCR_USER }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Verify all expected images
+        run: |
+          TAG="${{ env.TAG }}"
+          IMAGES=(
+            "${{ env.REGISTRY }}/llm-d/llm-d-cuda:${TAG}"
+            "${{ env.REGISTRY }}/llm-d/llm-d-cuda-ubuntu:${TAG}"
+            "${{ env.REGISTRY }}/llm-d/llm-d-aws:${TAG}"
+            "${{ env.REGISTRY }}/llm-d/llm-d-cpu:${TAG}"
+            "${{ env.REGISTRY }}/llm-d/llm-d-rocm:${TAG}"
+            "${{ env.REGISTRY }}/llm-d/llm-d-xpu:${TAG}"
+            "${{ env.REGISTRY }}/llm-d/llm-d-hpu:${TAG}"
+          )
+
+          echo "## Release Image Verification for ${TAG}" >> $GITHUB_STEP_SUMMARY
+          echo "| Image | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
+
+          MISSING=0
+          for img in "${IMAGES[@]}"; do
+            if docker buildx imagetools inspect "$img" > /dev/null 2>&1; then
+              echo "| \`${img}\` | Found |" >> $GITHUB_STEP_SUMMARY
+              echo "OK: $img"
+            else
+              echo "| \`${img}\` | MISSING |" >> $GITHUB_STEP_SUMMARY
+              echo "MISSING: $img"
+              MISSING=$((MISSING + 1))
+            fi
+          done
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ $MISSING -gt 0 ]; then
+            echo "**${MISSING} image(s) missing from release ${TAG}**" >> $GITHUB_STEP_SUMMARY
+            echo "::error::${MISSING} image(s) missing from release ${TAG}"
+            exit 1
+          fi
+          echo "**All ${#IMAGES[@]} images verified for release ${TAG}**" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/verify-release-images.yaml
+++ b/.github/workflows/verify-release-images.yaml
@@ -1,0 +1,68 @@
+name: Verify Release Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to verify (e.g. v0.5.1)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  verify-release-images:
+    name: Verify all release images exist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.GHCR_USER }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Verify all expected images
+        run: |
+          TAG="${{ inputs.tag }}"
+          IMAGES=(
+            "${{ env.REGISTRY }}/llm-d/llm-d-cuda:${TAG}"
+            "${{ env.REGISTRY }}/llm-d/llm-d-cuda-ubuntu:${TAG}"
+            "${{ env.REGISTRY }}/llm-d/llm-d-aws:${TAG}"
+            "${{ env.REGISTRY }}/llm-d/llm-d-cpu:${TAG}"
+            "${{ env.REGISTRY }}/llm-d/llm-d-rocm:${TAG}"
+            "${{ env.REGISTRY }}/llm-d/llm-d-xpu:${TAG}"
+            "${{ env.REGISTRY }}/llm-d/llm-d-hpu:${TAG}"
+          )
+
+          echo "## Release Image Verification for ${TAG}" >> $GITHUB_STEP_SUMMARY
+          echo "| Image | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
+
+          MISSING=0
+          for img in "${IMAGES[@]}"; do
+            if docker buildx imagetools inspect "$img" > /dev/null 2>&1; then
+              echo "| \`${img}\` | Found |" >> $GITHUB_STEP_SUMMARY
+              echo "OK: $img"
+            else
+              echo "| \`${img}\` | MISSING |" >> $GITHUB_STEP_SUMMARY
+              echo "MISSING: $img"
+              MISSING=$((MISSING + 1))
+            fi
+          done
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ $MISSING -gt 0 ]; then
+            echo "**${MISSING} image(s) missing from release ${TAG}**" >> $GITHUB_STEP_SUMMARY
+            echo "::error::${MISSING} image(s) missing from release ${TAG}"
+            exit 1
+          fi
+          echo "**All ${#IMAGES[@]} images verified for release ${TAG}**" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
  ## Summary

  - Add a `verify-release-images` job at the end of `ci-release.yaml` that checks all
   7 expected images exist in the registry after all build jobs complete
  - Create a standalone `verify-release-images.yaml` workflow that can be triggered
  on-demand against any release tag for auditing

  Closes #978

  ## Details

  After a recent release, a missing container image was only caught because a
  community member reported it on Slack. While individual build jobs verify their own
   digests, there was no single step validating the complete set of images is present
   in the registry.

  The new `verify-release-images` job:
  - Runs after all 6 terminal build/manifest jobs using `if: always()`
  - Probes each expected image (`cuda`, `cuda-ubuntu`, `aws`, `cpu`, `rocm`, `xpu`,
  `hpu`) with `docker buildx imagetools inspect`
  - Outputs a summary table to the GitHub Step Summary
  - Fails with a clear error listing any missing images

  The standalone workflow accepts a `tag` input via `workflow_dispatch`, enabling
  maintainers to audit any past release.

@llm-d/release-crew I will test the workflow `verify-release-images.yaml` once the PR is merged. GitHub is not allowing me to run the independent workflow from the branch