### PR TITLE
build: add infiniband-diags to rdma-tools runtime image

### DIFF
--- a/docker/Dockerfile.rdma-tools
+++ b/docker/Dockerfile.rdma-tools
@@ -101,7 +101,7 @@ WORKDIR /root
 
 # Install runtime utilities
 RUN dnf install -y \
-    wget procps-ng jq bc iputils ethtool net-tools \
+    wget procps-ng jq bc iputils ethtool net-tools infiniband-diags \
     numactl kmod systemd-udev libpcap python3 hostname \
     && dnf clean all
 


### PR DESCRIPTION
The infiniband-diags package provides IB diagnostic tools (ibstat, ibstatus, ibping, perfquery) needed to diagnose InfiniBand subnets. These are essential for RoCE/InfiniBand validation alongside the existing perftest and iperf3 tools.

Signed-off-by: Raj Joshi <rajjoshi@redhat.com>

## Testing

- Built the rdma-tools image locally and verified:
  - `infiniband-diags-57.0-2.el9.x86_64` installs successfully via dnf
  - `ibstat` available at `/usr/sbin/ibstat`
  - `ibstatus` available at `/usr/sbin/ibstatus`
  - `rpm -q infiniband-diags` confirms package presence