### PR TITLE
fix(docker): add LIBRARY_PATH and ldconfig to CUDA runtime stage

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -337,7 +337,15 @@ ${LD_LIBRARY_PATH}" \
     TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;8.9;9.0;9.0a;10.0;12.0+PTX" \
     FLASHINFER_VERSION=${FLASHINFER_VERSION} \
     CUDA_MAJOR=${CUDA_MAJOR} \
-    CUDA_MINOR=${CUDA_MINOR}
+    CUDA_MINOR=${CUDA_MINOR} \
+    LIBRARY_PATH="\
+/usr/local/nvidia/lib:/usr/local/nvidia/lib64:\
+${CUDA_HOME}/lib64:\
+${EFA_PREFIX}/lib:${EFA_PREFIX}/lib64:\
+${UCX_PREFIX}/lib:${UCX_PREFIX}/lib64:\
+${NVSHMEM_DIR}/lib:${NVSHMEM_DIR}/lib64:\
+/usr/local/lib:/usr/local/lib64:\
+${LIBRARY_PATH}"
 
 # Install runtime RDMA core packages through AWS EFA installer if EFA is enabled
 COPY docker/scripts/cuda/common/package-utils.sh /tmp/package-utils.sh
@@ -416,6 +424,11 @@ RUN if [ -d /opt/nixl/include ]; then \
         fi; \
     fi; \
     rm -rf /opt/nixl
+
+# Rebuild dynamic linker cache for libraries copied from the builder stage
+RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/local.conf && \
+    echo "/usr/local/lib64" >> /etc/ld.so.conf.d/local.conf && \
+    ldconfig
 
 # Install uv and setup Python virtual environment
 RUN export UV_INSTALL_DIR=/usr/local/bin && \


### PR DESCRIPTION
## What's broken?

vLLM containers built with vLLM v0.17.1+ crash on GKE at startup with:
```
/usr/bin/ld: cannot find -l:libcuda.so.1
```
Torch inductor's JIT compilation (`gcc`) fails because the compile-time linker cannot find `libcuda.so.1`.

## Who is affected?

Anyone running llm-d CUDA container images on GKE (or other environments where the NVIDIA driver is mounted at runtime by the NVIDIA Container Toolkit into `/usr/local/nvidia/lib64/`). Older images with vLLM < 0.17.1 are not affected.

## When does it trigger?

Consistently on container startup when vLLM initializes workers and torch inductor JIT-compiles CUDA utilities. Workaround confirmed by @jtechapps and @rlakhtakia: `export LIBRARY_PATH=/usr/local/nvidia/lib64:$LIBRARY_PATH` before starting vLLM.

## Where is the bug?

`docker/Dockerfile.cuda` — the **runtime stage** (line ~288+):
- `LD_LIBRARY_PATH` is set (line 325–334) covering runtime dynamic loading ✅
- `LIBRARY_PATH` is **not set** — the compile-time linker has no search paths ❌
- `ldconfig` is **never run** in the runtime stage — the linker cache is stale ❌

The builder stage (line 249–251) correctly has both `ld.so.conf.d` entries and `ldconfig`, but this doesn't carry over to the runtime stage.

## Why does it happen?

PR #606 switched the runtime base image from `cuda:*-devel-*` to `cuda:*-runtime-*` to reduce image size. The `-devel` image included CUDA stubs that the linker could find; `-runtime` does not. Subsequently, PR #727 removed `${CUDA_HOME}/compat` from `LD_LIBRARY_PATH` to avoid error 803 from loading stub drivers at runtime.

The key distinction: `LD_LIBRARY_PATH` is for the **runtime** dynamic linker (`ld.so`), while `LIBRARY_PATH` is for the **compile-time** static linker (`/usr/bin/ld` invoked by `gcc -l:`). The Dockerfile sets the former but not the latter.

When torch inductor JIT-compiles `cuda_utils.c` with `gcc -l:libcuda.so.1`, the compile-time linker searches:
1. `-L` paths (triton dir, `/usr/lib64`) — no `libcuda.so.1` here
2. `LIBRARY_PATH` env var — **not set**
3. `ldconfig` cache (`/etc/ld.so.cache`) — **never rebuilt** in runtime stage

All three miss → `cannot find -l:libcuda.so.1`.

## How did we fix it?

Two changes in the runtime stage of `docker/Dockerfile.cuda`:

1. **Add `LIBRARY_PATH` to the ENV block** — exposes NVIDIA runtime-injected paths (`/usr/local/nvidia/lib64/`) and CUDA toolkit paths to the compile-time linker. These paths mirror those already in `LD_LIBRARY_PATH`.

2. **Add `ld.so.conf.d` + `ldconfig` after library COPYs** — mirrors builder stage lines 249–251 exactly. Rebuilds the linker cache so libraries copied from the builder (gdrcopy, UCX, NVSHMEM, NIXL) are properly registered. Pattern already used in `Dockerfile.rdma-tools` line 118.

Both changes have direct precedent in the same repo — no new patterns introduced.

## How do we know it works?

- `LIBRARY_PATH` now includes `/usr/local/nvidia/lib64/` — the compile-time linker (`gcc -l:libcuda.so.1`) will find the GKE-injected `libcuda.so.1`
- `ldconfig` rebuilds the dynamic linker cache for libraries copied from the builder (gdrcopy, UCX, NVSHMEM, NIXL)
- Verified: lint passes (pre-existing envvar lint issue unchanged), diff is 1 file / 14 insertions / 1 deletion
- No `LD_LIBRARY_PATH` changes → cannot re-introduce error 803
- Workaround from issue thread (`export LIBRARY_PATH=/usr/local/nvidia/lib64:$LIBRARY_PATH`) is now baked into the image

Fixes #1063.
