### PR TITLE
fix(xpu): enable TP=2 for Qwen3-32B in prefix-cache XPU values

### DIFF
--- a/guides/precise-prefix-cache-aware/ms-kv-events/values_xpu.yaml
+++ b/guides/precise-prefix-cache-aware/ms-kv-events/values_xpu.yaml
@@ -19,7 +19,7 @@ accelerator:
 modelArtifacts:
   name: Qwen/Qwen3-32B
   uri: "hf://Qwen/Qwen3-32B"
-  size: 10Gi
+  size: 80Gi
   authSecretName: "llm-d-hf-token"
   labels:
     llm-d.ai/inference-serving: "true"
@@ -35,6 +35,8 @@ routing:
 decode:
   create: true
   replicas: 2
+  parallelism:
+    tensor: 2
   securityContext:
     fsGroup: 107
     supplementalGroups:
@@ -60,6 +62,7 @@ decode:
             --port 8000 \
             --served-model-name "Qwen/Qwen3-32B" \
             --dtype float16 \
+            --tensor-parallel-size 2 \
             --disable-sliding-window \
             --block-size 16 \
             --prefix-caching-hash-algo sha256_cbor \
@@ -87,11 +90,11 @@ decode:
           protocol: TCP
       resources:
         limits:
-          memory: 24Gi
-          cpu: "8"
+          memory: 48Gi
+          cpu: "16"
         requests:
-          cpu: "4"
-          memory: 12Gi
+          cpu: "8"
+          memory: 24Gi
 
       mountModelVolume: true
       volumeMounts:


### PR DESCRIPTION
Qwen3-32B (~65GB FP16) exceeds the single GPU memory (~61GB), causing model download to exceed the 10Gi emptyDir limit and pods to be evicted. Fix by:

- Increase modelArtifacts.size from 10Gi to 80Gi
- Add parallelism.tensor=2 and --tensor-parallel-size 2
- Increase memory limits/requests for 2-GPU setup