### PR TITLE
[guides] Add a commented `priorityClassName` for use in nightly CI/CD

### DIFF
--- a/guides/inference-scheduling/ms-inference-scheduling/digitalocean-values.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/digitalocean-values.yaml
@@ -25,6 +25,8 @@ accelerator:  # controls specialized hardware Type
 
 # DigitalOcean-specific container configuration
 decode:
+  create: true
+#  priorityClassName: nightly-gpu-critical
   replicas: 2
   containers:
     - name: "vllm"

--- a/guides/inference-scheduling/ms-inference-scheduling/values-hpu.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values-hpu.yaml
@@ -46,6 +46,7 @@ routing:
 # Decode pod configuration for Intel Gaudi - simplified with imageDefault
 decode:
   create: true
+#  priorityClassName: nightly-gpu-critical
   replicas: 1
   containers:
     - name: "vllm"

--- a/guides/inference-scheduling/ms-inference-scheduling/values.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values.yaml
@@ -30,6 +30,7 @@ accelerator:  # controls specialized hardware Type
 
 decode:
   create: true
+#  priorityClassName: nightly-gpu-critical
   parallelism:
     tensor: 2
     data: 1

--- a/guides/inference-scheduling/ms-inference-scheduling/values_amd.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_amd.yaml
@@ -30,6 +30,7 @@ accelerator:
 
 decode:
   create: true
+#  priorityClassName: nightly-gpu-critical
   parallelism:
     tensor: 2
     data: 1

--- a/guides/inference-scheduling/ms-inference-scheduling/values_cpu.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_cpu.yaml
@@ -31,6 +31,7 @@ routing:
 
 decode:
   create: true
+#  priorityClassName: nightly-gpu-critical
   replicas: 2
   monitoring:
     podmonitor:

--- a/guides/inference-scheduling/ms-inference-scheduling/values_gke.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_gke.yaml
@@ -30,7 +30,7 @@ accelerator:  # controls specialized hardware Type
 
 decode:
   create: true
-  priorityClassName: nightly-gpu-critical
+#  priorityClassName: nightly-gpu-critical
   parallelism:
     tensor: 2
     data: 1

--- a/guides/inference-scheduling/ms-inference-scheduling/values_sglang.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_sglang.yaml
@@ -22,6 +22,7 @@ accelerator:  # controls specialized hardware Type
 
 decode:
   create: true
+#  priorityClassName: nightly-gpu-critical
   replicas: 2
   monitoring:
     podmonitor:

--- a/guides/inference-scheduling/ms-inference-scheduling/values_tpu_v6.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_tpu_v6.yaml
@@ -21,6 +21,8 @@ routing:
     targetPort: 8000  # controls vLLM port to match up with sidecar if deployed
 
 decode:
+  create: true
+#  priorityClassName: nightly-gpu-critical
   parallelism:
     tensor: 8
   create: true

--- a/guides/inference-scheduling/ms-inference-scheduling/values_tpu_v7.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_tpu_v7.yaml
@@ -29,9 +29,10 @@ accelerator:
   type: "google"
 
 decode:
+  create: true
+#  priorityClassName: nightly-gpu-critical
   parallelism:
     tensor: 8
-  create: true
   replicas: 2
   extraConfig:
     nodeSelector:

--- a/guides/inference-scheduling/ms-inference-scheduling/values_xpu.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_xpu.yaml
@@ -33,7 +33,7 @@ routing:
 
 decode:
   create: true
-  replicas: 2
+#  priorityClassName: nightly-gpu-critical  replicas: 2
   securityContext:
     fsGroup: 107
     supplementalGroups:

--- a/guides/pd-disaggregation/ms-pd/values.yaml
+++ b/guides/pd-disaggregation/ms-pd/values.yaml
@@ -28,9 +28,10 @@ routing:
     secure: false
 
 decode:
+  create: true
+#  priorityClassName: nightly-gpu-critical
   parallelism:
     tensor: 4
-  create: true
   replicas: 1
   monitoring:
     podmonitor:
@@ -114,9 +115,10 @@ decode:
       emptyDir: {}
 
 prefill:
+  create: true
+#  priorityClassName: nightly-gpu-critical
   parallelism:
     tensor: 1
-  create: true
   replicas: 4
   monitoring:
     podmonitor:

--- a/guides/pd-disaggregation/ms-pd/values_amd.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_amd.yaml
@@ -23,10 +23,11 @@ routing:
     secure: false
 
 decode:
+  create: true
+#  priorityClassName: nightly-gpu-critical
   parallelism:
     tensor: 4
     data: 1
-  create: true
   replicas: 1
   monitoring:
     podmonitor:
@@ -116,9 +117,10 @@ decode:
     emptyDir: {}
 
 prefill:
+  create: true
+#  priorityClassName: nightly-gpu-critical
   parallelism:
     tensor: 1
-  create: true
   replicas: 4
   monitoring:
     podmonitor:

--- a/guides/pd-disaggregation/ms-pd/values_gke_rdma.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_gke_rdma.yaml
@@ -29,7 +29,7 @@ routing:
 
 decode:
   create: true
-  priorityClassName: nightly-gpu-critical
+#  priorityClassName: nightly-gpu-critical
   replicas: 1
   monitoring:
     podmonitor:
@@ -126,7 +126,7 @@ decode:
 
 prefill:
   create: true
