### PR TITLE
[Docs][6/N]: add Istio gateway setup guide

### DIFF
--- a/docs/wip-docs-new/getting-started/quickstart.md
+++ b/docs/wip-docs-new/getting-started/quickstart.md
@@ -66,8 +66,23 @@ helm install my-inference-pool \
 - The EPP is deployed with the default configuration (which uses prefix-cache aware and load-aware balancing).
 - The Proxy is deployed as a sidecar in the EPP pod.
 
+Verify the resources were created:
+
+```bash
+kubectl get pods,svc,inferencepool
 ```
->> TODO: kubectl view the resources
+
+Expected output:
+
+```
+NAME                                        READY   STATUS    RESTARTS   AGE
+pod/my-inference-pool-epp-f7c47758d-tblr4   2/2     Running   0          21s
+
+NAME                            TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                      AGE
+service/my-inference-pool-epp   ClusterIP   10.16.2.57   <none>        9002/TCP,9090/TCP,8081/TCP   21s
+
+NAME                                                          AGE
+inferencepool.inference.networking.k8s.io/my-inference-pool   21s
 ```
 
 Next, create the model servers Deployment (in this case, 2 replicas of vLLM running `openai/gpt-oss-20b`):
@@ -95,7 +110,7 @@ spec:
         - name: vllm
           image: "vllm/vllm-openai:latest"
           imagePullPolicy: Always
-          command: ["vllm serve openai/gpt-oss-20b"]
+          command: ["vllm", "serve", "openai/gpt-oss-20b"]
           ports:
             - containerPort: 8000
               name: http
@@ -113,8 +128,18 @@ EOF
 - A deployment with 2 replicas of vLLM is created
 - The model servers pods are automatically discovered by the EPP via the `app:my-model` selector.
 
+Verify the model server pods are running and discovered by the InferencePool:
+
+```bash
+kubectl get pods -l app=my-model
 ```
->> TODO: kubectl view the resources, and show they were added to the InfPool
+
+Expected output:
+
+```
+NAME                        READY   STATUS    RESTARTS   AGE
+my-model-667dcf89f5-c4swt   1/1     Running   0          20s
+my-model-667dcf89f5-tkzgh   1/1     Running   0          20s
 ```
 
 
@@ -143,10 +168,35 @@ spec:
 EOF
 ```
 
-Send an inference request.
+Send an inference request:
 
 ```bash
->> TODO: write an inference request
+kubectl exec curl -- curl -s http://my-inference-pool-epp:8081/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "openai/gpt-oss-20b",
+    "messages": [{"role": "user", "content": "Hello, who are you?"}],
+    "max_tokens": 50
+  }'
+```
+
+Expected output:
+
+```json
+{
+  "id": "chatcmpl-...",
+  "model": "openai/gpt-oss-20b",
+  "choices": [
+    {
+      "index": 0,
+      "finish_reason": "stop",
+      "message": {
+        "role": "assistant",
+        "content": "..."
+      }
+    }
+  ]
+}
 ```
 
 ## Cleanup

--- a/docs/wip-docs-new/guides/gateways/istio.md
+++ b/docs/wip-docs-new/guides/gateways/istio.md
@@ -12,9 +12,9 @@ This guide shows how to deploy llm-d with [Istio](https://istio.io/) as your [Ga
 - [jq](https://jqlang.org/download/)
 - Gateway API Inference Extension CRDs installed:
 
-  ```bash
-  kubectl apply -k https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd
-  ```
+```bash
+kubectl apply -k https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd
+```
 
 ## Step 1: Install Istio
 

--- a/docs/wip-docs-new/guides/gateways/istio.md
+++ b/docs/wip-docs-new/guides/gateways/istio.md
@@ -49,7 +49,7 @@ istiod-xxxxxxxxxx-xxxxx   1/1     Running   0          30s
 Deploy two replicas of vLLM running `openai/gpt-oss-20b`:
 
 > [!NOTE]
-> This example requires NVIDIA GPUs. For CPU-based testing, use the vLLM Simulator (`ghcr.io/llm-d/llm-d-inference-sim:latest`) instead.
+> This example uses NVIDIA GPUs. For CPU testing, use the vLLM Simulator (`ghcr.io/llm-d/llm-d-inference-sim:latest`).
 
 ```bash
 kubectl apply -f - <<'EOF'

--- a/docs/wip-docs-new/guides/gateways/istio.md
+++ b/docs/wip-docs-new/guides/gateways/istio.md
@@ -95,7 +95,7 @@ kubectl get pods -l app=my-model
 
 ## Step 3: Deploy the Gateway
 
