### PR TITLE
docs: fix typos detected by nightly scan (issue #1056)

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,3 @@
+[default.extend-words]
+ba = "ba"        # sed label syntax in YAML scripts
+MAPE = "MAPE"   # Mean Absolute Percentage Error (ML metric)

--- a/docs/wip-docs-new/architecture/README.md
+++ b/docs/wip-docs-new/architecture/README.md
@@ -4,15 +4,15 @@ High-level guide to llm-d architecture. Start here, then dive into specific guid
 
 ## Core
 
-At it core, llm-d contains the following key layers:
+At its core, llm-d contains the following key layers:
 
-- **Proxy** - Accepts requests from the users. It can be deployed as a Standalone Envoy Proxy or via Kuberentes Gateway API. The Proxy consults an EndPoint Picker (EPP) via the ext-proc protocol to determine which Model Server is optimal for a request.
+- **Proxy** - Accepts requests from the users. It can be deployed as a Standalone Envoy Proxy or via Kubernetes Gateway API. The Proxy consults an EndPoint Picker (EPP) via the ext-proc protocol to determine which Model Server is optimal for a request.
 
-- **EndPoint Picker (EPP)** - Selects which endpoint in an `InferencePool` is optimal for an specific request. The EPP is the "brains" of the scheduling decision that considers prefix-cache affinity, load signals, prioritziation, and (optionally) disaggregated serving.
+- **EndPoint Picker (EPP)** - Selects which endpoint in an `InferencePool` is optimal for a specific request. The EPP is the "brains" of the scheduling decision that considers prefix-cache affinity, load signals, prioritization, and (optionally) disaggregated serving.
 
-- **InferencePool** - The InferencePool API defines a group of Model Server Pods dedicated to serving AI models. An InferencePool is conceptually similar to a Kuberentes Service. Each InferencePool has an associated EPP which selects the optimal pod for a request.
+- **InferencePool** - The InferencePool API defines a group of Model Server Pods dedicated to serving AI models. An InferencePool is conceptually similar to a Kubernetes Service. Each InferencePool has an associated EPP which selects the optimal pod for a request.
 
-- **Model Server** - The Model Server (like vLLM or SGLang) executes the model on hardware accelerators. The Model Servers can be deployed through any deployment process, joining an `InferencePool` via Kuberentes labels and selectors.
+- **Model Server** - The Model Server (like vLLM or SGLang) executes the model on hardware accelerators. The Model Servers can be deployed through any deployment process, joining an `InferencePool` via Kubernetes labels and selectors.
 
 
 ![Basic architecture](../../assets/basic-architecture.svg)

--- a/docs/wip-docs-new/architecture/core/epp/configuration.md
+++ b/docs/wip-docs-new/architecture/core/epp/configuration.md
@@ -3,7 +3,7 @@ NEEDS TO BE REDONE!
 
 ## EPP Configuration
 
-The `EndpointPickerConfig` is used to cofigure the EPP deployment.
+The `EndpointPickerConfig` is used to configure the EPP deployment.
 
 The configuration text has the following form:
 
@@ -118,8 +118,8 @@ Each plugin can also be given a name, enabling the same plugin type to be instan
 - name: aName
   type: a-type
   parameters:
-    parm1: val1
-    parm2: val2
+    param1: val1
+    param2: val2
 ```
 
 The fields in a plugin entry are:
@@ -179,7 +179,7 @@ There are two types of plugins related to Scheduling: `Scorers` and `Pickers`
 
 #### Scorers
 
-During the scheduling process, each pod recieves a score for each scorer in the `schedulingProfile`:
+During the scheduling process, each pod receives a score for each scorer in the `schedulingProfile`:
 
 - `prefix-cache-scorer`: Scores pods based on the amount of the prompt is believed to be in the pod's KvCache. Parameters:
     - `blockSize`: specified the size of the blocks to break up the input prompt when calculating the block hashes. If not specified defaults to 64 
@@ -202,7 +202,7 @@ During the scheduling process, each pod recieves a score for each scorer in the 
 
 #### Pickers
 
-After each pod recieves a score for each scorer which are combined using the `weights`, the `picker` configures how we select the pod.
+After each pod receives a score for each scorer which are combined using the `weights`, the `picker` configures how we select the pod.
 
 - `max-score-picker`: Picks the pod with the maximum score from the list of candidates. This is the default picker plugin if not specified. Parameters:
     - `maxNumOfEndpoints`: Maximum number of endpoints to pick from the list of candidates, based on the scores of those endpoints. If not specified defaults to 1

--- a/docs/wip-docs-new/architecture/core/inferencepool.md
+++ b/docs/wip-docs-new/architecture/core/inferencepool.md
@@ -63,9 +63,9 @@ No explicit registration or enrollment is required. Once the labels match, the M
 
 ## Configuration
 
-### Installating the CRDs
+### Installing the CRDs
 
-The InferencePool CRDs are be installed from the Gateway Inference Extension API repository:
+The InferencePool CRDs can be installed from the Gateway Inference Extension API repository:
 
 ```bash
 IGW_LATEST_RELEASE=$(curl -s https://api.github.com/repos/kubernetes-sigs/gateway-api-inference-extension/releases \


### PR DESCRIPTION
## Summary

Fixes typos and grammar issues detected by the nightly scan in [#1056](https://github.com/llm-d/llm-d/issues/1056).

## Changes

**`docs/wip-docs-new/architecture/README.md`**  6 fixes
- `Kuberentes`  `Kubernetes` (3)
- `At it core`  `At its core`
- `prioritziation`  `prioritization`
- `an specific`  `a specific`

**`docs/wip-docs-new/architecture/core/epp/configuration.md`**  5 fixes
- `cofigure`  `configure`
- `parm1/parm2`  `param1/param2`
- `recieves`  `receives` (2)

**`docs/wip-docs-new/architecture/core/inferencepool.md`**  2 fixes
- `Installating`  `Installing`
- `are be installed`  `can be installed` (grammar fix)

**`_typos.toml`** (new file)
- Suppresses false positives: `ba` (sed label syntax) and `MAPE` (Mean Absolute Percentage Error, standard ML metric)

## Testing

Documentation-only changes. No code changes.

Closes #1056