### PR TITLE
Add Kustomization in pd-disaggregation guide

### DIFF
--- a/guides/pd-disaggregation/manifests/README.md
+++ b/guides/pd-disaggregation/manifests/README.md
@@ -1,0 +1,90 @@
+# Model Server and InferencePool Manifests
+
+This directory contains Kustomize manifests for deploying the Model Server (`ms-pd`) and Helm values files for deploying the `InferencePool` via the Gateway API Inference Extension (GAIE).
+
+These manifests serve as an alternative to the Helmfile-based deployment described in the main `guides/pd-disaggregation/README.md`, aligning with the pattern used in `guides/wide-ep-lws`.
+
+## Prerequisites
+
+Ensure you have created the namespace and set it as an environment variable:
+
+```bash
+export NAMESPACE=llm-d-pd # or your chosen namespace
+kubectl create namespace ${NAMESPACE}
+```
+
+Ensure you have created the `llm-d-hf-token` secret as described in the main README.
+
+## 1. Deploy Model Server (Kustomize)
+
+Navigate to the `guides/pd-disaggregation` directory:
+
+```bash
+cd guides/pd-disaggregation
+```
+
+Select the appropriate overlay for your hardware and apply it using `kubectl apply -k`:
+
+### GKE (Nvidia GPU)
+```bash
+kubectl apply -k ./manifests/modelserver/gke -n ${NAMESPACE}
+```
+
+### AMD GPU
+```bash
+kubectl apply -k ./manifests/modelserver/amd -n ${NAMESPACE}
+```
+
+### Cloud TPU
+```bash
+kubectl apply -k ./manifests/modelserver/tpu -n ${NAMESPACE}
+```
+
+### Intel HPU (Gaudi)
+```bash
+kubectl apply -k ./manifests/modelserver/hpu -n ${NAMESPACE}
+```
+
+### Intel XPU
+```bash
+kubectl apply -k ./manifests/modelserver/xpu -n ${NAMESPACE}
+```
+
+### SGLang (Nvidia GPU)
+```bash
+kubectl apply -k ./manifests/modelserver/sglang -n ${NAMESPACE}
+```
+
+### OpenShift (OCP)
+```bash
+kubectl apply -k ./manifests/modelserver/ocp -n ${NAMESPACE}
+```
+
+## 2. Deploy InferencePool (Helm)
+
+After deploying the model server, deploy the `InferencePool` using the Helm chart. This requires specifying the values file and the appropriate provider.
+
+### For vLLM (Default)
+
+```bash
+helm install llm-d-infpool \
+  -n ${NAMESPACE} \
+  -f ./manifests/inferencepool.values.yaml \
+  --set "provider.name=gke" \
+  oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool \
+  --version v1.4.0
+```
+
+### For SGLang
+
+```bash
+helm install llm-d-infpool \
+  -n ${NAMESPACE} \
+  -f ./manifests/inferencepool_sglang.values.yaml \
+  --set "provider.name=gke" \
+  oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool \
+  --version v1.4.0
+```
+
+> [!NOTE]
+> Change `--set "provider.name=gke"` to match your gateway provider (e.g., `istio`, `none`, etc.) as described in the main README under "Gateway options".

--- a/guides/pd-disaggregation/manifests/inferencepool.values.yaml
+++ b/guides/pd-disaggregation/manifests/inferencepool.values.yaml
@@ -1,0 +1,76 @@
+inferenceExtension:
+  replicas: 1
+  flags:
+  image:
+    name: llm-d-inference-scheduler
+    hub: ghcr.io/llm-d
+    tag: v0.7.0
+    pullPolicy: Always
+  extProcPort: 9002
+  pluginsConfigFile: "pd-config.yaml"
+  pluginsCustomConfig:  # THIS CONFIG NEEDS TO BE CHECKED FOR INF SCHEDULER NEW IMAGE
+    pd-config.yaml: |
+      # ALWAYS DO PD IN THIS EXAMPLE (THRESHOLD 0)
+      apiVersion: inference.networking.x-k8s.io/v1alpha1
+      kind: EndpointPickerConfig
+      featureGates:
+      - prepareDataPlugins
+      plugins:
+      - type: prefill-header-handler
+      - type: prefix-cache-scorer
+        parameters:
+          maxPrefixBlocksToMatch: 256
+          lruCapacityPerServer: 31250
+      - type: queue-scorer
+      - type: prefill-filter
+      - type: decode-filter
+      - type: max-score-picker
+      - type: prefix-based-pd-decider
+        parameters:
+          nonCachedTokens: 16
+      - type: pd-profile-handler
+        parameters:
+          primaryPort: 0
+          deciderPluginName: prefix-based-pd-decider
+      schedulingProfiles:
+      - name: prefill
+        plugins:
+        - pluginRef: prefill-filter
+        - pluginRef: max-score-picker
+        - pluginRef: prefix-cache-scorer
+          weight: 2
+        - pluginRef: queue-scorer
+          weight: 1
+      - name: decode
+        plugins:
+        - pluginRef: decode-filter
+        - pluginRef: max-score-picker
+        - pluginRef: prefix-cache-scorer
+          weight: 2
+        - pluginRef: queue-scorer
+          weight: 1
+      # All profiles using max score picker by default
+
+  # Distributed tracing configuration (OpenTelemetry)
+  tracing:
+    enabled: false
+    # otelExporterEndpoint: "http://otel-collector:4317"
+    # sampling:
+    #   sampler: "parentbased_traceidratio"
+    #   samplerArg: "0.1"
+  # Monitoring configuration for EPP
+  monitoring:
+    interval: "10s"
+    prometheus:
+      enabled: true
+      auth:
+        secretName: pd-gateway-sa-metrics-reader-secret
+
+inferencePool:
+  targetPorts:
+    - number: 8000
+  modelServerType: vllm
+  modelServers:
+    matchLabels:
+      llm-d.ai/inference-serving: "true"
+      llm-d.ai/guide: "pd-disaggregation"