-Create a `Gateway` resource. Istio watches this resource and automatically creates the Envoy-based gateway proxy that receives incoming traffic.
+Create a `Gateway` resource. Istio watches this resource and creates an Envoy-based proxy that accepts incoming traffic.
 
 ```bash
 kubectl apply -f - <<'EOF'

--- a/docs/wip-docs-new/guides/gateways/istio.md
+++ b/docs/wip-docs-new/guides/gateways/istio.md
@@ -1,31 +1,9 @@
 # Istio
 
-This guide shows how to deploy llm-d with [Istio](https://istio.io/) as your [Gateway API](https://gateway-api.sigs.k8s.io/) provider. By the end, inference requests will flow through an Istio-managed Gateway to your model servers through the llm-d EPP.
+This guide shows how to deploy llm-d with [Istio](https://istio.io/) as your [Gateway API](https://gateway-api.sigs.k8s.io/) provider. By the end, inference requests will flow from an Istio-managed Gateway to your model servers via the llm-d EPP.
 
 > [!NOTE]
-> This guide assumes you have already deployed model servers and are familiar with the llm-d [standalone quickstart](../../getting-started/quickstart.md). If you are new to llm-d, start there first.
-
-## Why Gateway API?
-
-The standalone quickstart runs the Envoy proxy and EPP together in a single pod. That is a good way to get started, but it is not how most production deployments are structured.
-
-[Gateway API](https://gateway-api.sigs.k8s.io/) is the Kubernetes-standard way to manage L4 and L7 traffic. When you use it with the [Gateway API Inference Extension](https://gateway-api-inference-extension.sigs.k8s.io/), a gateway such as Istio can send each inference request to the EPP for scheduling while still giving you the networking features you would expect in production, such as TLS termination, traffic splitting, and access control.
-
-```text
-                          Standalone
-                          ─────────
-  Client ──► [ Envoy + EPP (same pod) ] ──► vLLM Pods
-
-
-                          Istio Gateway
-                          ─────────────
-  Client ──► [ Istio Gateway ] ──► [ EPP ] ──► vLLM Pods
-                  │                    │
-                  │  ext-proc call     │
-                  └────────────────────┘
-```
-
-The request flow stays the same in both modes: the proxy asks the EPP where to send the request, then forwards it to the best model server. In this setup, Istio manages the gateway, TLS termination, and traffic policies for you.
+> This guide assumes familiarity with Gateway API and llm-d.
 
 ## Prerequisites
 
@@ -38,12 +16,10 @@ The request flow stays the same in both modes: the proxy asks the EPP where to s
   kubectl apply -k https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd
   ```
 
-- Model servers deployed and labeled (see [quickstart](../../getting-started/quickstart.md))
+## Step 1: Install Istio
 
 > [!NOTE]
 > Istio v1.28.0 or later is required for full Gateway API Inference Extension support.
-
-## Step 1: Install Istio
 
 Download and install Istio with the Gateway API Inference Extension flag enabled:
 
@@ -68,11 +44,60 @@ NAME                      READY   STATUS    RESTARTS   AGE
 istiod-xxxxxxxxxx-xxxxx   1/1     Running   0          30s
 ```
 
-## Step 2: Deploy the Gateway
+## Step 2: Deploy Model Servers
+
+Deploy two replicas of vLLM running `openai/gpt-oss-20b`:
+
+> [!NOTE]
+> This example requires NVIDIA GPUs. For CPU-based testing, use the vLLM Simulator (`ghcr.io/llm-d/llm-d-inference-sim:latest`) instead.
+
+```bash
+kubectl apply -f - <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-model
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: my-model
+  template:
+    metadata:
+      labels:
+        app: my-model
+        inference.networking.k8s.io/engine-type: vllm
+    spec:
+      containers:
+        - name: vllm
+          image: "vllm/vllm-openai:latest"
+          imagePullPolicy: Always
+          command: ["vllm", "serve", "openai/gpt-oss-20b"]
+          ports:
+            - containerPort: 8000
+              name: http
+              protocol: TCP
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+              ephemeral-storage: "100Gi"
+            requests:
+              nvidia.com/gpu: 1
+              ephemeral-storage: "100Gi"
+EOF
+```
+
+Verify the pods are running:
+
+```bash
+kubectl get pods -l app=my-model
+```
+
+## Step 3: Deploy the Gateway
 
 Create a `Gateway` resource. Istio watches this resource and automatically creates the Envoy-based gateway proxy that receives incoming traffic.
 
-```yaml
+```bash
 kubectl apply -f - <<'EOF'
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
@@ -102,9 +127,9 @@ llm-d-inference-gateway   istio   10.xx.xx.xx     True         30s
 
 Wait until `PROGRAMMED` shows `True` before proceeding.
 
-## Step 3: Deploy the InferencePool and EPP
+## Step 4: Deploy the InferencePool and EPP
 
-Next, deploy the `InferencePool` and EPP with the Helm chart, using `provider.name=istio`. This configures the EPP to work with an Istio-managed Gateway instead of the standalone proxy used in the quickstart.
+Deploy the `InferencePool` and EPP with the Helm chart, using `provider.name=istio`:
 
 ```bash
 IGW_CHART_VERSION=v1.4.0
