### PR TITLE
[Docs] Replace deprecated inference-scheduler features in guides

### DIFF
--- a/docs/wip-docs-new/architecture/advanced/disaggregation/README.md
+++ b/docs/wip-docs-new/architecture/advanced/disaggregation/README.md
@@ -3,11 +3,13 @@
 ## Functionality
 
 Disaggregated serving separates the **prefill** and **decode** stages of LLM inference onto different model server instances, enabling:
+
 * **Specialization of P and D** - LLM inference is composed of two distinct phases of inference - prefill (FLOPs-bound) and decode (memory bandwidth-bound). Disaggregation enables specialization, e.g. using a larger TP for the memory-bound decoding phase while a smaller TP for the computation-bound prefill phase.
 * **Avoidance of Request Interference** - For long context requests, prefills can slow down processing of existing requests in the decode phase. Separating the prefill phase of these long requests into dedicated prefill instances allows the ongoing decoding requests to be efficiently processed without being blocked by these long prefills, improving quality-of-service.
 * **Compatibility with DP/EP** - For DP/EP deployments of Mixture of Experts models, disaggregated serving is essential to avoid pipeline bubbles and leveraging the specialized "MaskedGEMM" format for decode.
 
 An implementation of disaggregated serving requires two key components:
+
 * **Request Flow Orchestration** - select and route the requests to the correct prefill and decode pods
 * **Efficient KV Transfer** - transfer the KV cache from the P instance to the D instance, typically over RDMA
 
@@ -47,18 +49,18 @@ Next we will discuss the design of the EPP and Routing Sidecar for disaggregated
 
 ### EPP
 
-The llm-d EPP supports disaggregation via the `pd-profile-handler`.
+The llm-d EPP supports disaggregation via the `disagg-profile-handler`.
 
 > [!NOTE]
 > Rather than hardcoding a single scheduling algorithm, the EPP delegates execution to one or more `Profile Handlers`, each of which represents a complete scheduling strategy. They can be thought of as "the dispatcher", which maps each incoming inference request to the right scheduling strategy before the scorers and pickers do their work of selecting the actual endpoint. By default, llm-d uses the `single-profile-handler` for simple aggregated serving.
 
-When configured with `pd-profile-handler`, the EPP processes requests in the following steps:
-- `proxy` forwards request metadata to the EPP.
-- `pd-profile-handler` runs the `decode-profile`, which executes the `filter`, `score`, `pick` scheduler profile to select D endpoint.
-- `pd-profile-handler` consults the `decider` — given how much of the prompt is cached on D, should this request run disagg?
-- If `no`: `pd-profile-handler` returns only the D endpoint to the `proxy`
-- If `yes` (large uncached suffix), `pd-profile-handler` also runs the `prefill-profile`, which executes the `filter`, `score`, `pick` scheduler profile to select the P endpoint and returns both the P and D endpoints to the proxy.
+When configured with `disagg-profile-handler`, the EPP processes requests in the following steps:
 
+* `proxy` forwards request metadata to the EPP.
+* `disagg-profile-handler` runs the `decode-profile`, which executes the `filter`, `score`, `pick` scheduler profile to select D endpoint.
+* `disagg-profile-handler` consults the `decider` — given how much of the prompt is cached on D, should this request run disagg?
+* If `no`: `disagg-profile-handler` returns only the D endpoint to the `proxy`
+* If `yes` (large uncached suffix), `disagg-profile-handler` also runs the `prefill-profile`, which executes the `filter`, `score`, `pick` scheduler profile to select the P endpoint and returns both the P and D endpoints to the proxy.
 
 The flow looks like this:
 
@@ -66,34 +68,35 @@ The flow looks like this:
 sequenceDiagram
     participant Proxy
     box EPP
-        participant PD-Profile-Handler
+        participant Disagg-Profile-Handler
         participant Decider
         participant Decode-Profile
         participant Prefill-Profile
     end
 
-    Proxy-->>PD-Profile-Handler: Request
-    PD-Profile-Handler-->>Decode-Profile: Request
+    Proxy-->>Disagg-Profile-Handler: Request
+    Disagg-Profile-Handler-->>Decode-Profile: Request
     Decode-Profile-->>Decode-Profile: Filter, Score, Pick
