### PR TITLE
fix: make nccl env scipt not found error obvious

### DIFF
--- a/guides/pd-disaggregation/ms-pd/values_gke_rdma.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_gke_rdma.yaml
@@ -62,7 +62,7 @@ decode:
       - -c
     args:
       - |
-        source /usr/local/gib/scripts/set_nccl_env.sh
+        source /usr/local/gib/scripts/set_nccl_env.sh || { echo "Error: NCCL env script not found. Exiting."; exit 1; }
         export LD_LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | sed ':a; N; $!ba; s/\n/:/g'):${LD_LIBRARY_PATH}
         echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
         export LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | head -1):${LIBRARY_PATH}
@@ -159,7 +159,7 @@ prefill:
       - -c
     args:
       - |
-        source /usr/local/gib/scripts/set_nccl_env.sh
+        source /usr/local/gib/scripts/set_nccl_env.sh || { echo "Error: NCCL env script not found. Exiting."; exit 1; }
         export LD_LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | sed ':a; N; $!ba; s/\n/:/g'):${LD_LIBRARY_PATH}
         echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
         export LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | head -1):${LIBRARY_PATH}


### PR DESCRIPTION
During prefill-decode (p/d) disaggregation, my cluster node somehow was missing the /usr/local/gib/scripts/set_nccl_env.sh script. Despite this missing dependency, the vLLM pod successfully starts without the NCCL environment being configured. This causes a silent failure where users unknowingly lose support for high-speed NCCL KV cache transfers.

This pr makes the error obvious and cause the pod to `CrashLoopBackOff`