### PR TITLE
build: add libibverbs-utils to rdma-tools runtime image

### DIFF
--- a/docker/Dockerfile.rdma-tools
+++ b/docker/Dockerfile.rdma-tools
@@ -102,7 +102,7 @@ WORKDIR /root
 # Install runtime utilities
 RUN dnf install -y \
     wget procps-ng jq bc iputils ethtool net-tools infiniband-diags \
-    numactl kmod systemd-udev libpcap python3 hostname \
+    libibverbs-utils numactl kmod systemd-udev libpcap python3 hostname \
     && dnf clean all
 
 # Install RDMA libraries from UBI (matches what perftest was compiled against)


### PR DESCRIPTION
The libibverbs-utils package provides IB verbs diagnostic tools needed to validate RDMA connectivity. In addition to `ibv_rc_pingpong` (needed to test data plane RC connectivity), it also brings tools like `ibv_devinfo`, `ibv_uc_pingpong`, `ibv_ud_pingpong`, and `ibv_srq_pingpong`. These complement the existing infiniband-diags and perftest tools in the rdma-tools image.

Signed-off-by: Raj Joshi <rajjoshi@redhat.com>

## Testing

- Built the rdma-tools image locally and verified:
  - `libibverbs-utils-57.0-2.el9.x86_64` installs successfully via dnf
  - `ibv_rc_pingpong` available at `/usr/bin/ibv_rc_pingpong`
  - `ibv_devinfo` available at `/usr/bin/ibv_devinfo`
  - `rpm -q libibverbs-utils` confirms package presence

Made with [Cursor](https://cursor.com)