-    Decode-Profile-->>PD-Profile-Handler: D Endpoint
-    PD-Profile-Handler-->>Decider: Num uncached tokens on D
-    Decider-->>PD-Profile-Handler: [do-pd] BOOL
+    Decode-Profile-->>Disagg-Profile-Handler: D Endpoint
+    Disagg-Profile-Handler-->>Decider: Num uncached tokens on D
+    Decider-->>Disagg-Profile-Handler: [do-pd] BOOL
     opt do-pd=FALSE
-        PD-Profile-Handler-->>Proxy: D Endpoint
+        Disagg-Profile-Handler-->>Proxy: D Endpoint
     end
 
-    PD-Profile-Handler-->>Prefill-Profile: Request
+    Disagg-Profile-Handler-->>Prefill-Profile: Request
     Prefill-Profile-->>Prefill-Profile: Filter, Score, Pick
-    Prefill-Profile-->>PD-Profile-Handler: P Endpoint
-    PD-Profile-Handler-->>Proxy: D, P Endpoint
+    Prefill-Profile-->>Disagg-Profile-Handler: P Endpoint
+    Disagg-Profile-Handler-->>Proxy: D, P Endpoint
 ```
 
 In this way, disaggregated serving functionality composes with the existing set of scheduling functionality, enabling use of the existing set of scorers for prefix and load aware routing in the disaggregated setting.
 
 Note that both the prefill and decode endpoints are part of one `InferencePool`. The `decode-profile` and `prefill-profile` are responsible for selecting only D workers or P workers in the `filter` step. llm-d uses the label `llm-d.ai/role` with the following values to filter:
+
 * `prefill` → prefill-only pods
 * `decode` → decode-capable pods
-* `prefill-decode` → pods capable of both prefill and decode 
+* `prefill-decode` → pods capable of both prefill and decode
 
 > [!NOTE]
 > It is possible to override the default labels by configuring the `EndpointPickerConfig` to use the generic by-label filter plugin instead of the `prefill-filter` / `decode-filter`. TODO: provide an example of this.
@@ -101,8 +104,9 @@ Note that both the prefill and decode endpoints are part of one `InferencePool`.
 ### Routing Proxy Sidecar
 
 The Routing Proxy is deployed as a sidecar in each decode pod, with a two-fold role:
-- Facilitate the multi-step inference request
-- Mutate the requests to follow each model server's KV transfer protocol
+
+* Facilitate the multi-step inference request
+* Mutate the requests to follow each model server's KV transfer protocol
 
 #### Request Flow
 
@@ -122,12 +126,13 @@ All non-completion routes (`GET /health`, and any other path) pass through to th
 #### KV Transfer Protocol
 
 vLLM and SGLang use slightly different protocols for KV Transfer between the P and D instance, inserting additional parameters in the body of the requests to facilitate the transfer:
-- **vLLM** (`nixlv2`, default) — A two-phase sequential protocol. The sidecar sends a prefill request with `kv_transfer_params` containing remote-decode metadata, and `max_tokens=1` to suppress output. It captures the KV transfer parameters from the prefiller's response and injects them into the decode request before forwarding it to the local decoder. If the prefiller returns a server error, the sidecar falls back to decoder-only mode (client errors are not retried).
-- **SGLang** (`sglang`) — Uses a concurrent prefill/decode model. Instead of waiting for prefill to complete, the sidecar injects bootstrap coordination parameters (`bootstrap_host`, `bootstrap_port`, `bootstrap_room`) into both requests, fires the prefill asynchronously in a goroutine (with `context.WithoutCancel` to prevent premature cancellation), and immediately sends the decode request synchronously. The decoder and prefiller coordinate KV transfer out-of-band via the bootstrap room.
 
-## Efficient KV Transfer 
+* **vLLM** (`nixlv2`, default) — A two-phase sequential protocol. The sidecar sends a prefill request with `kv_transfer_params` containing remote-decode metadata, and `max_tokens=1` to suppress output. It captures the KV transfer parameters from the prefiller's response and injects them into the decode request before forwarding it to the local decoder. If the prefiller returns a server error, the sidecar falls back to decoder-only mode (client errors are not retried).
+* **SGLang** (`sglang`) — Uses a concurrent prefill/decode model. Instead of waiting for prefill to complete, the sidecar injects bootstrap coordination parameters (`bootstrap_host`, `bootstrap_port`, `bootstrap_room`) into both requests, fires the prefill asynchronously in a goroutine (with `context.WithoutCancel` to prevent premature cancellation), and immediately sends the decode request synchronously. The decoder and prefiller coordinate KV transfer out-of-band via the bootstrap room.
 
-In addition to the **Request Flow Orchestation** which coordinates the metadata and RPC calls to each instance, efficient **KV Transfer** (which moves the KVs from the P instance to the D instance) is critical to a high performance disaggregated deployment.
+## Efficient KV Transfer
+
+In addition to the **Request Flow Orchestration** which coordinates the metadata and RPC calls to each instance, efficient **KV Transfer** (which moves the KVs from the P instance to the D instance) is critical to a high performance disaggregated deployment.
 
 vLLM and SGLang both support multiple KV transfer engines - in llm-d we currently focus on NIXL.
 

--- a/guides/pd-disaggregation/README.amd.md
+++ b/guides/pd-disaggregation/README.amd.md
@@ -71,14 +71,15 @@ Before proceeding, ensure your Kubernetes cluster is configured with the necessa
 2. Network Support (NIC)
 
 * A network operator is required to expose NIC devices. Choose the operator that matches your hardware:
-    - [AMD Network Operator](https://instinct.docs.amd.com/projects/network-operator/en/main/overview.html): For AMD AINIC hardware.
-    - [NVIDIA Network Operator](https://docs.nvidia.com/networking/display/kubernetes2410/nvidia+network+operator): For NVIDIA NIC hardware.
+  * [AMD Network Operator](https://instinct.docs.amd.com/projects/network-operator/en/main/overview.html): For AMD AINIC hardware.
+  * [NVIDIA Network Operator](https://docs.nvidia.com/networking/display/kubernetes2410/nvidia+network+operator): For NVIDIA NIC hardware.
 
 If you haven't installed these yet, follow the official [AMD GPU Installation Guide](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/installation/kubernetes-helm.html) and the [AMD Network Operator Installation Guide](https://instinct.docs.amd.com/projects/network-operator/en/main/installation/kubernetes-helm.html).
 
 #### Deployment
 
 To enact a P/D disaggregation deployment on AMD hardware, use the `-e amd` argument to helmfile as follow:
+
 ```bash
 cd guides/pd-disaggregation
 helmfile apply -e amd -n ${NAMESPACE}