-  priorityClassName: nightly-gpu-critical
+#  priorityClassName: nightly-gpu-critical
   replicas: 1
   monitoring:
     podmonitor:

--- a/guides/pd-disaggregation/ms-pd/values_hpu.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_hpu.yaml
@@ -33,9 +33,10 @@ routing:
     secure: false
 
 decode:
+  create: true
+#  priorityClassName: nightly-gpu-critical
   parallelism:
     tensor: 4
-  create: true
   replicas: 1
   monitoring:
     podmonitor:
@@ -131,9 +132,10 @@ decode:
     emptyDir: {}
 
 prefill:
+  create: true
+#  priorityClassName: nightly-gpu-critical
   parallelism:
     tensor: 1
-  create: true
   replicas: 4
   monitoring:
     podmonitor:

--- a/guides/pd-disaggregation/ms-pd/values_ocp_rdma.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_ocp_rdma.yaml
@@ -25,6 +25,8 @@ accelerator:  # controls specialized hardware Type
   type: nvidia
 
 decode:
+  create: true
+#  priorityClassName: nightly-gpu-critical
   replicas: 2
   initContainers:
     - name: preprocess
@@ -153,6 +155,8 @@ decode:
       emptyDir: {}
 
 prefill:
+  create: true
+#  priorityClassName: nightly-gpu-critical
   replicas: 1
   initContainers:
     - name: preprocess

--- a/guides/pd-disaggregation/ms-pd/values_tpu.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_tpu.yaml
@@ -32,9 +32,10 @@ routing:
     secure: false
 
 decode:
+  create: true
+#  priorityClassName: nightly-gpu-critical
   parallelism:
     tensor: 8
-  create: true
   replicas: 1
   extraConfig:
     nodeSelector:
@@ -128,9 +129,10 @@ decode:
       emptyDir: {}
 
 prefill:
+  create: true
+#  priorityClassName: nightly-gpu-critical
   parallelism:
     tensor: 8
-  create: true
   replicas: 2
   extraConfig:
     nodeSelector:

--- a/guides/pd-disaggregation/ms-pd/values_xpu.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_xpu.yaml
@@ -36,9 +36,10 @@ routing:
     secure: false
 
 decode:
+  create: true
+#  priorityClassName: nightly-gpu-critical
   parallelism:  # controls count of specialized hardware devices allocated
     tensor: 1
-  create: true
   replicas: 1
   securityContext:
     fsGroup: 107
@@ -135,9 +136,10 @@ decode:
       emptyDir: {}
 
 prefill:
+  create: true
+#  priorityClassName: nightly-gpu-critical
   parallelism:
     tensor: 1
-  create: true
   replicas: 3
   securityContext:
     fsGroup: 107

--- a/guides/precise-prefix-cache-aware/ms-kv-events/values.yaml
+++ b/guides/precise-prefix-cache-aware/ms-kv-events/values.yaml
@@ -30,6 +30,7 @@ accelerator:  # controls specialized hardware Type
 
 decode:
   create: true
+#  priorityClassName: nightly-gpu-critical
   parallelism:
     tensor: 2
     data: 1

--- a/guides/precise-prefix-cache-aware/ms-kv-events/values_pod_discovery.yaml
+++ b/guides/precise-prefix-cache-aware/ms-kv-events/values_pod_discovery.yaml
@@ -29,6 +29,7 @@ accelerator:
 
 decode:
   create: true
+#  priorityClassName: nightly-gpu-critical
   parallelism:
     tensor: 2
     data: 1

--- a/guides/precise-prefix-cache-aware/ms-kv-events/values_xpu.yaml
+++ b/guides/precise-prefix-cache-aware/ms-kv-events/values_xpu.yaml
@@ -34,6 +34,7 @@ routing:
 
 decode:
   create: true
+#  priorityClassName: nightly-gpu-critical
   replicas: 2
   securityContext:
     fsGroup: 107

--- a/guides/precise-prefix-cache-aware/ms-kv-events/values_xpu_pod_discovery.yaml
+++ b/guides/precise-prefix-cache-aware/ms-kv-events/values_xpu_pod_discovery.yaml
@@ -34,6 +34,7 @@ routing:
 
 decode:
   create: true
+#  priorityClassName: nightly-gpu-critical
   replicas: 2
   securityContext:
     fsGroup: 107

--- a/guides/simulated-accelerators/ms-sim/values.yaml
+++ b/guides/simulated-accelerators/ms-sim/values.yaml
@@ -27,6 +27,7 @@ routing:
 
 decode:
   create: true
+#  priorityClassName: nightly-gpu-critical
   replicas: 3
   monitoring:
     podmonitor:
@@ -106,6 +107,7 @@ decode:
 
 prefill:
   create: true
+#  priorityClassName: nightly-gpu-critical
   replicas: 1
   monitoring:
     podmonitor:

--- a/guides/workload-autoscaling/ms-workload-autoscaling/values.yaml
+++ b/guides/workload-autoscaling/ms-workload-autoscaling/values.yaml
@@ -26,9 +26,10 @@ routing:
     secure: false
 
 decode:
+  create: true
+#  priorityClassName: nightly-gpu-critical
   parallelism:
     tensor: 1  # each pod requests 1 gpu
-  create: true
   replicas: 2
   monitoring:
     podmonitor:


### PR DESCRIPTION
Whenever nightly CI/CD jobs are run, the comment is removed from the `priorityClassName` entry on each `values.yaml`