### PR TITLE
docs: rewrite predicted latency architecture and add well-lit path

### DIFF
--- a/docs/wip-docs-new/architecture/advanced/latency-predictor.md
+++ b/docs/wip-docs-new/architecture/advanced/latency-predictor.md
@@ -1,365 +1,136 @@
-THIS NEEDS TO BE UPDATED - Written by Claude
-
 # Latency Predictor
 
-The Latency Predictor is an experimental component that enables predicted-latency-based scheduling in llm-d.
+The Latency Predictor is the llm-d component behind predicted latency-based scheduling. Instead of scoring pods by coarse utilization signals alone, the EPP asks an online-trained ML model to predict **Time To First Token (TTFT)** and **Time Per Output Token (TPOT)** for each candidate pod, then routes on those predictions — optionally gated by per-request Service Level Objectives (SLOs).
 
-## Functionality
+This page is a reference for the component: its design, plugin pipeline, ML model, failure modes, and scaling characteristics. For step-by-step adoption — Helm enablement, SLO header usage, verification, troubleshooting — see the [Predicted Latency well-lit path](../../well-lit-paths/intelligent-inference-scheduling/predicted-latency.md). Design rationale and benchmarks are in the blog [Predicted Latency-Based Scheduling for LLMs](https://llm-d.ai/blog/predicted-latency-based-scheduling-for-llms).
 
-The Latency Predictor is an ML-based system that continuously learns from live traffic to predict per-endpoint request latency. It enables the EPP to make SLO-aware routing decisions -- choosing model server pods based on whether they can meet a request's latency targets rather than relying solely on utilization metrics like queue depth or KV-cache utilization.
+## Why Predicted Latency?
 
-### Why Predicted Latency?
+Utilization-based load balancing has structural gaps for LLM workloads:
 
-Utilization-based load balancing has fundamental limitations for LLM workloads:
+- **Request costs vary enormously.** A 10-token prompt and a 10,000-token prompt both count as one queued request, but their prefill and decode costs differ by orders of magnitude.
+- **Cache reuse is unstable.** Prefix hit rates shift as traffic patterns change, so static weights between cache affinity and utilization drift out of tune.
+- **Conflicting objectives.** Optimizing TPOT favors spreading load; optimizing TTFT and cache reuse favors consolidating it. No fixed weight configuration is correct in all regimes.
+- **No SLO awareness.** Utilization scorers cannot answer "can this pod serve this request within the caller's latency budget?"
 
-- **Request costs vary enormously.** A 10-token prompt and a 10,000-token prompt impose very different loads, but both count as one request in a queue.
-- **Cache reuse is unstable.** Prefix cache hit rates shift as traffic patterns change, making static weights unreliable.
-- **Conflicting objectives.** Optimizing for cache reuse (consolidating traffic onto fewer pods) conflicts with optimizing for low time-per-output-token (spreading load across pods). No fixed weight configuration handles all conditions.
-- **No SLO awareness.** Utilization-based scorers cannot answer the question "can this pod serve this request within the caller's latency budget?"
-
-The Latency Predictor addresses these gaps by predicting **p90 TTFT** (time to first token) and **p90 TPOT** (time per output token) for each candidate pod, given the pod's current state and the request's characteristics. The EPP's `slo-scorer` plugin then compares these predictions against per-request SLO targets to route traffic intelligently.
+The Latency Predictor closes those gaps by learning the mapping from `(pod state, request features) → latency` directly from live traffic, and letting the EPP reason about headroom against SLOs instead of hand-tuned weights.
 
 ## Design
 
 ### Architecture
 
-The Latency Predictor runs as a set of sidecar containers alongside the EPP. Three container types work together:
+The predictor ships as a set of sidecars alongside the EPP. A **training server** continuously retrains on completed requests. Multiple **prediction servers** read the latest model from a shared volume and answer prediction requests from the EPP on the hot path.
 
-```
-                    ┌──────────────────────────────────────────────────────┐
-                    │                    EPP Pod                           │
-                    │                                                      │
-                    │  ┌────────────┐       ┌───────────────────────────┐  │
-                    │  │    EPP     │       │   Training Server         │  │
- Inference ────────►│  │            │       │   (port 8000)             │  │
- Requests           │  │  slo-scorer├──────►│                           │  │
-                    │  │            │       │   Collects completed      │  │
-                    │  │            │       │   request data, retrains  │  │
-                    │  │            │       │   XGBoost models          │  │
-                    │  │            │       └───────────┬───────────────┘  │
-                    │  │            │                   │                  │
-                    │  │            │          writes models (.joblib)     │
-                    │  │            │                   │                  │
-                    │  │            │                   ▼                  │
-                    │  │            │       ┌──────────────────────────┐   │
-                    │  │            │       │   Shared Volume          │   │
-                    │  │            │       │   /models ──► /server_   │   │
-                    │  │            │       │               models     │   │
-                    │  │            │       └──────────────────────────┘   │
-                    │  │            │                   ▲                  │
-                    │  │            │          reads models (.joblib)      │
-                    │  │            │                   │                  │
-                    │  │            │       ┌───────────┴───────────────┐  │
-                    │  │            ├──────►│   Prediction Servers      │  │
-                    │  │            │predict│   (ports 8001, 8002, 8003)│  │
-                    │  │            │◄──────┤                           │  │
-                    │  │            │       │   Serve trained models,   │  │
-                    │  │            │       │   return p90 TTFT/TPOT    │  │
-                    │  └────────────┘       └───────────────────────────┘  │
-                    └──────────────────────────────────────────────────────┘
-```
+![Latency predictor sidecar architecture](https://raw.githubusercontent.com/llm-d/llm-d.github.io/main/static/img/blogs/predicted-latency/architecture_sidecars.webp)
 
-#### Training Server
+### Plugin Pipeline
 
-The training server (single instance, port 8000) continuously learns from completed requests:
-
-1. The EPP sends completed request data (actual TTFT, TPOT, and associated features) to the training server.
-2. The training server maintains a **stratified sliding-window dataset** -- samples are bucketed by KV-cache utilization (10% steps), prefix hit rate (0.25 steps), etc. to prevent the model from forgetting underrepresented traffic regimes.
-3. The model is retrained at a configurable interval (default: every 1 second, once at least 100 samples are collected).
-4. Updated model files (`.joblib`) are written to a shared volume.
-
-#### Prediction Servers
-
-Three prediction server instances (ports 8001, 8002, 8003) serve the trained models:
-
-1. They read model files from the shared volume.
-2. When the EPP needs to score candidate pods, a Go sidecar coalesces concurrent prediction requests within a 1ms window into a single batched HTTP call.
-3. Requests are load-balanced across the three prediction server instances, each running 28 uvicorn workers.
-4. Each prediction evaluates all candidate pods and returns predicted p90 TTFT and p90 TPOT per pod.
-
-#### ML Model
-
-The predictor uses **XGBoost quantile regression** (`reg:quantileerror`), chosen for its speed, accuracy, and online learning capability. Two independent models are trained -- one for TTFT and one for TPOT. Across benchmark runs, the models achieve approximately **5% Mean Absolute Percentage Error (MAPE)**.
-
-The target quantile is configurable via `LATENCY_QUANTILE_ALPHA` (default: 0.9 for p90).
-
-**TTFT model features:**
-
-| Feature | What It Captures |
-|---------|-----------------|
-| KV Cache Usage % | How full the decode state is -- high utilization means higher TPOT and slower TTFT |
-| Input Length | Weight of the prefill step -- longer prompts increase TTFT |
-| Queue Depth | Backlog before scheduling -- more waiting requests increase TTFT |
-| Running Requests | Active GPU concurrency -- higher concurrency increases both TTFT and TPOT |
-| Prefix Cache Match % | KV reuse potential -- high match rates reduce TTFT |
-| Input Tokens In Flight | Tokens dispatched but not yet prefilled, plus tokens still in KV cache -- captures incoming prefill pressure |
-
-**TPOT model features:**
-
-| Feature | What It Captures |
-|---------|-----------------|
-| KV Cache Usage % | KV-cache utilization |
-| Input Length | Input token count |
-| Queue Depth | Queued requests |
-| Running Requests | Active requests / GPU concurrency |
-| Tokens Generated | Output tokens produced so far |
-
-### How Endpoint Selection Works
-
-#### With SLO Headers
-
-1. The EPP calls the prediction servers to get predicted p90 TTFT and TPOT for each candidate pod.
-2. For each pod, the scorer computes **headroom**: `SLO target - predicted latency`.
-3. Pods are classified into **positive headroom** (can meet SLOs) and **negative headroom** (cannot meet SLOs) buckets.
-4. Within the positive bucket, the scorer selects the pod with the **least positive headroom** (best-fit packing), keeping other pods free for future requests.
-5. Headroom is computed as a weighted blend, defaulting to 80% TTFT + 20% TPOT.
-
-#### Without SLO Headers
-
-When `x-prediction-based-scheduling: true` is set but no SLO targets are provided (treated as SLO=0), the system routes to the pod with the **lowest predicted latency**.
-
-#### Request Shedding
-
-If a request has priority < 0 and no pod can meet both TTFT and TPOT SLOs, the request is **shed** rather than routed to a pod that will miss the SLO.
-
-#### Cache-Aware Affinity
-
-The scorer integrates prefix cache awareness with an epsilon-greedy strategy:
-
-- **Exploit (99%)**: Filter candidates to pods whose prefix cache score exceeds the affinity threshold. Among those, select the pod with the best predicted latency.
-- **Explore (1%)**: Ignore the affinity gate and consider all pods, seeding cache entries on non-sticky pods for diversity.
-- **Load gate**: If the best sticky pod's predicted TTFT exceeds the best overall pod's TTFT by more than a configurable penalty threshold, affinity is broken in favor of latency.
-
-### Current Limitations
-
-| Limitation | Details |
-|------------|---------|
-| Homogeneous pools only | All pods must have the same GPU type, model weights, and serving configuration. |
-| Streaming only | Only streaming workloads (`"stream": "true"`) are supported for training data collection. |
-| p90 only | Only p90 TTFT and TPOT are predicted. Other percentiles (p95, p99) are not yet available. |
-| No prefill/decode disaggregation | Prediction assumes a pod executes the entire request lifecycle. |
-| Unvalidated with advanced features | Not tested with LoRA adapters, speculative decoding, or beam search. |
-
-### Scaling
-
-Each prediction server can sustain approximately **300 QPS** (tested on c4-standard-192 with ~192 vCPUs). Scale horizontally by adding more prediction server sidecars and updating `PREDICTION_SERVER_URL` accordingly.
-
-| QPS | Avg Latency (ms) | p99 Latency (ms) | Prediction Servers |
-|-----|-------------------|-------------------|--------------------|
-| 100 | 3.5 | 46 | 1 |
-| 1,000 | 5.0 | 49 | 2 |
-| 2,500 | ~19 | ~36 | 1 |
-| 5,000 | ~27 | ~74 | 1 |
-| 7,500 | ~35 | ~96 | 3 |
-| 10,000 | ~48 | ~137 | 4 |
-
-## Configuration
-
-### Enabling the Latency Predictor
-
-Add the `--enable-latency-predictor` flag to the EPP container args:
-
-```yaml
-args:
-  - --config-file=/config/default-plugins.yaml
-  - --enable-latency-predictor
-```
-
-### EPP Environment Variables
-
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `PREDICTION_SERVER_URL` | CSV of in-pod predictor endpoints | `http://localhost:8001,http://localhost:8002,http://localhost:8003` |
-| `TRAINING_SERVER_URL` | Training server endpoint | `http://localhost:8000` |
-| `LATENCY_MAX_SAMPLE_SIZE` | Max sample size for latency data | |
-| `HEADROOM_TTFT_WEIGHT` | Weight for TTFT in positive headroom scoring | `0.8` |
-| `HEADROOM_TPOT_WEIGHT` | Weight for TPOT in positive headroom scoring | `0.2` |
-| `NEG_HEADROOM_TTFT_WEIGHT` | Weight for TTFT in negative headroom scoring | |
-| `NEG_HEADROOM_TPOT_WEIGHT` | Weight for TPOT in negative headroom scoring | |
-| `HEADROOM_SELECTION_STRATEGY` | `least` (compact/best-fit) or `most` (spread) | `least` |
-| `SLO_BUFFER_FACTOR` | Safety multiplier on TPOT SLOs | |
-
-### Training Server ConfigMap
-
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: latency-predictor-config
-data:
-  LATENCY_RETRAINING_INTERVAL_SEC: "1"
-  LATENCY_MIN_SAMPLES_FOR_RETRAIN: "100"
-  LATENCY_TTFT_MODEL_PATH: "/models/ttft.joblib"
-  LATENCY_TPOT_MODEL_PATH: "/models/tpot.joblib"
-  LATENCY_TTFT_SCALER_PATH: "/models/ttft_scaler.joblib"
-  LATENCY_TPOT_SCALER_PATH: "/models/tpot_scaler.joblib"
-  LATENCY_MODEL_TYPE: "xgboost"
-  LATENCY_MAX_TRAINING_DATA_SIZE_PER_BUCKET: "5000"
-```
-
-| Variable | Description |
-|----------|-------------|
-| `LATENCY_RETRAINING_INTERVAL_SEC` | How often (in seconds) the model is retrained from collected samples. |
-| `LATENCY_MIN_SAMPLES_FOR_RETRAIN` | Minimum number of completed request samples required before retraining. |
-| `LATENCY_MODEL_TYPE` | ML algorithm used for prediction. Currently only `xgboost` is supported. |
-| `LATENCY_MAX_TRAINING_DATA_SIZE_PER_BUCKET` | Maximum samples retained per stratification bucket in the sliding window. |
-| `LATENCY_QUANTILE_ALPHA` | Target quantile for prediction (default: `0.9` for p90). |
-| `LATENCY_TEST_TRAIN_RATIO` | Fraction of data held out for evaluation (default: `0.1`). |
-| `LATENCY_MAX_TEST_DATA_SIZE` | Maximum number of test samples (default: `1000`). |
-| `LATENCY_SAMPLE_WEIGHTING_FOR_PREFIX_CACHE` | When `true`, reweights underrepresented prefix cache buckets during training (default: `false`). |
-
-### Prediction Server ConfigMap
-
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: prediction-server-config
-data:
-  LATENCY_MODEL_TYPE: "xgboost"
-  PREDICT_HOST: "0.0.0.0"
-  LOCAL_TTFT_MODEL_PATH: "/server_models/ttft.joblib"
-  LOCAL_TPOT_MODEL_PATH: "/server_models/tpot.joblib"
-  LOCAL_TTFT_SCALER_PATH: "/server_models/ttft_scaler.joblib"
-  LOCAL_TPOT_SCALER_PATH: "/server_models/tpot_scaler.joblib"
-```
-
-### Plugin Configuration
-
-The `plugins-config` ConfigMap defines two scheduling profiles -- `default` for baseline routing and `slo` for prediction-based routing:
-
-```yaml
-apiVersion: inference.networking.x-k8s.io/v1alpha1
-kind: EndpointPickerConfig
-plugins:
-  - type: queue-scorer
-  - type: kv-cache-utilization-scorer
-  - type: prefix-cache-scorer
-  - type: slo-request-tracker
-  - type: slo-scorer
-  - type: slo-aware-profile-handler
-  - type: max-score-picker
-
-schedulingProfiles:
-  - name: default
-    plugins:
-      - pluginRef: slo-request-tracker
-      - pluginRef: prefix-cache-scorer
-      - pluginRef: queue-scorer
-      - pluginRef: kv-cache-utilization-scorer
-      - pluginRef: max-score-picker
-
-  - name: slo
-    plugins:
-      - pluginRef: prefix-cache-scorer
-        weight: 0
-      - pluginRef: slo-request-tracker
-      - pluginRef: slo-scorer
-      - pluginRef: max-score-picker
-```
-
-**Key plugins:**
+Latency-based scheduling is implemented as a pipeline of composable EPP plugins. When the latency predictor is enabled via the Helm chart, the full pipeline is wired up automatically. SLO-specific plugins are no-ops when a request does not include SLO headers, so the same pipeline handles both SLO and non-SLO traffic.
 
 | Plugin | Role |
 |--------|------|
-| `slo-request-tracker` | Captures per-request SLO targets from headers and tracks them through the request lifecycle. |
-| `slo-scorer` | Calls the prediction servers, compares predicted TTFT/TPOT against SLO targets, and scores pods by headroom. |
-| `slo-aware-profile-handler` | Automatically switches requests into the `slo` profile when SLO headers are present. |
+| `predicted-latency-producer` | Calls the prediction server sidecar(s) and attaches predicted TTFT/TPOT to each candidate endpoint. Predictions are conditioned on the pod's KV cache utilization, queue depth, and prefix cache match score. When SLO headers are present, headroom (`SLO − predicted`) is attached alongside. |
+| `prefix-cache-affinity-filter` | Narrows the candidate set to cache-warm endpoints when any endpoint's prefix cache match score exceeds the affinity threshold (default `0.80`). Includes two built-in guardrails against hot-spotting — a **TTFT load gate** that breaks affinity when the best cache-warm pod's predicted TTFT exceeds the best overall pod's by more than a configurable penalty, and a small **explore probability** (epsilon-greedy) that occasionally bypasses the filter entirely to seed cache entries on non-sticky pods. If no endpoint clears the threshold, the filter is a no-op. |
+| `slo-headroom-tier-filter` | Splits endpoints into a **positive** tier (predicted to meet SLO) and a **negative** tier (predicted to violate SLO), with probabilistic exploration of the negative tier so recovering pods still receive traffic. No-op when SLO headers are absent. |
+| `latency-scorer` | Scores endpoints. Without SLOs, lowest predicted latency wins. With SLOs, the score is derived from headroom under the configured [scoring strategy](#scoring-strategy). |
+| `latency-slo-admitter` | Rejects *sheddable* requests (priority < 0) when no endpoint can meet the SLO, rather than wasting capacity on a guaranteed miss. No-op when SLO headers are absent. |
+| `weighted-random-picker` | Selects an endpoint via weighted random selection over the scores. This spreads load while still favoring better-scoring endpoints, and avoids the "everyone piles onto the current best pod" failure mode of pure arg-max selection. |
 
-### Headroom Strategies
+If the prediction server is unreachable or fails to return a prediction, `latency-scorer` falls back to a composite score built from KV cache utilization, queue depth, and prefix cache match — so a predictor outage degrades to baseline heuristic routing rather than dropping traffic.
 
-The `HEADROOM_SELECTION_STRATEGY` environment variable controls how pods are selected from the positive headroom bucket:
+### Scoring Strategy
 
-- **`least`** (default) -- Best-fit / compact. Routes to the pod with the least headroom above the SLO, packing requests to keep other pods free for burst capacity.
-- **`most`** -- Spread. Routes to the pod with the most headroom, distributing load evenly across the pool.
+The `latency-scorer` plugin exposes a `headroomSelectionStrategy` parameter that only affects requests with SLO headers:
 
-### Per-Request SLO Headers
+- **`least`** (default). Bin-pack: prefer the endpoint closest to the SLO boundary — smallest positive headroom if any pod meets the SLO, smallest negative deficit otherwise. Maximizes utilization and keeps less-loaded pods free for bursty arrivals.
+- **`most`**. Spread: prefer the endpoint with the most positive headroom. More conservative, leaves slack for unexpected spikes. For negative headroom, `least` is always used regardless of this setting.
 
-Clients enable SLO-aware routing by setting HTTP headers on inference requests:
+Without SLO headers, both strategies score by lowest predicted latency.
 
-| Header | Description |
+### ML Model
+
+Predictions come from **XGBoost** regression models trained online. Two models are maintained — one for TTFT, one for TPOT — and retrained on a sliding window of completed requests.
+
+Training uses **stratified bucketing** — samples are partitioned by KV cache utilization (10% steps), prefix cache hit rate (0.25 steps), and similar features. Each bucket has its own sample cap, so traffic regimes that are rare in the current window (for example, a cold prefix cache during low load) are not forgotten by the model. Across benchmark runs the models achieve approximately **5% Mean Absolute Percentage Error** on both targets.
+
+**TTFT features**
+
+| Feature | What it captures |
+|---------|------------------|
+| KV Cache Usage % | Memory saturation and its effect on prefill scheduling |
+| Input Length | Prefill cost proxy — longer prompts dominate TTFT |
+| Queue Depth | Backlog before scheduling — more waiting requests delay first token |
+| Running Requests | GPU concurrency — contention with in-flight decode |
+| Prefix Cache Match % | KV reuse potential — high match rates collapse prefill work |
+| Input Tokens In Flight | Tokens dispatched but not yet prefilled, plus tokens still resident in KV — captures incoming prefill pressure |
+
+**TPOT features**
+
+| Feature | What it captures |
+|---------|------------------|
+| KV Cache Usage % | Memory pressure during decode |
+| Input Length | Input token count (affects attention cost) |
+| Queue Depth | Queue contention that leaks into decode batching |
+| Running Requests | Active decode batch size / GPU concurrency |
+| Tokens Generated | Output tokens produced so far |
+
+### Streaming Mode
+
+The `predicted-latency-producer` plugin has two training modes, exposed via a `streamingMode` parameter:
+
+- **`streamingMode: false`** (default) — Trains on end-to-end request latency. TTFT is recorded at response completion (effectively e2e latency); TPOT is not trained. Correct for mixed streaming/non-streaming workloads and for routing-only use without SLOs.
+- **`streamingMode: true`** — Trains separate TTFT and TPOT models. TTFT is recorded on the first streamed chunk; TPOT is sampled across subsequent tokens. This is the mode required for meaningful `x-slo-ttft-ms` / `x-slo-tpot-ms` enforcement, and it assumes the workload is fully streaming — a mixed workload in this mode will produce incorrect measurements for the non-streamed responses.
+
+### Cache Affinity Guardrails
+
+`prefix-cache-affinity-filter` implements an epsilon-greedy exploit/explore over cache locality, with a TTFT-based escape hatch:
+
+- **Exploit** (default path). If any endpoint's prefix cache match score exceeds the affinity threshold, the filter narrows the candidate set to those cache-warm endpoints so downstream scoring concentrates reuse on them.
+- **Explore** (small probability). On a configurable fraction of requests the filter bypasses itself entirely, letting traffic land on cache-cold pods so they can seed new entries — this prevents a single pod from permanently owning a hot prefix.
+- **TTFT load gate**. Even on the exploit path, if the best cache-warm pod's predicted TTFT is materially worse than the best overall pod's (by more than a configurable penalty), the filter breaks affinity and yields the full candidate set. This stops a hot prefix from piling up behind a saturated pod while cooler pods sit idle.
+
+`weighted-random-picker` sits at the end of the pipeline and is independent of cache affinity — it spreads load across the final scored set regardless of how those scores were produced.
+
+### Current Limitations
+
+The predictor assumes a **homogeneous inference pool** — every pod in the pool must share the same GPU type, model weights, and serving configuration. The features the model is trained on describe pod state (KV cache utilization, queue depth, running requests, prefix hit rate) without encoding pod shape, so predictions across heterogeneous hardware or serving configs would conflate regimes the model treats as identical. Heterogeneous pools are not yet modeled.
+
+### Scaling
+
+Each prediction sidecar sustains roughly 300 QPS of prediction work on a `c4-standard-192` node (~192 vCPUs). Because the EPP makes one prediction per candidate pod, total prediction load scales with `cluster QPS × pod count`. Scale horizontally by adding prediction sidecars and updating the predictor URL list.
+
+| Cluster QPS | Avg prediction latency (ms) | p99 prediction latency (ms) | Prediction servers |
+|-------------|------------------------------|------------------------------|---------------------|
+| 100         | 3.5                          | 46                           | 1                   |
+| 1,000       | 5.0                          | 49                           | 2                   |
+| 5,000       | ~27                          | ~74                          | 2                   |
+| 7,500       | ~35                          | ~96                          | 3                   |
+| 10,000      | ~48                          | ~137                         | 4                   |
+
+## Observability
+
+When the latency predictor is enabled, the EPP exposes Prometheus metrics for actual vs. predicted latency, prediction duration, and SLO violation tracking. The primary series are:
+
+| Metric | Description |
 |--------|-------------|
-| `x-prediction-based-scheduling: true` | Activates SLO-aware routing for the request. |
-| `x-slo-ttft-ms: <value>` | Target time-to-first-token in milliseconds. |
-| `x-slo-tpot-ms: <value>` | Target time-per-output-token in milliseconds. |
+| `inference_objective_request_ttft_seconds` | Actual TTFT distribution, per model / target model. |
+| `inference_objective_request_predicted_ttft_seconds` | Predicted TTFT distribution, per model / target model. |
+| `inference_objective_request_ttft_prediction_duration_seconds` | Time spent generating TTFT predictions. |
+| `inference_objective_request_tpot_seconds` | Actual TPOT distribution. |
+| `inference_objective_request_predicted_tpot_seconds` | Predicted TPOT distribution. |
+| `inference_objective_request_tpot_prediction_duration_seconds` | Time spent generating TPOT predictions. |
+| `inference_objective_request_ttft_slo_violation_total` | Counter of TTFT SLO violations. |
+| `inference_objective_request_tpot_slo_violation_total` | Counter of TPOT SLO violations. |
 
-## Examples
+All latency and prediction-duration series are Prometheus **histograms**, so dashboards should query them via `histogram_quantile` (and the counters via `rate`) rather than reading instantaneous values. Pairing actuals with predictions lets operators validate predictor accuracy in-situ; SLO violation counters are the primary signal for alerting on SLO breaches.
 
-### Sending a Request with SLO Headers
+## Source
 
-```bash
-curl $GATEWAY_IP/v1/completions \
-  -H 'Content-Type: application/json' \
-  -H 'x-prediction-based-scheduling: true' \
-  -H 'x-slo-ttft-ms: 200' \
-  -H 'x-slo-tpot-ms: 50' \
-  -d '{
-    "model": "meta-llama/Llama-3.1-8B-Instruct",
-    "prompt": "Explain the difference between prefill and decode.",
-    "max_tokens": 200,
-    "temperature": 0,
-    "stream": "true",
-    "stream_options": {"include_usage": "true"}
-  }'
-```
-
-### Response Observability
-
-When the latency predictor is enabled, the final SSE frame in streaming responses includes both predicted and actual latency metrics:
-
-```json
-{
-  "usage": {
-    "prompt_tokens": 12,
-    "completion_tokens": 200,
-    "ttft_ms": 59,
-    "avg_tpot_ms": 7.5,
-    "predicted_ttft_ms": 273.23,
-    "avg_predicted_tpot_ms": 97.19,
-    "tpot_observations_ms": [9, 6],
-    "predicted_tpot_observations_ms": [176.22, 18.17]
-  }
-}
-```
-
-This allows users to compare predictions against actuals and validate model accuracy. TPOT is sampled every 200th output token.
-
-### Full Plugin Configuration
-
-A complete `EndpointPickerConfig` with both default and SLO-aware profiles:
-
-```yaml
-apiVersion: inference.networking.x-k8s.io/v1alpha1
-kind: EndpointPickerConfig
-plugins:
-  - type: queue-scorer
-  - type: kv-cache-utilization-scorer
-  - type: prefix-cache-scorer
-  - type: slo-request-tracker
-  - type: slo-scorer
-  - type: slo-aware-profile-handler
-  - type: max-score-picker
-
-schedulingProfiles:
-  - name: default
-    plugins:
-      - pluginRef: slo-request-tracker
-      - pluginRef: prefix-cache-scorer
-      - pluginRef: queue-scorer
-      - pluginRef: kv-cache-utilization-scorer
-      - pluginRef: max-score-picker
-
-  - name: slo
-    plugins:
-      - pluginRef: prefix-cache-scorer
-        weight: 0
-      - pluginRef: slo-request-tracker
-      - pluginRef: slo-scorer
-      - pluginRef: max-score-picker
-```
+- **EPP plugins** (`predicted-latency-producer`, `prefix-cache-affinity-filter`, `latency-scorer`, `weighted-random-picker`, `slo-headroom-tier-filter`, `latency-slo-admitter`) live in [llm-d/llm-d-inference-scheduler](https://github.com/llm-d/llm-d-inference-scheduler). Per-plugin configuration references live alongside each plugin in that repo.
+- **Training and prediction server code** (the Python ML sidecars, XGBoost models, stratified sampler) lives in [llm-d/llm-d-latency-predictor](https://github.com/llm-d/llm-d-latency-predictor).
 
 ## Further Reading
 
-- [Predicted Latency-Based Scheduling Guide](../../../guides/predicted-latency-based-scheduling/README.md) -- step-by-step deployment and validation walkthrough
-- [Predicted Latency-Based Scheduling for LLMs](https://llm-d.ai/blog/predicted-latency-based-scheduling-for-llms) -- blog post with benchmarks and design rationale
-- [EPP Architecture](../core/epp.md) -- details on the plugin pipeline and scoring system
+- [Predicted Latency Well-Lit Path](../../well-lit-paths/intelligent-inference-scheduling/predicted-latency.md) — how to adopt this path: Helm enablement, request headers, verification, troubleshooting.
+- [Predicted Latency-Based Scheduling for LLMs](https://llm-d.ai/blog/predicted-latency-based-scheduling-for-llms) — design rationale and benchmark results.
+- [EPP Scheduling](../core/epp/scheduling.md) — how the plugin pipeline fits into EPP request handling.

--- a/docs/wip-docs-new/architecture/advanced/latency-predictor.md
+++ b/docs/wip-docs-new/architecture/advanced/latency-predictor.md
@@ -2,7 +2,7 @@
 
 The Latency Predictor is the llm-d component behind predicted latency-based scheduling. Instead of scoring pods by coarse utilization signals alone, the EPP asks an online-trained ML model to predict **Time To First Token (TTFT)** and **Time Per Output Token (TPOT)** for each candidate pod, then routes on those predictions — optionally gated by per-request Service Level Objectives (SLOs).
 
-This page is a reference for the component: its design, plugin pipeline, ML model, failure modes, and scaling characteristics. For step-by-step adoption — Helm enablement, SLO header usage, verification, troubleshooting — see the [Predicted Latency well-lit path](../../well-lit-paths/intelligent-inference-scheduling/predicted-latency.md). Design rationale and benchmarks are in the blog [Predicted Latency-Based Scheduling for LLMs](https://llm-d.ai/blog/predicted-latency-based-scheduling-for-llms).
+This page is a reference for the component: its design, EPP plugins, ML model, failure modes, and scaling characteristics. For step-by-step adoption — Helm enablement, SLO header usage, verification, troubleshooting — see the [Predicted Latency well-lit path](../../well-lit-paths/intelligent-inference-scheduling/predicted-latency.md). Design rationale and benchmarks are in the blog [Predicted Latency-Based Scheduling for LLMs](https://llm-d.ai/blog/predicted-latency-based-scheduling-for-llms).
 
 ## Why Predicted Latency?
 
@@ -15,43 +15,51 @@ Utilization-based load balancing has structural gaps for LLM workloads:
 
 The Latency Predictor closes those gaps by learning the mapping from `(pod state, request features) → latency` directly from live traffic, and letting the EPP reason about headroom against SLOs instead of hand-tuned weights.
 
-## Design
+## The Predictor
+
+The `predicted-latency-producer` plugin drives interactions with the predictor. For each request, it calls the predictor to obtain TTFT and TPOT predictions for every candidate pod, conditioned on the pod's state (KV cache utilization, queue depth, prefix cache match score). After the request is served, the producer sends the observed TTFT and ITL latencies back to the predictor as training samples, so the model is continuously retrained on live traffic.
+
+If the prediction server is unreachable or fails to return a prediction, the latency scorer falls back to a composite score built from KV cache utilization, queue depth, and prefix cache match — so a predictor outage degrades to baseline heuristic routing rather than dropping traffic.
 
 ### Architecture
 
-The predictor ships as a set of sidecars alongside the EPP. A **training server** continuously retrains on completed requests. Multiple **prediction servers** read the latest model from a shared volume and answer prediction requests from the EPP on the hot path.
+The predictor ships as a set of sidecars colocated with the EPP in the same pod. A **training server** continuously retrains on completed requests, and multiple **prediction servers** read the latest model from a shared volume and answer predictions from the EPP on the hot path.
 
-![Latency predictor sidecar architecture](https://raw.githubusercontent.com/llm-d/llm-d.github.io/main/static/img/blogs/predicted-latency/architecture_sidecars.webp)
-
-### Plugin Pipeline
-
-Latency-based scheduling is implemented as a pipeline of composable EPP plugins. When the latency predictor is enabled via the Helm chart, the full pipeline is wired up automatically. SLO-specific plugins are no-ops when a request does not include SLO headers, so the same pipeline handles both SLO and non-SLO traffic.
-
-| Plugin | Role |
-|--------|------|
-| `predicted-latency-producer` | Calls the prediction server sidecar(s) and attaches predicted TTFT/TPOT to each candidate endpoint. Predictions are conditioned on the pod's KV cache utilization, queue depth, and prefix cache match score. When SLO headers are present, headroom (`SLO − predicted`) is attached alongside. |
-| `prefix-cache-affinity-filter` | Narrows the candidate set to cache-warm endpoints when any endpoint's prefix cache match score exceeds the affinity threshold (default `0.80`). Includes two built-in guardrails against hot-spotting — a **TTFT load gate** that breaks affinity when the best cache-warm pod's predicted TTFT exceeds the best overall pod's by more than a configurable penalty, and a small **explore probability** (epsilon-greedy) that occasionally bypasses the filter entirely to seed cache entries on non-sticky pods. If no endpoint clears the threshold, the filter is a no-op. |
-| `slo-headroom-tier-filter` | Splits endpoints into a **positive** tier (predicted to meet SLO) and a **negative** tier (predicted to violate SLO), with probabilistic exploration of the negative tier so recovering pods still receive traffic. No-op when SLO headers are absent. |
-| `latency-scorer` | Scores endpoints. Without SLOs, lowest predicted latency wins. With SLOs, the score is derived from headroom under the configured [scoring strategy](#scoring-strategy). |
-| `latency-slo-admitter` | Rejects *sheddable* requests (priority < 0) when no endpoint can meet the SLO, rather than wasting capacity on a guaranteed miss. No-op when SLO headers are absent. |
-| `weighted-random-picker` | Selects an endpoint via weighted random selection over the scores. This spreads load while still favoring better-scoring endpoints, and avoids the "everyone piles onto the current best pod" failure mode of pure arg-max selection. |
-
-If the prediction server is unreachable or fails to return a prediction, `latency-scorer` falls back to a composite score built from KV cache utilization, queue depth, and prefix cache match — so a predictor outage degrades to baseline heuristic routing rather than dropping traffic.
-
-### Scoring Strategy
-
-The `latency-scorer` plugin exposes a `headroomSelectionStrategy` parameter that only affects requests with SLO headers:
-
-- **`least`** (default). Bin-pack: prefer the endpoint closest to the SLO boundary — smallest positive headroom if any pod meets the SLO, smallest negative deficit otherwise. Maximizes utilization and keeps less-loaded pods free for bursty arrivals.
-- **`most`**. Spread: prefer the endpoint with the most positive headroom. More conservative, leaves slack for unexpected spikes. For negative headroom, `least` is always used regardless of this setting.
-
-Without SLO headers, both strategies score by lowest predicted latency.
+```
+                ┌──────────────────────────────────────────────────────┐
+                │                      EPP Pod                         │
+                │                                                      │
+                │  ┌─────────────┐        ┌──────────────────────────┐ │
+                │  │             │        │   Training Server        │ │
+ Inference ────►│  │     EPP     │───────►│                          │ │
+ Requests       │  │             │samples │   Collects completed     │ │
+                │  │ latency-    │        │   requests, retrains     │ │
+                │  │ based       │        │   XGBoost models         │ │
+                │  │ plugins     │        └────────────┬─────────────┘ │
+                │  │             │                     │ writes        │
+                │  │             │                     ▼ models        │
+                │  │             │        ┌──────────────────────────┐ │
+                │  │             │        │   Shared Volume          │ │
+                │  │             │        └────────────┬─────────────┘ │
+                │  │             │                     │ reads         │
+                │  │             │                     ▼ models        │
+                │  │             │        ┌──────────────────────────┐ │
+                │  │             │───────►│   Prediction Servers     │ │
+                │  │             │predict │   (horizontally scaled)  │ │
+                │  │             │◄───────│                          │ │
+                │  │             │result  │   Serve TTFT/TPOT        │ │
+                │  │             │        │   predictions            │ │
+                │  └─────────────┘        └──────────────────────────┘ │
+                └──────────────────────────────────────────────────────┘
+```
 
 ### ML Model
 
 Predictions come from **XGBoost** regression models trained online. Two models are maintained — one for TTFT, one for TPOT — and retrained on a sliding window of completed requests.
 
 Training uses **stratified bucketing** — samples are partitioned by KV cache utilization (10% steps), prefix cache hit rate (0.25 steps), and similar features. Each bucket has its own sample cap, so traffic regimes that are rare in the current window (for example, a cold prefix cache during low load) are not forgotten by the model. Across benchmark runs the models achieve approximately **5% Mean Absolute Percentage Error** on both targets.
+
+The predictor assumes a **homogeneous inference pool** — every pod in the pool must share the same GPU type, model weights, and serving configuration. The features the model is trained on describe pod state (KV cache utilization, queue depth, running requests, prefix hit rate) without encoding pod shape, so predictions across heterogeneous hardware or serving configs would conflate regimes the model treats as identical. Heterogeneous pools are not yet modeled.
 
 **TTFT features**
 
@@ -74,28 +82,7 @@ Training uses **stratified bucketing** — samples are partitioned by KV cache u
 | Running Requests | Active decode batch size / GPU concurrency |
 | Tokens Generated | Output tokens produced so far |
 
-### Streaming Mode
-
-The `predicted-latency-producer` plugin has two training modes, exposed via a `streamingMode` parameter:
-
-- **`streamingMode: false`** (default) — Trains on end-to-end request latency. TTFT is recorded at response completion (effectively e2e latency); TPOT is not trained. Correct for mixed streaming/non-streaming workloads and for routing-only use without SLOs.
-- **`streamingMode: true`** — Trains separate TTFT and TPOT models. TTFT is recorded on the first streamed chunk; TPOT is sampled across subsequent tokens. This is the mode required for meaningful `x-slo-ttft-ms` / `x-slo-tpot-ms` enforcement, and it assumes the workload is fully streaming — a mixed workload in this mode will produce incorrect measurements for the non-streamed responses.
-
-### Cache Affinity Guardrails
-
-`prefix-cache-affinity-filter` implements an epsilon-greedy exploit/explore over cache locality, with a TTFT-based escape hatch:
-
-- **Exploit** (default path). If any endpoint's prefix cache match score exceeds the affinity threshold, the filter narrows the candidate set to those cache-warm endpoints so downstream scoring concentrates reuse on them.
-- **Explore** (small probability). On a configurable fraction of requests the filter bypasses itself entirely, letting traffic land on cache-cold pods so they can seed new entries — this prevents a single pod from permanently owning a hot prefix.
-- **TTFT load gate**. Even on the exploit path, if the best cache-warm pod's predicted TTFT is materially worse than the best overall pod's (by more than a configurable penalty), the filter breaks affinity and yields the full candidate set. This stops a hot prefix from piling up behind a saturated pod while cooler pods sit idle.
-
-`weighted-random-picker` sits at the end of the pipeline and is independent of cache affinity — it spreads load across the final scored set regardless of how those scores were produced.
-
-### Current Limitations
-
-The predictor assumes a **homogeneous inference pool** — every pod in the pool must share the same GPU type, model weights, and serving configuration. The features the model is trained on describe pod state (KV cache utilization, queue depth, running requests, prefix hit rate) without encoding pod shape, so predictions across heterogeneous hardware or serving configs would conflate regimes the model treats as identical. Heterogeneous pools are not yet modeled.
-
-### Scaling
+### Scalability
 
 Each prediction sidecar sustains roughly 300 QPS of prediction work on a `c4-standard-192` node (~192 vCPUs). Because the EPP makes one prediction per candidate pod, total prediction load scales with `cluster QPS × pod count`. Scale horizontally by adding prediction sidecars and updating the predictor URL list.
 
@@ -106,6 +93,42 @@ Each prediction sidecar sustains roughly 300 QPS of prediction work on a `c4-sta
 | 5,000       | ~27                          | ~74                          | 2                   |
 | 7,500       | ~35                          | ~96                          | 3                   |
 | 10,000      | ~48                          | ~137                         | 4                   |
+
+### Streaming Mode
+
+The `predicted-latency-producer` plugin has two training modes, exposed via a `streamingMode` parameter:
+
+- **`streamingMode: false`** (default) — Trains on end-to-end request latency. TTFT is recorded at response completion (effectively e2e latency); TPOT is not trained. **Use this mode if** your workload mixes streaming and non-streaming responses, or if you only need latency-aware routing without per-request SLO enforcement.
+- **`streamingMode: true`** — Trains separate TTFT and TPOT models. TTFT is recorded on the first streamed chunk; TPOT is sampled across subsequent tokens. **Use this mode if** your workload is fully streaming and you need meaningful `x-slo-ttft-ms` / `x-slo-tpot-ms` enforcement — a mixed workload in this mode will produce incorrect measurements for the non-streamed responses.
+
+## Scheduling Strategy
+
+Using the latency predictions obtained by `predicted-latency-producer`, scheduling is done using a sequence of filtering and scoring plugins to determine the optimal placement. When the latency predictor is enabled via the Helm chart, the full sequence is wired up automatically. SLO-specific plugins are no-ops when a request does not include SLO headers, so the same set of plugins handles both SLO and non-SLO annotated traffic.
+
+### Filtering Strategy
+
+Two filters narrow the candidate set before scoring.
+
+**`prefix-cache-affinity-filter`** narrows the candidate set to cache-warm endpoints when any endpoint's prefix cache match score exceeds the affinity threshold (default `0.80`). If no endpoint clears the threshold, the filter is a no-op. The filter implements an epsilon-greedy exploit/explore over cache locality, with a TTFT-based escape hatch:
+
+- **Exploit** (default path). The filter narrows to cache-warm endpoints so downstream scoring concentrates reuse on them.
+- **Explore** (small probability). On a configurable fraction of requests the filter bypasses itself entirely, letting traffic land on cache-cold pods so they can seed new entries — this prevents a single pod from permanently owning a hot prefix.
+- **TTFT load gate**. Even on the exploit path, if the best cache-warm pod's predicted TTFT is materially worse than the best overall pod's (by more than a configurable penalty), the filter breaks affinity and yields the full candidate set. This stops a hot prefix from piling up behind a saturated pod while cooler pods sit idle.
+
+**`slo-headroom-tier-filter`** splits endpoints into a **positive** tier (predicted to meet SLO) and a **negative** tier (predicted to violate SLO), with probabilistic exploration of the negative tier so recovering pods still receive traffic. No-op when SLO headers are absent.
+
+### Scoring Strategy
+
+Three plugins handle scoring and final selection.
+
+**`latency-scorer`** scores endpoints. Without SLO headers, lowest predicted latency wins. With SLO headers, the score is derived from headroom (`SLO − predicted`) via the `headroomSelectionStrategy` parameter:
+
+- **`least`** (default). Bin-pack: prefer the endpoint closest to the SLO boundary — smallest positive headroom if any pod meets the SLO, smallest negative deficit otherwise. Maximizes utilization and keeps less-loaded pods free for bursty arrivals.
+- **`most`**. Spread: prefer the endpoint with the most positive headroom. More conservative, leaves slack for unexpected spikes. For negative headroom, `least` is always used regardless of this setting.
+
+**`latency-slo-admitter`** rejects *sheddable* requests (priority < 0) when no endpoint can meet the SLO, rather than wasting capacity on a guaranteed miss. No-op when SLO headers are absent.
+
+**`weighted-random-picker`** selects an endpoint via weighted random selection over the scores. This spreads load while still favoring better-scoring endpoints, and avoids the "everyone piles onto the current best pod" failure mode of pure arg-max selection.
 
 ## Observability
 
@@ -133,4 +156,4 @@ All latency and prediction-duration series are Prometheus **histograms**, so das
 
 - [Predicted Latency Well-Lit Path](../../well-lit-paths/intelligent-inference-scheduling/predicted-latency.md) — how to adopt this path: Helm enablement, request headers, verification, troubleshooting.
 - [Predicted Latency-Based Scheduling for LLMs](https://llm-d.ai/blog/predicted-latency-based-scheduling-for-llms) — design rationale and benchmark results.
-- [EPP Scheduling](../core/epp/scheduling.md) — how the plugin pipeline fits into EPP request handling.
+- [EPP Scheduling](../core/epp/scheduling.md) — how the plugins fits into EPP request handling.

--- a/docs/wip-docs-new/well-lit-paths/intelligent-inference-scheduling/predicted-latency.md
+++ b/docs/wip-docs-new/well-lit-paths/intelligent-inference-scheduling/predicted-latency.md
@@ -1,0 +1,114 @@
+# Predicted Latency-Based Scheduling
+
+Route each inference request to the model server predicted to serve it fastest — and, optionally, only to a server predicted to meet its TTFT/TPOT SLO.
+
+This path is for operators who want to **adopt** predicted latency-based scheduling in an existing llm-d deployment. For what the component is and how it works internally — the plugin pipeline, the ML model, scaling characteristics, the full metric list — see [architecture/advanced/latency-predictor.md](../../architecture/advanced/latency-predictor.md).
+
+## When to Pick This Path
+
+Pick it when:
+
+- Your workload has **high variance in prompt and completion length**, and queue depth alone is a poor proxy for true load.
+- Your clients can express **per-request latency SLOs** (interactive vs. batch) and you want the gateway to enforce them.
+- Static weight tuning between cache affinity and load has become **fragile** as traffic shifts.
+
+Skip it when your pool is **heterogeneous** — mixed GPU types, model variants, or serving configurations in the same pool will produce inaccurate predictions, because the predictor assumes a single pod shape.
+
+## Prerequisites
+
+- A working Inference Gateway, `InferencePool`, and at least one model server. If you don't have this, start with [getting-started/quickstart.md](../../getting-started/quickstart.md).
+- Helm access to the chart used to deploy the EPP and inference pool.
+- A **homogeneous** pool — same GPU type, same model weights, same serving config across every pod.
+- If you plan to use SLO headers: a **fully streaming** workload (`"stream": true` on every request).
+
+## Deploy
+
+Enable the predictor by setting `inferenceExtension.latencyPredictor.enabled=true` when installing or upgrading the chart. This wires up the full plugin pipeline automatically — prediction, cache affinity filtering, SLO tier gating, scoring, admission control, and weighted endpoint selection. The SLO plugins stay idle until a request actually carries SLO headers, so it's safe to enable even for traffic that doesn't use SLOs yet.
+
+```bash
+helm install <release> . \
+  --set inferencePool.modelServers.matchLabels.app=<your-model-label> \
+  --set inferenceExtension.latencyPredictor.enabled=true \
+  --set inferenceExtension.monitoring.prometheus.enabled=true \
+  --set provider.name=gke \
+  -f values.yaml
+```
+
+### If You Want SLO Enforcement: Turn On Streaming Mode
+
+The `predicted-latency-producer` plugin has a `streamingMode` parameter. Its default (`false`) trains on end-to-end latency and does not train TPOT — fine for routing-only use, but incompatible with `x-slo-ttft-ms` / `x-slo-tpot-ms`. **Set `streamingMode: true` whenever you use SLO headers**, and make sure every request is actually streamed.
+
+Override it via `inferenceExtension.pluginsCustomConfig` in `values.yaml`:
+
+```yaml
+inferenceExtension:
+  latencyPredictor:
+    enabled: true
+  pluginsCustomConfig: |
+    apiVersion: inference.networking.x-k8s.io/v1alpha1
+    kind: EndpointPickerConfig
+    plugins:
+      - type: predicted-latency-producer
+        parameters:
+          streamingMode: true
+      # ...remaining plugins from the default pipeline...
+```
+
+### Scoring Strategy
+
+`latency-scorer` exposes `headroomSelectionStrategy` for SLO-annotated requests. Start with the default (`least`, bin-pack toward the SLO boundary). Switch to `most` (spread toward the endpoint with the most slack) only if you observe SLO violations clustering on the pods closest to the boundary during spikes. See the [architecture doc](../../architecture/advanced/latency-predictor.md#scoring-strategy) for the full mechanics.
+
+## Send Requests
+
+Once enabled, latency-based scheduling works on every request — no header changes needed. The gateway picks the endpoint with the lowest predicted latency.
+
+To opt an individual request into SLO-aware routing, add one or both headers:
+
+- `x-slo-ttft-ms` — Time-to-first-token SLO in milliseconds.
+- `x-slo-tpot-ms` — Time-per-output-token SLO in milliseconds.
+
+Example:
+
+```bash
+export GW_IP=$(kubectl get gateway/inference-gateway -o jsonpath='{.status.addresses[0].value}'):80
+
+curl -v $GW_IP/v1/completions \
+  -H 'Content-Type: application/json' \
+  -H 'x-slo-ttft-ms: 200' \
+  -H 'x-slo-tpot-ms: 50' \
+  -d '{
+    "model": "Qwen/Qwen3-32B",
+    "prompt": "Explain the difference between prefill and decode.",
+    "max_tokens": 200,
+    "temperature": 0,
+    "stream": true,
+    "stream_options": {"include_usage": true}
+  }'
+```
+
+Sheddable requests (priority < 0) are rejected at admission when no endpoint can meet the SLO, rather than routed to a guaranteed miss.
+
+## Verify
+
+Once traffic is flowing, confirm three things in Prometheus (see the [architecture doc](../../architecture/advanced/latency-predictor.md#observability) for the metric reference):
+
+1. **Predictions are being produced.** `inference_objective_request_ttft_prediction_duration_seconds` has non-zero samples. If it stays empty, the predictor sidecar is not being called — tail the EPP logs for `predicted-latency-producer` errors.
+2. **Predictions track reality.** Compare `inference_objective_request_predicted_ttft_seconds` against `inference_objective_request_ttft_seconds` over a rolling window. A healthy deployment converges to within a few percent after warmup.
+3. **SLOs are being honored.** If you're sending SLO-annotated traffic, `inference_objective_request_ttft_slo_violation_total` and `..._tpot_slo_violation_total` should increment only under genuine saturation.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| Prediction duration metrics empty | Predictor sidecar unreachable — EPP falls back to composite heuristic scoring. Check sidecar readiness and `PREDICTION_SERVER_URL`. |
+| Large, persistent drift between predicted and actual TTFT | `streamingMode` mismatch (set to `false` on a streaming workload, or vice versa), or workload drifted outside the training window. |
+| High TPOT SLO violation rate at low QPS | `streamingMode: false` — TPOT is not being trained. Flip it to `true` and restart. |
+| SLO violations cluster on a few pods during spikes | Scoring strategy is `least`; try `most` for more headroom at the cost of utilization. |
+| Prediction-based routing degrades to baseline | Predictor error or sidecar restart — expected fallback, not a failure. Investigate sidecar logs. |
+
+## Related
+
+- [Latency Predictor Architecture](../../architecture/advanced/latency-predictor.md) — plugin pipeline, ML model, scaling characteristics, metric reference.
+- [llm-d/llm-d-inference-scheduler](https://github.com/llm-d/llm-d-inference-scheduler) — source for the EPP plugins and per-plugin configuration references.
+- [llm-d/llm-d-latency-predictor](https://github.com/llm-d/llm-d-latency-predictor) — source for the training and prediction server Python code.
+- [Predicted Latency-Based Scheduling for LLMs](https://llm-d.ai/blog/predicted-latency-based-scheduling-for-llms) — design rationale and benchmark results.


### PR DESCRIPTION
Rewrite architecture/advanced/latency-predictor.md to match the upstreamed plugin pipeline (predicted-latency-producer, prefix-cache-affinity-filter, slo-headroom-tier-filter, latency-scorer, latency-slo-admitter, weighted-random-picker) and point at the llm-d-inference-scheduler and llm-d-latency-predictor repos as the source of truth. Replace the ASCII sidecar diagram with the blog image.

Add a companion well-lit-path doc at
well-lit-paths/intelligent-inference-scheduling/predicted-latency.md focused on operator adoption: when to pick the path, Helm enablement, streaming mode, SLO headers, verification, and troubleshooting. The architecture doc stays as the component reference; the well-lit path links out instead of duplicating internals.