### PR TITLE
add OCI well-lit-path for P/D disaggregation

### DIFF
--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -104,6 +104,23 @@ You can also customize your gateway, for more information on how to do that see 
 
 This guide uses RDMA via InfiniBand or RoCE for disaggregated serving kv-cache transfer. The resource attributes required to configure accelerator networking are not yet standardized via [Kubernetes Dynamic Resource Allocation](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/) and so are parameterized per infra provider in the Helm charts. If your provider has a custom setting you will need to update the charts before deploying.
 
+##### OCI (Oracle Cloud Infrastructure)
+
+For OCI deployments, use `-e oci_amd` which configures SR-IOV RDMA networking and OCI-specific UCX transport variables:
+
+```bash
+helmfile apply -e oci_amd -n ${NAMESPACE}
+```
+
+OCI RDMA networking must be configured at the infrastructure level before deploying. Refer to the [OCI RDMA documentation](https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/managing-rdma-networking.htm).
+
+**_NOTE:_** The `NetworkAttachmentDefinition` name (`sriov-rdma-vf`) and `nvidia.com/sriov-rdma-vf` resource label in `ms-pd/values_oci_amd.yaml` must match your cluster's SR-IOV device plugin configuration.
+
+**Common gotchas:**
+* If you change tensor parallelism, update both `podAnnotations` VF count and `nvidia.com/sriov-rdma-vf` resource requests to match
+* Wrong `UCX_IB_GID_INDEX` causes silent fallback to TCP — set `UCX_PROTO_INFO=y` to verify RDMA is selected
+* `IPC_LOCK` capability is required for RDMA pinned memory; without it NIXL transfers will fail
+
 ### Install HTTPRoute
 
 Follow provider specific instructions for installing HTTPRoute.

