### PR TITLE
Images Preparation for v0.6.0

### DIFF
--- a/guides/inference-scheduling/ms-inference-scheduling/digitalocean-values.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/digitalocean-values.yaml
@@ -28,7 +28,7 @@ decode:
   replicas: 2
   containers:
     - name: "vllm"
-      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
+      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
       modelCommand: vllmServe  # Required by chart
       args:
         - "--gpu-memory-utilization"  # DigitalOcean GPU optimization

--- a/guides/inference-scheduling/ms-inference-scheduling/values-hpu.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values-hpu.yaml
@@ -50,7 +50,7 @@ decode:
   containers:
     - name: "vllm"
       # Use custom vLLM image for Gaudi for now
-      image: "ghcr.io/llm-d/llm-d-hpu-dev:pr-965"
+      image: "ghcr.io/llm-d/llm-d-hpu:v0.6.0"
 
       # Use imageDefault mode - chart will generate basic vLLM command automatically
       modelCommand: "imageDefault"

--- a/guides/inference-scheduling/ms-inference-scheduling/values.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values.yaml
@@ -42,7 +42,7 @@ decode:
       interval: "30s"
   containers:
     - name: "vllm"
-      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
+      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
       modelCommand: vllmServe
       args:
         - "--disable-uvicorn-access-log"

--- a/guides/inference-scheduling/ms-inference-scheduling/values_amd.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_amd.yaml
@@ -42,7 +42,7 @@ decode:
       interval: "30s"
   containers:
     - name: "vllm"
-      image: ghcr.io/llm-d/llm-d-rocm:v0.5.1
+      image: ghcr.io/llm-d/llm-d-rocm:v0.6.0
       modelCommand: vllmServe
       args:
         - "--disable-uvicorn-access-log"

--- a/guides/inference-scheduling/ms-inference-scheduling/values_cpu.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_cpu.yaml
@@ -40,7 +40,7 @@ decode:
       interval: "30s"
   containers:
     - name: "vllm"
-      image: ghcr.io/llm-d/llm-d-cpu:v0.5.1
+      image: ghcr.io/llm-d/llm-d-cpu:v0.6.0
       imagePullPolicy: IfNotPresent
       modelCommand: vllmServe
       securityContext:  # NUMA cross-node related

--- a/guides/inference-scheduling/ms-inference-scheduling/values_gke.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_gke.yaml
@@ -43,7 +43,7 @@ decode:
       interval: "30s"
   containers:
     - name: "vllm"
-      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
+      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
       modelCommand: custom # Use custom command
       command:
          - /bin/bash

--- a/guides/inference-scheduling/ms-inference-scheduling/values_xpu.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_xpu.yaml
@@ -47,7 +47,7 @@ decode:
   containers:
     - name: "vllm"
       # Use Intel latest published xpu image
-      image: ghcr.io/llm-d/llm-d-xpu:v0.5.1
+      image: ghcr.io/llm-d/llm-d-xpu:v0.6.0
       modelCommand: "vllmServe"
       args:
         - "--dtype"

--- a/guides/pd-disaggregation/README.xpu.md
+++ b/guides/pd-disaggregation/README.xpu.md
@@ -42,7 +42,7 @@ If you need to customize the vLLM version or build the image from source, you ca
 
 ```shell
 # Build with the default vLLM version from docker/common-versions
-make image-build DEVICE=xpu VERSION=v0.5.1
+make image-build DEVICE=xpu VERSION=v0.6.0
 ```
 
 #### Intel Corporation Battlemage G21
@@ -52,7 +52,7 @@ make image-build DEVICE=xpu VERSION=v0.5.1
 git clone https://github.com/vllm-project/vllm.git
 cd vllm
 git checkout v0.15.1
-docker build -f docker/Dockerfile.xpu -t ghcr.io/llm-d/llm-d-xpu-dev:v0.5.1 --shm-size=4g .
+docker build -f docker/Dockerfile.xpu -t ghcr.io/llm-d/llm-d-xpu-dev:v0.6.0 --shm-size=4g .
 ```
 
 ### Available Build Arguments
@@ -116,7 +116,7 @@ If you built the Intel XPU image in Step 0, load it into the Kind cluster:
 
 ```shell
 # Load the built image into Kind cluster
-kind load docker-image ghcr.io/llm-d/llm-d-xpu:v0.5.1 --name llm-d-cluster
+kind load docker-image ghcr.io/llm-d/llm-d-xpu:v0.6.0 --name llm-d-cluster
 
 # Or if you built with custom tag
 kind load docker-image llm-d:custom-xpu --name llm-d-cluster

