### PR TITLE
feat: add Rebellions as a supported accelerator vendor

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -18,7 +18,7 @@
 | Launch Partner | Mistral AI | 2025 | [Mistral AI](https://mistral.ai) | Mistral AI is a launch partner supporting the llm-d community for distributed generative AI inference at scale. |
 | Contributor | DaoCloud | 2025 | [DaoCloud](https://www.daocloud.io) | DaoCloud contributes to llm-d, leveraging P/D disaggregation and KV-cache architectures in its d.run MaaS platform. |
 | Contributor | Moreh | 2025 | [Moreh](https://moreh.io) | Moreh contributes to llm-d, actively improving KV-cache management and vLLM rendering, along with P/D disaggregation for distributed inference. |
-| Contributor | Rebellions | 2025 | [Rebellions](https://rebellions.ai) | Rebellions contributes to llm-d, enabling support for the ATOM NPU accelerator to bring high-performance, energy-efficient AI inference to the platform. |
+| Contributor | Rebellions | 2025 | [Rebellions](https://rebellions.ai) | Rebellions contributes to llm-d, enabling support for the NPU accelerator to bring high-performance, energy-efficient AI inference to the platform. |
 | University Supporter | University of California, Berkeley (Sky Computing Lab) | 2025 | [Sky Computing Lab](https://sky.cs.berkeley.edu) | The Sky Computing Lab at UC Berkeley, originators of vLLM, are founding academic supporters of llm-d. |
 | University Supporter | University of Chicago (LMCache Lab) | 2025 | [LMCache Lab](https://lmcache.ai) | The LMCache Lab at the University of Chicago, originators of LMCache, are founding academic supporters of llm-d. |
 | User | Tesla | 2025 | [Tesla](https://www.tesla.com/) | The Tesla ML Platform team are users of llm-d. |

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -18,6 +18,7 @@
 | Launch Partner | Mistral AI | 2025 | [Mistral AI](https://mistral.ai) | Mistral AI is a launch partner supporting the llm-d community for distributed generative AI inference at scale. |
 | Contributor | DaoCloud | 2025 | [DaoCloud](https://www.daocloud.io) | DaoCloud contributes to llm-d, leveraging P/D disaggregation and KV-cache architectures in its d.run MaaS platform. |
 | Contributor | Moreh | 2025 | [Moreh](https://moreh.io) | Moreh contributes to llm-d, actively improving KV-cache management and vLLM rendering, along with P/D disaggregation for distributed inference. |
+| Contributor | Rebellions | 2025 | [Rebellions](https://rebellions.ai) | Rebellions contributes to llm-d, enabling support for the ATOM NPU accelerator to bring high-performance, energy-efficient AI inference to the platform. |
 | University Supporter | University of California, Berkeley (Sky Computing Lab) | 2025 | [Sky Computing Lab](https://sky.cs.berkeley.edu) | The Sky Computing Lab at UC Berkeley, originators of vLLM, are founding academic supporters of llm-d. |
 | University Supporter | University of Chicago (LMCache Lab) | 2025 | [LMCache Lab](https://lmcache.ai) | The LMCache Lab at the University of Chicago, originators of LMCache, are founding academic supporters of llm-d. |
 | User | Tesla | 2025 | [Tesla](https://www.tesla.com/) | The Tesla ML Platform team are users of llm-d. |

--- a/docs/accelerators/README.md
+++ b/docs/accelerators/README.md
@@ -14,7 +14,7 @@ Maintainers for each accelerator type are listed below. See our well-lit path gu
 | Intel | XPU | Yuan Wu (@yuanwu2017, <yuan.wu@intel.com>) | [Inference Scheduling](../../guides/inference-scheduling/README.md), [Prefill/Decode Disaggregation](../../guides/pd-disaggregation/README.md) |
 | Intel | HPU | Sakari Poussa (@poussa, <sakari.poussa@intel.com>) | [Inference Scheduling](../../guides/inference-scheduling/README.md) |
 | NVIDIA | GPU | Will Eaton (<weaton@redhat.com>), Greg (<grpereir@redhat.com>) | All |
-| Rebellions | ATOM NPU | Jinmoo Seok (@rebel-jinmoo, <jinmoo_seok@rebellions.ai>), Minwook Ahn (@rebel-minwook, <minwook.ahn@rebellions.ai>) | [Inference Scheduling](../../guides/inference-scheduling/README.md) |
+| Rebellions | ATOM | Jinmoo Seok (@rebel-jinmoo, <jinmoo_seok@rebellions.ai>), Minwook Ahn (@rebel-minwook, <minwook.ahn@rebellions.ai>) | [Inference Scheduling](../../guides/inference-scheduling/README.md) |
 
 ## Requirements
 

--- a/docs/accelerators/README.md
+++ b/docs/accelerators/README.md
@@ -14,7 +14,7 @@ Maintainers for each accelerator type are listed below. See our well-lit path gu
 | Intel | XPU | Yuan Wu (@yuanwu2017, <yuan.wu@intel.com>) | [Inference Scheduling](../../guides/inference-scheduling/README.md), [Prefill/Decode Disaggregation](../../guides/pd-disaggregation/README.md) |
 | Intel | HPU | Sakari Poussa (@poussa, <sakari.poussa@intel.com>) | [Inference Scheduling](../../guides/inference-scheduling/README.md) |
 | NVIDIA | GPU | Will Eaton (<weaton@redhat.com>), Greg (<grpereir@redhat.com>) | All |
-| Rebellions | ATOM | Jinmoo Seok (@rebel-jinmoo, <jinmoo_seok@rebellions.ai>), Minwook Ahn (@rebel-minwook, <minwook.ahn@rebellions.ai>) | [Inference Scheduling](../../guides/inference-scheduling/README.md) |
+| Rebellions | NPU | Jinmoo Seok (@rebel-jinmoo, <jinmoo_seok@rebellions.ai>), Minwook Ahn (@rebel-minwook, <minwook.ahn@rebellions.ai>) | [Inference Scheduling](../../guides/inference-scheduling/README.md) |
 
 ## Requirements
 

--- a/docs/accelerators/README.md
+++ b/docs/accelerators/README.md
@@ -14,6 +14,7 @@ Maintainers for each accelerator type are listed below. See our well-lit path gu
 | Intel | XPU | Yuan Wu (@yuanwu2017, <yuan.wu@intel.com>) | [Inference Scheduling](../../guides/inference-scheduling/README.md), [Prefill/Decode Disaggregation](../../guides/pd-disaggregation/README.md) |
 | Intel | HPU | Sakari Poussa (@poussa, <sakari.poussa@intel.com>) | [Inference Scheduling](../../guides/inference-scheduling/README.md) |
 | NVIDIA | GPU | Will Eaton (<weaton@redhat.com>), Greg (<grpereir@redhat.com>) | All |
+| Rebellions | ATOM NPU | Jinmoo Seok (@rebel-jinmoo, <jinmoo_seok@rebellions.ai>), Minwook Ahn (@rebel-minwook, <minwook.ahn@rebellions.ai>) | [Inference Scheduling](../../guides/inference-scheduling/README.md) |
 
 ## Requirements
 
@@ -52,6 +53,7 @@ Each vendor provides Device Plugins for their accelerators. The following plugin
 - [Intel XPU Device Plugin](https://github.com/intel/intel-device-plugins-for-kubernetes/blob/main/cmd/gpu_plugin/README.md)
 - [Intel Gaudi Device Plugin](https://docs.habana.ai/en/latest/Installation_Guide/Additional_Installation/Kubernetes_Installation/Intel_Gaudi_Kubernetes_Device_Plugin.html)
 - [NVIDIA GPU Device Plugin](https://github.com/NVIDIA/k8s-device-plugin)
+- [Rebellions NPU Operator](https://docs.rbln.ai/latest/software/system_management/kubernetes/about_npu_operator.html)
 
 ### Dynamic Resource Allocation
 


### PR DESCRIPTION
## Summary
Add Rebellions as a supported accelerator vendor with the NPU.

## Changes
- Add Rebellions NPU to the vendor support table in `docs/accelerators/README.md`
- Add Rebellions NPU Operator link to the Device Plugins section
- Add Rebellions as a Contributor in `ADOPTERS.md`

## Maintainers
- Jinmoo Seok (@rebel-jinmoo, jinmoo_seok@rebellions.ai)
- Minwook Ahn (@rebel-minwook, minwook.ahn@rebellions.ai)

## Related
- llm-d-modelservice PR: llm-d-incubation/llm-d-modelservice#250
- Device Plugin: https://docs.rbln.ai/latest/software/system_management/kubernetes/about_npu_operator.html

Signed-off-by: Jinmoo Seok <jinmoo_seok@rebellions.ai>