--- a/guides/pd-disaggregation/manifests/inferencepool_sglang.values.yaml
+++ b/guides/pd-disaggregation/manifests/inferencepool_sglang.values.yaml
@@ -1,0 +1,78 @@
+inferenceExtension:
+  replicas: 1
+  image:
+    name: llm-d-inference-scheduler
+    hub: ghcr.io/llm-d
+    tag: v0.6.0
+    pullPolicy: Always
+  extProcPort: 9002
+  pluginsConfigFile: "pd-config.yaml"
+  pluginsCustomConfig: # THIS CONFIG NEEDS TO BE CHECKED FOR INF SCHEDULER NEW IMAGE
+    pd-config.yaml: |
+      # ALWAYS DO PD IN THIS EXAMPLE (THRESHOLD 0)
+      apiVersion: inference.networking.x-k8s.io/v1alpha1
+      kind: EndpointPickerConfig
+      featureGates:
+      - prepareDataPlugins
+      plugins:
+      - type: prefill-header-handler
+      - type: prefix-cache-scorer
+        parameters:
+          maxPrefixBlocksToMatch: 256
+          lruCapacityPerServer: 31250
+      - type: queue-scorer
+      - type: prefill-filter
+      - type: decode-filter
+      - type: max-score-picker
+      - type: always-disagg-pd-decider
+      - type: pd-profile-handler
+        parameters:
+          primaryPort: 0
+          deciderPluginName: always-disagg-pd-decider
+      schedulingProfiles:
+      - name: prefill
+        plugins:
+        - pluginRef: prefill-filter
+        - pluginRef: max-score-picker
+        - pluginRef: prefix-cache-scorer
+          weight: 2
+        - pluginRef: queue-scorer
+          weight: 1
+      - name: decode
+        plugins:
+        - pluginRef: decode-filter
+        - pluginRef: max-score-picker
+        - pluginRef: prefix-cache-scorer
+          weight: 2
+        - pluginRef: queue-scorer
+          weight: 1
+      # All profiles using max score picker by default
+  flags:
+    total-queued-requests-metric: "sglang:num_queue_reqs"
+    kv-cache-usage-percentage-metric: "sglang:token_usage"
+    lora-info-metric: "" # Set an empty metric to disable LoRA metric scraping as they are not supported by SGLang yet.
+    cache-info-metric: "" # Set an empty metric to disable CacheInfoMetrics metrics as not all vLLM used metrics has SGLang equivalents 
+
+  # Distributed tracing configuration (OpenTelemetry)
+  tracing:
+    enabled: false
+    # otelExporterEndpoint: "http://otel-collector:4317"
+    # sampling:
+    #   sampler: "parentbased_traceidratio"
+    #   samplerArg: "0.1"
+  # Monitoring configuration for EPP
+  monitoring:
+    interval: "10s"
+    prometheus:
+      enabled: true
+      auth:
+        secretName: pd-gateway-sa-metrics-reader-secret
+
+inferencePool:
+  targetPorts:
+    - number: 8000
+  modelServerType: sglang
+  modelServers:
+    matchLabels:
+      llm-d.ai/inference-serving: "true"
+      llm-d.ai/guide: "pd-disaggregation"

--- a/guides/pd-disaggregation/manifests/modelserver/amd/kustomization.yaml
+++ b/guides/pd-disaggregation/manifests/modelserver/amd/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+  - ../common/podmonitors
+
+patches:
+  - path: patch-amd.yaml

--- a/guides/pd-disaggregation/manifests/modelserver/amd/patch-amd.yaml
+++ b/guides/pd-disaggregation/manifests/modelserver/amd/patch-amd.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ms-pd-llm-d-modelservice-decode
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/accelerator-vendor: amd
+      llm-d.ai/model: Llama-3.3-70B-Instruct-FP8-KV
+  template:
+    metadata:
+      labels:
+        llm-d.ai/accelerator-vendor: amd
+        llm-d.ai/model: Llama-3.3-70B-Instruct-FP8-KV
+    spec:
+      containers:
+        - name: vllm
+          image: ghcr.io/llm-d/llm-d-rocm:v0.6.0
+          args:
+            - amd/Llama-3.3-70B-Instruct-FP8-KV
+            - --port
+            - "8200"
+            - --tensor-parallel-size
+            - "4"
+            - --served-model-name
+            - "amd/Llama-3.3-70B-Instruct-FP8-KV"
+            - --block-size
+            - "128"
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+            - --disable-uvicorn-access-log
+            - --attention-backend
+            - ROCM_ATTN
+            - --max-model-len
+            - "32000"
+          resources:
+            limits:
+              memory: 256Gi
+            requests:
+              memory: 256Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ms-pd-llm-d-modelservice-prefill
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/accelerator-vendor: amd
+      llm-d.ai/model: Llama-3.3-70B-Instruct-FP8-KV
+  template:
+    metadata:
+      labels:
+        llm-d.ai/accelerator-vendor: amd
+        llm-d.ai/model: Llama-3.3-70B-Instruct-FP8-KV
+    spec:
+      containers:
+        - name: vllm
+          image: ghcr.io/llm-d/llm-d-rocm:v0.6.0
+          args:
+            - amd/Llama-3.3-70B-Instruct-FP8-KV
+            - --port
+            - "8000"
+            - --served-model-name
+            - "amd/Llama-3.3-70B-Instruct-FP8-KV"
+            - --block-size
+            - "128"
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+            - --disable-uvicorn-access-log
+            - --attention-backend
+            - ROCM_ATTN
+            - --max-model-len
+            - "32000"
+          resources:
+            limits:
+              memory: 256Gi
+            requests:
+              memory: 256Gi
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ms-pd-llm-d-modelservice-decode-podmonitor
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/accelerator-vendor: amd
+      llm-d.ai/model: Llama-3.3-70B-Instruct-FP8-KV
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ms-pd-llm-d-modelservice-prefill-podmonitor
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/accelerator-vendor: amd
+      llm-d.ai/model: Llama-3.3-70B-Instruct-FP8-KV

