### PR TITLE
Upgrade to CUDA13 and support GB200

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1031,18 +1031,7 @@ jobs:
   gb200-build-llm-d:
     needs: [detect-changes]
     if: ${{ needs.detect-changes.outputs.gb200 == 'true' }}
-    continue-on-error: true
-    strategy:
-      fail-fast: false
-      # GB200 build matrix: RHEL-only, amd64-only (for now)
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: vllm-runner
-            os: rhel
-            base_image_suffix: ubi9
-            image_suffix: ""
-    runs-on: ${{ matrix.runner }}
+    runs-on: vllm-runner-arm
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -1052,7 +1041,6 @@ jobs:
       - name: Load version configuration from file
         id: common-version
         run: |
-          # Read vLLM and CUDA versions from docker/common-versions file and set as outputs
           source docker/common-versions
           echo "repo=${VLLM_REPO}" >> $GITHUB_OUTPUT
           echo "commit_sha=${VLLM_COMMIT_SHA}" >> $GITHUB_OUTPUT
@@ -1077,16 +1065,15 @@ jobs:
           username: ${{ secrets.GHCR_USER }}
           password: ${{ secrets.GHCR_TOKEN }}
 
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200-dev${{ matrix.image_suffix }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
+      - name: Set image tag
+        id: set-tag
+        run: |
+          TAG="sha-$(git rev-parse --short HEAD)"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          PR_TAG="${{ github.event.pull_request.number }}"
+          if [ -n "${PR_TAG}" ]; then
+            echo "pr_tag=pr-${PR_TAG}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Calculate Cache Bust Timestamp
         id: cache_buster_timestamp
@@ -1099,16 +1086,15 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile.cuda
-          platforms: ${{ matrix.platform }}
+          platforms: linux/arm64
           target: builder
           push: false
-          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             CACHE_BUSTER=${{ steps.cache_buster_timestamp.outputs.cache_buster_timestamp }}
-            TARGETOS=${{ matrix.os }}
-            TARGETPLATFORM=${{ matrix.platform }}
-            BUILD_BASE_IMAGE_SUFFIX=${{ matrix.base_image_suffix }}
-            FINAL_BASE_IMAGE_SUFFIX=${{ matrix.base_image_suffix }}
+            TARGETOS=rhel
+            TARGETPLATFORM=linux/arm64
+            BUILD_BASE_IMAGE_SUFFIX=ubi9
+            FINAL_BASE_IMAGE_SUFFIX=ubi9
             CUDA_MAJOR=${{ steps.common-version.outputs.cuda_major }}
             CUDA_MINOR=${{ steps.common-version.outputs.cuda_minor }}
             CUDA_PATCH=${{ steps.common-version.outputs.cuda_patch }}
@@ -1123,22 +1109,22 @@ jobs:
           DOCKER_BUILDKIT: "1"
           BUILDKIT_PROGRESS: "plain"
 
-      - name: Build the final image layer
-        id: build-image-final-layer
+      - name: Build and push the final image
+        id: build-and-push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/Dockerfile.cuda
           target: runtime
-          platforms: ${{ matrix.platform }}
+          platforms: linux/arm64
           push: true
-          provenance: false
+          provenance: true
           build-args: |
             CACHE_BUSTER=${{ steps.cache_buster_timestamp.outputs.cache_buster_timestamp }}
-            TARGETOS=${{ matrix.os }}
-            TARGETPLATFORM=${{ matrix.platform }}
-            BUILD_BASE_IMAGE_SUFFIX=${{ matrix.base_image_suffix }}
-            FINAL_BASE_IMAGE_SUFFIX=${{ matrix.base_image_suffix }}
+            TARGETOS=rhel
+            TARGETPLATFORM=linux/arm64
+            BUILD_BASE_IMAGE_SUFFIX=ubi9
+            FINAL_BASE_IMAGE_SUFFIX=ubi9
             CUDA_MAJOR=${{ steps.common-version.outputs.cuda_major }}
             CUDA_MINOR=${{ steps.common-version.outputs.cuda_minor }}
             CUDA_PATCH=${{ steps.common-version.outputs.cuda_patch }}
@@ -1151,185 +1137,20 @@ jobs:
             VLLM_PREBUILT=${{ steps.common-version.outputs.prebuilt }}
             VLLM_USE_PRECOMPILED=${{ steps.common-version.outputs.use_precompiled }}
             LLM_D_OFFLOADING_CONNECTOR_VERSION=${{ steps.common-version.outputs.offloading_connector_version }}
-          labels: ${{ steps.meta.outputs.labels }}
-          outputs: >-
-            type=image,name=${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200-dev${{ matrix.image_suffix }},
-            push-by-digest=true,name-canonical=true,push=true
+          tags: |
+            ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200-dev:${{ steps.set-tag.outputs.tag }}
+            ${{ steps.set-tag.outputs.pr_tag != '' && format('{0}/{1}-cuda-gb200-dev:{2}', env.REGISTRY, github.repository, steps.set-tag.outputs.pr_tag) || '' }}
+            ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event_name != 'pull_request' && format('{0}/{1}-cuda-gb200-dev:latest', env.REGISTRY, github.repository) || '' }}
           github-token: ${{ secrets.GHCR_TOKEN }}
         env:
           DOCKER_BUILDKIT: "1"
           BUILDKIT_PROGRESS: "plain"
 
