### PR TITLE
fix: use the proper git ref for tag extraction

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -226,6 +226,10 @@ jobs:
           username: ${{ secrets.GHCR_USER }}
           password: ${{ secrets.GHCR_TOKEN }}
 
+      - name: Compute short SHA from checkout
+        id: short-sha
+        run: echo "short_sha=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v6
@@ -234,7 +238,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha
+            type=raw,value=sha-${{ steps.short-sha.outputs.short_sha }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Calculate Cache Bust Timestamp
@@ -383,6 +387,10 @@ jobs:
           username: ${{ secrets.GHCR_USER }}
           password: ${{ secrets.GHCR_TOKEN }}
 
+      - name: Compute short SHA from checkout
+        id: short-sha
+        run: echo "short_sha=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v6
@@ -391,7 +399,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha
+            type=raw,value=sha-${{ steps.short-sha.outputs.short_sha }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Calculate Cache Bust Timestamp
@@ -632,7 +640,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha
+            type=raw,value=sha-${{ needs.cuda-success-check.outputs.shortsha }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Create and push manifest
@@ -753,6 +761,10 @@ jobs:
           username: ${{ secrets.GHCR_USER }}
           password: ${{ secrets.GHCR_TOKEN }}
 
+      - name: Compute short SHA from checkout
+        id: short-sha
+        run: echo "short_sha=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v6
@@ -761,7 +773,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha
+            type=raw,value=sha-${{ steps.short-sha.outputs.short_sha }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Calculate Cache Bust Timestamp
@@ -960,7 +972,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha
+            type=raw,value=sha-${{ needs.aws-success-check.outputs.shortsha }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Create and push manifest
@@ -1062,6 +1074,10 @@ jobs:
           username: ${{ secrets.GHCR_USER }}
           password: ${{ secrets.GHCR_TOKEN }}
 
+      - name: Compute short SHA from checkout
+        id: short-sha
+        run: echo "short_sha=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v6
@@ -1070,7 +1086,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha
+            type=raw,value=sha-${{ steps.short-sha.outputs.short_sha }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build & Push


### PR DESCRIPTION
fix for using the merge commit sha vs PR commit sha. EX: #1132 produces:
```
    DOCKER_METADATA_OUTPUT_TAGS: ghcr.io/llm-d/llm-d-cuda-dev:pr-1132
  ghcr.io/llm-d/llm-d-cuda-dev:sha-824601e
```
PR tag pullable where as sha is not. This is because 824... is the merge commit sha on the main repo, where as the actual commit sha on my PR is: 
```
docker pull --platform linux/amd64 ghcr.io/llm-d/llm-d-cuda-dev:sha-4de2f73
sha-4de2f73: Pulling from llm-d/llm-d-cuda-dev
015b03b764c0: Already exists
e993ad82d011: Already exists
8468ef3bbeff: Already exists
d8b987a3f180: Downloading [===================>                               ]  29.36MB/75.26MB
00a75c92d3e5: Already exists
a31fe918a805: Downloading [===================>                               ]  30.41MB/79.61MB
934da6d32fe0: Already exists
ba2392fe9612: Already exists
408597c678d9: Already exists
293950d1e391: Already exists
171ca3d667bd: Already exists
e21a9186f22a: Already exists
5d7be404d90c: Already exists
a2e2743a1110: Already exists
9915ada9dfaa: Downloading [==>                                                ]  28.31MB/525.1MB
7d79b966b2bd: Downloading [===================================>               ]  33.55MB/47.2MB
cccb77aecb63: Already exists
0d0fb840b68e: Already exists
a8c7f54a4d85: Already exists
5701320f0abd: Already exists
40d47e959016: Already exists
4f4fb700ef54: Already exists
e8521d8a1269: Already exists
6e8af4fd0a07: Already exists
57084edc2ec4: Already exists
d491c2cd2fb0: Already exists
51efdf800aea: Downloading [=================>                                 ]  29.36MB/81.65MB
8a0f862c3e69: Already exists
326f23ce5e23: Already exists
c9e8870c4893: Already exists
65eb9c20c69f: Already exists
1c5e078df91e: Already exists
1e0f5ba10f0b: Already exists
64a73677f9a0: Already exists
fabd5f5075ea: Downloading [>                                                  ]  30.41MB/2.308GB
fceb23c16d8e: Already exists
8b146ec810ef: Already exists
1eca766b19b7: Already exists
aaed69748058: Already exists
e192bebd3452: Already exists
f89e415f34e2: Already exists
aaa8aeb15b8e: Downloading [>                                                  ]  45.09MB/8.082GB
^C
```
which is pullable. This is a metadata extraction issue