--- a/guides/pd-disaggregation/manifests/modelserver/base/decode.yaml
+++ b/guides/pd-disaggregation/manifests/modelserver/base/decode.yaml
@@ -1,0 +1,144 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ms-pd-llm-d-modelservice-decode
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      llm-d.ai/accelerator-vendor: nvidia
+      llm-d.ai/guide: pd-disaggregation
+      llm-d.ai/hardware-variant: gpu
+      llm-d.ai/inference-serving: "true"
+      llm-d.ai/model: gpt-oss-120b
+      llm-d.ai/role: decode
+  template:
+    metadata:
+      labels:
+        llm-d.ai/accelerator-vendor: nvidia
+        llm-d.ai/guide: pd-disaggregation
+        llm-d.ai/hardware-variant: gpu
+        llm-d.ai/inference-serving: "true"
+        llm-d.ai/model: gpt-oss-120b
+        llm-d.ai/role: decode
+    spec:
+      initContainers:
+        - name: routing-proxy
+          args:
+            - --port=8000
+            - --vllm-port=8200
+            - --connector=nixlv2
+            - --zap-encoder=json
+            - --zap-log-level=debug
+            - --secure-proxy=false
+          image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8000
+          resources: {}
+          restartPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+    
+      serviceAccountName: ms-pd-llm-d-modelservice
+      
+      volumes:
+        - emptyDir: {}
+          name: metrics-volume
+        - emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi
+          name: shm
+        - emptyDir: {}
+          name: torch-compile-cache
+        - name: model-storage
+          emptyDir:
+            sizeLimit: 250Gi
+        
+      containers:
+        - name: vllm
+          image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+          command: ["vllm", "serve"]
+          args:
+            - openai/gpt-oss-120b
+            - --port
+            - "8200"
+            - --tensor-parallel-size
+            - "4"
+            - --served-model-name
+            - "openai/gpt-oss-120b"
+            - --block-size
+            - "128"
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+            - --disable-uvicorn-access-log
+            - --max-model-len
+            - "32000"
+          env:
+          - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: DP_SIZE
+            value: "1"
+          - name: TP_SIZE
+            value: "4"
+          - name: DP_SIZE_LOCAL
+            value: "1"
+          - name: HF_HOME
+            value: /model-cache
+          - name: HF_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: llm-d-hf-token
+                key: HF_TOKEN
+          ports:
+          - containerPort: 8200
+            name: vllm
+            protocol: TCP
+          - containerPort: 5600
+            name: nixl
+            protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health
+              port: vllm
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /v1/models
+              port: vllm
+            periodSeconds: 5
+            timeoutSeconds: 2
+          startupProbe:
+            failureThreshold: 60
+            httpGet:
+              path: /v1/models
+              port: vllm
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: "16"
+              memory: 64Gi
+              nvidia.com/gpu: "4"
+              rdma/ib: 1
+            requests:
+              cpu: "16"
+              memory: 64Gi
+              nvidia.com/gpu: "4"
+              rdma/ib: 1
+          volumeMounts:
+            - mountPath: /.config
+              name: metrics-volume
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /.cache
+              name: torch-compile-cache
+            - name: model-storage
+              mountPath: /model-cache

--- a/guides/pd-disaggregation/manifests/modelserver/base/kustomization.yaml
+++ b/guides/pd-disaggregation/manifests/modelserver/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - serviceAccount.yaml
+  - decode.yaml
+  - prefill.yaml

--- a/guides/pd-disaggregation/manifests/modelserver/base/podMonitors.yaml
+++ b/guides/pd-disaggregation/manifests/modelserver/base/podMonitors.yaml
@@ -1,0 +1,35 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ms-pd-llm-d-modelservice-decode-podmonitor
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/accelerator-vendor: nvidia
+      llm-d.ai/guide: pd-disaggregation
+      llm-d.ai/hardware-variant: gpu
+      llm-d.ai/inference-serving: "true"
+      llm-d.ai/model: gpt-oss-120b
+      llm-d.ai/role: decode
+  podMetricsEndpoints:
+  - port: "vllm"
+    path: /metrics
+    interval: 30s
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ms-pd-llm-d-modelservice-prefill-podmonitor
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/accelerator-vendor: nvidia
+      llm-d.ai/guide: pd-disaggregation
+      llm-d.ai/hardware-variant: gpu
+      llm-d.ai/inference-serving: "true"
+      llm-d.ai/model: gpt-oss-120b
+      llm-d.ai/role: prefill
+  podMetricsEndpoints:
+  - port: "vllm"
+    path: /metrics
+    interval: 30s

