### PR TITLE
fix(build): improve install_nixl.py error handling, logging, and configurability

### DIFF
--- a/docker/scripts/cpu/install_nixl.py
+++ b/docker/scripts/cpu/install_nixl.py
@@ -1,9 +1,11 @@
 # install_prerequisites.py
+import argparse
+import glob
+import logging
 import os
 import subprocess
 import sys
-import argparse
-import glob
+import time
 
 # --- Configuration ---
 WHEELS_CACHE_HOME = os.environ.get("WHEELS_CACHE_HOME", "/workspace/wheels_cache")
@@ -14,12 +16,67 @@ UCX_INSTALL_DIR = os.path.join('/tmp', 'ucx_install')
 UCX_REPO_URL = 'https://github.com/openucx/ucx.git'
 NIXL_REPO_URL = 'https://github.com/ai-dynamo/nixl.git'
 
+# Default versions (can be overridden via CLI args or env vars)
+DEFAULT_UCX_VERSION = os.environ.get("UCX_VERSION", "v1.19.x")
+DEFAULT_NIXL_VERSION = os.environ.get("NIXL_VERSION", "0.6.1")
+
+# Retry configuration
+MAX_RETRIES = 3
+RETRY_BACKOFF_BASE = 2  # seconds
+
+logger = logging.getLogger("install_nixl")
+
 
 # --- Helper Functions ---
-def run_command(command, cwd='.', env=None):
-    """Helper function to run a shell command and check for errors."""
-    print(f"--> Running command: {' '.join(command)} in '{cwd}'", flush=True)
+def run_command(command, cwd='.', env=None, dry_run=False):
+    """Run a shell command and check for errors.
+
+    Args:
+        command: Command and arguments as a list of strings.
+        cwd: Working directory for the command.
+        env: Environment variables for the command.
+        dry_run: If True, log the command without executing it.
+    """
+    cmd_str = ' '.join(command)
+    logger.info("Running command: %s in '%s'", cmd_str, cwd)
+    if dry_run:
+        logger.info("[DRY RUN] Skipped: %s", cmd_str)
+        return
     subprocess.check_call(command, cwd=cwd, env=env)
+
+
+def run_command_with_retry(command, cwd='.', env=None, dry_run=False,
+                           max_retries=MAX_RETRIES):
+    """Run a command with retry logic for transient network failures.
+
+    Uses exponential backoff between retries. Intended for network-dependent
+    operations such as git clone, git fetch, and pip install/wheel.
+
+    Args:
+        command: Command and arguments as a list of strings.
+        cwd: Working directory for the command.
+        env: Environment variables for the command.
+        dry_run: If True, log the command without executing it.
+        max_retries: Maximum number of retry attempts.
+    """
+    cmd_str = ' '.join(command)
+    for attempt in range(1, max_retries + 1):
+        try:
+            run_command(command, cwd=cwd, env=env, dry_run=dry_run)
+            return
+        except subprocess.CalledProcessError as exc:
+            if attempt == max_retries:
+                logger.error(
+                    "Command failed after %d attempts: %s", max_retries, cmd_str
+                )
+                raise
+            wait_time = RETRY_BACKOFF_BASE ** attempt
+            logger.warning(
+                "Command failed (attempt %d/%d, exit code %d): %s "
+                "— retrying in %ds...",
+                attempt, max_retries, exc.returncode, cmd_str, wait_time
+            )
+            time.sleep(wait_time)
 
 
 def is_pip_package_installed(package_name):
@@ -42,20 +99,20 @@ def find_nixl_wheel_in_cache(cache_dir):
     return None
 
 
-def install_system_dependencies():
+def install_system_dependencies(dry_run=False):
     """Installs required system packages using apt-get if run as root."""
     if os.geteuid() != 0:
-        print("\n---", flush=True)
-        print("WARNING: Not running as root. Skipping system dependency installation.", flush=True)
-        print("Please ensure the following packages are installed on your system:", flush=True)
-        print("  patchelf build-essential git cmake ninja-build autotools-dev automake meson libtool libtool-bin",
-              flush=True)
-        print("---\n", flush=True)
+        logger.warning("Not running as root. Skipping system dependency installation.")
+        logger.warning(
+            "Please ensure the following packages are installed on your system:\n"
+            "  patchelf build-essential git cmake ninja-build "
+            "autotools-dev automake meson libtool libtool-bin"
+        )
         return
 
-    print("--- Running as root. Installing system dependencies... ---", flush=True)
+    logger.info("Running as root. Installing system dependencies...")
     apt_packages = [
-        "patchelf",  # <-- Add patchelf here
+        "patchelf",
         "build-essential",
         "git",
         "cmake",
@@ -66,44 +123,50 @@ def install_system_dependencies():
         "libtool",
         "libtool-bin"
     ]
