### PR TITLE
fix(ci): narrow detect-changes filters to avoid cross-triggering tests

### DIFF
--- a/.github/workflows/ci-pr-test.yaml
+++ b/.github/workflows/ci-pr-test.yaml
@@ -86,37 +86,33 @@ jobs:
               - .github/workflows/ci-pr-test.yaml
               - .github/workflows/e2e-inference-scheduling-xpu.yaml
               - docker/common-versions
-              - guides/**/values_xpu.yaml
-              - guides/inference-scheduling/ms-inference-scheduling/values_xpu.yaml
+              - guides/inference-scheduling/**/values_xpu.yaml
               - guides/inference-scheduling/helmfile.yaml.gotmpl
             xpu-pd-disaggregation:
               - .github/workflows/ci-pr-test.yaml
               - .github/workflows/e2e-pd-xpu.yaml
               - docker/common-versions
-              - guides/**/values_xpu.yaml
-              - guides/pd-disaggregation/ms-pd/values_xpu.yaml
+              - guides/pd-disaggregation/**/values_xpu.yaml
               - guides/pd-disaggregation/README.xpu.md
               - guides/pd-disaggregation/helmfile.yaml.gotmpl
             xpu-prefix-cache:
               - .github/workflows/ci-pr-test.yaml
               - .github/workflows/e2e-prefix-cache-xpu.yaml
               - docker/common-versions
-              - guides/**/values_xpu.yaml
               - guides/precise-prefix-cache-aware/**/values_xpu.yaml
               - guides/precise-prefix-cache-aware/helmfile.yaml.gotmpl
             hpu-inference-scheduling:
               - .github/workflows/ci-pr-test.yaml
               - .github/workflows/e2e-inference-scheduling-hpu.yaml
               - docker/Dockerfile.hpu
-              - guides/**/values-hpu.yaml
-              - guides/inference-scheduling/ms-inference-scheduling/values-hpu.yaml
+              - guides/inference-scheduling/**/values-hpu.yaml
               - guides/inference-scheduling/helmfile.yaml.gotmpl
             hpu-pd-disaggregation:
               - .github/workflows/ci-pr-test.yaml
               - .github/workflows/e2e-pd-hpu.yaml
+              - .github/scripts/e2e/**
               - docker/Dockerfile.hpu
-              - guides/**/values_hpu.yaml
-              - guides/pd-disaggregation/ms-pd/values_hpu.yaml
+              - guides/pd-disaggregation/**/values_hpu.yaml
               - guides/pd-disaggregation/README.hpu.md
               - guides/pd-disaggregation/helmfile.yaml.gotmpl
 

--- a/.github/workflows/ci-pr-test.yaml
+++ b/.github/workflows/ci-pr-test.yaml
@@ -110,7 +110,6 @@ jobs:
             hpu-pd-disaggregation:
               - .github/workflows/ci-pr-test.yaml
               - .github/workflows/e2e-pd-hpu.yaml
-              - .github/scripts/e2e/**
               - docker/Dockerfile.hpu
               - guides/pd-disaggregation/**/values_hpu.yaml
               - guides/pd-disaggregation/README.hpu.md


### PR DESCRIPTION
Replace overly broad guides/**/values_xpu.yaml and guides/**/values_hpu.yaml globs with guide-specific paths so that changes to one guide (e.g. prefix-cache) don't trigger unrelated tests (e.g. PD, inference-scheduling).