--- a/guides/pd-disaggregation/ms-pd/values.yaml
+++ b/guides/pd-disaggregation/ms-pd/values.yaml
@@ -40,7 +40,7 @@ decode:
       interval: "30s"
   containers:
     - name: "vllm"
-      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
+      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
       modelCommand: vllmServe
       args:
         - "--block-size"
@@ -126,7 +126,7 @@ prefill:
       interval: "30s"
   containers:
     - name: "vllm"
-      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
+      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
       modelCommand: vllmServe
       args:
         - "--block-size"

--- a/guides/pd-disaggregation/ms-pd/values_amd.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_amd.yaml
@@ -36,7 +36,7 @@ decode:
       interval: "30s"
   containers:
     - name: "vllm"
-      image: ghcr.io/llm-d/llm-d-rocm:v0.5.1
+      image: ghcr.io/llm-d/llm-d-rocm:v0.6.0
       modelCommand: vllmServe
       args:
         - "--block-size"
@@ -128,7 +128,7 @@ prefill:
       interval: "30s"
   containers:
     - name: "vllm"
-      image: ghcr.io/llm-d/llm-d-rocm:v0.5.1
+      image: ghcr.io/llm-d/llm-d-rocm:v0.6.0
       modelCommand: vllmServe
       args:
         - "--block-size"

--- a/guides/pd-disaggregation/ms-pd/values_gke_rdma.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_gke_rdma.yaml
@@ -55,7 +55,7 @@ decode:
     tensor: 4
   containers:
   - name: "vllm"
-    image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
+    image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
     modelCommand: custom # Use custom command
     command:
       - /bin/bash
@@ -152,7 +152,7 @@ prefill:
     tensor: 4
   containers:
   - name: "vllm"
-    image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
+    image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
     modelCommand: custom # Use custom command
     command:
       - /bin/bash

--- a/guides/pd-disaggregation/ms-pd/values_hpu.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_hpu.yaml
@@ -45,7 +45,7 @@ decode:
       interval: "30s"
   containers:
   - name: vllm
-    image: "ghcr.io/llm-d/llm-d-hpu-dev:pr-965"
+    image: "ghcr.io/llm-d/llm-d-hpu:v0.6.0"
     imagePullPolicy: IfNotPresent
     securityContext:
       privileged: true
@@ -143,7 +143,7 @@ prefill:
       interval: "30s"
   containers:
   - name: vllm
-    image: "ghcr.io/llm-d/llm-d-hpu-dev:pr-965"
+    image: "ghcr.io/llm-d/llm-d-hpu:v0.6.0"
     imagePullPolicy: IfNotPresent
     securityContext:
       privileged: true

--- a/guides/pd-disaggregation/ms-pd/values_ocp_rdma.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_ocp_rdma.yaml
@@ -43,7 +43,7 @@ decode:
     k8s.v1.cni.cncf.io/networks: "multi-nic-compute"
   containers:
   - name: "vllm"
-    image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
+    image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
     modelCommand: custom
     command:
       - /bin/bash
@@ -171,7 +171,7 @@ prefill:
     k8s.v1.cni.cncf.io/networks: "multi-nic-compute"
   containers:
   - name: "vllm"
-    image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
+    image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
     modelCommand: custom
     command:
       - /bin/bash

--- a/guides/pd-disaggregation/ms-pd/values_xpu.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_xpu.yaml
@@ -52,7 +52,7 @@ decode:
       interval: "30s"
   containers:
     - name: "vllm"
-      image: ghcr.io/llm-d/llm-d-xpu:v0.5.1
+      image: ghcr.io/llm-d/llm-d-xpu:v0.6.0
       modelCommand: vllmServe
       args:
         - "--block-size"
@@ -151,7 +151,7 @@ prefill:
       interval: "30s"
   containers:
     - name: "vllm"
-      image: ghcr.io/llm-d/llm-d-xpu:v0.5.1
+      image: ghcr.io/llm-d/llm-d-xpu:v0.6.0
       modelCommand: vllmServe
       args:
         - "--block-size"

--- a/guides/precise-prefix-cache-aware/ms-kv-events/values.yaml
+++ b/guides/precise-prefix-cache-aware/ms-kv-events/values.yaml
@@ -42,7 +42,7 @@ decode:
       interval: "30s"
   containers:
     - name: "vllm"
-      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
+      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
       modelCommand: vllmServe
       args:
         - "--block-size=16"

--- a/guides/precise-prefix-cache-aware/ms-kv-events/values_pod_discovery.yaml
+++ b/guides/precise-prefix-cache-aware/ms-kv-events/values_pod_discovery.yaml
@@ -41,7 +41,7 @@ decode:
       interval: "30s"
   containers:
     - name: "vllm"
-      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
+      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
       modelCommand: vllmServe
       args:
         - "--block-size=16"