@@ -95,21 +96,23 @@ This command triggers the deployment of the disaggregated configuration describe
 ### RIXL Configuration
 
 #### UCX Transport & Logging
+
 RIXL uses the UCX library as its underlying transport mechanism for KV transfers. While UCX typically automates its configuration, you may need to manually tune the following environment variables if the default selections are suboptimal.
 
 **Network & Transport Tuning**
 Use these variables to specify how and where data travels across your hardware:
+
 * UCX_TLS: Defines the allowed Transport Layer protocols (e.g., tcp, rc, ud, sm).
 * UCX_IB_GID_INDEX: Specifies the Global Identifier (GID) index for InfiniBand or RoCE devices.
 * UCX_IB_TRAFFIC_CLASS: Specifies the KV transfer traffic class to use for InfiniBand or RoCE devices.
 
 **Debugging & Logging**
 Use these variables to verify your configuration or troubleshoot issues:
+
 * UCX_LOG_LEVEL: Adjusts the verbosity of UCX logs (e.g., info, debug, trace, etc..).
 * UCX_PROTO_INFO: Set to 'y' to display the specific protocols and devices selected for both intra-node (local) and inter-node (remote) communications.
 
 For more UCX customizations, please refer to the [UCX documentation](https://openucx.org/documentation/)
-
 
 ### Gateway options
 
@@ -193,22 +196,24 @@ For instructions on getting started making inference requests see [our docs](../
 
 ## Tuning Selective PD
 
-Selective PD is a feature in the `inference-scheduler` within the context of prefill-decode disaggregation, although it is disabled by default. This feature enables routing to just decode even with the P/D deployed. To enable it, you will need to set `threshold` value for the `pd-profile-handler` plugin, in the [GAIE values file](./gaie-pd/values.yaml). You can see the value of this here:
+Selective PD is a feature in the `inference-scheduler` within the context of prefill-decode disaggregation. The `disagg-profile-handler` plugin delegates the prefill/decode decision to a `decider` plugin. In the [GAIE values file](./gaie-pd/values.yaml), you can see the current configuration:
 
 ```bash
-cat gaie-pd/values.yaml | yq '.inferenceExtension.pluginsCustomConfig."pd-config.yaml"' | yq '.plugins[] | select(.type == "pd-profile-handler")'
-type: pd-profile-handler
+cat gaie-pd/values.yaml | yq '.inferenceExtension.pluginsCustomConfig."pd-config.yaml"' | yq '.plugins[] | select(.type == "disagg-profile-handler")'
+type: disagg-profile-handler
 parameters:
-  threshold: 0 # update this
-  hashBlockSize: 5
+  deciders:
+    prefill: prefix-based-pd-decider
 ```
+
+The `prefix-based-pd-decider` determines whether to disaggregate based on the number of uncached tokens. You can tune its `nonCachedTokens` threshold in the decider plugin configuration.
 
 Some examples in which you might want to do selective PD might include:
 
 * When the prompt is short enough, the overhead of splitting inference into prefill and decode phases and transferring the KV cache between GPUs becomes larger than simply running both phases on a single decode inference worker.
 * When Prefill units are at full capacity.
 
-For information on this plugin, see our [`pd-profile-handler` docs in the inference-scheduler](https://github.com/llm-d/llm-d-inference-scheduler/blob/v0.3.0/docs/architecture.md?plain=1#L205-L210)
+For information on this plugin, see our [`disagg-profile-handler` docs in the inference-scheduler](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/docs/architecture.md#disaggprofilehandler)
 
 ## Cleanup
 

--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -45,6 +45,7 @@ This guide expects 8 Nvidia GPUs of any kind, and RDMA via InfiniBand or RoCE be
 ### Intel HPU Hardware Requirements
 
 For Intel HPU deployments:
+
 * Intel Gaudi2/3 machine with at least 2 Gaudi2 cards.
 
 ## Prerequisites
@@ -71,6 +72,7 @@ Use the helmfile to compose and install the stack. The Namespace in which the st
 cd guides/pd-disaggregation
 helmfile apply -n ${NAMESPACE}
 ```
+
 **For Intel HPU deployments**, use the HPU-specific environment:
 
 ```bash
@@ -115,6 +117,7 @@ An OKE Cluster with RDMA networking must be deployed prior to launching llm-d on
 **_NOTE:_** The `NetworkAttachmentDefinition` name (`sriov-rdma-vf`) and `nvidia.com/sriov-rdma-vf` resource label in `ms-pd/values_oci_amd.yaml` must match your cluster's SR-IOV device plugin configuration.
 
 **Common gotchas:**
+
 * If you change tensor parallelism, update both `podAnnotations` VF count and `nvidia.com/sriov-rdma-vf` resource requests to match
 * Wrong `UCX_IB_GID_INDEX` causes silent fallback to TCP — set `UCX_PROTO_INFO=y` to verify RDMA is selected
 * `IPC_LOCK` capability is required for RDMA pinned memory; without it NIXL transfers will fail
@@ -186,26 +189,29 @@ For instructions on getting started making inference requests see [our docs](../
 
 ## Tuning Selective PD
 
-Selective PD is a feature in the `inference-scheduler` within the context of prefill-decode disaggregation, although it is disabled by default. This feature enables routing to just decode even with the P/D deployed. To enable it, you will need to set `threshold` value for the `pd-profile-handler` plugin, in the [GAIE values file](./gaie-pd/values.yaml). You can see the value of this here:
+Selective PD is a feature in the `inference-scheduler` within the context of prefill-decode disaggregation. The `disagg-profile-handler` plugin delegates the prefill/decode decision to a `decider` plugin. In the [GAIE values file](./gaie-pd/values.yaml), you can see the current configuration:
 
 ```bash
-cat gaie-pd/values.yaml | yq '.inferenceExtension.pluginsCustomConfig."pd-config.yaml"' | yq '.plugins[] | select(.type == "pd-profile-handler")'
-type: pd-profile-handler
+cat gaie-pd/values.yaml | yq '.inferenceExtension.pluginsCustomConfig."pd-config.yaml"' | yq '.plugins[] | select(.type == "disagg-profile-handler")'
+type: disagg-profile-handler
 parameters:
-  threshold: 0 # update this
-  hashBlockSize: 5
+  deciders:
+    prefill: prefix-based-pd-decider
 ```
+
+The `prefix-based-pd-decider` determines whether to disaggregate based on the number of uncached tokens. You can tune its `nonCachedTokens` threshold in the decider plugin configuration.
 
 Some examples in which you might want to do selective PD might include:
 
 * When the prompt is short enough that the amount of work split inference into prefill and decode phases, and then open a kv transfer between those two GPUs is greater than the amount of work to do both phases on the same decode inference worker.
 * When Prefill units are at full capacity.
 
-For information on this plugin, see our [`pd-profile-handler` docs in the inference-scheduler](https://github.com/llm-d/llm-d-inference-scheduler/blob/v0.7.0/docs/architecture.md?plain=1#L205-L210)
+For information on this plugin, see our [`disagg-profile-handler` docs in the inference-scheduler](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/docs/architecture.md#disaggprofilehandler)
 
 ## Benchmarking
 
 ### Overview
+
 The primary objective of this benchmark is to validate the correctness of the P/D disaggregation setup.
 
 In this example, we deployed the user guide on GKE using the modified [Gateway options](./README.md#gateway-options) described above:
@@ -213,6 +219,7 @@ In this example, we deployed the user guide on GKE using the modified [Gateway o
 ```bash
 helmfile apply -e gke_pd_rdma -n ${NAMESPACE}
 ```
+
 This setup serves the `openai/gpt-oss-120b` model using the following specifications:
 
 * Provider: GKE
@@ -260,7 +267,6 @@ On the decode node, you should see the corresponding completion entry:
 (APIServer pid=1) (EngineCore_DP0 pid=322) DEBUG 01-31 07:12:26 [distributed/.../v1/nixl_connector.py:725] NIXLConnector request_finished(chatcmpl-51b9a341-ca93-43f7-92fc-98b51f41d7e7), request_status=FINISHED_STOPPED, kv_transfer_params={'do_remote_decode': False, 'do_remote_prefill': False, 'remote_block_ids': [2, 3], 'remote_engine_id': '7520acd6-838a-4c0b-af97-a06e18a4f1c4', 'remote_host': '10.116.24.5', 'remote
 ```
 
-
 ### Run Benchmark
 
 We use the [inference-perf](https://github.com/kubernetes-sigs/inference-perf/tree/main) benchmark tool to verify the setup by generating random datasets with 1K input length and 1K output length across different concurrency levels.
@@ -273,7 +279,7 @@ export GATEWAY_IP=$(kubectl get gateway/llm-d-inference-gateway -n ${NAMESPACE} 
 
 The `GATEWAY_IP` environment variable will be used in the [benchmark template](./benchmark-templates/guide.yaml).
 
-2. Follow the [benchmark guide](../../helpers/benchmark.md) to deploy the benchmark tool and analyze the benchmark results. Notably, select the corresponding benchmark template:
+2. Follow the [benchmark guide](../../guides/benchmark/README.md) to deploy the benchmark tool and analyze the benchmark results. Notably, select the corresponding benchmark template:
 
 ```bash
 export BENCH_TEMPLATE_DIR="${LLMD_ROOT_DIR}"/guides/pd-disaggregation/benchmark-templates
@@ -442,7 +448,6 @@ export BENCHMARK_TEMPLATE="${BENCH_TEMPLATE_DIR}"/guide.yaml
   ```
 
 </details>
-
 
 ## Cleanup
 

--- a/guides/pd-disaggregation/README.tpu.md
+++ b/guides/pd-disaggregation/README.tpu.md
@@ -203,9 +203,24 @@ For more information see [our docs](../02_verifying_a_guide.md)
 
 ## Tuning Selective PD
 
-Selective PD is a feature in the `inference-scheduler` within the context of prefill-decode disaggregation, although it is disabled by default. This feature enables routing to just decode even with the P/D deployed.
+Selective PD is a feature in the `inference-scheduler` within the context of prefill-decode disaggregation. The `disagg-profile-handler` plugin delegates the prefill/decode decision to a `decider` plugin. In the [GAIE values file](./gaie-pd/values.yaml), you can see the current configuration:
 
-For information on this plugin, see our [`pd-profile-handler` docs in the inference-scheduler](https://github.com/llm-d/llm-d-inference-scheduler/blob/v0.7.0/docs/architecture.md?plain=1#L205-L210)
+```bash
+cat gaie-pd/values.yaml | yq '.inferenceExtension.pluginsCustomConfig."pd-config.yaml"' | yq '.plugins[] | select(.type == "disagg-profile-handler")'
+type: disagg-profile-handler
+parameters:
+  deciders:
+    prefill: prefix-based-pd-decider
+```
+
+The `prefix-based-pd-decider` determines whether to disaggregate based on the number of uncached tokens. You can tune its `nonCachedTokens` threshold in the decider plugin configuration.
+
+Some examples in which you might want to do selective PD might include:
+
+* When the prompt is short enough, the overhead of splitting inference into prefill and decode phases and transferring the KV cache between GPUs becomes larger than simply running both phases on a single decode inference worker.
+* When Prefill units are at full capacity.
+
+For information on this plugin, see our [`disagg-profile-handler` docs in the inference-scheduler](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/docs/architecture.md#disaggprofilehandler)
 
 ## Cleanup
 

--- a/guides/pd-disaggregation/gaie-pd/values.yaml
+++ b/guides/pd-disaggregation/gaie-pd/values.yaml
@@ -16,7 +16,7 @@ inferenceExtension:
       featureGates:
       - prepareDataPlugins
       plugins:
-      - type: prefill-header-handler
+      - type: disagg-headers-handler
       - type: prefix-cache-scorer
         parameters:
           maxPrefixBlocksToMatch: 256
@@ -28,10 +28,10 @@ inferenceExtension:
       - type: prefix-based-pd-decider
         parameters:
           nonCachedTokens: 16
-      - type: pd-profile-handler
+      - type: disagg-profile-handler
         parameters:
-          primaryPort: 0
-          deciderPluginName: prefix-based-pd-decider
+          deciders:
+            prefill: prefix-based-pd-decider
       schedulingProfiles:
       - name: prefill
         plugins:

--- a/guides/pd-disaggregation/gaie-pd/values_sglang.yaml
+++ b/guides/pd-disaggregation/gaie-pd/values_sglang.yaml
@@ -15,7 +15,7 @@ inferenceExtension:
       featureGates:
       - prepareDataPlugins
       plugins:
-      - type: prefill-header-handler
+      - type: disagg-headers-handler
       - type: prefix-cache-scorer
         parameters:
           maxPrefixBlocksToMatch: 256
@@ -25,10 +25,10 @@ inferenceExtension:
       - type: decode-filter
       - type: max-score-picker
       - type: always-disagg-pd-decider
-      - type: pd-profile-handler
+      - type: disagg-profile-handler
         parameters:
-          primaryPort: 0
-          deciderPluginName: always-disagg-pd-decider
+          deciders:
+            prefill: always-disagg-pd-decider
       schedulingProfiles:
       - name: prefill
         plugins:
@@ -51,7 +51,7 @@ inferenceExtension:
     total-queued-requests-metric: "sglang:num_queue_reqs"
     kv-cache-usage-percentage-metric: "sglang:token_usage"
     lora-info-metric: "" # Set an empty metric to disable LoRA metric scraping as they are not supported by SGLang yet.
-    cache-info-metric: "" # Set an empty metric to disable CacheInfoMetrics metrics as not all vLLM used metrics has SGLang equivalents 
+    cache-info-metric: "" # Set an empty metric to disable CacheInfoMetrics metrics as not all vLLM used metrics have SGLang equivalents
 
   # Distributed tracing configuration (OpenTelemetry)
   tracing:

--- a/guides/wide-ep-lws/experimental-dp-aware/manifests/inferencepool.values.yaml
+++ b/guides/wide-ep-lws/experimental-dp-aware/manifests/inferencepool.values.yaml
@@ -28,17 +28,20 @@ inferenceExtension:
       # since it's not yet possible to route to individual DP ranks
       apiVersion: inference.networking.x-k8s.io/v1alpha1
       kind: EndpointPickerConfig
+      featureGates:
+      - prepareDataPlugins
       plugins:
-      - type: prefill-header-handler
+      - type: disagg-headers-handler
       - type: prefill-filter
       - type: decode-filter
       - type: prefix-cache-scorer
       - type: active-request-scorer
       - type: queue-scorer
-      - type: pd-profile-handler
+      - type: always-disagg-pd-decider
+      - type: disagg-profile-handler
         parameters:
-          threshold: 0
-          hashBlockSize: 5
+          deciders:
+            prefill: always-disagg-pd-decider
       schedulingProfiles:
       - name: prefill
         plugins:

--- a/guides/wide-ep-lws/manifests/inferencepool.values.yaml
+++ b/guides/wide-ep-lws/manifests/inferencepool.values.yaml
@@ -28,17 +28,20 @@ inferenceExtension:
       # since it's not yet possible to route to individual DP ranks
       apiVersion: inference.networking.x-k8s.io/v1alpha1
       kind: EndpointPickerConfig
+      featureGates:
+      - prepareDataPlugins
       plugins:
-      - type: prefill-header-handler
+      - type: disagg-headers-handler
       - type: prefill-filter
       - type: decode-filter
       - type: random-picker
         parameters:
           maxNumOfEndpoints: 1
-      - type: pd-profile-handler
+      - type: always-disagg-pd-decider
+      - type: disagg-profile-handler
         parameters:
-          threshold: 0
-          hashBlockSize: 5
+          deciders:
+            prefill: always-disagg-pd-decider
       schedulingProfiles:
       - name: prefill
         plugins:


### PR DESCRIPTION
SUMMARY:
* Replace deprecated `pd-profile-handler` with `disagg-profile-handler` (nested `deciders` params) in all guides and docs
* Replace deprecated `prefill-header-handler` with `disagg-headers-handler`
* Remove deprecated `primaryPort`, `hashBlockSize`, `threshold` parameters
* Update pinned version links to `main` branch
* Add `featureGates: [prepareDataPlugins]` and `always-disagg-pd-decider` to wide-ep configs
* Fix grammar nits, typos, and formatting issues flagged in review

Fixes #1155

## Files Changed (8)

**YAML configs:**
- `guides/pd-disaggregation/gaie-pd/values.yaml`
- `guides/pd-disaggregation/gaie-pd/values_sglang.yaml`
- `guides/wide-ep-lws/manifests/inferencepool.values.yaml`
- `guides/wide-ep-lws/experimental-dp-aware/manifests/inferencepool.values.yaml`

**READMEs:**
- `guides/pd-disaggregation/README.md`
- `guides/pd-disaggregation/README.amd.md`
- `guides/pd-disaggregation/README.tpu.md`

**Architecture docs:**
- `docs/wip-docs-new/architecture/advanced/disaggregation/README.md`

> **Note:** Changes to `docs/wip-docs-new/architecture/core/epp/configuration.md` (`blockSize` → `blockSizeTokens`) were deferred per @roytman's review feedback, pending the upstream GAIE merge into inference-scheduler (llm-d/llm-d-inference-scheduler#747).

## Deprecation Mappings

| Old (deprecated) | New | Source |
|---|---|---|
| `pd-profile-handler` | `disagg-profile-handler` | [inference-scheduler PR #732](https://github.com/llm-d/llm-d-inference-scheduler/pull/732) |
| `prefill-header-handler` | `disagg-headers-handler` | [inference-scheduler PR #758](https://github.com/llm-d/llm-d-inference-scheduler/pull/758) |
| `primaryPort` param | Removed | [inference-scheduler PR #727](https://github.com/llm-d/llm-d-inference-scheduler/pull/727) |
| `hashBlockSize` param | Removed | [inference-scheduler PR #748](https://github.com/llm-d/llm-d-inference-scheduler/pull/748) |
| `threshold` param (flat) | Use explicit decider plugin | [inference-scheduler PR #732](https://github.com/llm-d/llm-d-inference-scheduler/pull/732) |
| `deciderPluginName` (flat) | `deciders.prefill` (nested) | [inference-scheduler PR #732](https://github.com/llm-d/llm-d-inference-scheduler/pull/732) |
| `blockSize` (prefix-cache-scorer) | `blockSizeTokens` | [inference-scheduler #641](https://github.com/llm-d/llm-d-inference-scheduler/pull/641) |

cc @robertgshaw2-redhat @ahg-g @roytman
