### PR TITLE
fix concurrency group to sha not PR

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -55,7 +55,7 @@ env:
   IMAGE_NAME: llm-d
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.sha }}
 
 jobs:
   pre-commit:


### PR DESCRIPTION
Issue: race condition: GitHub may not have fully cleaned up the concurrency group from the cancelled run before the new one evaluated, causing the new one to see the group as occupied and get skipped.
Should resolve: https://llm-d.slack.com/archives/C08SDCKT9PV/p1775227812016989?thread_ts=1775192704.942389&cid=C08SDCKT9PV
cc @llm-d/release-crew 