### PR TITLE
Fix llm-d performance dashboard queries

### DIFF
--- a/docs/monitoring/grafana/dashboards/llm-performance-kv-cache.json
+++ b/docs/monitoring/grafana/dashboards/llm-performance-kv-cache.json
@@ -908,8 +908,8 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "inference_pool_ready_pods{name=\"gaie-cpu-inference\", namespace=~\"$namespace\"}",
-          "legendFormat": "Ready Pods",
+          "expr": "inference_pool_ready_pods{namespace=~\"$namespace\"}",
+          "legendFormat": "{{name}} Ready Pods",
           "refId": "A"
         },
         {
@@ -917,8 +917,8 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "inference_pool_average_queue_size{name=\"gaie-cpu-inference\", namespace=~\"$namespace\"}",
-          "legendFormat": "Average Queue Size",
+          "expr": "inference_pool_average_queue_size{namespace=~\"$namespace\"}",
+          "legendFormat": "{{name}} Average Queue Size",
           "refId": "B"
         }
       ],
@@ -987,8 +987,8 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "inference_pool_average_kv_cache_utilization{name=\"gaie-cpu-inference\", namespace=~\"$namespace\"}",
-          "legendFormat": "Pool KV Cache Utilization",
+          "expr": "inference_pool_average_kv_cache_utilization{namespace=~\"$namespace\"}",
+          "legendFormat": "{{name}} Pool KV Cache Utilization",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
## Summary
- switch the Inter-Token Latency panel to the current `vllm:inter_token_latency_seconds_bucket` metric
- aggregate histogram buckets by `le` so `histogram_quantile` renders correctly
- remove the hardcoded EPP pool name so pool health and KV cache panels render across deployments with different pool names

## Testing
- `jq empty docs/monitoring/grafana/dashboards/llm-performance-kv-cache.json`

Fixes: #1096
