### PR TITLE
docs: assign a level of maturity for each guide

### DIFF
--- a/guides/benchmark/README.md
+++ b/guides/benchmark/README.md
@@ -17,7 +17,7 @@ For full, customizable benchmarking, please refer to [llm-d-benchmark](https://g
     chmod u+x run_only.sh
     ```
 
-- Prepare a Persistent Volume Claim (PVC) to store the benchmark results. The PVC must have `RWX` write permissions and be large enough (`200Gi` recommended).  
+- Prepare a Persistent Volume Claim (PVC) to store the benchmark results. The PVC must have `RWX` write permissions and be large enough (`200Gi` recommended).
   Alternatively, use the `-o` option of `run_only.sh` to output results to ephemeral storage and then copy them over to a local directory or to a cloud bucket.
 
   <details>
@@ -841,7 +841,7 @@ To allow easier comparison between results from different harnesses, the benchma
 
 ### Graphical report
 
-Some harnesses also generate plots of the results. In our example, `inference-perf` generates several plots under the `analysis` sub directory. In [llm-d-benchmark](https://github.com/llm-d/llm-d-benchmark) there are examples of more complex plots (see [analysis.ipynb](https://github.com/llm-d/llm-d-benchmark/blob/main/analysis/analysis.ipynb)).
+Some harnesses also generate plots of the results. In our example, `inference-perf` generates several plots under the `analysis` sub directory. In [llm-d-benchmark](https://github.com/llm-d/llm-d-benchmark) there are examples of more complex plots (see [analysis.ipynb](https://github.com/llm-d/llm-d-benchmark/blob/main/docs/analysis/analysis.ipynb)).
 
 ---
 

--- a/guides/inference-scheduling/README.md
+++ b/guides/inference-scheduling/README.md
@@ -1,5 +1,7 @@
 # Well-lit Path: Intelligent Inference Scheduling
 
+## **MATURITY** : High (tested nightly on OpenShift, Google Kubernetes Engine and CoreWeave Kubernetes Service)
+
 ## Overview
 
 This guide deploys the recommended out of the box [scheduling configuration](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/docs/architecture.md) for most vLLM and SGLang deployments, reducing tail latency and increasing throughput through load-aware and prefix-cache aware balancing. This can be run on two GPUs that can load [Qwen/Qwen3-32B](https://huggingface.co/Qwen/Qwen3-32B).

--- a/guides/pd-disaggregation/README.amd.md
+++ b/guides/pd-disaggregation/README.amd.md
@@ -1,5 +1,7 @@
 # AMD GPU well-lit Path for P/D Disaggregation
 
+## **MATURITY** : Experimental (not regularly tested by maintainers)
+
 ## Overview
 
 This guide demonstrates how to deploy models using vLLM's P/D disaggregation support with RIXL. This guide has been validated on:
@@ -151,7 +153,7 @@ helm list -n ${NAMESPACE}
 NAME        NAMESPACE   REVISION    UPDATED                                 STATUS      CHART                       APP VERSION
 gaie-pd     llm-d-pd    1           2026-02-04 16:08:57.461356878 +0000 UTC deployed    inferencepool-v1.4.0   v1.4.0
 infra-pd    llm-d-pd    1           2026-02-04 16:08:56.394680393 +0000 UTC deployed    llm-d-infra-v1.4.0          v0.4.0
-ms-pd       llm-d-pd    1           2026-02-04 16:08:59.144726828 +0000 UTC deployed    llm-d-modelservice-v0.4.7   v0.4.0   
+ms-pd       llm-d-pd    1           2026-02-04 16:08:59.144726828 +0000 UTC deployed    llm-d-modelservice-v0.4.7   v0.4.0
 ```
 
 * Out of the box with the example you should have the following resources:

--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -1,5 +1,7 @@
 # Well-lit Path: P/D Disaggregation
 
+## **MATURITY** : High (tested nightly on OpenShift, Google Kubernetes Engine and CoreWeave Kubernetes Service)
+
 ## Overview
 
 This guide demonstrates how to deploy GPT-OSS-120B using vLLM's P/D disaggregation support with NIXL. This guide has been validated on:

--- a/guides/pd-disaggregation/README.tpu.md
+++ b/guides/pd-disaggregation/README.tpu.md
@@ -1,5 +1,7 @@
 # Google TPU P/D Disaggregation Deployment Guide
 
+## **MATURITY** : Experimental (not regularly tested by maintainers)
+
 ## Overview
 
 This document provides complete steps for deploying a PD (Prefill-Decode) disaggregation service on a Google Kubernetes Engine (GKE) cluster using the Llama-3.3-70B-Instruct model. PD disaggregation separates the prefill and decode phases of inference, enabling more efficient resource utilization and improved throughput.

--- a/guides/pd-disaggregation/README.xpu.md
+++ b/guides/pd-disaggregation/README.xpu.md
@@ -1,5 +1,9 @@
 # Intel XPU PD Disaggregation Deployment Guide
 
+## **MATURITY** : Experimental (not regularly tested by maintainers)
+
+## Overview
+
 This document provides complete steps for deploying Intel XPU PD (Prefill-Decode) disaggregation service on Kubernetes cluster using DeepSeek-R1-Distill-Qwen-1.5B model. PD disaggregation separates the prefill and decode phases of inference, allowing for more efficient resource utilization and improved throughput.
 
 ## Prerequisites

--- a/guides/precise-prefix-cache-aware/README.md
+++ b/guides/precise-prefix-cache-aware/README.md
@@ -1,5 +1,7 @@
 # Feature: Precise Prefix Cache Aware Routing
 
+## **MATURITY** : Medium (tested nightly on OpenShift)
+
 ## Overview
 
 This guide demonstrates how to configure the inference scheduler to use the new precise prefix cache aware routing based on [vLLM KV-Events](https://github.com/vllm-project/vllm/issues/16669) data. Precise prefix cache aware routing pulls up-to-date prefix cache status from serving instances, eliminating the need for additional indexing services and increasing cache hit rate at high throughput.

--- a/guides/predicted-latency-based-scheduling/README.md
+++ b/guides/predicted-latency-based-scheduling/README.md
@@ -1,5 +1,7 @@
 # Experimental Feature: Predicted Latency based Load Balancing
 
+## **MATURITY** : Experimental (not regularly tested by maintainers)
+
 ## Overview
 
 This experimental feature introduces **predicted latency based load balancing**, where scheduling decisions are guided by real-time predictions of request latency rather than only utilization metrics like queue depth or KV-cache utilization.

--- a/guides/simulated-accelerators/README.md
+++ b/guides/simulated-accelerators/README.md
@@ -1,5 +1,7 @@
 # Feature: llm-d Accelerator Simulation
 
+## **MATURITY** : Medium (tested nightly on OpenShift)
+
 ## Overview
 
 Conducting large scale testing of AI/ML workloads is difficult when capacity is limited or already committed to production workloads. `llm-d` provides a lightweight model server that mimics the behavior of executing inference without requiring an attached accelerator. This simulated server can be run in wide or dense configurations on CPU-only machines to validate the correct behavior of other parts of the system, including Kubernetes autoscaling and the `inference-scheduler`.

--- a/guides/tiered-prefix-cache/README.md
+++ b/guides/tiered-prefix-cache/README.md
@@ -1,5 +1,7 @@
 # Well-lit Path: Prefix Cache Offloading
 
+## **MATURITY** : Medium (tested nightly on OpenShift)
+
 ## Overview
 
 Efficient caching of prefix computation states to avoid recomputation is crucial for boosting Large Language Model (LLM) inference performance such as Time to First Token (TTFT) and overall throughput, as well as reducing the cost.
@@ -56,7 +58,7 @@ Offloading prefix cache to a shared (remote) storage tier provides several impor
 
 However, shared storage introduces additional operational and performance considerations. Latency and throughput depend on the characteristics of the underlying storage system, so careful evaluation is required to ensure that cache transfer overhead does not negatively impact inference performance.
 
-Integration between the storage system and llm-d is achieved through vLLM connectors. The specific connector and data path depend on the storage system type and the underlying transport mechanism. 
+Integration between the storage system and llm-d is achieved through vLLM connectors. The specific connector and data path depend on the storage system type and the underlying transport mechanism.
 For example, different implementations may use CPU staging buffers, GPU Direct Storage (GDS), or NIXL-based data movement.
 Any storage connector that is compatible with vLLM can be used **transparently within the llm-d project**.
 

--- a/guides/wide-ep-lws/README.md
+++ b/guides/wide-ep-lws/README.md
@@ -1,5 +1,7 @@
 # Well-lit Path: Wide Expert Parallelism (EP/DP) with LeaderWorkerSet
 
+## **MATURITY** : Experimental (not regularly tested by maintainers)
+
 ## Overview
 
 This guide demonstrates how to deploy DeepSeek-R1-0528 using vLLM's P/D disaggregation support with NIXL in a wide expert parallel pattern with LeaderWorkerSets. This guide has been validated on:
@@ -206,7 +208,7 @@ We use the [inference-perf](https://github.com/kubernetes-sigs/inference-perf/tr
 
 ### Run Benchmark
 
-1. Deploy the wide-ep-lws stack following the Installation steps above. Once the stack is ready, obtain the gateway IP: 
+1. Deploy the wide-ep-lws stack following the Installation steps above. Once the stack is ready, obtain the gateway IP:
 
 ```bash
 export GATEWAY_IP=$(kubectl get gateway/llm-d-inference-gateway -n ${NAMESPACE} -o jsonpath='{.status.addresses[0].value}')

--- a/guides/workload-autoscaling/README.hpa-igw.md
+++ b/guides/workload-autoscaling/README.hpa-igw.md
@@ -1,5 +1,7 @@
 # Autoscaling Workloads with HPA and IGW Metrics
 
+## **MATURITY** : Experimental (not regularly tested by maintainers)
+
 This guide explains how to configure autoscaling for LLM workloads by integrating the
 Kubernetes Horizontal Pod Autoscaler (HPA) with metrics emitted by the Inference
 Gateway (IGW). By using gateway-level signals like queue depth and active request counts,

--- a/guides/workload-autoscaling/README.md
+++ b/guides/workload-autoscaling/README.md
@@ -1,5 +1,7 @@
 # Workload Autoscaling
 
+## **MATURITY** : Experimental (not regularly tested by maintainers)
+
 Traditional autoscaling indicators like resource utilization metrics (CPU/GPU) are often lagging indicators — they only reflect saturation after it has already occurred, by which point latency has spiked and requests may be failing. For LLM inference, this problem is compounded by the fact that GPU utilization is often pegged near 100% during active batching regardless of actual load, making it an unreliable signal entirely.
 
 Effective LLM autoscaling requires proactive, SLO-aware signals that reflect the true state of the inference system — queue depth, in-flight request counts, and KV cache pressure — so that capacity can be added before end-user latency is impacted.

--- a/guides/workload-autoscaling/README.wva.md
+++ b/guides/workload-autoscaling/README.wva.md
@@ -1,5 +1,7 @@
 # Autoscaling with Workload Variant Autoscaler (WVA)
 
+## **MATURITY** : Experimental (not regularly tested by maintainers)
+
 > **Version Compatibility**: This guide is tested and validated with **WVA v0.5.1**. Ensure that all version references in installation commands match this version for compatibility.
 >
 > **Breaking Changes in v0.5.1**: If upgrading from v0.4.1 or earlier, see the [Upgrading](#upgrading) section below for required migration steps.


### PR DESCRIPTION
Additionally, fixed a broken link on `guides/benchmark`