--- a/guides/pd-disaggregation/manifests/modelserver/base/prefill.yaml
+++ b/guides/pd-disaggregation/manifests/modelserver/base/prefill.yaml
@@ -1,0 +1,121 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ms-pd-llm-d-modelservice-prefill
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      llm-d.ai/accelerator-vendor: nvidia
+      llm-d.ai/guide: pd-disaggregation
+      llm-d.ai/hardware-variant: gpu
+      llm-d.ai/inference-serving: "true"
+      llm-d.ai/model: gpt-oss-120b
+      llm-d.ai/role: prefill
+  template:
+    metadata:
+      labels:
+        llm-d.ai/accelerator-vendor: nvidia
+        llm-d.ai/guide: pd-disaggregation
+        llm-d.ai/hardware-variant: gpu
+        llm-d.ai/inference-serving: "true"
+        llm-d.ai/model: gpt-oss-120b
+        llm-d.ai/role: prefill
+    spec:
+      serviceAccountName: ms-pd-llm-d-modelservice
+      volumes:
+        - emptyDir: {}
+          name: metrics-volume
+        - emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi
+          name: shm
+        - emptyDir: {}
+          name: torch-compile-cache
+        - name: model-storage
+          emptyDir:
+            sizeLimit: 250Gi
+      containers:
+        - name: vllm
+          image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+          command: ["vllm", "serve"]
+          args:
+            - openai/gpt-oss-120b
+            - --port
+            - "8000"
+            - --served-model-name
+            - "openai/gpt-oss-120b"
+            - --block-size
+            - "128"
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+            - --disable-uvicorn-access-log
+            - --max-model-len
+            - "32000"
+          env:
+          - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: DP_SIZE
+            value: "1"
+          - name: TP_SIZE
+            value: "1"
+          - name: DP_SIZE_LOCAL
+            value: "1"
+          - name: HF_HOME
+            value: /model-cache
+          - name: HF_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: llm-d-hf-token
+                key: HF_TOKEN
+          ports:
+          - containerPort: 8000
+            name: vllm
+            protocol: TCP
+          - containerPort: 5600
+            name: nixl
+            protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health
+              port: vllm
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /v1/models
+              port: vllm
+            periodSeconds: 5
+            timeoutSeconds: 2
+          startupProbe:
+            failureThreshold: 60
+            httpGet:
+              path: /v1/models
+              port: vllm
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: "8"
+              memory: 64Gi
+              nvidia.com/gpu: "1"
+              rdma/ib: 1
+            requests:
+              cpu: "8"
+              memory: 64Gi
+              nvidia.com/gpu: "1"
+              rdma/ib: 1
+          volumeMounts:
+            - mountPath: /.config
+              name: metrics-volume
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /.cache
+              name: torch-compile-cache
+            - name: model-storage
+              mountPath: /model-cache

--- a/guides/pd-disaggregation/manifests/modelserver/base/serviceAccount.yaml
+++ b/guides/pd-disaggregation/manifests/modelserver/base/serviceAccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ms-pd-llm-d-modelservice

--- a/guides/pd-disaggregation/manifests/modelserver/common/podmonitors/kustomization.yaml
+++ b/guides/pd-disaggregation/manifests/modelserver/common/podmonitors/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - podMonitors.yaml

--- a/guides/pd-disaggregation/manifests/modelserver/common/podmonitors/podMonitors.yaml
+++ b/guides/pd-disaggregation/manifests/modelserver/common/podmonitors/podMonitors.yaml
@@ -1,0 +1,35 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ms-pd-llm-d-modelservice-decode-podmonitor
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/accelerator-vendor: nvidia
+      llm-d.ai/guide: pd-disaggregation
+      llm-d.ai/hardware-variant: gpu
+      llm-d.ai/inference-serving: "true"
+      llm-d.ai/model: gpt-oss-120b
+      llm-d.ai/role: decode
+  podMetricsEndpoints:
+  - port: "vllm"
+    path: /metrics
+    interval: 30s
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ms-pd-llm-d-modelservice-prefill-podmonitor
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/accelerator-vendor: nvidia
+      llm-d.ai/guide: pd-disaggregation
+      llm-d.ai/hardware-variant: gpu
+      llm-d.ai/inference-serving: "true"
+      llm-d.ai/model: gpt-oss-120b
+      llm-d.ai/role: prefill
+  podMetricsEndpoints:
+  - port: "vllm"
+    path: /metrics
+    interval: 30s

--- a/guides/pd-disaggregation/manifests/modelserver/gke-common/kustomization.yaml
+++ b/guides/pd-disaggregation/manifests/modelserver/gke-common/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+
+patches:
+  - target:
+      kind: Deployment
+      name: ms-pd-llm-d-modelservice-decode
+    patch: |-
+      [
+        {"op": "remove", "path": "/spec/template/spec/containers/0/resources/limits/rdma~1ib"},
+        {"op": "remove", "path": "/spec/template/spec/containers/0/resources/requests/rdma~1ib"}
+      ]
+  - target:
+      kind: Deployment
+      name: ms-pd-llm-d-modelservice-prefill
+    patch: |-
+      [
+        {"op": "remove", "path": "/spec/template/spec/containers/0/resources/limits/rdma~1ib"},
+        {"op": "remove", "path": "/spec/template/spec/containers/0/resources/requests/rdma~1ib"}
+      ]

--- a/guides/pd-disaggregation/manifests/modelserver/gke/kustomization.yaml
+++ b/guides/pd-disaggregation/manifests/modelserver/gke/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../gke-common

--- a/guides/pd-disaggregation/manifests/modelserver/hpu/kustomization.yaml
+++ b/guides/pd-disaggregation/manifests/modelserver/hpu/kustomization.yaml
@@ -1,0 +1,33 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+  - ../common/podmonitors
+
+patches:
+  - path: patch-hpu.yaml
+  - target:
+      kind: Deployment
+      name: ms-pd-llm-d-modelservice-decode
+    patch: |-
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/limits/nvidia.com~1gpu
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/requests/nvidia.com~1gpu
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/limits/rdma~1ib
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/requests/rdma~1ib
+  - target:
+      kind: Deployment
+      name: ms-pd-llm-d-modelservice-prefill
+    patch: |-
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/limits/nvidia.com~1gpu
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/requests/nvidia.com~1gpu
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/limits/rdma~1ib
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/requests/rdma~1ib