@@ -116,9 +141,6 @@ helm install llm-d-infpool \
   --version ${IGW_CHART_VERSION} \
   oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
 ```
-
-> [!NOTE]
-> Compared with the standalone quickstart, the main difference here is the Helm chart and provider setting: use `charts/inferencepool` and set `provider.name=istio`.
 
 Verify the EPP is running and the InferencePool is created:
 
@@ -138,11 +160,11 @@ inferencepool.inference.networking.k8s.io/llm-d-infpool    30s
 
 The EPP pod shows `1/1` rather than `2/2` because there is no sidecar proxy in this setup. Istio manages the gateway proxy separately.
 
-## Step 4: Configure the HTTPRoute
+## Step 5: Configure the HTTPRoute
 
 Create an `HTTPRoute` to connect the Gateway to the `InferencePool`. When traffic reaches the Gateway, this route sends the request to the `InferencePool`, where the EPP chooses the best model server.
 
-```yaml
+```bash
 kubectl apply -f - <<'EOF'
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -174,7 +196,7 @@ kubectl get httproute llm-d-route -o yaml | grep -A5 "conditions:"
 
 Both `Accepted` and `ResolvedRefs` conditions should show `status: "True"`.
 
-## Step 5: Send a Request
+## Step 6: Send a Request
 
 Get the Gateway's external address:
 
@@ -215,12 +237,11 @@ Expected output:
 
 ## Cleanup
 
-If you are using a test cluster, you can remove the resources created in this guide with the following commands:
-
 ```bash
 kubectl delete httproute llm-d-route
 helm uninstall llm-d-infpool
 kubectl delete gateway llm-d-inference-gateway