-    run_command(['apt-get', 'update'])
-    run_command(['apt-get', 'install', '-y'] + apt_packages)
-    print("--- System dependencies installed successfully. ---\n", flush=True)
+    run_command(['apt-get', 'update'], dry_run=dry_run)
+    run_command(['apt-get', 'install', '-y'] + apt_packages, dry_run=dry_run)
+    logger.info("System dependencies installed successfully.")
 
 
 def build_and_install_prerequisites(args):
     """Builds UCX and NIXL from source, creating a self-contained wheel."""
 
-    # ... (initial checks and setup are unchanged) ...
+    dry_run = args.dry_run
+    ucx_version = args.ucx_version
+    nixl_version = args.nixl_version
+
     if not args.force_reinstall and is_pip_package_installed('nixl'):
-        print("--> NIXL is already installed. Nothing to do.", flush=True)
+        logger.info("NIXL is already installed. Nothing to do.")
         return
 
     cached_wheel = find_nixl_wheel_in_cache(WHEELS_CACHE_HOME)
     if not args.force_reinstall and cached_wheel:
-        print(f"\n--> Found self-contained wheel: {os.path.basename(cached_wheel)}.", flush=True)
-        print("--> Installing from cache, skipping all source builds.", flush=True)
+        logger.info("Found self-contained wheel: %s.", os.path.basename(cached_wheel))
+        logger.info("Installing from cache, skipping all source builds.")
         install_command = [sys.executable, '-m', 'pip', 'install', cached_wheel]
-        run_command(install_command)
-        print("\n--- Installation from cache complete. ---", flush=True)
+        run_command_with_retry(install_command, dry_run=dry_run)
+        logger.info("Installation from cache complete.")
         return
 
-    print("\n--> No installed package or cached wheel found. Starting full build process...", flush=True)
-    print("\n--> Installing auditwheel...", flush=True)
-    run_command([sys.executable, '-m', 'pip', 'install', 'auditwheel'])
-    install_system_dependencies()
+    logger.info("No installed package or cached wheel found. Starting full build process...")
+
+    logger.info("Installing auditwheel...")
+    run_command_with_retry(
+        [sys.executable, '-m', 'pip', 'install', 'auditwheel'], dry_run=dry_run
+    )
+    install_system_dependencies(dry_run=dry_run)
     ucx_install_path = os.path.abspath(UCX_INSTALL_DIR)
-    print(f"--> Using wheel cache directory: {WHEELS_CACHE_HOME}", flush=True)
-    os.makedirs(WHEELS_CACHE_HOME, exist_ok=True)
+    logger.info("Using wheel cache directory: %s", WHEELS_CACHE_HOME)
+    if not dry_run:
+        os.makedirs(WHEELS_CACHE_HOME, exist_ok=True)
 
     # -- Step 1: Build UCX from source --
-    # ... (UCX build process is unchanged) ...
-    print("\n[1/3] Configuring and building UCX from source...", flush=True)
+    logger.info("[1/3] Configuring and building UCX from source (version: %s)...", ucx_version)
     if not os.path.exists(UCX_DIR):
-        run_command(['git', 'clone', UCX_REPO_URL, UCX_DIR])
+        run_command_with_retry(['git', 'clone', UCX_REPO_URL, UCX_DIR], dry_run=dry_run)
     ucx_source_path = os.path.abspath(UCX_DIR)
-    run_command(['git', 'checkout', 'v1.19.x'], cwd=ucx_source_path)
-    run_command(['./autogen.sh'], cwd=ucx_source_path)
+    run_command(['git', 'checkout', ucx_version], cwd=ucx_source_path, dry_run=dry_run)
+    run_command(['./autogen.sh'], cwd=ucx_source_path, dry_run=dry_run)
     configure_command = [
         './configure',
         f'--prefix={ucx_install_path}',
@@ -116,18 +179,24 @@ def build_and_install_prerequisites(args):
         '--with-verbs',
         '--enable-mt',
     ]
-    run_command(configure_command, cwd=ucx_source_path)
-    run_command(['make', '-j', str(os.cpu_count() or 1)], cwd=ucx_source_path)
-    run_command(['make', 'install'], cwd=ucx_source_path)
-    print("--- UCX build and install complete ---", flush=True)
+    run_command(configure_command, cwd=ucx_source_path, dry_run=dry_run)
+    run_command(
+        ['make', '-j', str(os.cpu_count() or 1)], cwd=ucx_source_path, dry_run=dry_run
+    )
+    run_command(['make', 'install'], cwd=ucx_source_path, dry_run=dry_run)
+    logger.info("UCX build and install complete.")
 
     # -- Step 2: Build NIXL wheel from source --