--- a/guides/pd-disaggregation/manifests/modelserver/hpu/patch-hpu.yaml
+++ b/guides/pd-disaggregation/manifests/modelserver/hpu/patch-hpu.yaml
@@ -1,0 +1,133 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ms-pd-llm-d-modelservice-decode
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/hardware-variant: hpu
+      llm-d.ai/hardware-vendor: intel
+      llm-d.ai/model: Qwen3-8B
+  template:
+    metadata:
+      labels:
+        llm-d.ai/hardware-variant: hpu
+        llm-d.ai/hardware-vendor: intel
+        llm-d.ai/model: Qwen3-8B
+    spec:
+      containers:
+        - name: vllm
+          image: ghcr.io/llm-d/llm-d-hpu:v0.6.0
+          securityContext:
+            privileged: true
+          args:
+            - "--enforce-eager"
+            - "--gpu-memory-utilization"
+            - "0.9"
+            - "--kv-transfer-config"
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"cpu"}'
+          env:
+            - name: OMPI_MCA_btl_vader_single_copy_mechanism
+              value: "none"
+            - name: HABANA_LOGS
+              value: "/tmp/habana_logs"
+            - name: UCX_TLS
+              value: "tcp"
+            - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+              value: "5600"
+            - name: VLLM_LOGGING_LEVEL
+              value: "DEBUG"
+            - name: VLLM_SKIP_WARMUP
+              value: "true"
+            - name: PT_HPU_LAZY_MODE
+              value: "1"
+            - name: PT_HPU_ENABLE_LAZY_COLLECTIVES
+              value: "true"
+            - name: LD_LIBRARY_PATH
+              value: "/usr/lib/nixl_ofi:/usr/local/lib:/usr/lib:/opt/amazon/openmpi/lib:/usr/lib/habanalabs"
+            - name: DO_NOT_TRACK
+              value: "1"
+            - name: VLLM_USE_V1
+              value: "1"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ms-pd-llm-d-modelservice-prefill
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/hardware-variant: hpu
+      llm-d.ai/hardware-vendor: intel
+      llm-d.ai/model: Qwen3-8B
+  template:
+    metadata:
+      labels:
+        llm-d.ai/hardware-variant: hpu
+        llm-d.ai/hardware-vendor: intel
+        llm-d.ai/model: Qwen3-8B
+    spec:
+      containers:
+        - name: vllm
+          image: ghcr.io/llm-d/llm-d-hpu:v0.6.0
+          securityContext:
+            privileged: true
+          args:
+            - "--enforce-eager"
+            - "--gpu-memory-utilization"
+            - "0.9"
+            - "--kv-transfer-config"
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"cpu"}'
+          env:
+            - name: OMPI_MCA_btl_vader_single_copy_mechanism
+              value: "none"
+            - name: HABANA_LOGS
+              value: "/tmp/habana_logs"
+            - name: UCX_TLS
+              value: "tcp"
+            - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+              value: "5600"
+            - name: VLLM_LOGGING_LEVEL
+              value: "DEBUG"
+            - name: VLLM_SKIP_WARMUP
+              value: "true"
+            - name: PT_HPU_LAZY_MODE
+              value: "1"
+            - name: PT_HPU_ENABLE_LAZY_COLLECTIVES
+              value: "true"
+            - name: LD_LIBRARY_PATH
+              value: "/usr/lib/nixl_ofi:/usr/local/lib:/usr/lib:/opt/amazon/openmpi/lib:/usr/lib/habanalabs"
+            - name: DO_NOT_TRACK
+              value: "1"
+            - name: VLLM_USE_V1
+              value: "1"
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ms-pd-llm-d-modelservice-decode-podmonitor
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/hardware-variant: hpu
+      llm-d.ai/hardware-vendor: intel
+      llm-d.ai/model: Qwen3-8B
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ms-pd-llm-d-modelservice-prefill-podmonitor
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/hardware-variant: hpu
+      llm-d.ai/hardware-vendor: intel
+      llm-d.ai/model: Qwen3-8B

--- a/guides/pd-disaggregation/manifests/modelserver/ocp/kustomization.yaml
+++ b/guides/pd-disaggregation/manifests/modelserver/ocp/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+
+patches:
+  - path: patch-ocp.yaml
+  - target:
+      kind: Deployment
+      name: ms-pd-llm-d-modelservice-decode
+    patch: |-
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/limits/rdma~1ib
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/requests/rdma~1ib
+  - target:
+      kind: Deployment
+      name: ms-pd-llm-d-modelservice-prefill
+    patch: |-
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/limits/rdma~1ib
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/requests/rdma~1ib