+kubectl delete deployment my-model
 istioctl uninstall --purge -y
 kubectl delete namespace istio-system
 ```

--- a/docs/wip-docs-new/guides/gateways/istio.md
+++ b/docs/wip-docs-new/guides/gateways/istio.md
@@ -1,0 +1,274 @@
+# Istio
+
+This guide shows how to deploy llm-d with [Istio](https://istio.io/) as your [Gateway API](https://gateway-api.sigs.k8s.io/) provider. By the end, inference requests will flow through an Istio-managed Gateway to your model servers through the llm-d EPP.
+
+> [!NOTE]
+> This guide assumes you have already deployed model servers and are familiar with the llm-d [standalone quickstart](../../getting-started/quickstart.md). If you are new to llm-d, start there first.
+
+## Why Gateway API?
+
+The standalone quickstart runs the Envoy proxy and EPP together in a single pod. That is a good way to get started, but it is not how most production deployments are structured.
+
+[Gateway API](https://gateway-api.sigs.k8s.io/) is the Kubernetes-standard way to manage L4 and L7 traffic. When you use it with the [Gateway API Inference Extension](https://gateway-api-inference-extension.sigs.k8s.io/), a gateway such as Istio can send each inference request to the EPP for scheduling while still giving you the networking features you would expect in production, such as TLS termination, traffic splitting, and access control.
+
+```text
+                          Standalone
+                          ─────────
+  Client ──► [ Envoy + EPP (same pod) ] ──► vLLM Pods
+
+
+                          Istio Gateway
+                          ─────────────
+  Client ──► [ Istio Gateway ] ──► [ EPP ] ──► vLLM Pods
+                  │                    │
+                  │  ext-proc call     │
+                  └────────────────────┘
+```
+
+The request flow stays the same in both modes: the proxy asks the EPP where to send the request, then forwards it to the best model server. In this setup, Istio manages the gateway, TLS termination, and traffic policies for you.
+
+## Prerequisites
+
+- A Kubernetes cluster running one of the three most recent [Kubernetes releases](https://kubernetes.io/releases/)
+- [Helm](https://helm.sh/docs/intro/install/)
+- [jq](https://jqlang.org/download/)
+- Gateway API Inference Extension CRDs installed:
+
+  ```bash
+  kubectl apply -k https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd
+  ```
+
+- Model servers deployed and labeled (see [quickstart](../../getting-started/quickstart.md))
+
+> [!NOTE]
+> Istio v1.28.0 or later is required for full Gateway API Inference Extension support.
+
+## Step 1: Install Istio
+
+Download and install Istio with the Gateway API Inference Extension flag enabled:
+
+```bash
+ISTIO_VERSION=1.28.0
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${ISTIO_VERSION} sh -
+export PATH="$PWD/istio-${ISTIO_VERSION}/bin:$PATH"
+istioctl install -y \
+  --set values.pilot.env.ENABLE_GATEWAY_API_INFERENCE_EXTENSION=true
+```
+
+Verify the installation:
+
+```bash
+kubectl get pods -n istio-system
+```
+
+Expected output:
+
+```text
+NAME                      READY   STATUS    RESTARTS   AGE
+istiod-xxxxxxxxxx-xxxxx   1/1     Running   0          30s
+```
+
+## Step 2: Deploy the Gateway
+
+Create a `Gateway` resource. Istio watches this resource and automatically creates the Envoy-based gateway proxy that receives incoming traffic.
+
+```yaml
+kubectl apply -f - <<'EOF'
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: llm-d-inference-gateway
+spec:
+  gatewayClassName: istio
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+EOF
+```
+
+Verify the Gateway is accepted:
+
+```bash
+kubectl get gateway llm-d-inference-gateway
+```
+
+Expected output:
+
+```text
+NAME                      CLASS   ADDRESS         PROGRAMMED   AGE
+llm-d-inference-gateway   istio   10.xx.xx.xx     True         30s
+```
+
+Wait until `PROGRAMMED` shows `True` before proceeding.
+
+## Step 3: Deploy the InferencePool and EPP
+
+Next, deploy the `InferencePool` and EPP with the Helm chart, using `provider.name=istio`. This configures the EPP to work with an Istio-managed Gateway instead of the standalone proxy used in the quickstart.
+
+```bash
+IGW_CHART_VERSION=v1.4.0
+
+helm install llm-d-infpool \
+  --dependency-update \
+  --set inferencePool.modelServers.matchLabels.app=my-model \
+  --set provider.name=istio \
+  --version ${IGW_CHART_VERSION} \
+  oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
+```
+
+> [!NOTE]
+> Compared with the standalone quickstart, the main difference here is the Helm chart and provider setting: use `charts/inferencepool` and set `provider.name=istio`.
+
+Verify the EPP is running and the InferencePool is created:
+
+```bash
+kubectl get pods,inferencepool
+```
+
+Expected output:
+
+```text
+NAME                                     READY   STATUS    RESTARTS   AGE
+pod/llm-d-infpool-epp-xxxxxxxxx-xxxxx    1/1     Running   0          30s
+
+NAME                                                       AGE
+inferencepool.inference.networking.k8s.io/llm-d-infpool    30s
+```
+
+The EPP pod shows `1/1` rather than `2/2` because there is no sidecar proxy in this setup. Istio manages the gateway proxy separately.
+
+## Step 4: Configure the HTTPRoute
+
+Create an `HTTPRoute` to connect the Gateway to the `InferencePool`. When traffic reaches the Gateway, this route sends the request to the `InferencePool`, where the EPP chooses the best model server.
+
+```yaml
+kubectl apply -f - <<'EOF'
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: llm-d-route
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: llm-d-inference-gateway
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: inference.networking.k8s.io
+          kind: InferencePool
+          name: llm-d-infpool
+          port: 8000
+EOF
+```
+
+Verify the HTTPRoute is accepted:
+
+```bash
+kubectl get httproute llm-d-route -o yaml | grep -A5 "conditions:"
+```
+
+Both `Accepted` and `ResolvedRefs` conditions should show `status: "True"`.
+
+## Step 5: Send a Request
+
+Get the Gateway's external address:
+
+```bash
+export GATEWAY_IP=$(kubectl get gateway llm-d-inference-gateway -o jsonpath='{.status.addresses[0].value}')
+```
+
+Send an inference request through the Istio Gateway:
+
+```bash
+curl -s http://${GATEWAY_IP}/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "openai/gpt-oss-20b",
+    "messages": [{"role": "user", "content": "Hello, who are you?"}],
+    "max_tokens": 50
+  }'
+```
+
+Expected output:
+
+```json
+{
+  "id": "chatcmpl-...",
+  "model": "openai/gpt-oss-20b",
+  "choices": [
+    {
+      "index": 0,
+      "finish_reason": "stop",
+      "message": {
+        "role": "assistant",
+        "content": "..."
+      }
+    }
+  ]
+}
+```
+
+## Cleanup
+
+If you are using a test cluster, you can remove the resources created in this guide with the following commands:
+
+```bash
+kubectl delete httproute llm-d-route
+helm uninstall llm-d-infpool
+kubectl delete gateway llm-d-inference-gateway
+istioctl uninstall --purge -y
+kubectl delete namespace istio-system
+```
+
+## Troubleshooting
+
+### Gateway not showing `PROGRAMMED=True`
+
+```bash
+kubectl describe gateway llm-d-inference-gateway
+kubectl get pods -n istio-system
+kubectl logs -n istio-system deployment/istiod --tail=20
+```
+
+Verify Istio was installed with the inference extension flag enabled.
+
+### EPP pod in CrashLoopBackOff
+
+```bash
+kubectl logs <epp-pod-name> --tail=20
+```
+
+Common causes:
+
+- InferencePool not created: check `kubectl get inferencepool`
+- CRDs not installed: check `kubectl get crd | grep inference`
+
+### HTTPRoute not accepted
+
+```bash
+kubectl describe httproute llm-d-route
+```
+
+Verify that `parentRefs` matches the Gateway name and `backendRefs` matches the InferencePool name.
+
+### No response from Gateway IP
+
+```bash
+kubectl get gateway llm-d-inference-gateway -o jsonpath='{.status.addresses[0].value}'
+```
+
+If the address is empty, your Gateway may still be waiting for a LoadBalancer service. Check that your cluster supports external load balancers.
+
+## Further Reading
+
+- [Istio documentation](https://istio.io/latest/docs/)
+- [Gateway API documentation](https://gateway-api.sigs.k8s.io/)
+- [Gateway API Inference Extension](https://gateway-api-inference-extension.sigs.k8s.io/)
+- [Compatible gateway implementations](https://gateway-api-inference-extension.sigs.k8s.io/implementations/gateways/)
+- [Proxy architecture](../../architecture/core/proxy.md): how standalone and gateway modes compare
+- [InferencePool](../../architecture/core/inferencepool.md): the backend resource referenced by HTTPRoute

--- a/docs/wip-docs-new/guides/gateways/istio.md
+++ b/docs/wip-docs-new/guides/gateways/istio.md
@@ -7,10 +7,10 @@ This guide shows how to deploy llm-d with [Istio](https://istio.io/) as your [Ga
 
 ## Prerequisites
 
-- A Kubernetes cluster running one of the three most recent [Kubernetes releases](https://kubernetes.io/releases/)
-- [Helm](https://helm.sh/docs/intro/install/)
-- [jq](https://jqlang.org/download/)
-- Gateway API Inference Extension CRDs installed:
+* A Kubernetes cluster running one of the three most recent [Kubernetes releases](https://kubernetes.io/releases/)
+* [Helm](https://helm.sh/docs/intro/install/)
+* [jq](https://jqlang.org/download/)
+* Gateway API Inference Extension CRDs installed:
 
 ```bash
 kubectl apply -k https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd

