### PR TITLE
[Docs] Feature matrix and artifacts

### DIFF
--- a/docs/wip-docs-new/getting-started/artifacts.md
+++ b/docs/wip-docs-new/getting-started/artifacts.md
@@ -8,12 +8,12 @@ llm-d publishes container images to the GitHub Container Registry (`ghcr.io/llm-
 
 ### Model Server Images
 
-These images bundle vLLM (or SGLang) with the libraries required for llm-d's well-lit paths (NIXL, DeepEP, etc.).
+These images bundle vLLM and SGLang (CUDA only) with the libraries required for llm-d's well-lit paths (NIXL, DeepEP, etc.).
 
 | Image | Accelerator | Base OS | Architectures | Status |
 |-------|-------------|---------|---------------|--------|
-| `ghcr.io/llm-d/llm-d-cuda` | NVIDIA CUDA | RHEL UBI9 | amd64, arm64 | Available |
-| `ghcr.io/llm-d/llm-d-cuda` (debug) | NVIDIA CUDA | RHEL UBI9 | amd64 | Available |
+| `ghcr.io/llm-d/llm-d-cuda:v0.7.0` | NVIDIA CUDA | RHEL UBI9 | amd64, arm64 | Available |
+| `ghcr.io/llm-d/llm-d-cuda:v0.7.0-debug` | NVIDIA CUDA | RHEL UBI9 | amd64 | Available |
 | `ghcr.io/llm-d/llm-d-aws` | NVIDIA CUDA + EFA | RHEL UBI9 | amd64, arm64 | Available |
 | `ghcr.io/llm-d/llm-d-rocm` | AMD ROCm | RHEL UBI9 | amd64 | Available |
 | `ghcr.io/llm-d/llm-d-xpu` | Intel XPU | Ubuntu 24.04 | amd64 | Available |
@@ -53,18 +53,13 @@ llm-d uses two deployment methods depending on the guide. Both produce the same 
 
 Used by the helmfile-based guides (inference scheduling, P/D disaggregation, precise prefix cache, workload autoscaling, simulated accelerators).
 
-| Chart | Version | Registry | Repository |
-|-------|---------|----------|------------|
-| **llm-d-infra** | v1.4.0 | `https://llm-d-incubation.github.io/llm-d-infra/` | [llm-d-incubation/llm-d-infra](https://github.com/llm-d-incubation/llm-d-infra) |
-| **llm-d-modelservice** | v0.4.9 | `https://llm-d-incubation.github.io/llm-d-modelservice/` | [llm-d-incubation/llm-d-modelservice](https://github.com/llm-d-incubation/llm-d-modelservice) |
-| **InferencePool** | v1.4.0 | `oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool` | [kubernetes-sigs/gateway-api-inference-extension](https://github.com/kubernetes-sigs/gateway-api-inference-extension) |
-
-#### Optional Charts
-
-| Chart | Version | Purpose |
-|-------|---------|---------|
-| **workload-variant-autoscaler** | v0.7.0 | SLO-aware autoscaling |
-| **async-processor** | v0.6.1 | Queue-based async inference |
+| Chart | Version | Registry | Repository | Notes |
+|-------|---------|----------|------------|-------|
+| **llm-d-infra** | v1.4.0 | `https://llm-d-incubation.github.io/llm-d-infra/` | [llm-d-incubation/llm-d-infra](https://github.com/llm-d-incubation/llm-d-infra) | Core infrastructure (gateway, CRDs) |
+| **llm-d-modelservice** | v0.4.9 | `https://llm-d-incubation.github.io/llm-d-modelservice/` | [llm-d-incubation/llm-d-modelservice](https://github.com/llm-d-incubation/llm-d-modelservice) | Model server deployment |
+| **InferencePool** | v1.4.0 | `oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool` | [kubernetes-sigs/gateway-api-inference-extension](https://github.com/kubernetes-sigs/gateway-api-inference-extension) | InferencePool + EPP |
+| **workload-variant-autoscaler** | v0.7.0 | `https://llm-d.github.io/llm-d-workload-variant-autoscaler/` | [llm-d/llm-d-workload-variant-autoscaler](https://github.com/llm-d/llm-d-workload-variant-autoscaler) | Optional: SLO-aware autoscaling |
+| **async-processor** | v0.6.1 | TBD | TBD | Optional: Queue-based async inference |
 
 ### Kustomize Overlays
 
@@ -80,8 +75,10 @@ Each kustomize-based guide composes these recipes with guide-specific overlays f
 
 ## Gateway Provider Dependencies
 
-| Dependency | Version | Notes |
-|------------|---------|-------|
+Tested and supported versions for the v0.7.0 release. Newer versions may work but are not validated.
+
+| Dependency | Tested Version | Notes |
+|------------|----------------|-------|
 | Gateway API CRDs | v1.5.1 | Kubernetes SIG |
 | Gateway API Inference Extension CRDs | v1.4.0 | Kubernetes SIG |
 | Istio | 1.29.1 | Default gateway provider |

--- a/docs/wip-docs-new/getting-started/artifacts.md
+++ b/docs/wip-docs-new/getting-started/artifacts.md
@@ -1,6 +1,6 @@
 # Artifacts
 
-This page provides an inventory of all llm-d release artifacts including container images, Helm charts, Kustomize overlays, and key upstream dependencies. All versions listed correspond to the **v0.6.0** release.
+This page provides an inventory of all llm-d release artifacts including container images, Helm charts, Kustomize overlays, and key upstream dependencies. All versions listed correspond to the **v0.7.0** release.
 
 ## Container Images
 
@@ -16,8 +16,8 @@ These images bundle vLLM (or SGLang) with the libraries required for llm-d's wel
 | `ghcr.io/llm-d/llm-d-cuda` (debug) | NVIDIA CUDA | RHEL UBI9 | amd64 | Available |
 | `ghcr.io/llm-d/llm-d-aws` | NVIDIA CUDA + EFA | RHEL UBI9 | amd64, arm64 | Available |
 | `ghcr.io/llm-d/llm-d-rocm` | AMD ROCm | RHEL UBI9 | amd64 | Available |
-| `ghcr.io/llm-d/llm-d-xpu` | Intel XPU | Ubuntu 24.04 | amd64 | Temporarily Unavailable |
-| `ghcr.io/llm-d/llm-d-hpu` | Intel Gaudi HPU | Ubuntu 22.04 | amd64 | Temporarily Unavailable |
+| `ghcr.io/llm-d/llm-d-xpu` | Intel XPU | Ubuntu 24.04 | amd64 | Available |
+| `ghcr.io/llm-d/llm-d-hpu` | Intel Gaudi HPU | Ubuntu 22.04 | amd64 | Available |
 | `ghcr.io/llm-d/llm-d-cpu` | CPU | RHEL UBI9 | amd64 | Available |
 
 > The project is implementing a move to consuming upstream vLLM images directly, which would reduce the number of maintained images to a thin addon layer for llm-d-specific components. See [#1112](https://github.com/llm-d/llm-d/issues/1112).
@@ -26,19 +26,19 @@ These images bundle vLLM (or SGLang) with the libraries required for llm-d's wel
 
 | Image | Description | Version |
 |-------|-------------|---------|
-| `ghcr.io/llm-d/llm-d-inference-scheduler` | EPP — the inference-aware request router | v0.7.1 |
-| `ghcr.io/llm-d/llm-d-routing-sidecar` | P/D disaggregation sidecar for KV transfer coordination | v0.7.1 |
-| `ghcr.io/llm-d/llm-d-uds-tokenizer` | Unix domain socket tokenizer sidecar | v0.7.1 |
+| `ghcr.io/llm-d/llm-d-inference-scheduler` | EPP — the inference-aware request router | v0.8.0 |
+| `ghcr.io/llm-d/llm-d-routing-sidecar` | P/D disaggregation sidecar for KV transfer coordination | v0.8.0 |
+| `ghcr.io/llm-d/llm-d-uds-tokenizer` | Unix domain socket tokenizer sidecar | v0.8.0 |
 | `ghcr.io/llm-d/llm-d-kv-cache` | KV-cache block locality indexer library | v0.7.1 |
 | `ghcr.io/llm-d/llm-d-inference-sim` | GPU-free vLLM simulator for testing | v0.8.2 |
-| `ghcr.io/llm-d/llm-d-workload-variant-autoscaler` | SLO-aware workload autoscaler | v0.6.0 |
-| `ghcr.io/llm-d/llm-d-rdma-tools` | RDMA diagnostic and testing utilities | v0.6.0 |
+| `ghcr.io/llm-d/llm-d-workload-variant-autoscaler` | SLO-aware workload autoscaler | v0.7.0 |
+| `ghcr.io/llm-d/llm-d-rdma-tools` | RDMA diagnostic and testing utilities | v0.7.0 |
 
 ### Image Tags
 
 | Tag Pattern | Meaning |
 |-------------|---------|
-| `v0.6.0` | Release tag — pinned, immutable |
+| `v0.7.0` | Release tag — pinned, immutable |
 | `latest` | Latest build from `main` — rolling |
 | `sha-<short>` | Specific commit build |
 | `pr-<number>` | Build from a pull request (dev only) |
@@ -63,7 +63,7 @@ Used by the helmfile-based guides (inference scheduling, P/D disaggregation, pre
 
 | Chart | Version | Purpose |
 |-------|---------|---------|
-| **workload-variant-autoscaler** | v0.6.0 | SLO-aware autoscaling |
+| **workload-variant-autoscaler** | v0.7.0 | SLO-aware autoscaling |
 | **async-processor** | v0.6.1 | Queue-based async inference |
 
 ### Kustomize Overlays
@@ -86,7 +86,7 @@ Each kustomize-based guide composes these recipes with guide-specific overlays f
 | Gateway API Inference Extension CRDs | v1.4.0 | Kubernetes SIG |
 | Istio | 1.29.1 | Default gateway provider |
 | AgentGateway | v1.0.0 | Preferred for new deployments |
-| kgateway | v2.2.1 | **Deprecated** — will be removed in next release |
+| kgateway | v2.2.3 | **Deprecated** — will be removed in next release |
 
 ## Key Upstream Dependencies
 

--- a/docs/wip-docs-new/getting-started/artifacts.md
+++ b/docs/wip-docs-new/getting-started/artifacts.md
@@ -75,21 +75,21 @@ Each kustomize-based guide composes these recipes with guide-specific overlays f
 
 ## Gateway Provider Dependencies
 
-Tested and supported versions for the v0.7.0 release. Newer versions may work but are not validated.
+Tested and supported versions for the v0.7.0 release.
 
-| Dependency | Tested Version | Notes |
-|------------|----------------|-------|
-| Gateway API CRDs | v1.5.1 | Kubernetes SIG |
-| Gateway API Inference Extension CRDs | v1.4.0 | Kubernetes SIG |
-| Istio | 1.29.1 | Default gateway provider |
-| AgentGateway | v1.0.0 | Preferred for new deployments |
-| kgateway | v2.2.3 | **Deprecated** — will be removed in next release |
+| Dependency | Supported Versions | Notes |
+|------------|-------------------|-------|
+| Gateway API CRDs | v1.5.x | Kubernetes SIG |
+| Gateway API Inference Extension CRDs | v1.4.x | Kubernetes SIG |
+| Istio | 1.29.x | Default gateway provider |
+| AgentGateway | v1.0.x | Preferred for new deployments |
+| kgateway | v2.2.x | **Deprecated** — will be removed in next release |
 
 ## Key Upstream Dependencies
 
-Pinned in the container image build. See [upstream-versions.md](https://github.com/llm-d/llm-d/blob/main/docs/upstream-versions.md) for the authoritative source.
+Exact versions pinned in the v0.7.0 container images. See [upstream-versions.md](https://github.com/llm-d/llm-d/blob/main/docs/upstream-versions.md) for the authoritative source.
 
-| Dependency | Version | Purpose |
+| Dependency | Pinned Version (v0.7.0) | Purpose |
 |------------|---------|---------|
 | **vLLM** | v0.17.1 | Primary inference engine |
 | **CUDA** | 12.9.1 | GPU compute runtime |

--- a/docs/wip-docs-new/getting-started/artifacts.md
+++ b/docs/wip-docs-new/getting-started/artifacts.md
@@ -1,3 +1,130 @@
 # Artifacts
 
-This document provides a inventory of all llm-d release artifacts including container images and Helm charts.
+This page provides an inventory of all llm-d release artifacts including container images, Helm charts, Kustomize overlays, and key upstream dependencies. All versions listed correspond to the **v0.6.0** release.
+
+## Container Images
+
+llm-d publishes container images to the GitHub Container Registry (`ghcr.io/llm-d/`).
+
+### Model Server Images
+
+These images bundle vLLM (or SGLang) with the libraries required for llm-d's well-lit paths (NIXL, DeepEP, etc.).
+
+| Image | Accelerator | Base OS | Architectures | Status |
+|-------|-------------|---------|---------------|--------|
+| `ghcr.io/llm-d/llm-d-cuda` | NVIDIA CUDA | RHEL UBI9 | amd64, arm64 | Available |
+| `ghcr.io/llm-d/llm-d-cuda` (debug) | NVIDIA CUDA | RHEL UBI9 | amd64 | Available |
+| `ghcr.io/llm-d/llm-d-aws` | NVIDIA CUDA + EFA | RHEL UBI9 | amd64, arm64 | Available |
+| `ghcr.io/llm-d/llm-d-rocm` | AMD ROCm | RHEL UBI9 | amd64 | Available |
+| `ghcr.io/llm-d/llm-d-xpu` | Intel XPU | Ubuntu 24.04 | amd64 | Temporarily Unavailable |
+| `ghcr.io/llm-d/llm-d-hpu` | Intel Gaudi HPU | Ubuntu 22.04 | amd64 | Temporarily Unavailable |
+| `ghcr.io/llm-d/llm-d-cpu` | CPU | RHEL UBI9 | amd64 | Available |
+
+> The project is implementing a move to consuming upstream vLLM images directly, which would reduce the number of maintained images to a thin addon layer for llm-d-specific components. See [#1112](https://github.com/llm-d/llm-d/issues/1112).
+
+### Sidecar and Infrastructure Images
+
+| Image | Description | Version |
+|-------|-------------|---------|
+| `ghcr.io/llm-d/llm-d-inference-scheduler` | EPP — the inference-aware request router | v0.7.1 |
+| `ghcr.io/llm-d/llm-d-routing-sidecar` | P/D disaggregation sidecar for KV transfer coordination | v0.7.1 |
+| `ghcr.io/llm-d/llm-d-uds-tokenizer` | Unix domain socket tokenizer sidecar | v0.7.1 |
+| `ghcr.io/llm-d/llm-d-kv-cache` | KV-cache block locality indexer library | v0.7.1 |
+| `ghcr.io/llm-d/llm-d-inference-sim` | GPU-free vLLM simulator for testing | v0.8.2 |
+| `ghcr.io/llm-d/llm-d-workload-variant-autoscaler` | SLO-aware workload autoscaler | v0.6.0 |
+| `ghcr.io/llm-d/llm-d-rdma-tools` | RDMA diagnostic and testing utilities | v0.6.0 |
+
+### Image Tags
+
+| Tag Pattern | Meaning |
+|-------------|---------|
+| `v0.6.0` | Release tag — pinned, immutable |
+| `latest` | Latest build from `main` — rolling |
+| `sha-<short>` | Specific commit build |
+| `pr-<number>` | Build from a pull request (dev only) |
+
+> Development images use the `-dev` suffix in the image name (e.g., `llm-d-cuda-dev`). Release images drop the suffix.
+
+## Deployment Manifests
+
+llm-d uses two deployment methods depending on the guide. Both produce the same Kubernetes resources. The project is migrating to kustomize-first installation ([#850](https://github.com/llm-d/llm-d/issues/850)).
+
+### Helm Charts
+
+Used by the helmfile-based guides (inference scheduling, P/D disaggregation, precise prefix cache, workload autoscaling, simulated accelerators).
+
+| Chart | Version | Registry | Repository |
+|-------|---------|----------|------------|
+| **llm-d-infra** | v1.4.0 | `https://llm-d-incubation.github.io/llm-d-infra/` | [llm-d-incubation/llm-d-infra](https://github.com/llm-d-incubation/llm-d-infra) |
+| **llm-d-modelservice** | v0.4.9 | `https://llm-d-incubation.github.io/llm-d-modelservice/` | [llm-d-incubation/llm-d-modelservice](https://github.com/llm-d-incubation/llm-d-modelservice) |
+| **InferencePool** | v1.4.0 | `oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool` | [kubernetes-sigs/gateway-api-inference-extension](https://github.com/kubernetes-sigs/gateway-api-inference-extension) |
+
+#### Optional Charts
+
+| Chart | Version | Purpose |
+|-------|---------|---------|
+| **workload-variant-autoscaler** | v0.6.0 | SLO-aware autoscaling |
+| **async-processor** | v0.6.1 | Queue-based async inference |
+
+### Kustomize Overlays
+
+Used by the kustomize-based guides (tiered prefix cache, wide expert-parallelism). Reusable base layers live in `guides/recipes/`.
+
+| Recipe | Path | Description |
+|--------|------|-------------|
+| **Gateway** | `guides/recipes/gateway/` | Base gateway manifest with provider overlays (Istio, AgentGateway, GKE, kgateway) |
+| **InferencePool** | `guides/recipes/inferencepool/` | InferencePool + EPP deployment |
+| **vLLM** | `guides/recipes/vllm/` | Model server base with standard overlay |
+
+Each kustomize-based guide composes these recipes with guide-specific overlays for the target accelerator and infrastructure provider.
+
+## Gateway Provider Dependencies
+
+| Dependency | Version | Notes |
+|------------|---------|-------|
+| Gateway API CRDs | v1.5.1 | Kubernetes SIG |
+| Gateway API Inference Extension CRDs | v1.4.0 | Kubernetes SIG |
+| Istio | 1.29.1 | Default gateway provider |
+| AgentGateway | v1.0.0 | Preferred for new deployments |
+| kgateway | v2.2.1 | **Deprecated** — will be removed in next release |
+
+## Key Upstream Dependencies
+
+Pinned in the container image build. See [upstream-versions.md](https://github.com/llm-d/llm-d/blob/main/docs/upstream-versions.md) for the authoritative source.
+
+| Dependency | Version | Purpose |
+|------------|---------|---------|
+| **vLLM** | v0.17.1 | Primary inference engine |
+| **CUDA** | 12.9.1 | GPU compute runtime |
+| **Python** | 3.12 | Runtime |
+| **PyTorch** | 2.9.1 | ML framework |
+| **NIXL** | 0.10.0 | KV-cache transport for P/D disaggregation |
+| **LMCache** | v0.3.14 | Tiered KV-cache offloading |
+| **InfiniStore** | 0.2.33 | Distributed cache storage backend |
+| **DeepEP** | llm-d-release-v0.5.1 | Expert-parallelism communication |
+| **DeepGEMM** | v2.1.1.post3 | High-performance inference compute |
+| **FlashInfer** | v0.6.1 | Efficient attention kernels |
+| **NVSHMEM** | v3.5.19-1 | GPU-side RDMA communication |
+| **UCX** | v1.20.0 | Unified communication framework |
+| **GDRCopy** | v2.5.2 | GPU direct RDMA memory copies |
+| **LeaderWorkerSet** | v0.7.0 | Multi-node pod orchestration (Wide EP) |
+
+### Hardware-Specific vLLM Variants
+
+| Variant | Version | Upstream |
+|---------|---------|----------|
+| vLLM Gaudi (HPU) | 1.22.0 | [HabanaAI/vllm-fork](https://github.com/HabanaAI/vllm-fork) |
+| vLLM TPU | v0.13.2-ironwood | [vllm-project/vllm](https://github.com/vllm-project/vllm) |
+
+## Source Repositories
+
+| Repository | Language | Description |
+|------------|----------|-------------|
+| [llm-d/llm-d](https://github.com/llm-d/llm-d) | — | Main repo: docs, Dockerfiles, guides, CI |
+| [llm-d/llm-d-inference-scheduler](https://github.com/llm-d/llm-d-inference-scheduler) | Go | EPP routing engine and P/D sidecar |
+| [llm-d/llm-d-kv-cache](https://github.com/llm-d/llm-d-kv-cache) | Go | KV-cache block locality indexer |
+| [llm-d/llm-d-inference-sim](https://github.com/llm-d/llm-d-inference-sim) | Go | GPU-free vLLM simulator |
+| [llm-d/llm-d-benchmark](https://github.com/llm-d/llm-d-benchmark) | Python | Benchmarking framework |
+| [llm-d/llm-d-workload-variant-autoscaler](https://github.com/llm-d/llm-d-workload-variant-autoscaler) | Go | SLO-aware workload autoscaler |
+| [llm-d-incubation/llm-d-infra](https://github.com/llm-d-incubation/llm-d-infra) | Helm | Infrastructure chart (gateway, CRDs) |
+| [llm-d-incubation/llm-d-modelservice](https://github.com/llm-d-incubation/llm-d-modelservice) | Helm | Model server deployment chart |

--- a/docs/wip-docs-new/getting-started/artifacts.md
+++ b/docs/wip-docs-new/getting-started/artifacts.md
@@ -51,15 +51,15 @@ llm-d uses two deployment methods depending on the guide. Both produce the same 
 
 ### Helm Charts
 
-Used by the helmfile-based guides (inference scheduling, P/D disaggregation, precise prefix cache, workload autoscaling, simulated accelerators).
-
 | Chart | Version | Registry | Repository | Notes |
 |-------|---------|----------|------------|-------|
-| **llm-d-infra** | v1.4.0 | `https://llm-d-incubation.github.io/llm-d-infra/` | [llm-d-incubation/llm-d-infra](https://github.com/llm-d-incubation/llm-d-infra) | Core infrastructure (gateway, CRDs) |
-| **llm-d-modelservice** | v0.4.9 | `https://llm-d-incubation.github.io/llm-d-modelservice/` | [llm-d-incubation/llm-d-modelservice](https://github.com/llm-d-incubation/llm-d-modelservice) | Model server deployment |
+| **Standalone Router** | v1.4.0 | `oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone` | [kubernetes-sigs/gateway-api-inference-extension](https://github.com/kubernetes-sigs/gateway-api-inference-extension) | Standalone Router (EPP+Envoy sidecar) |
 | **InferencePool** | v1.4.0 | `oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool` | [kubernetes-sigs/gateway-api-inference-extension](https://github.com/kubernetes-sigs/gateway-api-inference-extension) | InferencePool + EPP |
 | **workload-variant-autoscaler** | v0.7.0 | `https://llm-d.github.io/llm-d-workload-variant-autoscaler/` | [llm-d/llm-d-workload-variant-autoscaler](https://github.com/llm-d/llm-d-workload-variant-autoscaler) | Optional: SLO-aware autoscaling |
 | **async-processor** | v0.6.1 | TBD | TBD | Optional: Queue-based async inference |
+| **llm-d-infra** | v1.4.0 | `https://llm-d-incubation.github.io/llm-d-infra/` | [llm-d-incubation/llm-d-infra](https://github.com/llm-d-incubation/llm-d-infra) | (Deprecated) Core infrastructure (gateway, CRDs). Used in legacy helmfile based guides prior to llm-d v0.7. |
+| **llm-d-modelservice** | v0.4.9 | `https://llm-d-incubation.github.io/llm-d-modelservice/` | [llm-d-incubation/llm-d-modelservice](https://github.com/llm-d-incubation/llm-d-modelservice) | (Deprecated) Model server deployment. Used in legacy helmfile based guides prior to llm-d v0.7. |
+
 
 ### Kustomize Overlays
 
@@ -68,14 +68,15 @@ Used by the kustomize-based guides (tiered prefix cache, wide expert-parallelism
 | Recipe | Path | Description |
 |--------|------|-------------|
 | **Gateway** | `guides/recipes/gateway/` | Base gateway manifest with provider overlays (Istio, AgentGateway, GKE, kgateway) |
-| **InferencePool** | `guides/recipes/inferencepool/` | InferencePool + EPP deployment |
-| **vLLM** | `guides/recipes/vllm/` | Model server base with standard overlay |
+| **InferencePool** | `guides/recipes/scheduler/` | InferencePool + EPP deployment |
+| **vLLM** | `guides/recipes/modelserver/` | Model server base with standard overlay |
 
 Each kustomize-based guide composes these recipes with guide-specific overlays for the target accelerator and infrastructure provider.
 
 ## Gateway Provider Dependencies
 
-Tested and supported versions for the v0.7.0 release.
+By default, llm-d guides runs a standalone router without a gateway. For gateway mode, the following gateway dependencies
+are tested and supported versions for the v0.7.0 release.
 
 | Dependency | Supported Versions | Notes |
 |------------|-------------------|-------|

--- a/docs/wip-docs-new/getting-started/feature-matrix.md
+++ b/docs/wip-docs-new/getting-started/feature-matrix.md
@@ -2,7 +2,7 @@
 
 llm-d supports multiple model servers, accelerator backends, and infrastructure providers at various levels of maturity.
 
-This page describes the current coverage as validated in the v0.6.0 release and nightly CI.
+This page describes the current coverage as validated in the v0.7.0 release and nightly CI.
 
 ## Well-Lit Paths × Model Server × Accelerator
 
@@ -26,7 +26,7 @@ This page describes the current coverage as validated in the v0.6.0 release and 
 | NVIDIA CUDA | ✅ | — |
 | Intel XPU | ✅ | — |
 
-**Nightly CI**: OpenShift (CUDA)
+**Nightly CI**: OpenShift (CUDA), CoreWeave (CUDA), GKE (CUDA)
 
 > SGLang uses a radix-tree cache architecture. Support requires the [KVEvents abstraction](https://github.com/llm-d/llm-d-kv-cache/issues/240) which is in design.
 
@@ -86,13 +86,24 @@ This page describes the current coverage as validated in the v0.6.0 release and 
 
 **Nightly CI**: None
 
+### Batch Gateway
+
+| Backend | vLLM | SGLang |
+|---------|------|--------|
+| PostgreSQL + Redis | ✅ | — |
+| S3 + Redis | ✅ | — |
+
+**Nightly CI**: None
+
+> Provides OpenAI-compatible Batch API (`/v1/batches`, `/v1/files`) for offline inference workloads.
+
 ## Infrastructure Providers
 
 | Provider | Inference Scheduling | P/D Disaggregation | Wide EP | Tiered Prefix Cache | Precise Prefix Cache | WVA |
 |----------|---------------------|--------------------|---------|--------------------|-----------------------|-----|
 | **OpenShift** | Nightly | Nightly | Nightly | Nightly | Nightly | Nightly |
-| **GKE** | Nightly | Nightly | Nightly | — | — | — |
-| **CoreWeave (CKS)** | Nightly | Nightly | Nightly | — | — | Nightly |
+| **GKE** | Nightly | Nightly | Nightly | — | Nightly | — |
+| **CoreWeave (CKS)** | Nightly | Nightly | Nightly | — | Nightly | Nightly |
 | **Minikube** | Manual | — | — | — | — | — |
 | **DigitalOcean** | Manual | — | — | — | — | — |
 | **AKS** | Manual | — | — | — | — | — |

--- a/docs/wip-docs-new/getting-started/feature-matrix.md
+++ b/docs/wip-docs-new/getting-started/feature-matrix.md
@@ -1,13 +1,170 @@
 # Feature Matrix
 
-llm-d supports multiple Model Servers and accelerators at various levels of maturity. 
+llm-d supports multiple model servers, accelerator backends, and infrastructure providers at various levels of maturity.
 
-This page describes how llm-d release validates each "Well-Lit Path" against a subset of these in each release.
+This page describes the current coverage as validated in the v0.6.0 release and nightly CI.
 
---> fill in with the most recent release coverage, add maturity level
+## Well-Lit Paths × Model Server × Accelerator
 
-| Well-Lit Path                       | vLLM - CUDA | vLLM - AMD | vLLM - TPU | SGL - CUDA | SGL - AMD | SGL - TPU |
-|-------------------------------------|-------------|------------|------------|------------|-----------|-----------|
-| optimized baseline    | X           | X          | X          | X          | X         | X         |
-| P/D Disaggregation                  | X           |            | X          | X          |           |           |
+### Intelligent Inference Scheduling
 
+| Accelerator | vLLM | SGLang |
+|-------------|------|--------|
+| NVIDIA CUDA | ✅ | ✅ |
+| AMD ROCm | ✅ | — |
+| Intel XPU | ✅ | — |
+| Intel Gaudi (HPU) | ✅ | — |
+| Google TPU | ✅ | — |
+| CPU | ✅ | — |
+
+**Nightly CI**: OpenShift (CUDA), GKE (CUDA), CoreWeave (CUDA), XPU (PR-triggered), HPU (PR-triggered)
+
+### Precise Prefix-Cache-Aware Routing
+
+| Accelerator | vLLM | SGLang |
+|-------------|------|--------|
+| NVIDIA CUDA | ✅ | — |
+| Intel XPU | ✅ | — |
+
+**Nightly CI**: OpenShift (CUDA)
+
+> SGLang uses a radix-tree cache architecture. Support requires the [KVEvents abstraction](https://github.com/llm-d/llm-d-kv-cache/issues/240) which is in design.
+
+### Prefill/Decode Disaggregation
+
+| Accelerator | vLLM | SGLang |
+|-------------|------|--------|
+| NVIDIA CUDA | ✅ | ✅ |
+| AMD ROCm | ✅ | — |
+| Intel XPU | ✅ | — |
+| Google TPU | ✅ | — |
+
+**Nightly CI**: OpenShift (CUDA), GKE (CUDA), CoreWeave (CUDA)
+
+### Wide Expert-Parallelism
+
+| Accelerator | vLLM | SGLang |
+|-------------|------|--------|
+| NVIDIA CUDA | ✅ | — |
+
+**Nightly CI**: OpenShift (CUDA), GKE (CUDA), CoreWeave (CUDA)
+
+> Requires LeaderWorkerSet (LWS) for multi-node orchestration. DP-aware scheduling variant is under development.
+
+### Tiered Prefix Cache
+
+| Variant | vLLM | SGLang |
+|---------|------|--------|
+| CPU offload | ✅ | — |
+| Storage offload | ✅ | — |
+
+**Nightly CI**: OpenShift (CUDA)
+
+### Workload Autoscaling
+
+| Variant | vLLM | SGLang |
+|---------|------|--------|
+| HPA + IGW Metrics | ✅ | — |
+| Workload Variant Autoscaler (WVA) | ✅ | — |
+
+**Nightly CI**: OpenShift (WVA), CoreWeave (WVA)
+
+### Predicted Latency-Based Scheduling
+
+| Accelerator | vLLM | SGLang |
+|-------------|------|--------|
+| NVIDIA CUDA | ✅ | — |
+
+**Nightly CI**: None
+
+### Asynchronous Processing
+
+| Backend | vLLM | SGLang |
+|---------|------|--------|
+| Redis | ✅ | — |
+| GCP Pub/Sub | ✅ | — |
+
+**Nightly CI**: None
+
+## Infrastructure Providers
+
+| Provider | Inference Scheduling | P/D Disaggregation | Wide EP | Tiered Prefix Cache | Precise Prefix Cache | WVA |
+|----------|---------------------|--------------------|---------|--------------------|-----------------------|-----|
+| **OpenShift** | Nightly | Nightly | Nightly | Nightly | Nightly | Nightly |
+| **GKE** | Nightly | Nightly | Nightly | — | — | — |
+| **CoreWeave (CKS)** | Nightly | Nightly | Nightly | — | — | Nightly |
+| **Minikube** | Manual | — | — | — | — | — |
+| **DigitalOcean** | Manual | — | — | — | — | — |
+| **AKS** | Manual | — | — | — | — | — |
+
+## Gateway Providers
+
+| Provider | Status | Notes |
+|----------|--------|-------|
+| **Istio** | Default | Used in all well-lit paths |
+| **AgentGateway** | Supported | Preferred for new self-installed deployments |
+| **GKE Gateway** | Supported | Externally managed, used in GKE guides |
+| **kgateway** | Deprecated | Will be removed in next release |
+
+## Support Matrix
+
+### Supported Hardware
+
+| Accelerator | Supported Devices | Notes |
+|-------------|-------------------|-------|
+| NVIDIA CUDA | A100, H100, H200, B200 | Primary platform. All well-lit paths validated. |
+| AMD ROCm | MI250, MI300X | Inference scheduling and P/D disaggregation. |
+| Google TPU | v5e, v6e, v7 | GKE only. P/D and inference scheduling. |
+| Intel XPU | Data Center GPU Max 1550, BMG (Battlemage) | Uses DRA. Inference scheduling, P/D, precise prefix cache. |
+| Intel Gaudi (HPU) | Gaudi 2, Gaudi 3 | Uses DRA. Inference scheduling. |
+| CPU | Intel Xeon (Sapphire Rapids+), AMD EPYC | 64 cores, 64 GB RAM per replica. |
+
+### Software Requirements
+
+| Component | Minimum Version | Notes |
+|-----------|-----------------|-------|
+| Kubernetes | 1.30+ | Gateway API v1 support required |
+| Gateway API CRDs | v1.5.1 | |
+| Gateway API Inference Extension CRDs | v1.4.0 | |
+| Helm | 3.x | For helmfile-based guides |
+| Helmfile | 0.x | For helmfile-based guides |
+| kubectl | 1.30+ | |
+| kustomize | 5.x | For kustomize-based guides (tiered prefix cache, wide EP) |
+
+### Installation Methods
+
+llm-d guides use two deployment methods. Both produce the same Kubernetes resources.
+
+| Method | Used By | Notes |
+|--------|---------|-------|
+| **Helmfile** | Inference scheduling, P/D disaggregation, precise prefix cache, workload autoscaling, simulated accelerators | Composes three Helm charts (infra, InferencePool, modelservice). |
+| **Kustomize** | Tiered prefix cache, wide expert-parallelism | Declarative overlays. Reusable base layers in `guides/recipes/`. |
+
+> The project is migrating from helmfile to kustomize-first installation ([tracking issue](https://github.com/llm-d/llm-d/issues/850)). New guides should prefer kustomize. Existing helmfile-based guides will be migrated in phases.
+
+## Guide Maturity
+
+Each well-lit path guide is assigned a maturity level reflecting its testing and documentation coverage.
+
+| Level | Definition |
+|-------|------------|
+| **High** | Tested nightly across multiple infrastructure providers (OpenShift, GKE, CoreWeave). Benchmarked and documented. |
+| **Medium** | Tested nightly on at least one infrastructure provider. Documented with deployment guide. |
+| **Experimental** | Functional but not regularly tested by maintainers. May have known limitations. |
+
+| Guide | Maturity | Nightly Providers |
+|-------|----------|-------------------|
+| Intelligent Inference Scheduling (vLLM, CUDA) | High | OpenShift, GKE, CoreWeave |
+| Intelligent Inference Scheduling (SGLang, CUDA) | Medium | — |
+| Intelligent Inference Scheduling (AMD, XPU, HPU, TPU, CPU) | Experimental | XPU, HPU (PR-triggered) |
+| Precise Prefix-Cache-Aware Routing | Medium | OpenShift |
+| Prefill/Decode Disaggregation (vLLM, CUDA) | High | OpenShift, GKE, CoreWeave |
+| Prefill/Decode Disaggregation (SGLang, CUDA) | Experimental | — |
+| Prefill/Decode Disaggregation (AMD, XPU, TPU) | Experimental | — |
+| Wide Expert-Parallelism | Experimental | OpenShift, GKE, CoreWeave |
+| Tiered Prefix Cache | Medium | OpenShift |
+| Simulated Accelerators | Medium | OpenShift |
+| Workload Autoscaling (WVA) | Experimental | OpenShift, CoreWeave |
+| Workload Autoscaling (HPA + IGW) | Experimental | — |
+| Predicted Latency-Based Scheduling | Experimental | — |
+| Asynchronous Processing | Experimental | — |

--- a/docs/wip-docs-new/getting-started/feature-matrix.md
+++ b/docs/wip-docs-new/getting-started/feature-matrix.md
@@ -120,7 +120,7 @@ This page describes the current coverage as validated in the v0.7.0 release and 
 
 ### Supported Hardware
 
-For accelerator maintainer contacts and contribution requirements, see [Accelerator Support](../../accelerators/README.md).
+For accelerator maintainer contacts and contribution requirements, see [Accelerator Support](../../accelerators/README.md). The information below is also maintained in that document and will be consolidated into this feature matrix in a future docs revision.
 
 | Accelerator | Supported Devices | Notes |
 |-------------|-------------------|-------|

--- a/docs/wip-docs-new/getting-started/feature-matrix.md
+++ b/docs/wip-docs-new/getting-started/feature-matrix.md
@@ -6,7 +6,7 @@ This page describes the current coverage as validated in the v0.7.0 release and 
 
 ## Well-Lit Paths × Model Server × Accelerator
 
-### Intelligent Inference Scheduling
+### Optimized Baseline
 
 | Accelerator | vLLM | SGLang |
 |-------------|------|--------|
@@ -166,9 +166,9 @@ Each well-lit path guide is assigned a maturity level reflecting its testing and
 
 | Guide | Maturity | Nightly Providers |
 |-------|----------|-------------------|
-| Intelligent Inference Scheduling (vLLM, CUDA) | High | OpenShift, GKE, CoreWeave |
-| Intelligent Inference Scheduling (SGLang, CUDA) | Medium | — |
-| Intelligent Inference Scheduling (AMD, XPU, HPU, TPU, CPU) | Experimental | XPU, HPU (PR-triggered) |
+| Optimized Baseline (vLLM, CUDA) | High | OpenShift, GKE, CoreWeave |
+| Optimized Baseline (SGLang, CUDA) | Medium | — |
+| Optimized Baseline (AMD, XPU, HPU, TPU, CPU) | Experimental | XPU, HPU (PR-triggered) |
 | Precise Prefix-Cache-Aware Routing | Medium | OpenShift |
 | Prefill/Decode Disaggregation (vLLM, CUDA) | High | OpenShift, GKE, CoreWeave |
 | Prefill/Decode Disaggregation (SGLang, CUDA) | Experimental | — |

--- a/docs/wip-docs-new/getting-started/feature-matrix.md
+++ b/docs/wip-docs-new/getting-started/feature-matrix.md
@@ -98,7 +98,7 @@ This page describes the current coverage as validated in the v0.7.0 release and 
 
 ## Infrastructure Providers
 
-| Provider | Inference Scheduling | P/D Disaggregation | Wide EP | Tiered Prefix Cache | Precise Prefix Cache | WVA |
+| Provider | Optimized Baseline | P/D Disaggregation | Wide EP | Tiered Prefix Cache | Precise Prefix Cache | WVA |
 |----------|---------------------|--------------------|---------|--------------------|-----------------------|-----|
 | **OpenShift** | Nightly | Nightly | Nightly | Nightly | Nightly | Nightly |
 | **GKE** | Nightly | Nightly | Nightly | — | Nightly | — |
@@ -125,10 +125,10 @@ For accelerator maintainer contacts and contribution requirements, see [Accelera
 | Accelerator | Supported Devices | Notes |
 |-------------|-------------------|-------|
 | NVIDIA CUDA | A100, H100, H200, B200 | Primary platform. All well-lit paths validated. |
-| AMD ROCm | MI250, MI300X | Inference scheduling and P/D disaggregation. |
-| Google TPU | v5e, v6e, v7 | GKE only. P/D and inference scheduling. |
-| Intel XPU | Data Center GPU Max 1550, BMG (Battlemage) | Uses DRA. Inference scheduling, P/D, precise prefix cache. |
-| Intel Gaudi (HPU) | Gaudi 2, Gaudi 3 | Uses DRA. Inference scheduling. |
+| AMD ROCm | MI250, MI300X | Optimized baseline and P/D disaggregation. |
+| Google TPU | v5e, v6e, v7 | GKE only. P/D and optimized baseline. |
+| Intel XPU | Data Center GPU Max 1550, BMG (Battlemage) | Uses DRA. Opitmized baseline, P/D, precise prefix cache. |
+| Intel Gaudi (HPU) | Gaudi 2, Gaudi 3 | Uses DRA. Optimized baseline. |
 | CPU | Intel Xeon (Sapphire Rapids+), AMD EPYC | 64 cores, 64 GB RAM per replica. |
 
 ### Software Requirements
@@ -147,12 +147,12 @@ For accelerator maintainer contacts and contribution requirements, see [Accelera
 
 llm-d guides use two deployment methods. Both produce the same Kubernetes resources.
 
-| Method | Used By | Notes |
-|--------|---------|-------|
-| **Helmfile** | Inference scheduling, P/D disaggregation, precise prefix cache, workload autoscaling, simulated accelerators | Composes three Helm charts (infra, InferencePool, modelservice). |
-| **Kustomize** | Tiered prefix cache, wide expert-parallelism | Declarative overlays. Reusable base layers in `guides/recipes/`. |
+| Method | Notes |
+|--------|-------|
+| **Helm** | Used to deploy llm-d router in standalone and gateway modes, async processor, etc. |
+| **Kustomize** | Used to deploy declarative overlays for model servers, gateways, etc. Reusable base layers in `guides/recipes/`. |
 
-> The project is migrating from helmfile to kustomize-first installation ([tracking issue](https://github.com/llm-d/llm-d/issues/850)). New guides should prefer kustomize. Existing helmfile-based guides will be migrated in phases.
+> The project is migrating from helmfile to kustomize-first installation ([tracking issue](https://github.com/llm-d/llm-d/issues/850)). New guides should prefer kustomize.
 
 ## Guide Maturity
 

--- a/docs/wip-docs-new/getting-started/feature-matrix.md
+++ b/docs/wip-docs-new/getting-started/feature-matrix.md
@@ -23,12 +23,10 @@ This page describes the current coverage as validated in the v0.7.0 release and 
 
 | Accelerator | vLLM | SGLang |
 |-------------|------|--------|
-| NVIDIA CUDA | ✅ | — |
+| NVIDIA CUDA | ✅ | ✅ |
 | Intel XPU | ✅ | — |
 
 **Nightly CI**: OpenShift (CUDA), CoreWeave (CUDA), GKE (CUDA)
-
-> SGLang uses a radix-tree cache architecture. Support requires the [KVEvents abstraction](https://github.com/llm-d/llm-d-kv-cache/issues/240) which is in design.
 
 ### Prefill/Decode Disaggregation
 
@@ -53,10 +51,11 @@ This page describes the current coverage as validated in the v0.7.0 release and 
 
 ### Tiered Prefix Cache
 
-| Variant | vLLM | SGLang |
-|---------|------|--------|
-| CPU offload | ✅ | — |
-| Storage offload | ✅ | — |
+| Accelerator | CPU Offload (vLLM) | Storage Offload (vLLM) | SGLang |
+|-------------|--------------------|-----------------------|--------|
+| NVIDIA CUDA | ✅ | ✅ | — |
+| Intel XPU | — | — | — |
+| Google TPU | Coming soon | — | — |
 
 **Nightly CI**: OpenShift (CUDA)
 
@@ -120,6 +119,8 @@ This page describes the current coverage as validated in the v0.7.0 release and 
 ## Support Matrix
 
 ### Supported Hardware
+
+For accelerator maintainer contacts and contribution requirements, see [Accelerator Support](../../accelerators/README.md).
 
 | Accelerator | Supported Devices | Notes |
 |-------------|-------------------|-------|


### PR DESCRIPTION
## Summary

Populates the `feature-matrix.md` and `artifacts.md` stubs in `docs/wip-docs-new/getting-started/` for the documentation revamp (#1103).

**Feature Matrix** covers:
- Well-lit path x model server x accelerator coverage (v0.6.0)
- Infrastructure provider nightly CI coverage
- Gateway provider support
- Support matrix: hardware devices, software requirements, installation methods (Helm vs Kustomize)
- Per-guide maturity levels (High / Medium / Experimental)

**Artifacts** inventories all v0.6.0 release deliverables:
- Container images (model server + sidecar/infra) with registries, tags, and availability
- Deployment manifests: Helm charts and Kustomize overlays
- Gateway provider dependencies
- Key upstream dependency versions (vLLM, CUDA, NIXL, DeepEP, etc.)
- Hardware-specific vLLM variants
- Source repositories

Both pages reference the kustomize migration (#850) and upstream image consolidation (#1112).