-    print("\n[2/3] Building NIXL wheel from source...", flush=True)
+    logger.info("[2/3] Building NIXL wheel from source (version: %s)...", nixl_version)
     if not os.path.exists(NIXL_DIR):
-        run_command(['git', 'clone', NIXL_REPO_URL, NIXL_DIR])
+        run_command_with_retry(['git', 'clone', NIXL_REPO_URL, NIXL_DIR], dry_run=dry_run)
 
-    run_command(['git', 'fetch', '--all'], cwd=NIXL_DIR)
-    run_command(['git', 'checkout', 'tags/0.6.1', '-b', 'release-0.6.1'], cwd=NIXL_DIR)
+    run_command_with_retry(['git', 'fetch', '--all'], cwd=NIXL_DIR, dry_run=dry_run)
+    nixl_tag = f'tags/{nixl_version}'
+    nixl_branch = f'release-{nixl_version}'
+    run_command(
+        ['git', 'checkout', nixl_tag, '-b', nixl_branch], cwd=NIXL_DIR, dry_run=dry_run
+    )
 
     build_env = os.environ.copy()
     build_env['PKG_CONFIG_PATH'] = os.path.join(ucx_install_path, 'lib', 'pkgconfig')
@@ -135,55 +204,99 @@ def build_and_install_prerequisites(args):
     ucx_plugin_path = os.path.join(ucx_lib_path, 'ucx')
     existing_ld_path = os.environ.get('LD_LIBRARY_PATH', '')
     build_env['LD_LIBRARY_PATH'] = f"{ucx_lib_path}:{ucx_plugin_path}:{existing_ld_path}".strip(':')
-    print(f"--> Using LD_LIBRARY_PATH: {build_env['LD_LIBRARY_PATH']}", flush=True)
+    logger.debug("Using LD_LIBRARY_PATH: %s", build_env['LD_LIBRARY_PATH'])
 
     temp_wheel_dir = os.path.join(ROOT_DIR, 'temp_wheelhouse')
-    run_command([sys.executable, '-m', 'pip', 'wheel', '.', '--no-deps', f'--wheel-dir={temp_wheel_dir}'],
-                cwd=os.path.abspath(NIXL_DIR),
-                env=build_env)
+    run_command_with_retry(
+        [sys.executable, '-m', 'pip', 'wheel', '.', '--no-deps', f'--wheel-dir={temp_wheel_dir}'],
+        cwd=os.path.abspath(NIXL_DIR),
+        env=build_env,
+        dry_run=dry_run,
+    )
 
     # -- Step 3: Repair the wheel, excluding the already-bundled plugin --
-    print("\n[3/3] Repairing NIXL wheel to include UCX libraries...", flush=True)
-    unrepaired_wheel = find_nixl_wheel_in_cache(temp_wheel_dir)
-    if not unrepaired_wheel:
-        raise RuntimeError("Failed to find the NIXL wheel after building it.")
+    logger.info("[3/3] Repairing NIXL wheel to include UCX libraries...")
+    if not dry_run:
+        unrepaired_wheel = find_nixl_wheel_in_cache(temp_wheel_dir)
+        if not unrepaired_wheel:
+            raise RuntimeError("Failed to find the NIXL wheel after building it.")
+    else:
+        unrepaired_wheel = "<wheel-placeholder>"
 
-    # --- 👇 THE CORRECTED COMMAND 👇 ---
-    # We tell auditwheel to ignore the plugin that mesonpy already handled.
+    # Exclude the UCX plugin that mesonpy already bundles.
     auditwheel_command = [
         'auditwheel',
         'repair',
         '--exclude',
-        'libplugin_UCX.so',  # <-- Exclude the problematic library
+        'libplugin_UCX.so',
         unrepaired_wheel,
         f'--wheel-dir={WHEELS_CACHE_HOME}'
     ]
-    run_command(auditwheel_command, env=build_env)
-    # --- 👆 END CORRECTION 👆 ---
+    run_command(auditwheel_command, env=build_env, dry_run=dry_run)
 
-    # --- CLEANUP ---
-    # No more temporary files to remove, just the temp wheelhouse
-    run_command(['rm', '-rf', temp_wheel_dir])
-    # --- END CLEANUP ---
+    # --- Cleanup ---
+    run_command(['rm', '-rf', temp_wheel_dir], dry_run=dry_run)
 