--- a/guides/pd-disaggregation/manifests/modelserver/ocp/patch-ocp.yaml
+++ b/guides/pd-disaggregation/manifests/modelserver/ocp/patch-ocp.yaml
@@ -1,0 +1,192 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ms-pd-llm-d-modelservice-decode
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/model: Qwen3-32B
+  template:
+    metadata:
+      labels:
+        llm-d.ai/model: Qwen3-32B
+      annotations:
+        k8s.v1.cni.cncf.io/networks: "multi-nic-compute"
+    spec:
+      serviceAccountName: default
+      initContainers:
+        - name: preprocess
+          image: ghcr.io/llm-d/llm-d-benchmark:v0.5.2
+          imagePullPolicy: Always
+          command: ["set_llmdbench_environment.py", "-e", "/shared-config/llmdbench_env.sh", "-i"]
+          env:
+            - name: NCCL_EXCLUDE_IB_HCA
+              value: "mlx5_0,mlx5_2,mlx5_4,mlx5_8,mlx5_7,mlx5_10,mlx5_12,mlx5_14,mlx5_16"
+          volumeMounts:
+          - name: shared-config
+            mountPath: /shared-config
+      containers:
+        - name: vllm
+          image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - |
+              source /shared-config/llmdbench_env.sh; vllm serve Qwen/Qwen3-32B \
+              --host 0.0.0.0 \
+              --served-model-name Qwen/Qwen3-32B \
+              --port $VLLM_METRICS_PORT \
+              --block-size $VLLM_BLOCK_SIZE \
+              --max-model-len $VLLM_MAX_MODEL_LEN \
+              --tensor-parallel-size $TP_SIZE \
+              --kv-transfer-config "{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}" \
+              --no-enable-log-requests \
+              --disable-uvicorn-access-log
+          env:
+            - name: NCCL_EXCLUDE_IB_HCA
+              value: "mlx5_0,mlx5_2,mlx5_4,mlx5_8,mlx5_7,mlx5_10,mlx5_12,mlx5_14,mlx5_16"
+            - name: VLLM_BLOCK_SIZE
+              value: "128"
+            - name: VLLM_MAX_MODEL_LEN
+              value: "32000"
+            - name: VLLM_INFERENCE_PORT
+              value: "8000"
+            - name: VLLM_METRICS_PORT
+              value: "8200"
+            - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+              value: "5557"
+            - name: UCX_TLS
+              value: "sm,cuda_ipc,cuda_copy,tcp"
+            - name: UCX_SOCKADDR_TLS_PRIORITY
+              value: "tcp"
+            - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+          resources:
+            limits:
+              cpu: "32"
+              memory: 128Gi
+              rdma/roce_gdr: "2"
+            requests:
+              cpu: "32"
+              memory: 128Gi
+              rdma/roce_gdr: "2"
+          securityContext:
+            capabilities:
+              add:
+              - "IPC_LOCK"
+              - "SYS_RAWIO"
+              - "NET_ADMIN"
+              - "NET_RAW"
+            runAsGroup: 0
+            runAsUser: 0
+          volumeMounts:
+            - name: shared-config
+              mountPath: /shared-config
+      volumes:
+        - name: shared-config
+          emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ms-pd-llm-d-modelservice-prefill
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/model: Qwen3-32B
+  template:
+    metadata:
+      labels:
+        llm-d.ai/model: Qwen3-32B
+      annotations:
+        k8s.v1.cni.cncf.io/networks: "multi-nic-compute"
+    spec:
+      serviceAccountName: default
+      initContainers:
+        - name: preprocess
+          image: ghcr.io/llm-d/llm-d-benchmark:v0.5.2
+          imagePullPolicy: Always
+          command: ["set_llmdbench_environment.py", "-e", "/shared-config/llmdbench_env.sh", "-i"]
+          env:
+            - name: NCCL_EXCLUDE_IB_HCA
+              value: "mlx5_0,mlx5_2,mlx5_4,mlx5_8,mlx5_7,mlx5_10,mlx5_12,mlx5_14,mlx5_16"
+          volumeMounts:
+          - name: shared-config
+            mountPath: /shared-config
+      containers:
+        - name: vllm
+          image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - |
+              source /shared-config/llmdbench_env.sh; vllm serve Qwen/Qwen3-32B \
+              --host 0.0.0.0 \
+              --served-model-name Qwen/Qwen3-32B \
+              --port $VLLM_INFERENCE_PORT \
+              --block-size $VLLM_BLOCK_SIZE \
+              --max-model-len $VLLM_MAX_MODEL_LEN \
+              --tensor-parallel-size $TP_SIZE \
+              --kv-transfer-config "{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}" \
+              --no-enable-log-requests \
+              --disable-uvicorn-access-log \
+              --no-enable-prefix-caching
+          env:
+            - name: NCCL_EXCLUDE_IB_HCA
+              value: "mlx5_0,mlx5_2,mlx5_4,mlx5_8,mlx5_7,mlx5_10,mlx5_12,mlx5_14,mlx5_16"
+            - name: VLLM_BLOCK_SIZE
+              value: "128"
+            - name: VLLM_MAX_MODEL_LEN
+              value: "32000"
+            - name: VLLM_INFERENCE_PORT
+              value: "8000"
+            - name: VLLM_METRICS_PORT
+              value: "8200"
+            - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+              value: "5557"
+            - name: UCX_TLS
+              value: "sm,cuda_ipc,cuda_copy,tcp"
+            - name: UCX_SOCKADDR_TLS_PRIORITY
+              value: "tcp"
+            - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+          resources:
+            limits:
+              cpu: "32"
+              memory: 128Gi
+              rdma/roce_gdr: "2"
+            requests:
+              cpu: "32"
+              memory: 128Gi
+              rdma/roce_gdr: "2"
+          securityContext:
+            capabilities:
+              add:
+              - "IPC_LOCK"
+              - "SYS_RAWIO"
+              - "NET_ADMIN"
+              - "NET_RAW"
+            runAsGroup: 0
+            runAsUser: 0
+          volumeMounts:
+            - name: shared-config
+              mountPath: /shared-config
+      volumes:
+        - name: shared-config
+          emptyDir: {}

--- a/guides/pd-disaggregation/manifests/modelserver/sglang/kustomization.yaml
+++ b/guides/pd-disaggregation/manifests/modelserver/sglang/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+  - ../common/podmonitors
+
+patches:
+  - path: patch-sglang.yaml