--- a/guides/precise-prefix-cache-aware/ms-kv-events/values_xpu.yaml
+++ b/guides/precise-prefix-cache-aware/ms-kv-events/values_xpu.yaml
@@ -48,7 +48,7 @@ decode:
   containers:
     - name: "vllm"
       # Use Intel latest published xpu image
-      image: ghcr.io/llm-d/llm-d-xpu:v0.5.1
+      image: ghcr.io/llm-d/llm-d-xpu:v0.6.0
       modelCommand: custom
       command:
         - /bin/sh

--- a/guides/precise-prefix-cache-aware/ms-kv-events/values_xpu_pod_discovery.yaml
+++ b/guides/precise-prefix-cache-aware/ms-kv-events/values_xpu_pod_discovery.yaml
@@ -47,7 +47,7 @@ decode:
       interval: "30s"
   containers:
     - name: "vllm"
-      image: ghcr.io/llm-d/llm-d-xpu:v0.5.1
+      image: ghcr.io/llm-d/llm-d-xpu:v0.6.0
       modelCommand: custom
       command:
         - /bin/sh

--- a/guides/tiered-prefix-cache/cpu/manifests/vllm/lmcache-connector/kustomization.yaml
+++ b/guides/tiered-prefix-cache/cpu/manifests/vllm/lmcache-connector/kustomization.yaml
@@ -10,7 +10,7 @@ patches:
     patch: |-
       - op: replace
         path: /spec/template/spec/containers/0/image
-        value: ghcr.io/llm-d/llm-d-cuda:v0.5.1
+        value: ghcr.io/llm-d/llm-d-cuda:v0.6.0
       - op: replace
         path: /spec/template/spec/containers/0/command
         value:

--- a/guides/wide-ep-lws/manifests/modelserver/base/decode.yaml
+++ b/guides/wide-ep-lws/manifests/modelserver/base/decode.yaml
@@ -65,7 +65,7 @@ spec:
             emptyDir: {}
         containers:
           - name: vllm
-            image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
+            image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
             securityContext:
               capabilities:
                 add:

--- a/guides/wide-ep-lws/manifests/modelserver/base/prefill.yaml
+++ b/guides/wide-ep-lws/manifests/modelserver/base/prefill.yaml
@@ -35,7 +35,7 @@ spec:
             emptyDir: {}
         containers:
           - name: vllm
-            image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
+            image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
             securityContext:
               capabilities:
                 add:

--- a/guides/workload-autoscaling/ms-workload-autoscaling/values.yaml
+++ b/guides/workload-autoscaling/ms-workload-autoscaling/values.yaml
@@ -40,7 +40,7 @@ decode:
         release: llmd  # Required for Prometheus to discover this PodMonitor
   containers:
     - name: "vllm"
-      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
+      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
       modelCommand: vllmServe
       args:
         - "--disable-uvicorn-access-log"


### PR DESCRIPTION
## Core Image Version Updates

| Image | Previous | New | Files |
|---|---|---|---|
| llm-d-cuda | v0.5.1 | v0.6.0 | `inference-scheduling/ms-inference-scheduling/values.yaml`, `values_gke.yaml`, `digitalocean-values.yaml`; `pd-disaggregation/ms-pd/values.yaml`, `values_ocp_rdma.yaml`, `values_gke_rdma.yaml`; `precise-prefix-cache-aware/ms-kv-events/values.yaml`, `values_pod_discovery.yaml`; `wide-ep-lws/manifests/modelserver/base/prefill.yaml`, `decode.yaml`; `workload-autoscaling/ms-workload-autoscaling/values.yaml`; `tiered-prefix-cache/cpu/manifests/vllm/lmcache-connector/kustomization.yaml` |
| llm-d-cpu | v0.5.1 | v0.6.0 | `inference-scheduling/ms-inference-scheduling/values_cpu.yaml` |
| llm-d-rocm | v0.5.1 | v0.6.0 | `inference-scheduling/ms-inference-scheduling/values_amd.yaml`; `pd-disaggregation/ms-pd/values_amd.yaml` |
| llm-d-xpu | v0.5.1 | v0.6.0 | `inference-scheduling/ms-inference-scheduling/values_xpu.yaml`; `pd-disaggregation/ms-pd/values_xpu.yaml`, `README.xpu.md`; `precise-prefix-cache-aware/ms-kv-events/values_xpu.yaml`, `values_xpu_pod_discovery.yaml` |
| llm-d-hpu | llm-d-hpu-dev:pr-965 | llm-d-hpu:v0.6.0 | `inference-scheduling/ms-inference-scheduling/values-hpu.yaml`; `pd-disaggregation/ms-pd/values_hpu.yaml` |

cc. @llm-d/release-crew 