-    newly_built_wheel = find_nixl_wheel_in_cache(WHEELS_CACHE_HOME)
-    if not newly_built_wheel:
-        raise RuntimeError("Failed to find the repaired NIXL wheel.")
+    if not dry_run:
+        newly_built_wheel = find_nixl_wheel_in_cache(WHEELS_CACHE_HOME)
+        if not newly_built_wheel:
+            raise RuntimeError("Failed to find the repaired NIXL wheel.")
+    else:
+        newly_built_wheel = "<wheel-placeholder>"
 
-    print(f"--> Successfully built self-contained wheel: {os.path.basename(newly_built_wheel)}. Now installing...",
-          flush=True)
+    logger.info(
+        "Successfully built self-contained wheel: %s. Now installing...",
+        os.path.basename(newly_built_wheel)
+    )
     install_command = [sys.executable, '-m', 'pip', 'install', newly_built_wheel]
     if args.force_reinstall:
         install_command.insert(-1, '--force-reinstall')
 
-    run_command(install_command)
-    print("--- NIXL installation complete ---", flush=True)
+    run_command_with_retry(install_command, dry_run=dry_run)
+    logger.info("NIXL installation complete.")
+
+
+def setup_logging(verbose=False):
+    """Configure logging with a timestamped format."""
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Build and install UCX and NIXL dependencies.")
-    parser.add_argument('--force-reinstall',
-                        action='store_true',
-                        help='Force rebuild and reinstall of UCX and NIXL even if they are already installed.')
+    parser = argparse.ArgumentParser(
+        description="Build and install UCX and NIXL dependencies."
+    )
+    parser.add_argument(
+        '--force-reinstall',
+        action='store_true',
+        help='Force rebuild and reinstall even if already installed.',
+    )
+    parser.add_argument(
+        '--ucx-version',
+        default=DEFAULT_UCX_VERSION,
+        help=f'UCX version/branch to checkout (default: {DEFAULT_UCX_VERSION}). '
+             'Can also be set via UCX_VERSION env var.',
+    )
+    parser.add_argument(
+        '--nixl-version',
+        default=DEFAULT_NIXL_VERSION,
+        help=f'NIXL version tag to checkout (default: {DEFAULT_NIXL_VERSION}). '
+             'Can also be set via NIXL_VERSION env var.',
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Log all commands without executing them.',
+    )
+    parser.add_argument(
+        '--verbose', '-v',
+        action='store_true',
+        help='Enable verbose (DEBUG level) logging output.',
+    )
     args = parser.parse_args()
+    setup_logging(verbose=args.verbose)
     build_and_install_prerequisites(args)


### PR DESCRIPTION
## Summary

Improves `install_nixl.py` with better error handling, structured logging, and configurability without changing the default build behavior.

## Problem

The current `install_nixl.py` script has several maintainability and reliability issues:

1. **No structured logging** - uses 30+ raw `print()` calls with `flush=True`, making it hard to filter output by severity or add timestamps  
2. **No retry logic** - network-dependent operations (`git clone`, `git fetch`, `pip install`, `pip wheel`) fail immediately on transient errors, causing unnecessary Docker build failures  
3. **Hardcoded versions** - UCX version (`v1.19.x`) and NIXL version (`0.6.1`) are embedded directly in the function body, requiring code changes to update  
4. **Stale code comments** - leftover development markers (`👇 THE CORRECTED COMMAND 👇`, `# <-- Add patchelf here`, etc.)  
5. **No dry-run capability** - no way to validate the build configuration without actually executing commands  

## Changes

- **Structured logging**: Replaced all `print()` calls with Python's `logging` module. Log messages include timestamps and severity levels. Added `--verbose` / `-v` flag to enable `DEBUG`-level output.  
- **Retry with backoff**: Added `run_command_with_retry()` helper that retries network-dependent commands up to 3 times with exponential backoff. Non-network commands (`make`, `./configure`, etc.) remain fail-fast.  
- **Configurable versions**: Added `--ucx-version` and `--nixl-version` CLI arguments with sensible defaults. Also supports `UCX_VERSION` and `NIXL_VERSION` environment variables (CLI args take precedence).  
- **Dry-run mode**: Added `--dry-run` flag that logs all commands without executing them, useful for CI validation and debugging build configurations.  
- **Comment cleanup**: Removed stale development markers and placeholder comments.  

## Backward Compatibility

**No behavior change** when using default arguments. The script produces identical results. Only the output format and error resilience are improved.

## Testing

- `python -m py_compile docker/scripts/cpu/install_nixl.py` — syntax validation passes  
- `python docker/scripts/cpu/install_nixl.py --help` — all new arguments documented  
- Full integration testing was performed in a Linux Docker build environment (UCX/NIXL source builds)