--- a/guides/pd-disaggregation/manifests/modelserver/sglang/patch-sglang.yaml
+++ b/guides/pd-disaggregation/manifests/modelserver/sglang/patch-sglang.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ms-pd-llm-d-modelservice-decode
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/model: Qwen3-14B
+  template:
+    metadata:
+      labels:
+        llm-d.ai/model: Qwen3-14B
+    spec:
+      containers:
+        - name: vllm
+          image: docker.io/lmsysorg/sglang:v0.5.6.post2
+          command: ["python3", "-m", "sglang.launch_server"]
+          args:
+            - "--model-path"
+            - "Qwen/Qwen3-14B"
+            - "--port"
+            - "8200"
+            - "--host"
+            - "0.0.0.0"
+            - "--disaggregation-mode"
+            - "decode"
+            - "--disaggregation-transfer-backend"
+            - "nixl"
+            - "--tensor-parallel-size"
+            - "4"
+            - "--log-level"
+            - "debug"
+            - "--enable-metrics"
+            - "--log-requests"
+            - "--context-length"
+            - "32000"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ms-pd-llm-d-modelservice-prefill
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/model: Qwen3-14B
+  template:
+    metadata:
+      labels:
+        llm-d.ai/model: Qwen3-14B
+    spec:
+      containers:
+        - name: vllm
+          image: docker.io/lmsysorg/sglang:v0.5.6.post2
+          command: ["python3", "-m", "sglang.launch_server"]
+          args:
+            - "--model-path"
+            - "Qwen/Qwen3-14B"
+            - "--port"
+            - "8000"
+            - "--host"
+            - "0.0.0.0"
+            - "--disaggregation-mode"
+            - "prefill"
+            - "--disaggregation-transfer-backend"
+            - "nixl"
+            - "--tensor-parallel-size"
+            - "1"
+            - "--log-level"
+            - "debug"
+            - "--enable-metrics"
+            - "--log-requests"
+            - "--context-length"
+            - "32000"
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ms-pd-llm-d-modelservice-decode-podmonitor
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/model: Qwen3-14B
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ms-pd-llm-d-modelservice-prefill-podmonitor
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/model: Qwen3-14B

--- a/guides/pd-disaggregation/manifests/modelserver/tpu/kustomization.yaml
+++ b/guides/pd-disaggregation/manifests/modelserver/tpu/kustomization.yaml
@@ -1,0 +1,57 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+  - ../common/podmonitors
+
+patches:
+  - path: patch-tpu.yaml
+  - target:
+      kind: Deployment
+      name: ms-pd-llm-d-modelservice-decode
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/ports
+        value:
+          - containerPort: 8000
+            name: vllm
+            protocol: TCP
+          - containerPort: 9100
+            name: tpu-kv-transfer
+            protocol: TCP
+          - containerPort: 9600
+            name: tpu-pd-coord
+            protocol: TCP
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/limits/nvidia.com~1gpu
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/requests/nvidia.com~1gpu
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/limits/rdma~1ib
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/requests/rdma~1ib
+  - target:
+      kind: Deployment
+      name: ms-pd-llm-d-modelservice-prefill
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/ports
+        value:
+          - containerPort: 8000
+            name: vllm
+            protocol: TCP
+          - containerPort: 9100
+            name: tpu-kv-transfer
+            protocol: TCP
+          - containerPort: 9600
+            name: tpu-pd-coord
+            protocol: TCP
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/limits/nvidia.com~1gpu
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/requests/nvidia.com~1gpu
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/limits/rdma~1ib
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/requests/rdma~1ib

--- a/guides/pd-disaggregation/manifests/modelserver/tpu/patch-tpu.yaml
+++ b/guides/pd-disaggregation/manifests/modelserver/tpu/patch-tpu.yaml
@@ -1,0 +1,123 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ms-pd-llm-d-modelservice-decode
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/hardware-variant: tpu
+      llm-d.ai/hardware-vendor: google
+      llm-d.ai/model: Llama-3.3-70B-Instruct
+  template:
+    metadata:
+      labels:
+        llm-d.ai/hardware-variant: tpu
+        llm-d.ai/hardware-vendor: google
+        llm-d.ai/model: Llama-3.3-70B-Instruct
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-tpu-topology: "2x4"
+        cloud.google.com/gke-tpu-accelerator: "tpu-v6e-slice"
+      containers:
+        - name: vllm
+          image: vllm/vllm-tpu:v0.13.2-ironwood
+          args:
+            - "--tensor-parallel-size"
+            - "8"
+            - "--kv-transfer-config"
+            - '{"kv_connector":"TPUConnector", "kv_connector_module_path" : "tpu_inference.distributed.tpu_connector", "kv_role":"kv_both", "kv_ip" : "$(POD_IP)"}'
+            - "--disable-uvicorn-access-log"
+            - "--max-model-len"
+            - "32000"
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: TPU_SIDE_CHANNEL_PORT
+              value: "9600"
+            - name: TPU_KV_TRANSFER_PORT
+              value: "9100"
+          ports:
+            - containerPort: 8000
+              name: vllm
+              protocol: TCP
+            - containerPort: 9100
+              name: tpu-kv-transfer
+              protocol: TCP
+            - containerPort: 9600
+              name: tpu-pd-coord
+              protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ms-pd-llm-d-modelservice-prefill
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/hardware-variant: tpu
+      llm-d.ai/hardware-vendor: google
+      llm-d.ai/model: Llama-3.3-70B-Instruct
+  template:
+    metadata:
+      labels:
+        llm-d.ai/hardware-variant: tpu
+        llm-d.ai/hardware-vendor: google
+        llm-d.ai/model: Llama-3.3-70B-Instruct
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-tpu-topology: "2x4"
+        cloud.google.com/gke-tpu-accelerator: "tpu-v6e-slice"
+      containers:
+        - name: vllm
+          image: vllm/vllm-tpu:v0.13.2
+          args:
+            - "--tensor-parallel-size"
+            - "8"
+            - "--kv-transfer-config"
+            - '{"kv_connector":"TPUConnector", "kv_connector_module_path" : "tpu_inference.distributed.tpu_connector", "kv_role":"kv_producer", "kv_ip" : "$(POD_IP)"}'
+            - "--disable-uvicorn-access-log"
+            - "--max-model-len"
+            - "32000"
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: TPU_SIDE_CHANNEL_PORT
+              value: "9600"
+            - name: TPU_KV_TRANSFER_PORT
+              value: "9100"
+          ports:
+            - containerPort: 8000
+              name: vllm
+              protocol: TCP
+            - containerPort: 9100
+              name: tpu-kv-transfer
+              protocol: TCP
+            - containerPort: 9600
+              name: tpu-pd-coord
+              protocol: TCP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ms-pd-llm-d-modelservice-decode-podmonitor
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/hardware-variant: tpu
+      llm-d.ai/hardware-vendor: google
+      llm-d.ai/model: Llama-3.3-70B-Instruct
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ms-pd-llm-d-modelservice-prefill-podmonitor
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/hardware-variant: tpu
+      llm-d.ai/hardware-vendor: google
+      llm-d.ai/model: Llama-3.3-70B-Instruct