--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -112,7 +112,7 @@ For OCI deployments, use `-e oci_amd` which configures SR-IOV RDMA networking an
 helmfile apply -e oci_amd -n ${NAMESPACE}
 ```
 
-OCI RDMA networking must be configured at the infrastructure level before deploying. Refer to the [OCI RDMA documentation](https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/managing-rdma-networking.htm).
+An OKE Cluster with RDMA networking must be deployed prior to launching llm-d on OCI. Refer to [the oci-hpc-oke stack](https://github.com/oracle-quickstart/oci-hpc-oke) for deployment.
 
 **_NOTE:_** The `NetworkAttachmentDefinition` name (`sriov-rdma-vf`) and `nvidia.com/sriov-rdma-vf` resource label in `ms-pd/values_oci_amd.yaml` must match your cluster's SR-IOV device plugin configuration.
 

--- a/guides/pd-disaggregation/helmfile.yaml.gotmpl
+++ b/guides/pd-disaggregation/helmfile.yaml.gotmpl
@@ -23,6 +23,8 @@ environments:
       - ../prereq/gateway-provider/common-configurations/istio.yaml
   hpu: &HPU
     <<: *I
+  oci_amd: &OCI_AMD
+    <<: *I
   ocp: &OCP
     <<: *I
   aks: &AKS
@@ -77,7 +79,7 @@ releases:
               enabled: true
     {{- end }}
     # Apply destination rule for anything istio
-    {{- if or (eq .Environment.Name "istio") (eq .Environment.Name "default") (eq .Environment.Name "aks") (eq .Environment.Name "amd") (eq .Environment.Name "xpu") (eq .Environment.Name "hpu") (eq .Environment.Name "ocp") }}
+    {{- if or (eq .Environment.Name "istio") (eq .Environment.Name "default") (eq .Environment.Name "aks") (eq .Environment.Name "amd") (eq .Environment.Name "xpu") (eq .Environment.Name "hpu") (eq .Environment.Name "oci_amd") (eq .Environment.Name "ocp") }}
       - provider:
           name: {{ .Environment.Values.provider.name }}
           istio:
@@ -110,6 +112,8 @@ releases:
       - ms-pd/values_xpu.yaml
     {{- else if eq .Environment.Name "hpu" }}
       - ms-pd/values_hpu.yaml
+    {{- else if eq .Environment.Name "oci_amd" }}
+      - ms-pd/values_oci_amd.yaml
     {{- else if eq .Environment.Name "ocp" }}
       - ms-pd/values_ocp_rdma.yaml
     {{- else if eq .Environment.Name "gke_tpu" }}

--- a/guides/pd-disaggregation/ms-pd/values_oci_amd.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_oci_amd.yaml
@@ -1,0 +1,257 @@
+multinode: false
+
+# OCI OKE deployment of Llama-3.3-70B-Instruct-FP8-KV on BM.GPU.MI300X.8 nodes
+# Network: NVIDIA Network Operator SR-IOV VFs (nvidia.com/sriov-rdma-vf) over RoCE
+# Resource layout per BM.GPU.MI300X.8 node: 8x amd.com/gpu, 8x nvidia.com/sriov-rdma-vf
+# This config fills one node: 1 decode (TP=4, 4 GPU + 4 VF) + 4 prefill (TP=1, 1 GPU + 1 VF each)
+
+modelArtifacts:
+  uri: "hf://amd/Llama-3.3-70B-Instruct-FP8-KV"
+  size: 100Gi
+  authSecretName: "llm-d-hf-token"
+  name: "amd/Llama-3.3-70B-Instruct-FP8-KV"
+  labels:
+    llm-d.ai/inference-serving: "true"
+    llm-d.ai/guide: "pd-disaggregation"
+    llm-d.ai/hardware-variant: "gpu"
+    llm-d.ai/accelerator-vendor: "amd"
+    llm-d.ai/model: "Llama-3.3-70B-Instruct-FP8-KV"
+
+accelerator:
+  type: amd
+
+routing:
+  servicePort: 8000
+  proxy:
+    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
+    connector: nixlv2
+    secure: false
+
+decode:
+  create: true
+  parallelism:
+    tensor: 4
+    data: 1
+  replicas: 1
+  monitoring:
+    podmonitor:
+      enabled: true
+      portName: "vllm"
+      path: "/metrics"
+      interval: "30s"
+  podAnnotations:
+    # SR-IOV VFs via Multus CNI — 4 interfaces to match tensor parallelism (TP=4)
+    # The SriovNetwork CR "sriov-rdma-vf" is published to namespace "default"
+    k8s.v1.cni.cncf.io/networks: |
+      [
+        {"name":"sriov-rdma-vf","namespace":"default","interface":"net1"},
+        {"name":"sriov-rdma-vf","namespace":"default","interface":"net2"},
+        {"name":"sriov-rdma-vf","namespace":"default","interface":"net3"},
+        {"name":"sriov-rdma-vf","namespace":"default","interface":"net4"}
+      ]
+  containers:
+    - name: "vllm"
+      image: ghcr.io/llm-d/llm-d-rocm:v0.6.0
+      modelCommand: vllmServe
+      args:
+        - "--block-size"
+        - "128"
+        - "--kv-transfer-config"
+        - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+        - "--disable-uvicorn-access-log"
+        - "--attention-backend"
+        - "ROCM_ATTN"  # required when prefill TP != decode TP
+        - "--max-model-len"
+        - "32000"
+      env:
+        - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+          value: "5600"
+        - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        # UCX transport for OCI RoCE via SR-IOV VFs
+        # rc/ud = RDMA reliable/unreliable connected over RoCE, sm = shared memory, cuda_copy = fallback
+        - name: UCX_TLS
+          value: "rc,ud,sm,self,cuda_copy"
+        # RoCE v2 GID index — verify with: show_gids on the host; typically 3 on OCI
+        - name: UCX_IB_GID_INDEX
+          value: "3"
+      ports:
+        - containerPort: 8200
+          name: vllm
+          protocol: TCP
+        - containerPort: 5600
+          name: nixl
+          protocol: TCP
+      resources:
+        limits:
+          memory: 256Gi
+          cpu: "16"
+          # OCI SR-IOV RDMA VFs via NVIDIA Network Operator — 1 VF per GPU in TP group
+          nvidia.com/sriov-rdma-vf: "4"
+        requests:
+          memory: 256Gi
+          cpu: "16"
+          nvidia.com/sriov-rdma-vf: "4"
+      mountModelVolume: true
+      volumeMounts:
+        - name: metrics-volume
+          mountPath: /.config
+        - name: shm
+          mountPath: /dev/shm
+        - name: torch-compile-cache
+          mountPath: /.cache
+        - name: dev-infiniband
+          mountPath: /dev/infiniband
+      startupProbe:
+        httpGet:
+          path: /v1/models
+          port: vllm
+        initialDelaySeconds: 15
+        periodSeconds: 30
+        timeoutSeconds: 5
+        failureThreshold: 60
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: vllm
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 3
+      readinessProbe:
+        httpGet:
+          path: /v1/models
+          port: vllm
+        periodSeconds: 5
+        timeoutSeconds: 2
+        failureThreshold: 3
+      # IPC_LOCK allows UCX/RDMA to lock memory pages (mlock) — required for SR-IOV RDMA on OCI
+      extraConfig:
+        securityContext:
+          capabilities:
+            add:
+            - "IPC_LOCK"
+  volumes:
+  - name: metrics-volume
+    emptyDir: {}
+  - name: shm
+    emptyDir:
+      medium: Memory
+      sizeLimit: "16Gi"
+  - name: torch-compile-cache
+    emptyDir: {}
+  - name: dev-infiniband
+    hostPath:
+      path: /dev/infiniband
+      type: Directory
+
+prefill:
+  create: true
+  parallelism:
+    tensor: 1
+  replicas: 4
+  monitoring:
+    podmonitor:
+      enabled: true
+      portName: "vllm"
+      path: "/metrics"
+      interval: "30s"
+  podAnnotations:
+    # SR-IOV VFs via Multus CNI — 1 interface to match tensor parallelism (TP=1)
+    k8s.v1.cni.cncf.io/networks: |
+      [
+        {"name":"sriov-rdma-vf","namespace":"default","interface":"net1"}
+      ]
+  containers:
+    - name: "vllm"
+      image: ghcr.io/llm-d/llm-d-rocm:v0.6.0
+      modelCommand: vllmServe
+      args:
+        - "--block-size"
+        - "128"
+        - "--kv-transfer-config"
+        - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+        - "--disable-uvicorn-access-log"
+        - "--attention-backend"
+        - "ROCM_ATTN"  # required when prefill TP != decode TP
+        - "--max-model-len"
+        - "32000"
+      env:
+        - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+          value: "5600"
+        - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: UCX_TLS
+          value: "rc,ud,sm,self,cuda_copy"
+        - name: UCX_IB_GID_INDEX
+          value: "3"
+      ports:
+        - containerPort: 8000
+          name: vllm
+          protocol: TCP
+        - containerPort: 5600
+          name: nixl
+          protocol: TCP
+      resources:
+        limits:
+          memory: 256Gi
+          cpu: "8"
+          # 1 SR-IOV VF per prefill pod (TP=1 → 1 VF)
+          nvidia.com/sriov-rdma-vf: "1"
+        requests:
+          memory: 256Gi
+          cpu: "8"
+          nvidia.com/sriov-rdma-vf: "1"
+      mountModelVolume: true
+      volumeMounts:
+        - name: metrics-volume
+          mountPath: /.config
+        - name: shm
+          mountPath: /dev/shm
+        - name: torch-compile-cache
+          mountPath: /.cache
+        - name: dev-infiniband
+          mountPath: /dev/infiniband
+      startupProbe:
+        httpGet:
+          path: /v1/models
+          port: vllm
+        initialDelaySeconds: 15
+        periodSeconds: 30
+        timeoutSeconds: 5
+        failureThreshold: 60
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: vllm
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 3
+      readinessProbe:
+        httpGet:
+          path: /v1/models
+          port: vllm
+        periodSeconds: 5
+        timeoutSeconds: 2
+        failureThreshold: 3
+      extraConfig:
+        securityContext:
+          capabilities:
+            add:
+            - "IPC_LOCK"
+  volumes:
+  - name: metrics-volume
+    emptyDir: {}
+  - name: shm
+    emptyDir:
+      medium: Memory
+      sizeLimit: "16Gi"
+  - name: torch-compile-cache
+    emptyDir: {}
+  - name: dev-infiniband
+    hostPath:
+      path: /dev/infiniband
+      type: Directory


### PR DESCRIPTION
this builds on tyler smith's existing oci disaggregated serving work in the https://github.com/tlrmchlsmth/jpareto/tree/main/disagg repo (based on varun's original helmfile), updated to current upstream chart versions (modelservice v0.4.9, infra v1.4.0, gie v1.4.0) and integrated into the standard llm-d well-lit-path structure. 

tested and validated on OCI cluster