-      - name: Verify remote digest exists
-        if: ${{ steps.build-image-final-layer.outputs.digest != '' }}
-        run: |
-          set -x
-          digest="${{ steps.build-image-final-layer.outputs.digest }}"
-          ref="${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200-dev${{ matrix.image_suffix }}@${digest}"
-          echo "Checking remote ref: $ref"
-          docker buildx imagetools inspect "$ref" >/dev/null
-
-      - name: Export digest
-        if: ${{ steps.build-image-final-layer.outputs.digest != '' }}
-        run: |
-          mkdir -p /tmp/digests/${{ matrix.os }}
-          digest="${{ steps.build-image-final-layer.outputs.digest }}"
-          touch "/tmp/digests/${{ matrix.os }}/${digest#sha256:}"
-
-      - name: Upload digest
-        if: ${{ steps.build-image-final-layer.outputs.digest != '' }}
-        uses: actions/upload-artifact@v6
-        with:
-          name: digests-cuda-gb200-dev-${{ matrix.os }}-${{ matrix.platform == 'linux/arm64' && 'arm64' || 'amd64' }}
-          path: /tmp/digests/${{ matrix.os }}/*
-          if-no-files-found: error
-          retention-days: 1
-
-  gb200-success-check:
-    needs: gb200-build-llm-d
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    outputs:
-      any_succeeded: ${{ steps.check.outputs.any_succeeded }}
-      rhel_ok: ${{ steps.check.outputs.rhel_ok }}
-      shortsha: ${{ steps.export-sha.outputs.shortsha }}
-    steps:
-      - name: Download all digests (best-effort)
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests-raw
-          pattern: digests-cuda-gb200-dev-*
-        continue-on-error: true
-
-      - name: Reorganize digests by OS
-        run: |
-          mkdir -p /tmp/digests/rhel
-          shopt -s nullglob
-          for artifact_dir in /tmp/digests-raw/digests-cuda-gb200-dev-*; do
-            if [[ "$artifact_dir" == *-rhel-* ]]; then
-              cp -v "$artifact_dir"/* /tmp/digests/rhel/ 2>/dev/null || true
-            fi
-          done
-          echo "=== RHEL digests ==="
-          ls -la /tmp/digests/rhel/ || echo "No RHEL digests"
-
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.ref || '' }}
-
-      - name: Export Git Sha
-        id: export-sha
-        run: |
-          echo "shortsha=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
-
-      - id: check
-        shell: bash
-        run: |
-          shopt -s nullglob
-          rhel=(/tmp/digests/rhel/*)
-
-          any=false; [ ${#rhel[@]} -gt 0 ] && any=true
-          rhel_ok=false; [ ${#rhel[@]} -gt 0 ] && rhel_ok=true
-
-          echo "Downloaded ${#rhel[@]} RHEL digest(s)"
-          echo "any_succeeded=${any}" >> "$GITHUB_OUTPUT"
-          echo "rhel_ok=${rhel_ok}" >> "$GITHUB_OUTPUT"
-
-  gb200-manifest:
-    needs: gb200-success-check
-    if: ${{ needs.gb200-success-check.outputs.any_succeeded == 'true' }}
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - name: Check if build succeeded
-        id: should-run
-        run: |
-          rhel_ok="${{ needs.gb200-success-check.outputs.rhel_ok }}"
-          echo "rhel_ok=${rhel_ok}" >> $GITHUB_OUTPUT
-          if [ "${rhel_ok}" != "true" ]; then
-            echo "Skipping manifest creation - no successful builds"
-          fi
-
-      - name: Download digests
-        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests-raw
-          pattern: digests-cuda-gb200-dev-rhel-*
-
-      - name: Reorganize digests for manifest
-        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
-        run: |
-          mkdir -p /tmp/digests/rhel
-          shopt -s nullglob
-          for artifact_dir in /tmp/digests-raw/digests-cuda-gb200-dev-rhel-*; do
-            cp -v "$artifact_dir"/* /tmp/digests/rhel/ 2>/dev/null || true
-          done
-
-      - name: Set up Docker Buildx
-        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Container Registry
-        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.GHCR_USER }}
-          password: ${{ secrets.GHCR_TOKEN }}
-
-      - name: Extract metadata
-        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200-dev
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Create and push manifest
-        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
-        id: manifest
-        working-directory: /tmp/digests/rhel
-        run: |
-          set -x
-          SHORT_SHA="${{ needs.gb200-success-check.outputs.shortsha }}"
-          # build the list of source images (by digest)
-          sources=""
-          for digest in *; do
-            image="${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200-dev"
-            sources="$sources ${image}@sha256:$digest"
-          done
-
-          # create manifest and tag it
-          tags="-t ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200-dev:sha-${SHORT_SHA}"
-          if [ -n "${{ github.event.pull_request.number }}" ]; then
-            tags="$tags -t ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200-dev:pr-${{ github.event.pull_request.number }}"
-          fi
-          if [ "${{ github.ref }}" = "refs/heads/${{ github.event.repository.default_branch }}" ] && \
-             [ "${{ github.event_name }}" != "pull_request" ]; then
-            tags="$tags -t ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200-dev:latest"
-          fi
-          docker buildx imagetools create $tags $sources
-
-          # extract final manifest digest
-          MANIFEST_DIGEST=$(docker buildx imagetools inspect \
-            ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200-dev:sha-${SHORT_SHA} \
-            | awk '/^Digest:/ {print $2}')
-          echo "digest=${MANIFEST_DIGEST}" >> $GITHUB_OUTPUT
-
       - name: Run Trivy vulnerability scanner
-        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
         continue-on-error: true
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
-          image-ref: >-
-            ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200-dev@${{
-              steps.manifest.outputs.digest }}
+          image-ref: ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200-dev:${{ steps.set-tag.outputs.tag }}
           format: "sarif"
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH,MEDIUM"
@@ -1341,14 +1162,12 @@ jobs:
           TRIVY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
 
       - name: Upload Trivy scan results to GitHub Security tab
-        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
         continue-on-error: true
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: "trivy-results.sarif"
 
       - name: Display vulnerability summary
-        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
         run: |
           echo "=== Vulnerability Scan Summary ==="
           if [ -f trivy-results.sarif ]; then

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -23,7 +23,7 @@ on:
   workflow_dispatch:
     inputs:
       platforms:
-        description: "Platforms to build (comma-separated: cuda,aws,xpu,cpu,hpu)"
+        description: "Platforms to build (comma-separated: cuda,aws,gb200,xpu,cpu,hpu)"
         required: false
         default: "cuda"
         type: string
@@ -63,6 +63,7 @@ jobs:
     outputs:
       cuda: ${{ steps.force.outputs.cuda || steps.filter.outputs.cuda || steps.dispatch.outputs.cuda }}
       aws: ${{ steps.force.outputs.aws || steps.filter.outputs.aws || steps.dispatch.outputs.aws }}
+      gb200: ${{ steps.force.outputs.gb200 || steps.filter.outputs.gb200 || steps.dispatch.outputs.gb200 }}
       rocm: ${{ steps.force.outputs.rocm || steps.filter.outputs.rocm || steps.dispatch.outputs.rocm }}
       xpu: ${{ steps.force.outputs.xpu || steps.filter.outputs.xpu || steps.dispatch.outputs.xpu }}
       cpu: ${{ steps.force.outputs.cpu || steps.filter.outputs.cpu || steps.dispatch.outputs.cpu }}
@@ -75,6 +76,7 @@ jobs:
         run: |
           echo "cuda=true" >> $GITHUB_OUTPUT
           echo "aws=true" >> $GITHUB_OUTPUT
+          echo "gb200=true" >> $GITHUB_OUTPUT
           echo "rocm=true" >> $GITHUB_OUTPUT
           echo "xpu=true" >> $GITHUB_OUTPUT
           echo "cpu=true" >> $GITHUB_OUTPUT
@@ -109,6 +111,16 @@ jobs:
               - 'docker/packages/rpms/**'
               - 'patches/nvshmem_zero_ibv_ah_attr_3.3.20.patch'
               - 'patches/nvshmem_zero_ibv_ah_attr_v3.4.5-0.patch'
+            gb200:
+              - 'docker/Dockerfile.cuda'
+              - 'docker/common-versions'
+              - 'docker/scripts/common/**'
+              - 'docker/scripts/cuda/**'
+              - 'docker/packages/common/**'
+              - 'docker/packages/cuda/**'
+              - 'docker/packages/rpms/**'
+              - 'patches/nvshmem_zero_ibv_ah_attr_3.3.20.patch'
+              - 'patches/nvshmem_zero_ibv_ah_attr_v3.4.5-0.patch'
             rocm:
               - 'docker/Dockerfile.rocm'
             xpu:
@@ -130,6 +142,7 @@ jobs:
           platforms="${{ inputs.platforms }}"
           echo "cuda=$(echo $platforms | grep -q cuda && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "aws=$(echo $platforms | grep -q aws && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "gb200=$(echo $platforms | grep -q gb200 && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "rocm=$(echo $platforms | grep -q rocm && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "xpu=$(echo $platforms | grep -q xpu && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "cpu=$(echo $platforms | grep -q cpu && echo true || echo false)" >> $GITHUB_OUTPUT
@@ -1002,6 +1015,335 @@ jobs:
         if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
         continue-on-error: true
         uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: "trivy-results.sarif"
+
+      - name: Display vulnerability summary
+        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
+        run: |
+          echo "=== Vulnerability Scan Summary ==="
+          if [ -f trivy-results.sarif ]; then
+            echo "Scan completed. Check the Security tab for detailed results."
+          else
+            echo "No vulnerabilities found or scan failed."
+          fi
+
+  gb200-build-llm-d:
+    needs: [detect-changes]
+    if: ${{ needs.detect-changes.outputs.gb200 == 'true' }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      # GB200 build matrix: RHEL-only, amd64-only (for now)
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: vllm-runner
+            os: rhel
+            base_image_suffix: ubi9
+            image_suffix: ""
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || '' }}
+
+      - name: Load version configuration from file
+        id: common-version
+        run: |
+          # Read vLLM and CUDA versions from docker/common-versions file and set as outputs
+          source docker/common-versions
+          echo "repo=${VLLM_REPO}" >> $GITHUB_OUTPUT
+          echo "commit_sha=${VLLM_COMMIT_SHA}" >> $GITHUB_OUTPUT
+          echo "precompiled_wheel_commit=${VLLM_PRECOMPILED_WHEEL_COMMIT}" >> $GITHUB_OUTPUT
+          echo "prebuilt=${VLLM_PREBUILT}" >> $GITHUB_OUTPUT
+          echo "use_precompiled=${VLLM_USE_PRECOMPILED}" >> $GITHUB_OUTPUT
+          echo "cuda_major=${CUDA_MAJOR}" >> $GITHUB_OUTPUT
+          echo "cuda_minor=${CUDA_MINOR}" >> $GITHUB_OUTPUT
+          echo "cuda_patch=${CUDA_PATCH}" >> $GITHUB_OUTPUT
+          echo "offloading_connector_version=${LLM_D_OFFLOADING_CONNECTOR_VERSION}" >> $GITHUB_OUTPUT
+          echo "gb200_nvshmem_version=${GB200_NVSHMEM_VERSION}" >> $GITHUB_OUTPUT
+          echo "gb200_deepep_repo=${GB200_DEEPEP_REPO}" >> $GITHUB_OUTPUT
+          echo "gb200_deepep_version=${GB200_DEEPEP_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.GHCR_USER }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200-dev${{ matrix.image_suffix }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Calculate Cache Bust Timestamp
+        id: cache_buster_timestamp
+        run: |
+          echo "cache_buster_timestamp=$(date)" >> $GITHUB_OUTPUT
+
+      - name: Build the builder image layer
+        id: build-image-build-layer
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile.cuda
+          platforms: ${{ matrix.platform }}
+          target: builder
+          push: false
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            CACHE_BUSTER=${{ steps.cache_buster_timestamp.outputs.cache_buster_timestamp }}
+            TARGETOS=${{ matrix.os }}
+            TARGETPLATFORM=${{ matrix.platform }}
+            BUILD_BASE_IMAGE_SUFFIX=${{ matrix.base_image_suffix }}
+            FINAL_BASE_IMAGE_SUFFIX=${{ matrix.base_image_suffix }}
+            CUDA_MAJOR=${{ steps.common-version.outputs.cuda_major }}
+            CUDA_MINOR=${{ steps.common-version.outputs.cuda_minor }}
+            CUDA_PATCH=${{ steps.common-version.outputs.cuda_patch }}
+            NVSHMEM_VERSION=${{ steps.common-version.outputs.gb200_nvshmem_version }}
+            DEEPEP_REPO=${{ steps.common-version.outputs.gb200_deepep_repo }}
+            DEEPEP_VERSION=${{ steps.common-version.outputs.gb200_deepep_version }}
+          github-token: ${{ secrets.GHCR_TOKEN }}
+          secrets: |
+            aws_access_key_id=${{ secrets.AWS_ACCESS_KEY_ID_S3_BUCKET_ONLY }}
+            aws_secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY_S3_BUCKET_ONLY }}
+        env:
+          DOCKER_BUILDKIT: "1"
+          BUILDKIT_PROGRESS: "plain"
+
+      - name: Build the final image layer
+        id: build-image-final-layer
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile.cuda
+          target: runtime
+          platforms: ${{ matrix.platform }}
+          push: true
+          provenance: false
+          build-args: |
+            CACHE_BUSTER=${{ steps.cache_buster_timestamp.outputs.cache_buster_timestamp }}
+            TARGETOS=${{ matrix.os }}
+            TARGETPLATFORM=${{ matrix.platform }}
+            BUILD_BASE_IMAGE_SUFFIX=${{ matrix.base_image_suffix }}
+            FINAL_BASE_IMAGE_SUFFIX=${{ matrix.base_image_suffix }}
+            CUDA_MAJOR=${{ steps.common-version.outputs.cuda_major }}
+            CUDA_MINOR=${{ steps.common-version.outputs.cuda_minor }}
+            CUDA_PATCH=${{ steps.common-version.outputs.cuda_patch }}
+            NVSHMEM_VERSION=${{ steps.common-version.outputs.gb200_nvshmem_version }}
+            DEEPEP_REPO=${{ steps.common-version.outputs.gb200_deepep_repo }}
+            DEEPEP_VERSION=${{ steps.common-version.outputs.gb200_deepep_version }}
+            VLLM_REPO=${{ inputs.vllm_repo || steps.common-version.outputs.repo }}
+            VLLM_COMMIT_SHA=${{ inputs.vllm_commit_sha || steps.common-version.outputs.commit_sha }}
+            VLLM_PRECOMPILED_WHEEL_COMMIT=${{ inputs.vllm_precompiled_wheel_commit || steps.common-version.outputs.precompiled_wheel_commit }}
+            VLLM_PREBUILT=${{ steps.common-version.outputs.prebuilt }}
+            VLLM_USE_PRECOMPILED=${{ steps.common-version.outputs.use_precompiled }}
+            LLM_D_OFFLOADING_CONNECTOR_VERSION=${{ steps.common-version.outputs.offloading_connector_version }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: >-
+            type=image,name=${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200-dev${{ matrix.image_suffix }},
+            push-by-digest=true,name-canonical=true,push=true
+          github-token: ${{ secrets.GHCR_TOKEN }}
+        env:
+          DOCKER_BUILDKIT: "1"
+          BUILDKIT_PROGRESS: "plain"
+
+      - name: Verify remote digest exists
+        if: ${{ steps.build-image-final-layer.outputs.digest != '' }}
+        run: |
+          set -x
+          digest="${{ steps.build-image-final-layer.outputs.digest }}"
+          ref="${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200-dev${{ matrix.image_suffix }}@${digest}"
+          echo "Checking remote ref: $ref"
+          docker buildx imagetools inspect "$ref" >/dev/null
+
+      - name: Export digest
+        if: ${{ steps.build-image-final-layer.outputs.digest != '' }}
+        run: |
+          mkdir -p /tmp/digests/${{ matrix.os }}
+          digest="${{ steps.build-image-final-layer.outputs.digest }}"
+          touch "/tmp/digests/${{ matrix.os }}/${digest#sha256:}"
+
+      - name: Upload digest
+        if: ${{ steps.build-image-final-layer.outputs.digest != '' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: digests-cuda-gb200-dev-${{ matrix.os }}-${{ matrix.platform == 'linux/arm64' && 'arm64' || 'amd64' }}
+          path: /tmp/digests/${{ matrix.os }}/*
+          if-no-files-found: error
+          retention-days: 1
+
+  gb200-success-check:
+    needs: gb200-build-llm-d
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    outputs:
+      any_succeeded: ${{ steps.check.outputs.any_succeeded }}
+      rhel_ok: ${{ steps.check.outputs.rhel_ok }}
+      shortsha: ${{ steps.export-sha.outputs.shortsha }}
+    steps:
+      - name: Download all digests (best-effort)
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests-raw
+          pattern: digests-cuda-gb200-dev-*
+        continue-on-error: true
+
+      - name: Reorganize digests by OS
+        run: |
+          mkdir -p /tmp/digests/rhel
+          shopt -s nullglob
+          for artifact_dir in /tmp/digests-raw/digests-cuda-gb200-dev-*; do
+            if [[ "$artifact_dir" == *-rhel-* ]]; then
+              cp -v "$artifact_dir"/* /tmp/digests/rhel/ 2>/dev/null || true
+            fi
+          done
+          echo "=== RHEL digests ==="
+          ls -la /tmp/digests/rhel/ || echo "No RHEL digests"
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || '' }}
+
+      - name: Export Git Sha
+        id: export-sha
+        run: |
+          echo "shortsha=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
+
+      - id: check
+        shell: bash
+        run: |
+          shopt -s nullglob
+          rhel=(/tmp/digests/rhel/*)
+
+          any=false; [ ${#rhel[@]} -gt 0 ] && any=true
+          rhel_ok=false; [ ${#rhel[@]} -gt 0 ] && rhel_ok=true
+
+          echo "Downloaded ${#rhel[@]} RHEL digest(s)"
+          echo "any_succeeded=${any}" >> "$GITHUB_OUTPUT"
+          echo "rhel_ok=${rhel_ok}" >> "$GITHUB_OUTPUT"
+
+  gb200-manifest:
+    needs: gb200-success-check
+    if: ${{ needs.gb200-success-check.outputs.any_succeeded == 'true' }}
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Check if build succeeded
+        id: should-run
+        run: |
+          rhel_ok="${{ needs.gb200-success-check.outputs.rhel_ok }}"
+          echo "rhel_ok=${rhel_ok}" >> $GITHUB_OUTPUT
+          if [ "${rhel_ok}" != "true" ]; then
+            echo "Skipping manifest creation - no successful builds"
+          fi
+
+      - name: Download digests
+        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests-raw
+          pattern: digests-cuda-gb200-dev-rhel-*
+
+      - name: Reorganize digests for manifest
+        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
+        run: |
+          mkdir -p /tmp/digests/rhel
+          shopt -s nullglob
+          for artifact_dir in /tmp/digests-raw/digests-cuda-gb200-dev-rhel-*; do
+            cp -v "$artifact_dir"/* /tmp/digests/rhel/ 2>/dev/null || true
+          done
+
+      - name: Set up Docker Buildx
+        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.GHCR_USER }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Extract metadata
+        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200-dev
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Create and push manifest
+        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
+        id: manifest
+        working-directory: /tmp/digests/rhel
+        run: |
+          set -x
+          SHORT_SHA="${{ needs.gb200-success-check.outputs.shortsha }}"
+          # build the list of source images (by digest)
+          sources=""
+          for digest in *; do
+            image="${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200-dev"
+            sources="$sources ${image}@sha256:$digest"
+          done
+
+          # create manifest and tag it
+          tags="-t ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200-dev:sha-${SHORT_SHA}"
+          if [ -n "${{ github.event.pull_request.number }}" ]; then
+            tags="$tags -t ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200-dev:pr-${{ github.event.pull_request.number }}"
+          fi
+          if [ "${{ github.ref }}" = "refs/heads/${{ github.event.repository.default_branch }}" ] && \
+             [ "${{ github.event_name }}" != "pull_request" ]; then
+            tags="$tags -t ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200-dev:latest"
+          fi
+          docker buildx imagetools create $tags $sources
+
+          # extract final manifest digest
+          MANIFEST_DIGEST=$(docker buildx imagetools inspect \
+            ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200-dev:sha-${SHORT_SHA} \
+            | awk '/^Digest:/ {print $2}')
+          echo "digest=${MANIFEST_DIGEST}" >> $GITHUB_OUTPUT
+
+      - name: Run Trivy vulnerability scanner
+        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: >-
+            ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200-dev@${{
+              steps.manifest.outputs.digest }}
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH,MEDIUM"
+          scanners: vuln
+          timeout: 30m
+          skip-dirs: /root/.cache/uv
+        env:
+          TRIVY_USERNAME: ${{ secrets.GHCR_USER }}
+          TRIVY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: "trivy-results.sarif"
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -230,7 +230,7 @@ jobs:
             CACHE_BUSTER=${{ steps.cache_buster_timestamp.outputs.cache_buster_timestamp }}
             TARGETOS=${{ matrix.os }}
             TARGETPLATFORM=${{ matrix.platform }}
-            BUILD_BASE_IMAGE_SUFFIX=${{ matrix.os == 'ubuntu' && 'ubuntu20.04' || matrix.base_image_suffix }}
+            BUILD_BASE_IMAGE_SUFFIX=${{ matrix.os == 'ubuntu' && 'ubuntu24.04' || matrix.base_image_suffix }}
             FINAL_BASE_IMAGE_SUFFIX=${{ matrix.base_image_suffix }}
             CUDA_MAJOR=${{ steps.common-version.outputs.cuda_major }}
             CUDA_MINOR=${{ steps.common-version.outputs.cuda_minor }}
@@ -397,7 +397,7 @@ jobs:
             CACHE_BUSTER=${{ steps.cache_buster_timestamp.outputs.cache_buster_timestamp }}
             TARGETOS=${{ matrix.os }}
             TARGETPLATFORM=${{ matrix.platform }}
-            BUILD_BASE_IMAGE_SUFFIX=${{ matrix.os == 'ubuntu' && 'ubuntu20.04' || matrix.base_image_suffix }}
+            BUILD_BASE_IMAGE_SUFFIX=${{ matrix.os == 'ubuntu' && 'ubuntu24.04' || matrix.base_image_suffix }}
             FINAL_BASE_IMAGE_SUFFIX=${{ matrix.base_image_suffix }}
             CUDA_MAJOR=${{ steps.common-version.outputs.cuda_major }}
             CUDA_MINOR=${{ steps.common-version.outputs.cuda_minor }}
@@ -424,7 +424,7 @@ jobs:
             CACHE_BUSTER=${{ steps.cache_buster_timestamp.outputs.cache_buster_timestamp }}
             TARGETOS=${{ matrix.os }}
             TARGETPLATFORM=${{ matrix.platform }}
-            BUILD_BASE_IMAGE_SUFFIX=${{ matrix.os == 'ubuntu' && 'ubuntu20.04' || matrix.base_image_suffix }}
+            BUILD_BASE_IMAGE_SUFFIX=${{ matrix.os == 'ubuntu' && 'ubuntu24.04' || matrix.base_image_suffix }}
             FINAL_BASE_IMAGE_SUFFIX=${{ matrix.base_image_suffix }}
             CUDA_MAJOR=${{ steps.common-version.outputs.cuda_major }}
             CUDA_MINOR=${{ steps.common-version.outputs.cuda_minor }}

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -675,6 +675,307 @@ jobs:
             echo "No vulnerabilities found or scan failed."
           fi
 
+  release-gb200-llm-d:
+    strategy:
+      fail-fast: false
+      # GB200 release matrix: RHEL-only, amd64-only (for now)
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: vllm-runner
+            os: rhel
+            base_image_suffix: ubi9
+            image_suffix: ""
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.TAG }}
+          fetch-depth: 0
+
+      - name: Load version configuration from file
+        id: common-version
+        run: |
+          source docker/common-versions
+          echo "repo=${VLLM_REPO}" >> $GITHUB_OUTPUT
+          echo "commit_sha=${VLLM_COMMIT_SHA}" >> $GITHUB_OUTPUT
+          echo "precompiled_wheel_commit=${VLLM_PRECOMPILED_WHEEL_COMMIT}" >> $GITHUB_OUTPUT
+          echo "prebuilt=${VLLM_PREBUILT}" >> $GITHUB_OUTPUT
+          echo "use_precompiled=${VLLM_USE_PRECOMPILED}" >> $GITHUB_OUTPUT
+          echo "cuda_major=${CUDA_MAJOR}" >> $GITHUB_OUTPUT
+          echo "cuda_minor=${CUDA_MINOR}" >> $GITHUB_OUTPUT
+          echo "cuda_patch=${CUDA_PATCH}" >> $GITHUB_OUTPUT
+          echo "offloading_connector_version=${LLM_D_OFFLOADING_CONNECTOR_VERSION}" >> $GITHUB_OUTPUT
+          echo "gb200_nvshmem_version=${GB200_NVSHMEM_VERSION}" >> $GITHUB_OUTPUT
+          echo "gb200_deepep_repo=${GB200_DEEPEP_REPO}" >> $GITHUB_OUTPUT
+          echo "gb200_deepep_version=${GB200_DEEPEP_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.GHCR_USER }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200${{ matrix.image_suffix }}
+          tags: |
+            type=raw,value=${{ github.event.release.tag_name }},enable=${{ github.event_name == 'release' && github.event.action == 'published' }}
+            type=raw,value=${{ github.ref_name }},enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=latest,enable=true
+
+      - name: Build the builder image layer
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile.cuda
+          platforms: ${{ matrix.platform }}
+          target: builder
+          push: false
+          build-args: |
+            TARGETOS=${{ matrix.os }}
+            TARGETPLATFORM=${{ matrix.platform }}
+            BUILD_BASE_IMAGE_SUFFIX=${{ matrix.base_image_suffix }}
+            FINAL_BASE_IMAGE_SUFFIX=${{ matrix.base_image_suffix }}
+            CUDA_MAJOR=${{ steps.common-version.outputs.cuda_major }}
+            CUDA_MINOR=${{ steps.common-version.outputs.cuda_minor }}
+            CUDA_PATCH=${{ steps.common-version.outputs.cuda_patch }}
+            CACHE_BUSTER=${{ github.ref_name }}-${{ github.run_id }}
+            NVSHMEM_VERSION=${{ steps.common-version.outputs.gb200_nvshmem_version }}
+            DEEPEP_REPO=${{ steps.common-version.outputs.gb200_deepep_repo }}
+            DEEPEP_VERSION=${{ steps.common-version.outputs.gb200_deepep_version }}
+          labels: ${{ steps.meta.outputs.labels }}
+          github-token: ${{ secrets.GHCR_TOKEN }}
+          secrets: |
+            aws_access_key_id=${{ secrets.AWS_ACCESS_KEY_ID_S3_BUCKET_ONLY }}
+            aws_secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY_S3_BUCKET_ONLY }}
+        env:
+          DOCKER_BUILDKIT: "1"
+          BUILDKIT_PROGRESS: "plain"
+
+      - name: Build the final image layer
+        id: build-image-final-layer
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile.cuda
+          platforms: ${{ matrix.platform }}
+          target: runtime
+          push: true
+          build-args: |
+            TARGETOS=${{ matrix.os }}
+            TARGETPLATFORM=${{ matrix.platform }}
+            BUILD_BASE_IMAGE_SUFFIX=${{ matrix.base_image_suffix }}
+            FINAL_BASE_IMAGE_SUFFIX=${{ matrix.base_image_suffix }}
+            CUDA_MAJOR=${{ steps.common-version.outputs.cuda_major }}
+            CUDA_MINOR=${{ steps.common-version.outputs.cuda_minor }}
+            CUDA_PATCH=${{ steps.common-version.outputs.cuda_patch }}
+            CACHE_BUSTER=${{ github.ref_name }}-${{ github.run_id }}
+            NVSHMEM_VERSION=${{ steps.common-version.outputs.gb200_nvshmem_version }}
+            DEEPEP_REPO=${{ steps.common-version.outputs.gb200_deepep_repo }}
+            DEEPEP_VERSION=${{ steps.common-version.outputs.gb200_deepep_version }}
+            VLLM_REPO=${{ steps.common-version.outputs.repo }}
+            VLLM_COMMIT_SHA=${{ steps.common-version.outputs.commit_sha }}
+            VLLM_PRECOMPILED_WHEEL_COMMIT=${{ steps.common-version.outputs.precompiled_wheel_commit }}
+            VLLM_PREBUILT=${{ steps.common-version.outputs.prebuilt }}
+            VLLM_USE_PRECOMPILED=${{ steps.common-version.outputs.use_precompiled }}
+            LLM_D_OFFLOADING_CONNECTOR_VERSION=${{ steps.common-version.outputs.offloading_connector_version }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: >-
+            type=image,name=${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200${{ matrix.image_suffix }},
+            push-by-digest=true,name-canonical=true,push=true
+          github-token: ${{ secrets.GHCR_TOKEN }}
+        env:
+          DOCKER_BUILDKIT: "1"
+          BUILDKIT_PROGRESS: "plain"
+
+      - name: Verify remote digest exists
+        if: ${{ steps.build-image-final-layer.outputs.digest != '' }}
+        run: |
+          set -x
+          digest="${{ steps.build-image-final-layer.outputs.digest }}"
+          ref="${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200${{ matrix.image_suffix }}@${digest}"
+          echo "Checking remote ref: $ref"
+          docker buildx imagetools inspect "$ref" >/dev/null
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build-image-final-layer.outputs.digest }}"
+          if [ -z "$digest" ]; then
+            echo "ERROR: missing digest from build-image-final-layer (did the push succeed?)"
+            exit 1
+          fi
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v6
+        with:
+          name: digests-cuda-gb200-${{ matrix.os }}-${{ matrix.platform == 'linux/arm64' && 'arm64' || 'amd64' }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  release-gb200-success-check:
+    needs: release-gb200-llm-d
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    outputs:
+      any_succeeded: ${{ steps.check.outputs.any_succeeded }}
+      rhel_ok: ${{ steps.check.outputs.rhel_ok }}
+    steps:
+      - name: Download all digests (best-effort)
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests-raw
+          pattern: digests-cuda-gb200-*
+        continue-on-error: true
+
+      - name: Reorganize digests by OS
+        run: |
+          mkdir -p /tmp/digests/rhel
+          shopt -s nullglob
+          for artifact_dir in /tmp/digests-raw/digests-cuda-gb200-*; do
+            if [[ "$artifact_dir" == *-rhel-* ]]; then
+              cp -v "$artifact_dir"/* /tmp/digests/rhel/ 2>/dev/null || true
+            fi
+          done
+          echo "=== RHEL digests ==="
+          ls -la /tmp/digests/rhel/ || echo "No RHEL digests"
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - id: check
+        shell: bash
+        run: |
+          shopt -s nullglob
+          rhel=(/tmp/digests/rhel/*)
+
+          any=false; [ ${#rhel[@]} -gt 0 ] && any=true
+          rhel_ok=false; [ ${#rhel[@]} -gt 0 ] && rhel_ok=true
+
+          echo "Downloaded ${#rhel[@]} RHEL digest(s)"
+          echo "any_succeeded=${any}" >> "$GITHUB_OUTPUT"
+          echo "rhel_ok=${rhel_ok}" >> "$GITHUB_OUTPUT"
+
+  release-gb200-manifest:
+    needs: release-gb200-success-check
+    if: ${{ needs.release-gb200-success-check.outputs.any_succeeded == 'true' }}
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Check if build succeeded
+        id: should-run
+        run: |
+          rhel_ok="${{ needs.release-gb200-success-check.outputs.rhel_ok }}"
+          echo "rhel_ok=${rhel_ok}" >> $GITHUB_OUTPUT
+          if [ "${rhel_ok}" != "true" ]; then
+            echo "Skipping manifest creation - no successful builds"
+          fi
+
+      - name: Download digests
+        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests-raw
+          pattern: digests-cuda-gb200-rhel-*
+
+      - name: Reorganize digests for manifest
+        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
+        run: |
+          mkdir -p /tmp/digests/rhel
+          shopt -s nullglob
+          for artifact_dir in /tmp/digests-raw/digests-cuda-gb200-rhel-*; do
+            cp -v "$artifact_dir"/* /tmp/digests/rhel/ 2>/dev/null || true
+          done
+
+      - name: Set up Docker Buildx
+        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.GHCR_USER }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Extract metadata
+        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Create and push manifest
+        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
+        id: manifest
+        working-directory: /tmp/digests/rhel
+        run: |
+          set -x
+          # build the list of source images (by digest)
+          sources=""
+          for digest in *; do
+            image="${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200"
+            sources="$sources ${image}@sha256:$digest"
+          done
+
+          # create manifest and tag it
+          tags="-t ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200:${{ env.TAG }}"
+          tags="${tags} -t ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200:latest"
+          docker buildx imagetools create $tags $sources
+
+          # extract final manifest digest
+          MANIFEST_DIGEST=$(docker buildx imagetools inspect \
+            ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200:${{ env.TAG }} \
+            | awk '/^Digest:/ {print $2}')
+          echo "digest=${MANIFEST_DIGEST}" >> $GITHUB_OUTPUT
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: >-
+            ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200@${{
+              steps.manifest.outputs.digest }}
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH,MEDIUM"
+          scanners: vuln
+          timeout: 30m
+          skip-dirs: /root/.cache/uv
+        env:
+          TRIVY_USERNAME: ${{ secrets.GHCR_USER }}
+          TRIVY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "trivy-results.sarif"
+
+      - name: Display vulnerability summary
+        run: |
+          echo "=== Vulnerability Scan Summary ==="
+          if [ -f trivy-results.sarif ]; then
+            echo "Scan completed. Check the Security tab for detailed results."
+          else
+            echo "No vulnerabilities found or scan failed."
+          fi
+
   release-cpu-llm-d:
     runs-on: vllm-runner
     steps:

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -676,17 +676,7 @@ jobs:
           fi
 
   release-gb200-llm-d:
-    strategy:
-      fail-fast: false
-      # GB200 release matrix: RHEL-only, amd64-only (for now)
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: vllm-runner
-            os: rhel
-            base_image_suffix: ubi9
-            image_suffix: ""
-    runs-on: ${{ matrix.runner }}
+    runs-on: vllm-runner-arm
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -721,30 +711,20 @@ jobs:
           username: ${{ secrets.GHCR_USER }}
           password: ${{ secrets.GHCR_TOKEN }}
 
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200${{ matrix.image_suffix }}
-          tags: |
-            type=raw,value=${{ github.event.release.tag_name }},enable=${{ github.event_name == 'release' && github.event.action == 'published' }}
-            type=raw,value=${{ github.ref_name }},enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-            type=raw,value=latest,enable=true
-
       - name: Build the builder image layer
         id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/Dockerfile.cuda
-          platforms: ${{ matrix.platform }}
+          platforms: linux/arm64
           target: builder
           push: false
           build-args: |
-            TARGETOS=${{ matrix.os }}
-            TARGETPLATFORM=${{ matrix.platform }}
-            BUILD_BASE_IMAGE_SUFFIX=${{ matrix.base_image_suffix }}
-            FINAL_BASE_IMAGE_SUFFIX=${{ matrix.base_image_suffix }}
+            TARGETOS=rhel
+            TARGETPLATFORM=linux/arm64
+            BUILD_BASE_IMAGE_SUFFIX=ubi9
+            FINAL_BASE_IMAGE_SUFFIX=ubi9
             CUDA_MAJOR=${{ steps.common-version.outputs.cuda_major }}
             CUDA_MINOR=${{ steps.common-version.outputs.cuda_minor }}
             CUDA_PATCH=${{ steps.common-version.outputs.cuda_patch }}
@@ -752,7 +732,6 @@ jobs:
             NVSHMEM_VERSION=${{ steps.common-version.outputs.gb200_nvshmem_version }}
             DEEPEP_REPO=${{ steps.common-version.outputs.gb200_deepep_repo }}
             DEEPEP_VERSION=${{ steps.common-version.outputs.gb200_deepep_version }}
-          labels: ${{ steps.meta.outputs.labels }}
           github-token: ${{ secrets.GHCR_TOKEN }}
           secrets: |
             aws_access_key_id=${{ secrets.AWS_ACCESS_KEY_ID_S3_BUCKET_ONLY }}
@@ -761,20 +740,21 @@ jobs:
           DOCKER_BUILDKIT: "1"
           BUILDKIT_PROGRESS: "plain"
 
-      - name: Build the final image layer
-        id: build-image-final-layer
+      - name: Build and push the final image
+        id: build-and-push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/Dockerfile.cuda
-          platforms: ${{ matrix.platform }}
+          platforms: linux/arm64
           target: runtime
           push: true
+          provenance: true
           build-args: |
-            TARGETOS=${{ matrix.os }}
-            TARGETPLATFORM=${{ matrix.platform }}
-            BUILD_BASE_IMAGE_SUFFIX=${{ matrix.base_image_suffix }}
-            FINAL_BASE_IMAGE_SUFFIX=${{ matrix.base_image_suffix }}
+            TARGETOS=rhel
+            TARGETPLATFORM=linux/arm64
+            BUILD_BASE_IMAGE_SUFFIX=ubi9
+            FINAL_BASE_IMAGE_SUFFIX=ubi9
             CUDA_MAJOR=${{ steps.common-version.outputs.cuda_major }}
             CUDA_MINOR=${{ steps.common-version.outputs.cuda_minor }}
             CUDA_PATCH=${{ steps.common-version.outputs.cuda_patch }}
@@ -788,170 +768,19 @@ jobs:
             VLLM_PREBUILT=${{ steps.common-version.outputs.prebuilt }}
             VLLM_USE_PRECOMPILED=${{ steps.common-version.outputs.use_precompiled }}
             LLM_D_OFFLOADING_CONNECTOR_VERSION=${{ steps.common-version.outputs.offloading_connector_version }}
-          labels: ${{ steps.meta.outputs.labels }}
-          outputs: >-
-            type=image,name=${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200${{ matrix.image_suffix }},
-            push-by-digest=true,name-canonical=true,push=true
+          tags: |
+            ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200:${{ env.TAG }}
+            ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200:latest
           github-token: ${{ secrets.GHCR_TOKEN }}
         env:
           DOCKER_BUILDKIT: "1"
           BUILDKIT_PROGRESS: "plain"
 
-      - name: Verify remote digest exists
-        if: ${{ steps.build-image-final-layer.outputs.digest != '' }}
-        run: |
-          set -x
-          digest="${{ steps.build-image-final-layer.outputs.digest }}"
-          ref="${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200${{ matrix.image_suffix }}@${digest}"
-          echo "Checking remote ref: $ref"
-          docker buildx imagetools inspect "$ref" >/dev/null
-
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build-image-final-layer.outputs.digest }}"
-          if [ -z "$digest" ]; then
-            echo "ERROR: missing digest from build-image-final-layer (did the push succeed?)"
-            exit 1
-          fi
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v6
-        with:
-          name: digests-cuda-gb200-${{ matrix.os }}-${{ matrix.platform == 'linux/arm64' && 'arm64' || 'amd64' }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  release-gb200-success-check:
-    needs: release-gb200-llm-d
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    outputs:
-      any_succeeded: ${{ steps.check.outputs.any_succeeded }}
-      rhel_ok: ${{ steps.check.outputs.rhel_ok }}
-    steps:
-      - name: Download all digests (best-effort)
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests-raw
-          pattern: digests-cuda-gb200-*
-        continue-on-error: true
-
-      - name: Reorganize digests by OS
-        run: |
-          mkdir -p /tmp/digests/rhel
-          shopt -s nullglob
-          for artifact_dir in /tmp/digests-raw/digests-cuda-gb200-*; do
-            if [[ "$artifact_dir" == *-rhel-* ]]; then
-              cp -v "$artifact_dir"/* /tmp/digests/rhel/ 2>/dev/null || true
-            fi
-          done
-          echo "=== RHEL digests ==="
-          ls -la /tmp/digests/rhel/ || echo "No RHEL digests"
-
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - id: check
-        shell: bash
-        run: |
-          shopt -s nullglob
-          rhel=(/tmp/digests/rhel/*)
-
-          any=false; [ ${#rhel[@]} -gt 0 ] && any=true
-          rhel_ok=false; [ ${#rhel[@]} -gt 0 ] && rhel_ok=true
-
-          echo "Downloaded ${#rhel[@]} RHEL digest(s)"
-          echo "any_succeeded=${any}" >> "$GITHUB_OUTPUT"
-          echo "rhel_ok=${rhel_ok}" >> "$GITHUB_OUTPUT"
-
-  release-gb200-manifest:
-    needs: release-gb200-success-check
-    if: ${{ needs.release-gb200-success-check.outputs.any_succeeded == 'true' }}
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - name: Check if build succeeded
-        id: should-run
-        run: |
-          rhel_ok="${{ needs.release-gb200-success-check.outputs.rhel_ok }}"
-          echo "rhel_ok=${rhel_ok}" >> $GITHUB_OUTPUT
-          if [ "${rhel_ok}" != "true" ]; then
-            echo "Skipping manifest creation - no successful builds"
-          fi
-
-      - name: Download digests
-        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests-raw
-          pattern: digests-cuda-gb200-rhel-*
-
-      - name: Reorganize digests for manifest
-        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
-        run: |
-          mkdir -p /tmp/digests/rhel
-          shopt -s nullglob
-          for artifact_dir in /tmp/digests-raw/digests-cuda-gb200-rhel-*; do
-            cp -v "$artifact_dir"/* /tmp/digests/rhel/ 2>/dev/null || true
-          done
-
-      - name: Set up Docker Buildx
-        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Container Registry
-        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.GHCR_USER }}
-          password: ${{ secrets.GHCR_TOKEN }}
-
-      - name: Extract metadata
-        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Create and push manifest
-        if: ${{ steps.should-run.outputs.rhel_ok == 'true' }}
-        id: manifest
-        working-directory: /tmp/digests/rhel
-        run: |
-          set -x
-          # build the list of source images (by digest)
-          sources=""
-          for digest in *; do
-            image="${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200"
-            sources="$sources ${image}@sha256:$digest"
-          done
-
-          # create manifest and tag it
-          tags="-t ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200:${{ env.TAG }}"
-          tags="${tags} -t ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200:latest"
-          docker buildx imagetools create $tags $sources
-
-          # extract final manifest digest
-          MANIFEST_DIGEST=$(docker buildx imagetools inspect \
-            ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200:${{ env.TAG }} \
-            | awk '/^Digest:/ {print $2}')
-          echo "digest=${MANIFEST_DIGEST}" >> $GITHUB_OUTPUT
-
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
-          image-ref: >-
-            ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200@${{
-              steps.manifest.outputs.digest }}
+          image-ref: ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200:${{ env.TAG }}
           format: "sarif"
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH,MEDIUM"
@@ -963,6 +792,7 @@ jobs:
           TRIVY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
 
       - name: Upload Trivy scan results to GitHub Security tab
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: "trivy-results.sarif"

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -98,7 +98,7 @@ jobs:
           build-args: |
             TARGETOS=${{ matrix.os }}
             TARGETPLATFORM=${{ matrix.platform }}
-            BUILD_BASE_IMAGE_SUFFIX=${{ matrix.os == 'ubuntu' && 'ubuntu20.04' || matrix.base_image_suffix }}
+            BUILD_BASE_IMAGE_SUFFIX=${{ matrix.os == 'ubuntu' && 'ubuntu24.04' || matrix.base_image_suffix }}
             FINAL_BASE_IMAGE_SUFFIX=${{ matrix.base_image_suffix }}
             CUDA_MAJOR=${{ steps.common-version.outputs.cuda_major }}
             CUDA_MINOR=${{ steps.common-version.outputs.cuda_minor }}
@@ -132,7 +132,7 @@ jobs:
           build-args: |
             TARGETOS=${{ matrix.os }}
             TARGETPLATFORM=${{ matrix.platform }}
-            BUILD_BASE_IMAGE_SUFFIX=${{ matrix.os == 'ubuntu' && 'ubuntu20.04' || matrix.base_image_suffix }}
+            BUILD_BASE_IMAGE_SUFFIX=${{ matrix.os == 'ubuntu' && 'ubuntu24.04' || matrix.base_image_suffix }}
             FINAL_BASE_IMAGE_SUFFIX=${{ matrix.base_image_suffix }}
             CUDA_MAJOR=${{ steps.common-version.outputs.cuda_major }}
             CUDA_MINOR=${{ steps.common-version.outputs.cuda_minor }}

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,35 @@ NEW_TAG ?= sha256...
 # DEVICE, options: ['cuda', 'xpu', 'cpu', 'hpu']
 DEVICE ?= cuda
 
+# ARCH, options: ['amd64', 'arm64']
+ARCH ?= amd64
+
+# OS, options: ['rhel', 'ubuntu']
+OS ?= rhel
+
+# CUDA version (e.g., 12.8, 13.0)
+CUDA_VERSION ?= 13.0
+CUDA_MAJOR := $(word 1,$(subst ., ,$(CUDA_VERSION)))
+CUDA_MINOR := $(word 2,$(subst ., ,$(CUDA_VERSION)))
+
+# USE_SCCACHE: set to true to enable sccache (requires AWS credentials)
+USE_SCCACHE ?= false
+
+# MAX_JOBS: parallel compilation jobs (reduce to avoid OOM, e.g., MAX_JOBS=2)
+MAX_JOBS ?= 2
+
+# TORCH_CUDA_ARCH_LIST: CUDA architectures to build for
+# TORCH_CUDA_ARCH_LIST ?= 7.0;7.5;8.0;8.6;8.9;9.0;9.0a;10.0;12.0+PTX
+TORCH_CUDA_ARCH_LIST ?= "10.0"
+
+# Map OS to base image suffix
+ifeq ($(OS), ubuntu)
+	BASE_IMAGE_SUFFIX := ubuntu24.04
+else
+	BASE_IMAGE_SUFFIX := ubi9
+endif
+BUILD_BASE_IMAGE_SUFFIX := $(BASE_IMAGE_SUFFIX)
+
 IMAGE_BASE ?= ghcr.io/llm-d/$(PROJECT_NAME)-$(DEVICE)
 
 BUILD_CONTEXT ?= .
@@ -47,11 +76,10 @@ ifeq ($(BUILD_DEBUG), true)
 	IMAGE_BASE := $(IMAGE_BASE)-debug
 endif
 
-IMG := $(IMAGE_BASE):$(VERSION)
+IMG := $(IMAGE_BASE):$(VERSION)-$(ARCH)
 
 CONTAINER_TOOL := $(shell (command -v docker >/dev/null 2>&1 && echo docker) || (command -v podman >/dev/null 2>&1 && echo podman) || echo "")
 BUILDER := $(shell command -v buildah >/dev/null 2>&1 && echo buildah || echo $(CONTAINER_TOOL))
-PLATFORMS ?= linux/amd64 # linux/arm64 # linux/s390x,linux/ppc64le
 
 # SUPPRESS_PYTHON_OUTPUT: Set to "1" or "true" to suppress verbose pip output during build (default: verbose enabled)
 SUPPRESS_PYTHON_OUTPUT ?=
@@ -63,11 +91,16 @@ ENABLE_EFA ?= false
 .PHONY: help
 help: ## Print help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+	@printf "\n\033[1mArchitecture Examples:\033[0m\n"
+	@printf "  \033[36mmake image-build ARCH=amd64\033[0m                              # Build for x86_64 (default)\n"
+	@printf "  \033[36mmake image-build ARCH=arm64\033[0m                              # Build for ARM64\n"
+	@printf "  \033[36mmake image-build ARCH=arm64 OS=ubuntu\033[0m                    # ARM64 with Ubuntu base\n"
+	@printf "  \033[36mmake image-build ARCH=arm64 OS=ubuntu CUDA_VERSION=13.0\033[0m  # ARM64, Ubuntu, CUDA 13\n"
 	@printf "\n\033[1mXPU Build Examples:\033[0m\n"
 	@printf "  \033[36mmake image-build DEVICE=xpu\033[0m                    # Build Intel XPU Docker image\n"
 	@printf "  \033[36mmake image-build DEVICE=xpu VERSION=v0.2.0\033[0m     # Build with specific version\n"
 	@printf "  \033[36mmake image-push DEVICE=xpu\033[0m                     # Push Intel XPU Docker image\n"
-	@printf "  \033[36mmake image-retag DEVICE=xpu NEW_TAG=test\033[0m                     # Re-Tag Intel XPU Docker image\n"
+	@printf "  \033[36mmake image-retag DEVICE=xpu NEW_TAG=test\033[0m       # Re-Tag Intel XPU Docker image\n"
 	@printf "  \033[36mmake env DEVICE=xpu\033[0m                            # Show XPU environment variables\n"
 	@printf "\n\033[1mCUDA Build Examples:\033[0m\n"
 	@printf "  \033[36mmake image-build DEVICE=cuda\033[0m                            # Build CUDA Docker image (default, no EFA)\n"
@@ -103,39 +136,25 @@ buildah-build: check-builder ## Build and push image (multi-arch if supported)
 	@echo "✅ Using builder: $(BUILDER)"
 	@if [ "$(DEVICE)" = "xpu" ]; then $(MAKE) xpu-prepare; fi
 	@if [ "$(BUILDER)" = "buildah" ]; then \
-	  echo "🔧 Buildah detected: Performing multi-arch build with $(DOCKERFILE_DIR)/$(DOCKERFILE)…"; \
-	  FINAL_TAG=$(IMG); \
-	  for arch in amd64; do \
-		ARCH_TAG=$$FINAL_TAG-$$arch; \
-	    echo "📦 Building for architecture: $$arch"; \
-		buildah build --file $(DOCKERFILE_PATH) --arch=$$arch --os=linux --layers \
-			$(if $(filter cuda,$(DEVICE)),--build-arg ENABLE_EFA=$(ENABLE_EFA)) \
-			-t $(IMG)-$$arch $(BUILD_CONTEXT) || exit 1; \
-	    echo "🚀 Pushing image: $(IMG)-$$arch"; \
-	    buildah push $(IMG)-$$arch docker://$(IMG)-$$arch || exit 1; \
-	  done; \
-	  echo "🧼 Removing existing manifest (if any)..."; \
-	  buildah manifest rm $$FINAL_TAG || true; \
-	  echo "🧱 Creating and pushing manifest list: $(IMG)"; \
-	  buildah manifest create $(IMG); \
-	  for arch in amd64; do \
-	    ARCH_TAG=$$FINAL_TAG-$$arch; \
-	    buildah manifest add $$FINAL_TAG $$ARCH_TAG; \
-	  done; \
-	  buildah manifest push --all $(IMG) docker://$(IMG); \
+	  echo "🔧 Buildah detected: Building for $(ARCH) with $(DOCKERFILE_PATH)…"; \
+	  buildah build --file $(DOCKERFILE_PATH) --arch=$(ARCH) --os=linux --layers \
+		$(if $(filter cuda,$(DEVICE)),--build-arg ENABLE_EFA=$(ENABLE_EFA)) \
+		-t $(IMG) $(BUILD_CONTEXT) || exit 1; \
+	  echo "🚀 Pushing image: $(IMG)"; \
+	  buildah push $(IMG) docker://$(IMG) || exit 1; \
 	elif [ "$(BUILDER)" = "docker" ]; then \
-	  echo "🐳 Docker detected: Building with buildx..."; \
+	  echo "🐳 Docker detected: Building with buildx for linux/$(ARCH)..."; \
 	  sed -e '1 s/\(^FROM\)/FROM --platform=$${BUILDPLATFORM}/' $(DOCKERFILE_PATH) >$(DOCKERFILE_DIR)/Dockerfile.cross; \
 	  - docker buildx create --use --name image-builder || true; \
 	  docker buildx use image-builder; \
-	  docker buildx build --push --platform=$(PLATFORMS) --tag $(IMG) \
+	  docker buildx build --push --platform=linux/$(ARCH) --tag $(IMG) \
 		$(if $(filter cuda,$(DEVICE)),--build-arg ENABLE_EFA=$(ENABLE_EFA)) \
 		-f $(DOCKERFILE_DIR)/Dockerfile.cross $(BUILD_CONTEXT) || exit 1; \
 	  docker buildx rm image-builder || true; \
 	  rm $(DOCKERFILE_DIR)/Dockerfile.cross; \
 	elif [ "$(BUILDER)" = "podman" ]; then \
-	  echo "⚠️ Podman detected: Building single-arch image..."; \
-	  podman build --format=docker -f $(DOCKERFILE_PATH) -t $(IMG) $(BUILD_CONTEXT) || exit 1; \
+	  echo "⚠️ Podman detected: Building for linux/$(ARCH)..."; \
+	  podman build --platform=linux/$(ARCH) --format=docker -f $(DOCKERFILE_PATH) -t $(IMG) $(BUILD_CONTEXT) || exit 1; \
 	  podman push $(IMG) || exit 1; \
 	else \
 	  echo "❌ No supported container tool available."; \
@@ -144,9 +163,17 @@ buildah-build: check-builder ## Build and push image (multi-arch if supported)
 
 .PHONY:	image-build
 image-build: check-container-tool ## Build Docker image using $(CONTAINER_TOOL)
-	@printf "\033[33;1m==== Building Docker image $(IMG) ====\033[0m\n"
+	@printf "\033[33;1m==== Building Docker image $(IMG) for linux/$(ARCH) ====\033[0m\n"
 	@if [ "$(DEVICE)" = "xpu" ]; then $(MAKE) xpu-prepare; fi
-	$(CONTAINER_TOOL) build --progress=plain --platform $(PLATFORMS) \
+	$(CONTAINER_TOOL) build --progress=plain --platform linux/$(ARCH) \
+		--build-arg CUDA_MAJOR=$(CUDA_MAJOR) \
+		--build-arg CUDA_MINOR=$(CUDA_MINOR) \
+		--build-arg TARGETOS=$(OS) \
+		--build-arg BUILD_BASE_IMAGE_SUFFIX=$(BUILD_BASE_IMAGE_SUFFIX) \
+		--build-arg FINAL_BASE_IMAGE_SUFFIX=$(BASE_IMAGE_SUFFIX) \
+		--build-arg USE_SCCACHE=$(USE_SCCACHE) \
+		--build-arg MAX_JOBS=$(MAX_JOBS) \
+		--build-arg TORCH_CUDA_ARCH_LIST="$(TORCH_CUDA_ARCH_LIST)" \
 		$(if $(SUPPRESS_PYTHON_OUTPUT),--build-arg SUPPRESS_PYTHON_OUTPUT=$(SUPPRESS_PYTHON_OUTPUT)) \
 		--build-arg BUILD_DEBUG=$(BUILD_DEBUG) \
 		$(if $(filter cuda,$(DEVICE)),--build-arg ENABLE_EFA=$(ENABLE_EFA)) \
@@ -270,6 +297,11 @@ uninstall-rbac: check-kubectl check-kustomize check-envsubst ## Uninstall RBAC
 env:
 	@echo "IMAGE_BASE=$(IMAGE_BASE)"
 	@echo "VERSION=$(VERSION)"
+	@echo "ARCH=$(ARCH)"
+	@echo "OS=$(OS)"
+	@echo "CUDA_VERSION=$(CUDA_VERSION) ($(CUDA_MAJOR).$(CUDA_MINOR))"
+	@echo "BASE_IMAGE_SUFFIX=$(BASE_IMAGE_SUFFIX)"
+	@echo "USE_SCCACHE=$(USE_SCCACHE)"
 	@echo "IMG=$(IMG)"
 	@echo "CONTAINER_TOOL=$(CONTAINER_TOOL)"
 

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,19 @@ SUPPRESS_PYTHON_OUTPUT ?=
 # When enabled, EFA installer provides RDMA packages; otherwise use CUDA base image packages
 ENABLE_EFA ?= false
 
+# ENABLE_GB200: Set to "true" to build with GB200-specific NVSHMEM and DeepEP versions (default: false)
+ENABLE_GB200 ?= false
+
+# Override NVSHMEM version and DeepEP repo/version for GB200 builds
+NVSHMEM_VERSION_OVERRIDE ?=
+DEEPEP_REPO_OVERRIDE ?=
+DEEPEP_VERSION_OVERRIDE ?=
+ifeq ($(ENABLE_GB200), true)
+	NVSHMEM_VERSION_OVERRIDE := $(GB200_NVSHMEM_VERSION)
+	DEEPEP_REPO_OVERRIDE := $(GB200_DEEPEP_REPO)
+	DEEPEP_VERSION_OVERRIDE := $(GB200_DEEPEP_VERSION)
+endif
+
 .PHONY: help
 help: ## Print help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
@@ -105,7 +118,8 @@ help: ## Print help
 	@printf "\n\033[1mCUDA Build Examples:\033[0m\n"
 	@printf "  \033[36mmake image-build DEVICE=cuda\033[0m                            # Build CUDA Docker image (default, no EFA)\n"
 	@printf "  \033[36mmake image-build DEVICE=cuda BUILD_DEBUG=true\033[0m           # Build CUDA Docker image with debug symbols\n"
-	@printf "  \033[36mmake image-build DEVICE=cuda ENABLE_EFA=true\033[0m   # Build CUDA image with EFA support\n"
+	@printf "  \033[36mmake image-build DEVICE=cuda ENABLE_EFA=true\033[0m            # Build CUDA image with EFA support\n"
+	@printf "  \033[36mmake image-build DEVICE=cuda ENABLE_GB200=true\033[0m          # Build CUDA image for GB200\n"
 
 ##@ Development
 
@@ -139,6 +153,9 @@ buildah-build: check-builder ## Build and push image (multi-arch if supported)
 	  echo "🔧 Buildah detected: Building for $(ARCH) with $(DOCKERFILE_PATH)…"; \
 	  buildah build --file $(DOCKERFILE_PATH) --arch=$(ARCH) --os=linux --layers \
 		$(if $(filter cuda,$(DEVICE)),--build-arg ENABLE_EFA=$(ENABLE_EFA)) \
+		$(if $(NVSHMEM_VERSION_OVERRIDE),--build-arg NVSHMEM_VERSION=$(NVSHMEM_VERSION_OVERRIDE)) \
+		$(if $(DEEPEP_REPO_OVERRIDE),--build-arg DEEPEP_REPO=$(DEEPEP_REPO_OVERRIDE)) \
+		$(if $(DEEPEP_VERSION_OVERRIDE),--build-arg DEEPEP_VERSION=$(DEEPEP_VERSION_OVERRIDE)) \
 		-t $(IMG) $(BUILD_CONTEXT) || exit 1; \
 	  echo "🚀 Pushing image: $(IMG)"; \
 	  buildah push $(IMG) docker://$(IMG) || exit 1; \
@@ -149,6 +166,9 @@ buildah-build: check-builder ## Build and push image (multi-arch if supported)
 	  docker buildx use image-builder; \
 	  docker buildx build --push --platform=linux/$(ARCH) --tag $(IMG) \
 		$(if $(filter cuda,$(DEVICE)),--build-arg ENABLE_EFA=$(ENABLE_EFA)) \
+		$(if $(NVSHMEM_VERSION_OVERRIDE),--build-arg NVSHMEM_VERSION=$(NVSHMEM_VERSION_OVERRIDE)) \
+		$(if $(DEEPEP_REPO_OVERRIDE),--build-arg DEEPEP_REPO=$(DEEPEP_REPO_OVERRIDE)) \
+		$(if $(DEEPEP_VERSION_OVERRIDE),--build-arg DEEPEP_VERSION=$(DEEPEP_VERSION_OVERRIDE)) \
 		-f $(DOCKERFILE_DIR)/Dockerfile.cross $(BUILD_CONTEXT) || exit 1; \
 	  docker buildx rm image-builder || true; \
 	  rm $(DOCKERFILE_DIR)/Dockerfile.cross; \
@@ -177,6 +197,9 @@ image-build: check-container-tool ## Build Docker image using $(CONTAINER_TOOL)
 		$(if $(SUPPRESS_PYTHON_OUTPUT),--build-arg SUPPRESS_PYTHON_OUTPUT=$(SUPPRESS_PYTHON_OUTPUT)) \
 		--build-arg BUILD_DEBUG=$(BUILD_DEBUG) \
 		$(if $(filter cuda,$(DEVICE)),--build-arg ENABLE_EFA=$(ENABLE_EFA)) \
+		$(if $(NVSHMEM_VERSION_OVERRIDE),--build-arg NVSHMEM_VERSION=$(NVSHMEM_VERSION_OVERRIDE)) \
+		$(if $(DEEPEP_REPO_OVERRIDE),--build-arg DEEPEP_REPO=$(DEEPEP_REPO_OVERRIDE)) \
+		$(if $(DEEPEP_VERSION_OVERRIDE),--build-arg DEEPEP_VERSION=$(DEEPEP_VERSION_OVERRIDE)) \
 		-t $(IMG) -f $(DOCKERFILE_PATH) $(BUILD_CONTEXT)
 
 .PHONY: xpu-prepare

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -9,16 +9,20 @@ ARG FINAL_BASE_IMAGE_SUFFIX=${BASE_IMAGE_SUFFIX}
 ######################## SYSTEM CONFIGURATION ########################
 
 # CUDA version - provided via build args from docker/common-versions file via GH workflow
-ARG CUDA_MAJOR=12
-ARG CUDA_MINOR=9
-ARG CUDA_PATCH=1
+ARG CUDA_MAJOR=13
+ARG CUDA_MINOR=0
+ARG CUDA_PATCH=2
 ARG TARGETOS=rhel
-ARG TARGETPLATFORM=linux/amd64
+ARG TARGETPLATFORM
 ARG BASE_IMAGE_SUFFIX=ubi9
 ARG PYTHON_VERSION=3.12
 
 ARG USE_SCCACHE=true
 ARG BUILD_DEBUG=false
+
+# CUDA architectures to build for (reduce for faster builds and less memory usage)
+# For GB200/Blackwell: "10.0"
+ARG TORCH_CUDA_ARCH_LIST="8.0;8.6;8.9;9.0;9.0a;10.0;12.0+PTX"
 
 ######################## COMPONENT VERSIONS ########################
 
@@ -50,21 +54,21 @@ ARG LMCACHE_REPO="https://github.com/LMCache/LMCache.git"
 ARG LMCACHE_VERSION="v0.4.1"
 
 # Kernels
-# NM fork of Deepep for duplicate nvshmem IBGDA definitions, see: https://github.com/deepseek-ai/DeepEP/pull/581.
-# Also GKE nic-pe mapping, see: https://github.com/deepseek-ai/DeepEP/pull/466 
-# Commits cherry-picked on top of: `https://github.com/deepseek-ai/DeepEP/commit/567632dd59810d77b3cc05553df953cc0f779799`
 ARG DEEPEP_REPO="https://github.com/neuralmagic/DeepEP"
-# branch: https://github.com/neuralmagic/DeepEP/tree/llm-d-release-v0.5.1, but frozen at commit:
 ARG DEEPEP_VERSION="38d21b7f9bb6f3b102b1819d09439686eaa87ce8"
 
+# GB200-specific DeepEP variant (built alongside standard, selected via --target runtime-gb200)
+ARG DEEPEP_GB200_REPO="https://github.com/tlrmchlsmth/DeepEP"
+ARG DEEPEP_GB200_VERSION="sgl-gb200-blog-pt2"
 ARG DEEPGEMM_REPO="https://github.com/deepseek-ai/DeepGEMM"
 ARG DEEPGEMM_VERSION="v2.1.1.post3"
-
 ARG FLASHINFER_REPO="https://github.com/flashinfer-ai/flashinfer.git"
-ARG FLASHINFER_VERSION="v0.6.4"
+# May need to be dropped to v0.6.4
+ARG FLASHINFER_VERSION="v0.6.6"
 
 # vLLM build settings - provided via build args from docker/common-versions file
 # Override here for platform-specific testing or via build args
+# For CUDA 13.0: build from source (precompiled wheels only exist for CUDA 12.x)
 ARG VLLM_REPO
 ARG VLLM_COMMIT_SHA
 ARG VLLM_PRECOMPILED_WHEEL_COMMIT
@@ -92,6 +96,7 @@ ARG PYTHON_VERSION
 ARG NVSHMEM_VERSION
 
 ARG USE_SCCACHE
+ARG TORCH_CUDA_ARCH_LIST
 ARG BUILD_DEBUG
 
 ARG ENABLE_EFA
@@ -111,7 +116,7 @@ ENV LANG="C.UTF-8" \
     UV_HTTP_TIMEOUT="500" \
     UV_INDEX_STRATEGY="unsafe-best-match" \
     UV_LINK_MODE="copy" \
-    TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;8.9;9.0;9.0a;10.0;12.0+PTX" \
+    TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" \
     PYTHON_VERSION="${PYTHON_VERSION}" \
     UV_TORCH_BACKEND="${UV_TORCH_BACKEND:-cu${CUDA_MAJOR}${CUDA_MINOR}}" \
     UV_BUILD_CONSTRAINT="/tmp/build-constraints.txt" \
@@ -137,7 +142,7 @@ RUN --mount=type=cache,target=/var/cache/dnf \
     rm -f /tmp/install-base-packages.sh /tmp/package-utils.sh && \
     rm -rf /tmp/packages
 
-# Install cmake from script for consistency between ubuntu22.04 and rhel9
+# Install cmake from script for consistency between ubuntu24.04 and rhel9
 COPY docker/scripts/cuda/builder/install-cmake.sh /tmp/install-cmake.sh
 RUN --mount=type=cache,target=/var/cache/git \
     /tmp/install-cmake.sh && \
@@ -163,6 +168,7 @@ ENV NVSHMEM_DIR="/opt/nvshmem-${NVSHMEM_VERSION}" \
     NIXL_PREFIX="/opt/nixl" \
     EFA_PREFIX="/opt/amazon/efa"
 
+# CUDA 13.0 moved CCCL (libcudacxx) headers to include/cccl/ subdirectory
 ENV PATH="${NVSHMEM_DIR}/bin:${VIRTUAL_ENV}/bin:${PATH}" \
     LIBRARY_PATH="\
 ${EFA_PREFIX}/lib:${EFA_PREFIX}/lib64:\
@@ -172,7 +178,7 @@ ${CUDA_HOME}/lib64:\
 /usr/local/lib:/usr/local/lib64:\
 ${LIBRARY_PATH}" \
     CPATH="${NVSHMEM_DIR}/include:\
-${CUDA_HOME}/include:\
+${CUDA_HOME}/include:${CUDA_HOME}/include/cccl:\
 /usr/local/include:\
 /usr/include:\
 ${CPATH}" \
@@ -207,17 +213,8 @@ RUN --mount=type=cache,target=/var/cache/git \
     /tmp/build-ucx.sh && \
     rm -f /tmp/build-ucx.sh
 
-# Build NVSHMEM
-ARG NVSHMEM_USE_GIT
-ARG NVSHMEM_REPO
-ARG NVSHMEM_VERSION
-ENV NVSHMEM_CUDA_ARCHITECTURES="90a;100"
-COPY docker/scripts/cuda/builder/build-nvshmem.sh /tmp/build-nvshmem.sh
-RUN --mount=type=cache,target=/var/cache/git \
-    --mount=type=secret,id=aws_access_key_id \
-    --mount=type=secret,id=aws_secret_access_key \
-    /tmp/build-nvshmem.sh && \
-    rm -f /tmp/build-nvshmem.sh
+# NVSHMEM is installed via pip (nvidia-nvshmem-cu${CUDA_MAJOR}) in the runtime stage
+# No longer building from source
 
 
 # Pin torch, so all deps are built against the same version
@@ -273,6 +270,8 @@ WORKDIR /workspace/vllm
 # Build compiled packages as wheels (only ones that need build tools)
 ARG DEEPEP_REPO
 ARG DEEPEP_VERSION
+ARG DEEPEP_GB200_REPO
+ARG DEEPEP_GB200_VERSION
 ARG DEEPGEMM_REPO
 ARG DEEPGEMM_VERSION
 ARG FLASHINFER_REPO
@@ -305,6 +304,11 @@ ARG PYTHON_VERSION
 ARG NVSHMEM_VERSION
 ARG BUILD_NIXL_FROM_SOURCE
 ARG FLASHINFER_VERSION
+ARG TORCH_CUDA_ARCH_LIST
+ARG USE_SCCACHE
+
+# Build parallelism - reduce to avoid OOM on memory-constrained systems
+ARG MAX_JOBS=4
 ARG ENABLE_EFA
 ARG EFA_INSTALLER_VERSION
 ARG LLM_D_OFFLOADING_CONNECTOR_VERSION
@@ -312,29 +316,30 @@ ARG LLM_D_OFFLOADING_CONNECTOR_VERSION
 COPY docker/constraints.txt /tmp/constraints.txt
 
 ENV LANG="C.UTF-8" \
+    MAX_JOBS="${MAX_JOBS}" \
     LC_ALL="C.UTF-8" \
     PYTHON_VERSION="${PYTHON_VERSION}" \
     UV_TORCH_BACKEND="${UV_TORCH_BACKEND:-cu${CUDA_MAJOR}${CUDA_MINOR}}" \
     UV_CONSTRAINT="/tmp/constraints.txt" \
     VIRTUAL_ENV="/opt/vllm" \
-    NVSHMEM_DIR="/opt/nvshmem-${NVSHMEM_VERSION}" \
     UCX_PREFIX="/opt/ucx" \
     EFA_PREFIX="/opt/amazon/efa" \
     CUDA_HOME="/usr/local/cuda"
 
+# NVSHMEM is installed via pip (nvidia-nvshmem-cu${CUDA_MAJOR}) - library path set below
 ENV LD_LIBRARY_PATH="\
+/opt/vllm/lib/python${PYTHON_VERSION}/site-packages/nvidia/nvshmem/lib:\
 /opt/vllm/lib64/python${PYTHON_VERSION}/site-packages/torch/lib:\
 /usr/local/nvidia/lib:/usr/local/nvidia/lib64:\
-${CUDA_HOME}/lib64:\
+${CUDA_HOME}/lib64:${CUDA_HOME}/compat:\
 ${EFA_PREFIX}/lib:${EFA_PREFIX}/lib64:\
 ${UCX_PREFIX}/lib:${UCX_PREFIX}/lib64:\
-${NVSHMEM_DIR}/lib:${NVSHMEM_DIR}/lib64:\
 /usr/local/lib:/usr/local/lib64:\
 /usr/lib/x86_64-linux-gnu:/usr/lib/aarch64-linux-gnu:\
 ${LD_LIBRARY_PATH}" \
-    PATH="${NVSHMEM_DIR}/bin:${UCX_PREFIX}/bin:${PATH}" \
-    CPATH="${NVSHMEM_DIR}/include:${CPATH}" \
-    TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;8.9;9.0;9.0a;10.0;12.0+PTX" \
+    PATH="${UCX_PREFIX}/bin:${PATH}" \
+    CPATH="${CUDA_HOME}/include:${CUDA_HOME}/include/cccl:${CPATH}" \
+    TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" \
     FLASHINFER_VERSION=${FLASHINFER_VERSION} \
     CUDA_MAJOR=${CUDA_MAJOR} \
     CUDA_MINOR=${CUDA_MINOR} \
@@ -371,7 +376,7 @@ RUN /tmp/install-offloading-connector.sh && \
 # Copy EFA installation if enabled
 # EFA libs are copied to /usr/lib64 during install-efa.sh and saved to /tmp/efa_libs
 COPY --from=builder /opt/amazon /opt/amazon/
-COPY --from=builder /tmp/efa_libs/* /usr/lib64/
+COPY --from=builder /tmp/efa_libs/ /usr/lib64/
 
 # Copy gdrcopy libraries from builder
 # Install to /usr/local/lib (always present) and multiarch lib dir
@@ -405,8 +410,7 @@ RUN if [ -d /tmp/gdrcopy_libs ]; then \
         rm -rf /tmp/gdrcopy_libs; \
     fi
 
-# Copy compiled NVSHMEM libraries from builder
-COPY --from=builder /opt/nvshmem-${NVSHMEM_VERSION}/ /opt/nvshmem-${NVSHMEM_VERSION}/
+# NVSHMEM is installed via pip (nvidia-nvshmem-cu${CUDA_MAJOR}) - no need to copy from builder
 
 COPY --from=builder /opt/nixl /opt/nixl
 RUN if [ -d /opt/nixl/include ]; then \
@@ -440,6 +444,11 @@ RUN export UV_INSTALL_DIR=/usr/local/bin && \
     ln -s /opt/vllm/bin/pip /usr/bin/pip && \
     uv pip install --no-cache -U wheel
 
+# Copy sccache from builder for vLLM source builds
+# sccache binary is always installed in builder; only configured/started when USE_SCCACHE=true
+COPY --from=builder /usr/local/bin/sccache /usr/local/bin/sccache
+COPY --from=builder /usr/local/bin/setup-sccache /usr/local/bin/setup-sccache
+
 # Copy compiled wheels
 COPY --from=builder /wheels/*.whl /tmp/wheels/
 
@@ -458,6 +467,7 @@ RUN mkdir -p /opt/vllm-source && \
 # Define commit SHAs as build args to avoid layer invalidation
 ARG VLLM_REPO
 ARG VLLM_COMMIT_SHA
+
 
 # vllm commit to use for precompiled wheel lookup (defaults to VLLM_COMMIT_SHA)
 # useful for testing feature branches with python-only changes against merge-base binaries
@@ -483,9 +493,24 @@ COPY scripts/warn-vllm-precompiled.sh /opt/
     # 3) install vllm from source with pulling precompiled binaries (shared libraries) from the vllm wheels index - less flexible dev option, may or may not work swapping shas but faster than full editable
     # 2) install vllm from a wheel on the vllm wheels index - prod option, no flexibility
 COPY docker/scripts/cuda/runtime/install-vllm.sh /tmp/install-vllm.sh
-RUN --mount=type=cache,target=/var/cache/git \
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=cache,target=/var/cache/git \
+    --mount=type=secret,id=aws_access_key_id \
+    --mount=type=secret,id=aws_secret_access_key \
+    bash -c "chmod +x /tmp/install-vllm.sh && \
+    export PATH=/usr/local/bin:\${PATH} && \
+    USE_SCCACHE=${USE_SCCACHE} TARGETPLATFORM=${TARGETPLATFORM} source /usr/local/bin/setup-sccache && \
     /tmp/install-vllm.sh && \
-    rm /tmp/install-vllm.sh
+    rm /tmp/install-vllm.sh && \
+    if [ \"\${USE_SCCACHE}\" = \"true\" ]; then sccache --show-stats || true; fi"
+
+# Register pip-installed nvidia library paths with ldconfig so they are found
+# even when LD_LIBRARY_PATH is overridden by the NVIDIA container runtime in k8s
+RUN echo "/opt/vllm/lib/python${PYTHON_VERSION}/site-packages/nvidia/nvshmem/lib" \
+        > /etc/ld.so.conf.d/nvidia-nvshmem.conf && \
+    echo "/opt/vllm/lib/python${PYTHON_VERSION}/site-packages/nvidia/nccl/lib" \
+        >> /etc/ld.so.conf.d/nvidia-nvshmem.conf && \
+    ldconfig
 
 # install OTEL packages to enable tracing
 COPY docker/packages/common/runtime-otel-package-requirements.txt /workspace/runtime-otel-package-requirements.txt
@@ -518,7 +543,7 @@ RUN mkdir -p "$LLM_D_MODELS_DIR" "$HF_HOME" && \
     find /var/lib/llm-d -type d -exec chmod g+s {} \; && \
     ln -snf /var/lib/llm-d/models /models
 
-ENV PATH="${VIRTUAL_ENV}/bin:/usr/local/nvidia/bin:${PATH}" \
+ENV PATH="${VIRTUAL_ENV}/bin:${CUDA_HOME}/bin:/usr/local/nvidia/bin:${PATH}" \
     HOME=/home/vllm \
     VLLM_USAGE_SOURCE=production-docker-image \
     VLLM_WORKER_MULTIPROC_METHOD=fork \
@@ -537,4 +562,23 @@ ENV PATH="${VIRTUAL_ENV}/bin:/usr/local/nvidia/bin:${PATH}" \
 USER 2000
 WORKDIR /home/vllm
 
+# ============================================================================
+# GB200 RUNTIME STAGE - Swap in GB200-specific DeepEP wheel
+# Usage: docker build --target runtime-gb200 ...
+# ============================================================================
+FROM runtime AS runtime-gb200
+
+USER 0
+COPY --from=builder /wheels-gb200/*.whl /tmp/wheels-gb200/
+RUN . /opt/vllm/bin/activate && \
+    uv pip uninstall deep-ep && \
+    uv pip install /tmp/wheels-gb200/*.whl && \
+    rm -rf /tmp/wheels-gb200
+USER 2000
+
 ENTRYPOINT ["python", "-m", "vllm.entrypoints.openai.api_server"]
+
+# ============================================================================
+# DEFAULT - runtime is the default target when no --target is specified
+# ============================================================================
+FROM runtime

--- a/docker/common-versions
+++ b/docker/common-versions
@@ -2,8 +2,9 @@
 # vLLM Version Configuration
 # ============================================================================
 # Used by CUDA and CPU platforms
-VLLM_REPO=https://github.com/vllm-project/vllm.git
-VLLM_COMMIT_SHA=1892993bc18e243e2c05841314c5e9c06a80c70d # maps to v0.17.1 tag
+VLLM_REPO=https://github.com/elvircrn/vllm.git
+VLLM_COMMIT_SHA=7de0c69eaf62cff588324db2b16d6e9c20f3ce95 # maps to elvir's cherrypicks on top of v0.19.1,
+# see: https://github.com/elvircrn/vllm/commits/llmd-0.19.1-nan-fixes/
 
 # ============================================================================
 # Cuda specific configs
@@ -14,9 +15,12 @@ VLLM_COMMIT_SHA=1892993bc18e243e2c05841314c5e9c06a80c70d # maps to v0.17.1 tag
 # CUDA-only configurations for precompiled binaries
 VLLM_PREBUILT=0                # 0=editable install, 1=use full prebuilt wheel
 VLLM_USE_PRECOMPILED=1         # 1=use precompiled binaries either from VLLM_COMMIT_SHA or VLLM_PRECOMPILED_WHEEL_COMMIT, 0=compile from source
+# If building vLLM from a precompiled commit in the vLLM wheel index (only commits off main),
+# which commit to use as the base for the compiled bits.
+VLLM_PRECOMPILED_WHEEL_COMMIT=b1388b1fbf5aaef47937fabe98931211684666a6 # maps to vLLM official 0.19.1 release
 
 # Uncomment VLLM_PRECOMPILED_WHEEL_COMMIT to use precompiled wheels from a different SHA1 than VLLM_COMMIT_SHA
-VLLM_PRECOMPILED_WHEEL_COMMIT=b1388b1fbf5aaef47937fabe98931211684666a6
+# VLLM_PRECOMPILED_WHEEL_COMMIT=1892993bc18e243e2c05841314c5e9c06a80c70d
 
 
 # Used by XPU, commit from vllm, point to v0.17.0
@@ -36,4 +40,4 @@ GB200_DEEPEP_REPO=https://github.com/fzyzcjy/DeepEP
 GB200_DEEPEP_VERSION=gb200_blog_part_2
 
 ### Offloading connector
-LLM_D_OFFLOADING_CONNECTOR_VERSION=0.17.1
+# LLM_D_OFFLOADING_CONNECTOR_VERSION=0.17.1

--- a/docker/common-versions
+++ b/docker/common-versions
@@ -1,8 +1,9 @@
 # ============================================================================
-# shared vLLM Version Configuration
+# vLLM Version Configuration
 # ============================================================================
+# Used by CUDA and CPU platforms
 VLLM_REPO=https://github.com/vllm-project/vllm.git
-VLLM_COMMIT_SHA=95c0f928cdeeaa21c4906e73cee6a156e1b3b995 # maps to v0.17.1 tag
+VLLM_COMMIT_SHA=1892993bc18e243e2c05841314c5e9c06a80c70d # maps to v0.17.1 tag
 
 # ============================================================================
 # Cuda specific configs
@@ -13,22 +14,26 @@ VLLM_COMMIT_SHA=95c0f928cdeeaa21c4906e73cee6a156e1b3b995 # maps to v0.17.1 tag
 # CUDA-only configurations for precompiled binaries
 VLLM_PREBUILT=0                # 0=editable install, 1=use full prebuilt wheel
 VLLM_USE_PRECOMPILED=1         # 1=use precompiled binaries either from VLLM_COMMIT_SHA or VLLM_PRECOMPILED_WHEEL_COMMIT, 0=compile from source
-# If building vLLM from a precompiled commit in the vLLM wheel index (only commits off main),
-# which commit to use as the base for the compiled bits.
-VLLM_PRECOMPILED_WHEEL_COMMIT=95c0f928cdeeaa21c4906e73cee6a156e1b3b995
 
-### Cuda Runtime versions
-CUDA_MAJOR=12
-CUDA_MINOR=9
-CUDA_PATCH=1
+# Uncomment VLLM_PRECOMPILED_WHEEL_COMMIT to use precompiled wheels from a different SHA1 than VLLM_COMMIT_SHA
+VLLM_PRECOMPILED_WHEEL_COMMIT=b1388b1fbf5aaef47937fabe98931211684666a6
 
+
+# Used by XPU, commit from vllm, point to v0.17.0
+VLLM_XPU_COMMIT_SHA=9dd656f0ea06ba452e1f26666c111ea4909cd488
+
+# ============================================================================
+# CUDA Version Configuration
+# ============================================================================
+# Used by CUDA builds (Dockerfile.cuda, Dockerfile.rdma-tools)
+CUDA_MAJOR=13
+CUDA_MINOR=0
+CUDA_PATCH=2
+
+### GB200-specific overrides
+GB200_NVSHMEM_VERSION=3.4.5-0
+GB200_DEEPEP_REPO=https://github.com/fzyzcjy/DeepEP
+GB200_DEEPEP_VERSION=gb200_blog_part_2
 
 ### Offloading connector
 LLM_D_OFFLOADING_CONNECTOR_VERSION=0.17.1
-
-# ============================================================================
-# XPU specific settings
-# ============================================================================
-
-# XPU vLLM version / commit sha
-VLLM_XPU_COMMIT_SHA=9dd656f0ea06ba452e1f26666c111ea4909cd488 # maps to v0.18.0rc2 tag for XPU RDMA support

--- a/docker/packages/cuda/builder-packages.json
+++ b/docker/packages/cuda/builder-packages.json
@@ -1,13 +1,9 @@
 {
   "rhel_to_ubuntu": {
-    "python${PYTHON_VERSION}": null,
-    "python${PYTHON_VERSION}-pip": null,
-    "python${PYTHON_VERSION}-wheel": null,
-    "python${PYTHON_VERSION}-devel": null,
-    "python3.9": "python3.9",
-    "python3.9-pip": "python3.9-venv",
-    "python3.9-wheel": "python3-wheel",
-    "python3.9-devel": "python3.9-dev",
+    "python${PYTHON_VERSION}": "python${PYTHON_VERSION}",
+    "python${PYTHON_VERSION}-pip": "python${PYTHON_VERSION}-venv",
+    "python${PYTHON_VERSION}-wheel": "python3-wheel",
+    "python${PYTHON_VERSION}-devel": "python${PYTHON_VERSION}-dev",
     "procps": "procps",
     "findutils": "findutils",
     "gcc": "gcc",

--- a/docker/packages/cuda/runtime-rdma-packages.json
+++ b/docker/packages/cuda/runtime-rdma-packages.json
@@ -2,6 +2,7 @@
   "rhel_to_ubuntu": {
     "librdmacm": "librdmacm1t64",
     "libibverbs": "libibverbs1",
-    "libibumad": "libibumad3"
+    "libibumad": "libibumad3",
+    "libmlx5": "libmlx5-1"
   }
 }

--- a/docker/scripts/common/setup-sccache.sh
+++ b/docker/scripts/common/setup-sccache.sh
@@ -35,20 +35,26 @@ if [ "${USE_SCCACHE}" = "true" ]; then
 
     if ! /usr/local/bin/sccache --start-server; then
         echo "Warning: sccache failed to start, continuing without cache" >&2
-        unset CMAKE_C_COMPILER_LAUNCHER CMAKE_CXX_COMPILER_LAUNCHER CMAKE_CUDA_COMPILER_LAUNCHER
         # Remove sccache binary so meson/cmake can't accidentally try to use it
         rm -f /usr/local/bin/sccache || true
+        unset CMAKE_C_COMPILER_LAUNCHER CMAKE_CXX_COMPILER_LAUNCHER CMAKE_CUDA_COMPILER_LAUNCHER
         return 0
     fi
 
     if ! /usr/local/bin/sccache --show-stats >/dev/null 2>&1; then
         echo "Warning: sccache not responding properly, disabling cache" >&2
         /usr/local/bin/sccache --stop-server 2>/dev/null || true
-        unset CMAKE_C_COMPILER_LAUNCHER CMAKE_CXX_COMPILER_LAUNCHER CMAKE_CUDA_COMPILER_LAUNCHER
         # Remove sccache binary so meson/cmake can't accidentally try to use it
         rm -f /usr/local/bin/sccache || true
+        unset CMAKE_C_COMPILER_LAUNCHER CMAKE_CXX_COMPILER_LAUNCHER CMAKE_CUDA_COMPILER_LAUNCHER
         return 0
     fi
 
-    echo "sccache successfully configured with cache prefix: ${SCCACHE_S3_KEY_PREFIX}"
+    echo "sccache successfully configured:"
+    echo "  - Bucket: ${SCCACHE_BUCKET}"
+    echo "  - Region: ${SCCACHE_REGION}"
+    echo "  - Key prefix: ${SCCACHE_S3_KEY_PREFIX}"
+    echo "  - Socket: ${SCCACHE_SERVER_UDS}"
+    echo "  - AWS credentials: $([ -n \"${AWS_ACCESS_KEY_ID:-}\" ] && echo 'set' || echo 'NOT SET')"
+    /usr/local/bin/sccache --show-stats 2>&1 | head -5
 fi

--- a/docker/scripts/cuda/builder/build-compiled-wheels.sh
+++ b/docker/scripts/cuda/builder/build-compiled-wheels.sh
@@ -5,8 +5,8 @@ set -Eeux
 #
 # Required environment variables:
 # - VIRTUAL_ENV: path to Python virtual environment
-# - CUDA_MAJOR: CUDA major version (e.g., 12)
-# - NVSHMEM_DIR: NVSHMEM installation directory
+# - CUDA_MAJOR: CUDA major version (e.g., 12, 13)
+# - CUDA_HOME: CUDA installation directory
 # - FLASHINFER_REPO: FlashInfer git repo
 # - FLASHINFER_VERSION: FlashInfer git ref
 # - DEEPEP_REPO: DeepEP repository URL
@@ -15,6 +15,9 @@ set -Eeux
 # - DEEPGEMM_VERSION: DeepGEMM version tag
 # - USE_SCCACHE: whether to use sccache (true/false)
 # - TARGETPLATFORM: Docker buildx platform (e.g., linux/amd64, linux/arm64)
+# Optional environment variables:
+# - DEEPEP_GB200_REPO: GB200-specific DeepEP repository URL
+# - DEEPEP_GB200_VERSION: GB200-specific DeepEP version tag
 
 echo "BEGIN COMPILED WHEEL BUILDS LOGGING"
 
@@ -27,6 +30,9 @@ cd /tmp
 
 # install build tools
 uv pip install build cuda-python numpy setuptools-scm ninja cmake requests filelock tqdm
+
+# Add CUDA stubs to library path for build-time linking (libcuda.so is not available in containers)
+export LIBRARY_PATH="${CUDA_HOME}/lib64/stubs:${LIBRARY_PATH:-}"
 # overwrite the TORCH_CUDA_ARCH_LIST for MoE kernels
 export TORCH_CUDA_ARCH_LIST="9.0a;10.0+PTX"
 
@@ -40,6 +46,12 @@ cd ..
 rm -rf flashinfer
 
 # build DeepEP wheel
+# Install NVSHMEM Python package instead of using source-built version
+# This avoids aarch64 static library linking issues
+uv pip install nvidia-nvshmem-cu${CUDA_MAJOR}
+# Unset NVSHMEM_DIR so DeepEP discovers NVSHMEM from the Python package
+unset NVSHMEM_DIR
+
 git clone "${DEEPEP_REPO}" deepep
 cd deepep
 git fetch origin "${DEEPEP_VERSION}" # Workaround for claytons floating commit
@@ -55,6 +67,26 @@ if [ -n "${BACKUP_CXXFLAGS+x}" ]; then
   export CXXFLAGS="${BACKUP_CXXFLAGS}"
 else
   unset CXXFLAGS
+fi
+
+# build GB200-specific DeepEP wheel (if configured)
+if [ -n "${DEEPEP_GB200_REPO:-}" ] && [ -n "${DEEPEP_GB200_VERSION:-}" ]; then
+  echo "=== Building GB200 DeepEP variant ==="
+  mkdir -p /wheels-gb200
+  git clone "${DEEPEP_GB200_REPO}" deepep-gb200
+  cd deepep-gb200
+  git fetch origin "${DEEPEP_GB200_VERSION}"
+  git checkout -q "${DEEPEP_GB200_VERSION}"
+  BACKUP_CXXFLAGS="${CXXFLAGS-}"
+  export CXXFLAGS="${CXXFLAGS:-} -D__NVSHMEM_NUMBA_SUPPORT__"
+  uv build --wheel --no-build-isolation --out-dir /wheels-gb200
+  cd ..
+  rm -rf deepep-gb200
+  if [ -n "${BACKUP_CXXFLAGS+x}" ]; then
+    export CXXFLAGS="${BACKUP_CXXFLAGS}"
+  else
+    unset CXXFLAGS
+  fi
 fi
 
 # build DeepGEMM wheel

--- a/docker/scripts/cuda/builder/build-lmcache.sh
+++ b/docker/scripts/cuda/builder/build-lmcache.sh
@@ -38,6 +38,9 @@ export LIBRARY_PATH="${CUDA_HOME}/lib64/stubs:${LIBRARY_PATH:-}"
 . /usr/local/bin/setup-sccache
 . "${VIRTUAL_ENV}/bin/activate"
 
+# PyTorch cpp_extension doesn't recognize "10.0f" syntax, normalize to standard format
+export TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST//10.0f/10.0}"
+
 if [ "${USE_SCCACHE}" = "true" ]; then
     # Keep CC/CXX pointing at real compilers so torch doesn't think
     # "sccache" itself is the compiler (logging/ABI warning issue)

--- a/docker/scripts/cuda/builder/build-nixl.sh
+++ b/docker/scripts/cuda/builder/build-nixl.sh
@@ -28,14 +28,14 @@ cd /tmp
 . /usr/local/bin/setup-sccache
 . "${VIRTUAL_ENV}/bin/activate"
 
-git clone "${NIXL_REPO}" nixl && cd nixl
-git checkout -q "${NIXL_VERSION}"
-
 if [ "${USE_SCCACHE}" = "true" ]; then
     export CC="sccache gcc" CXX="sccache g++" NVCC="sccache nvcc"
 fi
 
-# Ubuntu image needs to be built against Ubuntu 20.04 and EFA only supports 22.04 and 24.04.
+git clone "${NIXL_REPO}" nixl && cd nixl
+git checkout -q "${NIXL_VERSION}"
+
+# Enable EFA only for RHEL builds (Ubuntu EFA packages require 22.04+; gated on TARGETOS=rhel for now)
 EFA_FLAG=""
 if [ "${ENABLE_EFA}" = "true" ] && [ "$TARGETOS" = "rhel" ]; then
     EFA_FLAG="-Dlibfabric_path=${EFA_PREFIX}"
@@ -45,7 +45,7 @@ meson setup build \
     --prefix="${NIXL_PREFIX}" \
     -Dbuildtype=release \
     -Ducx_path="${UCX_PREFIX}" \
-    "${EFA_FLAG}" \
+    ${EFA_FLAG:+"$EFA_FLAG"} \
     -Dinstall_headers=true
 
 cd build

--- a/docker/scripts/cuda/builder/build-nvshmem.sh
+++ b/docker/scripts/cuda/builder/build-nvshmem.sh
@@ -41,7 +41,7 @@ if [ "${NVSHMEM_USE_GIT}" = "true" ]; then
 else
     curl -fsSL \
     -o "nvshmem_src_cuda${CUDA_MAJOR}.tar.gz" \
-    "https://developer.download.nvidia.com/compute/redist/nvshmem/${NVSHMEM_VERSION}/source/nvshmem_src_cuda12-all-all-${NVSHMEM_VERSION}.tar.gz"
+    "https://developer.download.nvidia.com/compute/redist/nvshmem/${NVSHMEM_VERSION}/source/nvshmem_src_cuda${CUDA_MAJOR}-all-all-${NVSHMEM_VERSION}.tar.gz"
 
     tar -xf "nvshmem_src_cuda${CUDA_MAJOR}.tar.gz"
     cd nvshmem_src
@@ -61,7 +61,7 @@ if [ "${ENABLE_EFA}" != "true" ] || [ "$TARGETOS" = "ubuntu" ]; then
     done
 fi
 
-# Ubuntu image needs to be built against Ubuntu 20.04 and EFA only supports 22.04 and 24.04.
+# Enable EFA only for RHEL builds (Ubuntu EFA packages require 22.04+; gated on TARGETOS=rhel for now)
 EFA_FLAGS=()
 if [ "${ENABLE_EFA}" = "true" ] && [ "$TARGETOS" = "rhel" ]; then
     EFA_FLAGS=(
@@ -116,6 +116,7 @@ cmake -S . -B build -G Ninja \
     -DNVSHMEM_PREFIX="${NVSHMEM_DIR}" \
     -DCMAKE_CUDA_ARCHITECTURES="${NVSHMEM_CUDA_ARCHITECTURES}" \
     -DCMAKE_CUDA_COMPILER="${CUDA_HOME}/bin/nvcc" \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
     -DNVSHMEM_PMIX_SUPPORT=0 \
     -DNVSHMEM_IBRC_SUPPORT=1 \
     -DNVSHMEM_IBGDA_SUPPORT=1 \
@@ -129,8 +130,7 @@ cmake -S . -B build -G Ninja \
     -DNVSHMEM_USE_NCCL=0 \
     -DNVSHMEM_BUILD_TESTS="${NVSHMEM_BUILD_PERF_TESTS}" \
     -DNVSHMEM_BUILD_EXAMPLES=0 \
-    -DNVSHMEM_BUILD_PYTHON_LIB="${BUILD_NVSHMEM4PY_BINDINGS}" \
-    -DNVSHMEM_BUILD_PYTHON_DEVICE_LIB="${BUILD_PYTHON_DEVICE_LIB}" \
+    -DNVSHMEM_BUILD_PYTHON_LIB=OFF \
     "${DEBUG_FLAGS[@]}" \
     "${CMAKE_EXTRA_FLAGS[@]}" \
     "${EFA_FLAGS[@]}"
@@ -147,54 +147,6 @@ fi
 ninja -C build -j"${MAX_JOBS}"
 cmake --install build
 rm -rf build
-
-# overwrite build perf tests for the 4py bindings
-NVSHMEM_BUILD_PERF_TESTS=0
-# re-build the build directory with nvshmem4py targets and explicitly call the right one.
-BUILD_NVSHMEM4PY_BINDINGS="ON"
-BUILD_PYTHON_DEVICE_LIB="ON"
-cmake -S . -B build -G Ninja \
-    -DNVSHMEM_PREFIX="${NVSHMEM_DIR}" \
-    -DCMAKE_CUDA_ARCHITECTURES="${NVSHMEM_CUDA_ARCHITECTURES}" \
-    -DCMAKE_CUDA_COMPILER="${CUDA_HOME}/bin/nvcc" \
-    -DNVSHMEM_PMIX_SUPPORT=0 \
-    -DNVSHMEM_IBRC_SUPPORT=1 \
-    -DNVSHMEM_IBGDA_SUPPORT=1 \
-    -DNVSHMEM_IBDEVX_SUPPORT=1 \
-    -DNVSHMEM_UCX_SUPPORT=1 \
-    -DUCX_HOME="${UCX_PREFIX}" \
-    -DNVSHMEM_SHMEM_SUPPORT=0 \
-    -DNVSHMEM_USE_GDRCOPY=1 \
-    -DGDRCOPY_HOME="/usr/local" \
-    -DNVSHMEM_MPI_SUPPORT=0 \
-    -DNVSHMEM_USE_NCCL=0 \
-    -DNVSHMEM_BUILD_TESTS="${NVSHMEM_BUILD_PERF_TESTS}" \
-    -DNVSHMEM_BUILD_EXAMPLES=0 \
-    -DNVSHMEM_BUILD_PYTHON_LIB="${BUILD_NVSHMEM4PY_BINDINGS}" \
-    -DNVSHMEM_BUILD_PYTHON_DEVICE_LIB="${BUILD_PYTHON_DEVICE_LIB}" \
-    "${DEBUG_FLAGS[@]}" \
-    "${CMAKE_EXTRA_FLAGS[@]}" \
-    "${EFA_FLAGS[@]}"
-
-# explicitly build one target after re-setting up build with all bindings options (default is via discovery)
-# Reuse MAX_JOBS calculation from above
-ninja -C build -j"${MAX_JOBS}" "build_nvshmem4py_wheel_cu${CUDA_MAJOR}_${PYTHON_VERSION}"
-
-# Parse our python version to platforming tag, eg: 3.12 --> 312
-PYTAG="cp${PYTHON_VERSION/./}"
-NVSHMEM4PY_WHEEL="$(find build/dist -maxdepth 1 -type f \
-  -name "nvshmem4py_cu${CUDA_MAJOR}-*-${PYTAG}-${PYTAG}-manylinux*.whl" \
-  | head -n 1)"
-
-if [ -z "${NVSHMEM4PY_WHEEL}" ]; then
-  echo "ERROR: nvshmem4py wheel not found in build/dist"
-  echo "  expected pattern: nvshmem4py_cu${CUDA_MAJOR}-*-${PYTAG}-${PYTAG}-manylinux*.whl"
-  echo "  contents of build/dist:"
-  ls -la build/dist || true
-  exit 1
-fi
-
-cp -v "${NVSHMEM4PY_WHEEL}" /wheels/
 
 cd /tmp
 rm -rf nvshmem_src*

--- a/docker/scripts/cuda/builder/build-ucx.sh
+++ b/docker/scripts/cuda/builder/build-ucx.sh
@@ -29,8 +29,8 @@ if [ "${USE_SCCACHE}" = "true" ]; then
     export CC="sccache gcc" CXX="sccache g++"
 fi
 
-# Enable EFA support if ENABLE_EFA is true and on RHEL
-# Ubuntu image needs to be built against Ubuntu 20.04 and EFA only supports 22.04 and 24.04.
+# Enable EFA support only for RHEL builds
+# (Ubuntu EFA packages require 22.04+; gated on TARGETOS=rhel for now)
 EFA_FLAG=""
 if [ "${ENABLE_EFA}" = "true" ] && [ "$TARGETOS" = "rhel" ]; then
     EFA_FLAG="--with-efa"

--- a/docker/scripts/cuda/builder/install-sccache.sh
+++ b/docker/scripts/cuda/builder/install-sccache.sh
@@ -9,27 +9,30 @@ set -Eeux
 
 TARGETOS="${TARGETOS:-rhel}"
 
+# Always install sccache binary (small download) so COPY --from=builder works
+# in downstream stages regardless of USE_SCCACHE setting.
+# detect architecture
+ARCH=$(uname -m)
+if [ "$ARCH" = "x86_64" ]; then
+    SCCACHE_ARCH="x86_64"
+elif [ "$ARCH" = "aarch64" ]; then
+    SCCACHE_ARCH="aarch64"
+else
+    echo "Unsupported architecture: $ARCH"
+    exit 1
+fi
+
+SCCACHE_VERSION="v0.11.0"
+mkdir -p /tmp/sccache
+cd /tmp/sccache
+curl -sLO https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-${SCCACHE_ARCH}-unknown-linux-musl.tar.gz
+tar -xf sccache-${SCCACHE_VERSION}-${SCCACHE_ARCH}-unknown-linux-musl.tar.gz
+mv sccache-${SCCACHE_VERSION}-${SCCACHE_ARCH}-unknown-linux-musl/sccache /usr/local/bin/sccache
+cd /tmp
+rm -rf /tmp/sccache
+
+# Only configure and verify sccache when enabled
 if [ "${USE_SCCACHE}" = "true" ]; then
-    # detect architecture
-    ARCH=$(uname -m)
-    if [ "$ARCH" = "x86_64" ]; then
-        SCCACHE_ARCH="x86_64"
-    elif [ "$ARCH" = "aarch64" ]; then
-        SCCACHE_ARCH="aarch64"
-    else
-        echo "Unsupported architecture: $ARCH"
-        exit 1
-    fi
-
-    SCCACHE_VERSION="v0.11.0"
-    mkdir -p /tmp/sccache
-    cd /tmp/sccache
-    curl -sLO https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-${SCCACHE_ARCH}-unknown-linux-musl.tar.gz
-    tar -xf sccache-${SCCACHE_VERSION}-${SCCACHE_ARCH}-unknown-linux-musl.tar.gz
-    mv sccache-${SCCACHE_VERSION}-${SCCACHE_ARCH}-unknown-linux-musl/sccache /usr/local/bin/sccache
-    cd /tmp
-    rm -rf /tmp/sccache
-
     # shellcheck source=/dev/null
     source /usr/local/bin/setup-sccache
 

--- a/docker/scripts/cuda/runtime/install-vllm.sh
+++ b/docker/scripts/cuda/runtime/install-vllm.sh
@@ -40,6 +40,40 @@ git -C /opt/vllm-source config --system --add safe.directory /opt/vllm-source
 git -C /opt/vllm-source fetch --depth=1 origin "${VLLM_COMMIT_SHA}" || true
 git -C /opt/vllm-source checkout -q "${VLLM_COMMIT_SHA}"
 
+# Apply cherry-pick commits if specified (for python-only patches on top of main)
+apply_cherrypick() {
+  local commit="$1"
+  local remote="$2"
+  if [ -z "${commit}" ]; then
+    return
+  fi
+  echo "DEBUG: Cherry-picking commit ${commit} from ${remote}"
+  # Add remote if it's a URL (not "origin")
+  if [ "${remote}" != "origin" ] && [ -n "${remote}" ]; then
+    git -C /opt/vllm-source remote add cherrypick_remote "${remote}" 2>/dev/null || true
+    git -C /opt/vllm-source fetch --depth=50 cherrypick_remote
+    git -C /opt/vllm-source cherry-pick --no-commit "${commit}"
+    git -C /opt/vllm-source remote remove cherrypick_remote
+  else
+    git -C /opt/vllm-source fetch --depth=50 origin
+    git -C /opt/vllm-source cherry-pick --no-commit "${commit}"
+  fi
+  echo "DEBUG: Successfully applied ${commit}"
+}
+
+apply_cherrypick "${VLLM_CHERRYPICK_1:-}" "${VLLM_CHERRYPICK_1_REMOTE:-origin}"
+apply_cherrypick "${VLLM_CHERRYPICK_2:-}" "${VLLM_CHERRYPICK_2_REMOTE:-origin}"
+
+# resolve VLLM_PRECOMPILED_WHEEL_COMMIT to actual commit SHA (wheel index uses SHAs, not tag names)
+# Only needed when using prebuilt or precompiled modes
+if [ "${VLLM_PREBUILT}" = "1" ] || [ "${VLLM_USE_PRECOMPILED}" = "1" ]; then
+  # fetch the ref if needed (in case it differs from VLLM_COMMIT_SHA)
+  git -C /opt/vllm-source fetch --depth=1 origin "${VLLM_PRECOMPILED_WHEEL_COMMIT}" 2>/dev/null || true
+  # if it's already a full SHA, rev-parse will return it unchanged
+  VLLM_PRECOMPILED_WHEEL_COMMIT=$(git -C /opt/vllm-source rev-parse "${VLLM_PRECOMPILED_WHEEL_COMMIT}")
+  echo "DEBUG: Resolved wheel commit SHA: ${VLLM_PRECOMPILED_WHEEL_COMMIT}"
+fi
+
 # detect if prebuilt wheel exists (using VLLM_PRECOMPILED_WHEEL_COMMIT for lookup)
 # note: vllm wheel index structure isn't pip-compatible, so we scrape the HTML directly
 echo "DEBUG: Looking for wheel at: https://wheels.vllm.ai/${VLLM_PRECOMPILED_WHEEL_COMMIT}/vllm/"
@@ -119,3 +153,7 @@ fi
 
 # cleanup
 rm -rf /tmp/wheels
+rm -rf /opt/vllm-source/.deps
+rm -rf /opt/vllm-source/.git
+rm -rf /opt/vllm-source/docs
+rm -rf /opt/vllm-source/tests


### PR DESCRIPTION
### Purpose

This branch upgrades the build infrastructure to CUDA 13.0, targeting GB200/Blackwell GPUs. It also updates vLLM to approximately `v0.18.0` (plus a few commits).

It adds an extra layer to the image to choose between two versions of DeepEP: The `runtime-gb200` stage is specifically for GB200 MNNVL systems.

It also upgrades the Ubuntu image to 24.04 across the board. Reasoning: Ubuntu 20.04 is EoL and there isn't a CUDA13 version to use. llm-d doesn't produce manylinux wheels so doesn't need to worry about glibc versioning, so the reason that vLLM uses 20.04 in its build stage doesn't apply here.

NVSHMEM no longer built from source. It now uses the `nvidia-nvshmem-cu13` pip package. I could not get the build from source working, I think related to the fact that NVSHMEM removed the static-only build https://github.com/NVIDIA/nvshmem/releases/tag/v3.5.19-1.

Also includes many various fixes.

_Continuation of #983 with squashed history._