--- a/guides/pd-disaggregation/manifests/modelserver/xpu/kustomization.yaml
+++ b/guides/pd-disaggregation/manifests/modelserver/xpu/kustomization.yaml
@@ -1,0 +1,33 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+  - ../common/podmonitors
+
+patches:
+  - path: patch-xpu.yaml
+  - target:
+      kind: Deployment
+      name: ms-pd-llm-d-modelservice-decode
+    patch: |-
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/limits/nvidia.com~1gpu
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/requests/nvidia.com~1gpu
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/limits/rdma~1ib
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/requests/rdma~1ib
+  - target:
+      kind: Deployment
+      name: ms-pd-llm-d-modelservice-prefill
+    patch: |-
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/limits/nvidia.com~1gpu
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/requests/nvidia.com~1gpu
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/limits/rdma~1ib
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/requests/rdma~1ib

--- a/guides/pd-disaggregation/manifests/modelserver/xpu/patch-xpu.yaml
+++ b/guides/pd-disaggregation/manifests/modelserver/xpu/patch-xpu.yaml
@@ -1,0 +1,117 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ms-pd-llm-d-modelservice-decode
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/hardware-variant: xpu
+      llm-d.ai/hardware-vendor: intel
+      llm-d.ai/model: Qwen3-0.6B
+  template:
+    metadata:
+      labels:
+        llm-d.ai/hardware-variant: xpu
+        llm-d.ai/hardware-vendor: intel
+        llm-d.ai/model: Qwen3-0.6B
+    spec:
+      securityContext:
+        fsGroup: 107
+        supplementalGroups:
+          - 107
+      containers:
+        - name: vllm
+          image: ghcr.io/llm-d/llm-d-xpu:v0.6.0
+          args:
+            - "--block-size"
+            - "64"
+            - "--kv-transfer-config"
+            - '{"kv_connector":"NixlConnector", "kv_role":"kv_both", "kv_buffer_device":"cpu"}'
+            - "--disable-uvicorn-access-log"
+            - "--max-model-len"
+            - "32000"
+          env:
+            - name: UCX_TLS
+              value: "tcp"
+            - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+              value: "5600"
+            - name: VLLM_USE_V1
+              value: "1"
+            - name: TORCH_LLM_ALLREDUCE
+              value: "1"
+            - name: VLLM_WORKER_MULTIPROC_METHOD
+              value: "spawn"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ms-pd-llm-d-modelservice-prefill
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/hardware-variant: xpu
+      llm-d.ai/hardware-vendor: intel
+      llm-d.ai/model: Qwen3-0.6B
+  template:
+    metadata:
+      labels:
+        llm-d.ai/hardware-variant: xpu
+        llm-d.ai/hardware-vendor: intel
+        llm-d.ai/model: Qwen3-0.6B
+    spec:
+      securityContext:
+        fsGroup: 107
+        supplementalGroups:
+          - 107
+      containers:
+        - name: vllm
+          image: ghcr.io/llm-d/llm-d-xpu:v0.6.0
+          args:
+            - "--block-size"
+            - "64"
+            - "--kv-transfer-config"
+            - '{"kv_connector":"NixlConnector", "kv_role":"kv_both", "kv_buffer_device":"cpu"}'
+            - "--disable-uvicorn-access-log"
+            - "--max-model-len"
+            - "32000"
+          env:
+            - name: UCX_TLS
+              value: "tcp"
+            - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+              value: "5600"
+            - name: VLLM_USE_V1
+              value: "1"
+            - name: TORCH_LLM_ALLREDUCE
+              value: "1"
+            - name: VLLM_WORKER_MULTIPROC_METHOD
+              value: "spawn"
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ms-pd-llm-d-modelservice-decode-podmonitor
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/hardware-variant: xpu
+      llm-d.ai/hardware-vendor: intel
+      llm-d.ai/model: Qwen3-0.6B
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ms-pd-llm-d-modelservice-prefill-podmonitor
+spec:
+  selector:
+    matchLabels:
+      llm-d.ai/hardware-variant: xpu
+      llm-d.ai/hardware-vendor: intel
+      llm-d.ai/model: Qwen3-0.6B


### PR DESCRIPTION
## Description
This PR migrates the Model Server (ms-pd) component from Helmfile to Kustomization within the pd-disaggregation guide. This aligns the deployment pattern with the one used in the wide-ep-lws guide, providing a more transparent and maintainable manifest structure.

## Key Changes
* Kustomize Base & Common: Created base manifests for ms-pd (decode, prefill, service account) and shared PodMonitor resources.
* Environment Overlays: Created specific overlays for all environment variants found in the original ms-pd chart:
  * gke (Nvidia GPU, removes RDMA)
  * amd (AMD specific configuration)
  * tpu (Cloud TPU specific config, clean ports)
  * hpu (Intel Gaudi specific config)
  * xpu (Intel XPU specific config)
  * sglang (Custom command for SGLang)
  * ocp (OpenShift specific config, custom resources)
* Manifests Organization: Copied and renamed GAIE values files to manifests/ directory (inferencepool.values.yaml and inferencepool_sglang.values.yaml) to match the wide-ep-lws structure.
* Documentation: Added a README.md in the manifests/ directory explaining how to use the Kustomize overlays and the corresponding Helm commands for the InferencePool.

## Verification
All overlays have been verified using kubectl kustomize to ensure they render correctly and match the requirements of the original values files.

## Next Step
1. Updated the main README.md files under pd guide, and integrate all the hardware specific  README files.
2. Remove the current helm based model server recipes. 