### PR TITLE
fix(xpu): enable TP=2 for Qwen3-32B for fixing XPU prefix-cache test failed

### DIFF
--- a/guides/precise-prefix-cache-aware/ms-kv-events/values_xpu.yaml
+++ b/guides/precise-prefix-cache-aware/ms-kv-events/values_xpu.yaml
@@ -64,7 +64,7 @@ decode:
             --dtype float16 \
             --tensor-parallel-size 2 \
             --disable-sliding-window \
-            --block-size 16 \
+            --block-size 64 \
             --prefix-caching-hash-algo sha256_cbor \
             --kv-events-config "{\"enable_kv_cache_events\":true,\"publisher\":\"zmq\",\"endpoint\":\"tcp://gaie-${GAIE_RELEASE_NAME_POSTFIX}-epp.${NAMESPACE}.svc.cluster.local:5557\",\"topic\":\"kv@${POD_IP}:8000@Qwen/Qwen3-32B\"}"
       env:

--- a/guides/precise-prefix-cache-aware/ms-kv-events/values_xpu_pod_discovery.yaml
+++ b/guides/precise-prefix-cache-aware/ms-kv-events/values_xpu_pod_discovery.yaml
@@ -60,7 +60,7 @@ decode:
             --served-model-name "Qwen/Qwen3-32B" \
             --dtype float16 \
             --disable-sliding-window \
-            --block-size 16 \
+            --block-size 64 \
             --prefix-caching-hash-algo sha256_cbor \
             --kv-events-config "{\"enable_kv_cache_events\":true,\"publisher\":\"zmq\",\"endpoint\":\"tcp://*:5557\",\"topic\":\"kv@${POD_IP}:8000@Qwen/Qwen3-32B\"}"
       env:


### PR DESCRIPTION
Qwen3-32B (~65GB FP16) exceeds the single Intel Max 1550 GPU memory (~61GB), causing model download to exceed the 10Gi emptyDir limit and pods to be evicted. Fix by:

- Increase modelArtifacts.size from 10Gi to 80Gi
- Add parallelism.tensor=2 and --tensor-parallel-size 2
- Increase memory limits/requests for 2-GPU setup