### PR TITLE
✨ Add glob patterns and run URL feedback to /test-nightly

### DIFF
--- a/.github/workflows/slash-test-nightly.yaml
+++ b/.github/workflows/slash-test-nightly.yaml
@@ -218,7 +218,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "$IS_FORK" = "true" ]; then
-            BRANCH="test-nightly/pr-${PR_NUMBER}"
+            # Include comment ID to avoid races when multiple /test-nightly
+            # commands on the same PR run concurrently.
+            BRANCH="test-nightly/pr-${PR_NUMBER}-${{ github.event.comment.id }}"
             git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
             git checkout -b "$BRANCH"
             # Add an empty commit so the branch tip has a fresh timestamp
@@ -254,6 +256,14 @@ jobs:
             // Record time before dispatching (used to identify new runs)
             const beforeDispatch = new Date();
 
+            // Get the HEAD SHA of the branch so we can correlate runs
+            // more precisely than timestamps alone.
+            const { data: refData } = await github.rest.git.getRef({
+              owner, repo,
+              ref: `heads/${ref}`,
+            });
+            const headSha = refData.object.sha;
+
             // Dispatch all workflows
             for (const m of matches) {
               console.log(`Dispatching ${m.workflowFile} on ref ${ref}`);
@@ -281,7 +291,10 @@ jobs:
                     per_page: 5,
                   });
 
+                  // Match on head_sha AND creation time to avoid picking
+                  // a run from a different concurrent dispatch.
                   const newRun = runs.find(r =>
+                    r.head_sha === headSha &&
                     new Date(r.created_at) >= beforeDispatch
                   );
                   if (newRun) {


### PR DESCRIPTION
## Summary

- Adds glob pattern support to `/test-nightly` so maintainers can trigger multiple nightlies at once: `/test-nightly *-ocp`, `/test-nightly inference-scheduling-*`
- After triggering, polls for the actual workflow run URL(s) and comments them back on the PR with direct links

### New usage examples
```
/test-nightly pd-disaggregation-ocp     # exact match (unchanged)
/test-nightly *-ocp                      # all OCP nightlies
/test-nightly inference-scheduling-*     # all inference-scheduling variants
/test-nightly wva-*                      # both wva-cks and wva-ocp
```

### Comment format
- **Single nightly**: detail table with direct run link
- **Multiple matches**: table of all triggered nightlies with individual run links

### How run URL works
After dispatching each workflow, the action polls the GitHub API (up to 60s) to find the newly created workflow run and includes its URL in the PR comment. If the run isn't found in time, falls back to a link to the workflow page.

cc @maugustosilva — these are the two features you requested! 🎉

## Test plan

- [ ] Comment `/test-nightly wva-ocp` on a PR → single nightly triggers, comment has direct run URL
- [ ] Comment `/test-nightly *-ocp` on a PR → all OCP nightlies trigger, comment shows table with run URLs
- [ ] Comment `/test-nightly inference-scheduling-*` → all inference-scheduling variants trigger
- [ ] Comment `/test-nightly bogus-*` → error: no matches, lists available nightlies
- [ ] Comment `/test-nightly` (no arg) → usage help shows glob pattern examples