### PR TITLE
Last version bump before cutting `v0.6` release

### DIFF
--- a/guides/pd-disaggregation/ms-pd/values.yaml
+++ b/guides/pd-disaggregation/ms-pd/values.yaml
@@ -23,7 +23,7 @@ modelArtifacts:
 routing:
   servicePort: 8000
   proxy:
-    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.0
+    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
     connector: nixlv2
     secure: false
 

--- a/guides/pd-disaggregation/ms-pd/values_amd.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_amd.yaml
@@ -18,7 +18,7 @@ accelerator:
 routing:
   servicePort: 8000
   proxy:
-    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.0
+    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
     connector: nixlv2
     secure: false
 

--- a/guides/pd-disaggregation/ms-pd/values_gke_rdma.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_gke_rdma.yaml
@@ -23,7 +23,7 @@ modelArtifacts:
 routing:
   servicePort: 8000
   proxy:
-    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.0
+    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
     connector: nixlv2
     secure: false
 

--- a/guides/pd-disaggregation/ms-pd/values_hpu.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_hpu.yaml
@@ -28,7 +28,7 @@ modelArtifacts:
 routing:
   servicePort: 8000
   proxy:
-    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.0
+    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
     connector: nixlv2
     secure: false
 

--- a/guides/pd-disaggregation/ms-pd/values_ocp_rdma.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_ocp_rdma.yaml
@@ -17,7 +17,7 @@ modelArtifacts:
 routing:
   servicePort: 8000
   proxy:
-    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.0
+    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
     connector: nixlv2
     secure: false
 

--- a/guides/pd-disaggregation/ms-pd/values_sglang.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_sglang.yaml
@@ -15,7 +15,7 @@ modelArtifacts:
 routing:
   servicePort: 8000
   proxy:
-    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.6.0
+    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
     connector: sglang
     secure: false
 

--- a/guides/pd-disaggregation/ms-pd/values_tpu.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_tpu.yaml
@@ -27,7 +27,7 @@ modelArtifacts:
 routing:
   servicePort: 8000
   proxy:
-    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.0
+    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
     connector: nixlv2
     secure: false
 

--- a/guides/pd-disaggregation/ms-pd/values_xpu.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_xpu.yaml
@@ -31,7 +31,7 @@ modelArtifacts:
 routing:
   servicePort: 8000
   proxy:
-    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.0
+    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
     connector: nixlv2
     secure: false
 

--- a/guides/precise-prefix-cache-aware/gaie-kv-events/values.yaml
+++ b/guides/precise-prefix-cache-aware/gaie-kv-events/values.yaml
@@ -34,7 +34,7 @@ inferenceExtension:
           key: HF_TOKEN
   sidecar:
     enabled: true
-    image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.7.0
+    image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.7.1
     imagePullPolicy: IfNotPresent
     name: tokenizer-uds
     configMap:

--- a/guides/precise-prefix-cache-aware/gaie-kv-events/values_pod_discovery.yaml
+++ b/guides/precise-prefix-cache-aware/gaie-kv-events/values_pod_discovery.yaml
@@ -16,7 +16,7 @@ inferenceExtension:
           key: HF_TOKEN
   sidecar:
     enabled: true
-    image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.7.0
+    image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.7.1
     imagePullPolicy: IfNotPresent
     name: tokenizer-uds
     configMap:

--- a/guides/simulated-accelerators/ms-sim/values.yaml
+++ b/guides/simulated-accelerators/ms-sim/values.yaml
@@ -21,7 +21,7 @@ modelArtifacts:
 routing:
   servicePort: 8000
   proxy:
-    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.0
+    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
     connector: nixlv2
     secure: false
 
@@ -36,7 +36,7 @@ decode:
       interval: "30s"
   initContainers:
     - name: uds-tokenizer
-      image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.7.0
+      image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.7.1
       imagePullPolicy: IfNotPresent
       restartPolicy: Always
       env:
@@ -115,7 +115,7 @@ prefill:
       interval: "30s"
   initContainers:
     - name: uds-tokenizer
-      image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.7.0
+      image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.7.1
       imagePullPolicy: IfNotPresent
       restartPolicy: Always
       env:

--- a/guides/wide-ep-lws/experimental-dp-aware/manifests/modelserver/base/decode.yaml
+++ b/guides/wide-ep-lws/experimental-dp-aware/manifests/modelserver/base/decode.yaml
@@ -47,7 +47,7 @@ spec:
               #   value: "parentbased_traceidratio"
               # - name: OTEL_TRACES_SAMPLER_ARG
               #   value: "0.1"
-            image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.0
+            image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
             imagePullPolicy: Always
             ports:
               - containerPort: 8000

--- a/guides/wide-ep-lws/manifests/modelserver/base/decode.yaml
+++ b/guides/wide-ep-lws/manifests/modelserver/base/decode.yaml
@@ -33,7 +33,7 @@ spec:
               - --zap-log-level=1
               - --secure-proxy=false
               - --enable-prefiller-sampling
-            image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.0
+            image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
             imagePullPolicy: Always
             # To enable tracing, uncomment:
             # env:


### PR DESCRIPTION
Bump the versions of `llm-d-uds-tokenizer` and `llm-d-routing-sidecar` to `v0.7.1`.