### PR TITLE
Updated maturity testing level on all guides

### DIFF
--- a/guides/inference-scheduling/README.md
+++ b/guides/inference-scheduling/README.md
@@ -1,6 +1,6 @@
 # Well-lit Path: Intelligent Inference Scheduling
 
-## **MATURITY** : High (tested nightly on OpenShift, Google Kubernetes Engine and CoreWeave Kubernetes Service)
+## **Automated Testing Coverage** : High (tested nightly on OpenShift, Google Kubernetes Engine and CoreWeave Kubernetes Service)
 
 ## Overview
 

--- a/guides/pd-disaggregation/README.amd.md
+++ b/guides/pd-disaggregation/README.amd.md
@@ -1,6 +1,6 @@
 # AMD GPU well-lit Path for P/D Disaggregation
 
-## **MATURITY** : Experimental (not regularly tested by maintainers)
+## **Automated Testing Coverage** : None (currently, not part of nightly testing by llm-d maintainers)
 
 ## Overview
 

--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -1,6 +1,6 @@
 # Well-lit Path: P/D Disaggregation
 
-## **MATURITY** : High (tested nightly on OpenShift, Google Kubernetes Engine and CoreWeave Kubernetes Service)
+## **Automated Testing Coverage** : High (tested nightly on OpenShift, Google Kubernetes Engine and CoreWeave Kubernetes Service)
 
 ## Overview
 

--- a/guides/pd-disaggregation/README.sglang.md
+++ b/guides/pd-disaggregation/README.sglang.md
@@ -1,5 +1,7 @@
 # P/D Disaggregation SGLang
 
+## **Automated Testing Coverage** : None (currently, not part of nightly testing by llm-d maintainers)
+
 ## Overview
 
 This document provides complete steps for deploying PD disaggregation service on Kubernetes cluster using SGLang inference server with NIXL as the data transfer backend. PD disaggregation separates the prefill and decode phases of inference, allowing for more efficient resource utilization and improved throughput.

--- a/guides/pd-disaggregation/README.tpu.md
+++ b/guides/pd-disaggregation/README.tpu.md
@@ -1,6 +1,6 @@
 # Google TPU P/D Disaggregation Deployment Guide
 
-**Automated test status**: Not currently part of nightly testing by llm-d maintainers.
+## **Automated Testing Coverage** : None (currently, not part of nightly testing by llm-d maintainers)
 
 ## Overview
 

--- a/guides/pd-disaggregation/README.xpu.md
+++ b/guides/pd-disaggregation/README.xpu.md
@@ -1,6 +1,6 @@
 # Intel XPU PD Disaggregation Deployment Guide
 
-## **MATURITY** : Experimental (not regularly tested by maintainers)
+## **Automated Testing Coverage** : None (currently, not part of nightly testing by llm-d maintainers)
 
 ## Overview
 

--- a/guides/precise-prefix-cache-aware/README.md
+++ b/guides/precise-prefix-cache-aware/README.md
@@ -1,6 +1,6 @@
 # Feature: Precise Prefix Cache Aware Routing
 
-## **MATURITY** : Medium (tested nightly on OpenShift)
+## **Automated Testing Coverage** : Medium (tested nightly on OpenShift)
 
 ## Overview
 

--- a/guides/predicted-latency-based-scheduling/README.md
+++ b/guides/predicted-latency-based-scheduling/README.md
@@ -1,6 +1,6 @@
 # Experimental Feature: Predicted Latency based Load Balancing
 
-## **MATURITY** : Experimental (not regularly tested by maintainers)
+## **Automated Testing Coverage** : None (currently, not part of nightly testing by llm-d maintainers)
 
 ## Overview
 

--- a/guides/simulated-accelerators/README.md
+++ b/guides/simulated-accelerators/README.md
@@ -1,6 +1,6 @@
 # Feature: llm-d Accelerator Simulation
 
-## **MATURITY** : Medium (tested nightly on OpenShift)
+## **Automated Testing Coverage** : Medium (tested nightly on OpenShift)
 
 ## Overview
 

--- a/guides/tiered-prefix-cache/README.md
+++ b/guides/tiered-prefix-cache/README.md
@@ -1,6 +1,6 @@
 # Well-lit Path: Prefix Cache Offloading
 
-## **MATURITY** : Medium (tested nightly on OpenShift)
+## **Automated Testing Coverage** : Medium (tested nightly on OpenShift)
 
 ## Overview
 

--- a/guides/wide-ep-lws/README.md
+++ b/guides/wide-ep-lws/README.md
@@ -1,6 +1,6 @@
 # Well-lit Path: Wide Expert Parallelism (EP/DP) with LeaderWorkerSet
 
-## **MATURITY** : Experimental (not regularly tested by maintainers)
+## **Automated Testing Coverage** : None (currently, not part of nightly testing by llm-d maintainers)
 
 ## Overview
 

--- a/guides/workload-autoscaling/README.hpa-igw.md
+++ b/guides/workload-autoscaling/README.hpa-igw.md
@@ -1,6 +1,6 @@
 # Autoscaling Workloads with HPA and IGW Metrics
 
-## **MATURITY** : Experimental (not regularly tested by maintainers)
+## **Automated Testing Coverage** : None (currently, not part of nightly testing by llm-d maintainers)
 
 This guide explains how to configure autoscaling for LLM workloads by integrating the
 Kubernetes Horizontal Pod Autoscaler (HPA) with metrics emitted by the Inference

--- a/guides/workload-autoscaling/README.md
+++ b/guides/workload-autoscaling/README.md
@@ -1,6 +1,6 @@
 # Workload Autoscaling
 
-## **MATURITY** : Experimental (not regularly tested by maintainers)
+## **Automated Testing Coverage** : Medium (tested nightly on OpenShift)
 
 Traditional autoscaling indicators like resource utilization metrics (CPU/GPU) are often lagging indicators — they only reflect saturation after it has already occurred, by which point latency has spiked and requests may be failing. For LLM inference, this problem is compounded by the fact that GPU utilization is often pegged near 100% during active batching regardless of actual load, making it an unreliable signal entirely.
 

--- a/guides/workload-autoscaling/README.wva.md
+++ b/guides/workload-autoscaling/README.wva.md
@@ -1,6 +1,6 @@
 # Autoscaling with Workload Variant Autoscaler (WVA)
 
-## **MATURITY** : Experimental (not regularly tested by maintainers)
+## **Automated Testing Coverage** : Medium (tested nightly on OpenShift)
 
 The [Workload Variant Autoscaler](https://github.com/llm-d-incubation/workload-variant-autoscaler) (WVA) provides dynamic autoscaling capabilities for llm-d inference deployments, automatically adjusting replica counts based on inference server saturation.
 


### PR DESCRIPTION
Instead of simply "maturity", used the more precise description "Automated Test Coverage". 

Additionally, updated WVA to reflect new status.