### PR TITLE
fix: add missing sizeLimit and fix label typo in inference-scheduling configs

### DIFF
--- a/guides/inference-scheduling/ms-inference-scheduling/values_sglang.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_sglang.yaml
@@ -101,7 +101,7 @@ decode:
   - name: dshm
     emptyDir:
       medium: Memory
- 
+      sizeLimit: 20Gi
 
 # PD disabled in this example
 prefill:

--- a/guides/inference-scheduling/ms-inference-scheduling/values_tpu_v6.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_tpu_v6.yaml
@@ -8,7 +8,7 @@ modelArtifacts:
   labels:
     llm-d.ai/inference-serving: "true"
     llm-d.ai/guide: "inference-scheduling"
-    llm-d.ai/hardware-vairant: "tpu"
+    llm-d.ai/hardware-variant: "tpu"
     llm-d.ai/hardware-vendor: "google"
     llm-d.ai/model: Llama-3.1-70B-Instruct
 


### PR DESCRIPTION
## Summary

- **values_sglang.yaml**: Add missing `sizeLimit: 20Gi` to `dshm` shared memory volume, consistent with the baseline `values.yaml` and `values_amd.yaml` in the same directory. Without this limit, pods can consume unbounded node memory.
- **values_tpu_v6.yaml**: Fix label typo `hardware-vairant` → `hardware-variant` so that label selectors referencing `llm-d.ai/hardware-variant` correctly match TPU v6 configurations.

## Test plan

- [ ] Verify `values_sglang.yaml` dshm volume now has `sizeLimit: 20Gi` matching other configs in the same guide
- [ ] Verify `values_tpu_v6.yaml` label reads `hardware-variant` (not `hardware-vairant`)
- [ ] Confirm no other files are affected