### PR TITLE
docs: bump inference-scheduler image to v0.7.1

### DIFF
--- a/guides/precise-prefix-cache-aware/gaie-kv-events/values.yaml
+++ b/guides/precise-prefix-cache-aware/gaie-kv-events/values.yaml
@@ -7,7 +7,7 @@ inferenceExtension:
     ###################
     name: llm-d-inference-scheduler
     hub: ghcr.io/llm-d
-    tag: v0.7.0
+    tag: v0.7.1
     ###################
     # name: epp
     # hub: registry.k8s.io/gateway-api-inference-extension

--- a/guides/precise-prefix-cache-aware/gaie-kv-events/values_pod_discovery.yaml
+++ b/guides/precise-prefix-cache-aware/gaie-kv-events/values_pod_discovery.yaml
@@ -5,7 +5,7 @@ inferenceExtension:
   image:
     name: llm-d-inference-scheduler
     hub: ghcr.io/llm-d
-    tag: v0.7.0
+    tag: v0.7.1
     pullPolicy: Always
   extProcPort: 9002
   env:


### PR DESCRIPTION
## Summary
- Bump `llm-d-inference-scheduler` image tag from v0.7.0 to v0.7.1 in precise-prefix-cache-aware guide values

## Test plan
- [ ] Verify scheduler v0.7.1 image exists at `ghcr.io/llm-d/llm-d-inference-scheduler:v0.7.1`
- [ ] Dry-run helm template with updated values
