### PR TITLE
Update ms-inference-scheduling/values_tpu_v7.yaml to use RunAI model streamer

### DIFF
--- a/guides/inference-scheduling/README.tpu.md
+++ b/guides/inference-scheduling/README.tpu.md
@@ -1,0 +1,69 @@
+# Google TPU Inference Scheduling Deployment Guide
+
+## **Automated Testing Coverage** : None (currently, not part of nightly testing by llm-d maintainers)
+
+## Overview
+
+This document provides complete steps for deploying the intelligent inference scheduling service on a Google Kubernetes Engine (GKE) cluster using TPU accelerators and the `Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8` model, utilizing the [Run:ai Model Streamer](https://docs.vllm.ai/en/stable/models/extensions/runai_model_streamer/) to load model weights directly from Google Cloud Storage (GCS) for high performance.
+
+For broader context on inference scheduling, gateway options, and architecture, refer to the [main inference scheduling guide](./README.md).
+
+## Hardware Requirements
+
+This guide uses Cloud TPU v7x accelerators on Google Cloud Platform (GCP). The default topology configured in `values_tpu_v7.yaml` requests a `2x2x1` TPU v7x topology. 
+
+## Prerequisites
+
+- Have the [proper client tools installed on your local system](../prereq/client-setup/README.md) to use this guide.
+- Create a namespace for installation.
+
+  ```bash
+  export NAMESPACE=llm-d-inference-scheduler # or any other namespace (shorter names recommended)
+  kubectl create namespace ${NAMESPACE}
+  ```
+- [Choose an llm-d version](../prereq/client-setup/README.md#llm-d-version)
+- Configure and deploy your [Gateway control plane](../prereq/gateway-provider/README.md)
+
+## Installation
+
+### Step 1: Prepare the GCS Bucket and Model (Run:ai Model Streamer)
+
+This deployment utilizes the Run:ai Model Streamer to load model weights directly from Google Cloud Storage (GCS) for a faster inference server start up time. Because there is currently no public bucket available with the required model, you must host it in your own bucket.
+
+1. Download the [Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8](https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8) model and upload it to a GCS bucket you control. You can do this in many ways, but one option is to deploy a [transfer job](https://gke-ai-labs.dev/docs/tutorials/storage/hf-gcs-transfer/) to hydrate the GCS bucket with model weights from Hugging Face.
+2. Open `ms-inference-scheduling/values_tpu_v7.yaml` and replace `<Insert GCS URI here>` with the GCS URI containing your model weights and your desired path for the XLA compilation cache. For example, if your GCS bucket is `my-gcs-bucket` and the model weights are at the path `Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8`, you would set `--model=gs://my-gcs-bucket/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8`. You should also set `VLLM_XLA_CACHE_PATH` to any valid GCS URI within the bucket where you want to store the XLA compilation cache, such as: `gs://my-gcs-bucket/xla-cache`.
+3. Open `ms-inference-scheduling/values_tpu_v7.yaml` and replace `placeholder-sa` with the Kubernetes Service account you will create in Step 2 below.
+
+### Step 2: Configure Workload Identity for GCS Access
+
+To allow the vLLM pods to read the model from your GCS bucket, you must configure a Kubernetes Service Account linked to a Google Cloud Service Account with Workload Identity.
+
+```bash 
+export PROJECT_ID=$(gcloud config get project)
+export PROJECT_NUMBER=$(gcloud projects describe ${PROJECT_ID} --format="value(projectNumber)") 
+export BUCKET_NAME=<Insert GCS bucket name here>
+export KSA_NAME=<Insert KSA name here>
+kubectl create sa $KSA_NAME -n $NAMESPACE
+gcloud storage buckets add-iam-policy-binding gs://${BUCKET_NAME} --member "principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$PROJECT_ID.svc.id.goog/subject/ns/${NAMESPACE}/sa/${KSA_NAME}" --role "roles/storage.objectUser"
+gcloud storage buckets add-iam-policy-binding gs://${BUCKET_NAME} --member "principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$PROJECT_ID.svc.id.goog/subject/ns/${NAMESPACE}/sa/${KSA_NAME}" --role "roles/storage.bucketViewer"
+```
+
+### Step 3: Install the Stack via Helmfile
+
+Use the helmfile to compose and install the stack. The Namespace in which the stack will be deployed will be derived from the `${NAMESPACE}` environment variable. If you have not set this, it will default to `llm-d-inference-scheduler` in this example.
+
+```bash
+cd guides/inference-scheduling
+helmfile apply -e gke_tpu_v7 -n ${NAMESPACE}
+```
+
+### Step 4: Install HTTPRoute
+Apply the GKE-specific HTTPRoute configuration to route traffic through your gateway:
+
+```bash
+kubectl apply -f httproute.gke.yaml -n ${NAMESPACE}
+```
+
+## Next Steps: Verification, Benchmarking, and Cleanup
+
+For all subsequent steps—including verifying your pods are running, benchmarking the deployment, and cleaning up resources—please follow the instructions in the [main inference scheduling guide](./README.md).

--- a/guides/inference-scheduling/ms-inference-scheduling/values_tpu_v7.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_tpu_v7.yaml
@@ -11,7 +11,6 @@ multinode: false
 modelArtifacts:
   uri: "hf://Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8"
   size: 700Gi
-  authSecretName: "llm-d-hf-token"
   name: Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8
   labels:
     llm-d.ai/inference-serving: "true"
@@ -22,11 +21,13 @@ modelArtifacts:
 
 routing:
   proxy:
-    enabled: false  # removes sidecar from deployment - no PD in inference scheduling
-    targetPort: 8000  # controls vLLM port to matchup with sidecar if deployed
+    enabled: false # removes sidecar from deployment - no PD in inference scheduling
+    targetPort: 8000 # controls vLLM port to matchup with sidecar if deployed
 
 accelerator:
   type: "google"
+
+serviceAccountOverride: "placeholder-sa"
 
 decode:
   parallelism:
@@ -40,14 +41,24 @@ decode:
   monitoring:
     podmonitor:
       enabled: true
-      portName: "vllm"  # decode vLLM service port (from routing.proxy.targetPort)
+      portName: "vllm" # decode vLLM service port (from routing.proxy.targetPort)
       path: "/metrics"
       interval: "30s"
   containers:
     - name: "vllm"
-      image: "vllm/vllm-tpu:v0.13.2-ironwood"
-      modelCommand: vllmServe
+      image: "vllm/vllm-tpu:nightly-20260401-a536749-8c0b626"
+      env:
+        - name: VLLM_XLA_CACHE_PATH
+          value: <Insert GCS URI here> # e.g. gs://my-gcs-bucket/xla-cache
+      modelCommand: custom
+      command:
+        - python3
+        - -m
+        - vllm.entrypoints.openai.api_server
       args:
+        - --model=<Insert GCS URI here> # e.g. "gs://my-gcs-bucket/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8"
+        - --load-format=runai_streamer
+        - --tensor_parallel_size=8
         - --data-parallel-size=1
         - --max-model-len=9216
         - --max-num-batched-tokens=1028
@@ -61,14 +72,10 @@ decode:
           protocol: TCP
       resources:
         limits:
-          memory: 64Gi
-          cpu: "16"
           google.com/tpu: 4
         requests:
-          memory: 64Gi
-          cpu: "16"
           google.com/tpu: 4
-      mountModelVolume: true
+      mountModelVolume: false
       volumeMounts:
         - name: metrics-volume
           mountPath: /.config


### PR DESCRIPTION
## Summary
- Update ms-inference-scheduling/values_tpu_v7.yaml to use RunAI model streamer to load the model from GCS instead of HF, which results in a significant reduction in inference server startup time. Specifically: 
    - Removed the `authSecretName` since we no longer pull from HF
    - Added serviceAccountOverride to specify a ServiceAccount that is used to configure access to the GCS bucket.
    - Changed the image to `vllm/vllm-tpu:nightly-20260401-a536749-8c0b626"` since `"vllm/vllm-tpu:v0.13.2-ironwood"` does not support the RunAI model streamer. 
    - I added `VLLM_XLA_CACHE_PATH` to allow for XLA compilation to be read from cache for improvements in e2e inference server warm start up times. 
    - Added the necessary vllm flags needed for RunAI model streamer (`--model=<GCS URI>` and `--load-format=runai_streamer`) 
    - Added `--tensor_parallel_size=8` because without this, tensor_parallel_size=1 is used by default, which leads to an HBM Resource Exhausted error. 
    - Set `mountModelVolume: false` to remove the HF_HOME assignment to remove the `model-storage emptyDir and the HF_HOME setting of `/model-cache`, which make the inference server start up crash if HF isn't being used. 
    - Removed the limit / request setting of `memory: 64Gi` which prevents RunAI model streamer from loading the model since the RunAI model streamer always needs RAM = model size for single host.
    - Removed the limit / request setting of `cpu: 16 ` to improve RUnAI model streamer perf. The streamer is designed to run in parallel to maximize throughput, so it can easily utilize lots of CPU.  Removing the limit allows the working pod to burst and use as much of the host node's available CPU as it needs to stream the weights quickly.
- Add new guides/inference-scheduling/README.tpu.md file with additional RunAI model streamer specific set up instructions.

## Testing

I tested by following the steps in guides/inference-scheduling/README.tpu.md, and confirmed the inference server was able to start up successfully on a v7x GKE cluster.

```
kubectl get pods -n $NAMESPACE
NAME                                                              READY   STATUS    RESTARTS   AGE
gaie-inference-scheduling-epp-d48d7f99f-jx5k2                     1/1     Running   0          3h13m
ms-inference-scheduling-llm-d-modelservice-decode-5b989cb7jbz4q   1/1     Running   0          126m
ms-inference-scheduling-llm-d-modelservice-decode-5b989cb7pq99t   1/1     Running   0          138m
```