--- a/docs/wip-docs-new/guides/gateways/istio.md
+++ b/docs/wip-docs-new/guides/gateways/istio.md
@@ -162,7 +162,7 @@ The EPP pod shows `1/1` rather than `2/2` because there is no sidecar proxy in t
 
 ## Step 5: Configure the HTTPRoute
 
-Create an `HTTPRoute` to connect the Gateway to the `InferencePool`. When traffic reaches the Gateway, this route sends the request to the `InferencePool`, where the EPP chooses the best model server.
+Create an `HTTPRoute` to connect the Gateway to the `InferencePool`. When traffic reaches the Gateway with this route, the Proxy will consult the EPP and forward the request to the selected pod.
 
 ```bash
 kubectl apply -f - <<'EOF'
@@ -265,9 +265,8 @@ kubectl logs <epp-pod-name> --tail=20
 ```
 
 Common causes:
-
-- InferencePool not created: check `kubectl get inferencepool`
-- CRDs not installed: check `kubectl get crd | grep inference`
+* InferencePool not created: check `kubectl get inferencepool`
+* CRDs not installed: check `kubectl get crd | grep inference`
 
 ### HTTPRoute not accepted
 


### PR DESCRIPTION
 ## Summary

  Fills in guides/gateways/istio.md with a complete setup guide:
  - Why Gateway API (standalone vs gateway framing)
  - Step-by-step: Istio install, Gateway, InferencePool, HTTPRoute
  - Working curl command for verification
  - Troubleshooting section for common issues

  Based on upstream GAIE docs and the proxy.md framing from #1121.

  ## Testing

  All helm chart paths and commands validated against v1.4.0 charts.
  Resource names consistent throughout (llm-d-inference-gateway,
  llm-d-infpool, llm-d-route).