### PR TITLE
release workflow fixes

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -850,7 +850,7 @@ jobs:
       - name: Checkout vLLM source
         uses: actions/checkout@v6
         with:
-          repository: ${{ steps.common-versions.outputs.repo }}
+          repository: vllm-project/vllm
           ref: ${{ steps.common-versions.outputs.commit_sha }}
           path: .cache/vllm-src
 
@@ -902,7 +902,6 @@ jobs:
           fi
 
   release-hpu-llm-d:
-
     strategy:
       fail-fast: false
     runs-on: vllm-runner
@@ -925,6 +924,7 @@ jobs:
         run: |
           export DEVICE=hpu
           export DOCKERFILE=Dockerfile.hpu
+          export BUILD_TYPE=prod
           export VERSION="${{ env.TAG }}"
           make image-build
           make image-push


### PR DESCRIPTION
Issue was that the HPU workflow was using makefile builds which default to the dev images without setting it to a production type build for release workflow.

Also while im here the checkout upgrade now expects a short repo name

cc @llm-d/release-crew 