### PR TITLE
Fixup merge conflict markers in `tiered-prefix-cache/storage/README.md`

### DIFF
--- a/guides/tiered-prefix-cache/storage/README.md
+++ b/guides/tiered-prefix-cache/storage/README.md
@@ -6,12 +6,7 @@ This guide explains how to offload the vLLM prefix cache (KV cache) to shared st
 
 ## Prerequisites
 
-<<<<<<< HEAD
 * Have the [proper client tools installed on your local system](../../../helpers/client-setup/README.md) to use this guide.
-* Ensure your cluster infrastructure is sufficient to [deploy high scale inference](../../prereq/infrastructure/README.md).
-=======
-* Have the [proper client tools installed on your local system](../../prereq/client-setup/README.md) to use this guide.
->>>>>>> origin/main
 * Configure and deploy your [Gateway control plane](../../prereq/gateway-provider/README.md).
 * Have the [Monitoring stack](../../../docs/monitoring/README.md) installed on your system.
 * Create a namespace for installation.


### PR DESCRIPTION
I couldn't find the reference for deploying high scale inference, so removed for now