### PR TITLE
proposal: capture GenAI prompts and completions as OTel events

### DIFF
--- a/docs/monitoring/tracing/otel-collector-with-payload-capture.yaml
+++ b/docs/monitoring/tracing/otel-collector-with-payload-capture.yaml
@@ -1,0 +1,174 @@
+# OTel Collector configuration with GenAI payload capture support.
+#
+# This variant extends otel-collector.yaml with:
+#   - A tail-sampling processor that keeps traces containing payload events
+#   - An attributes processor that redacts configured PII patterns
+#   - A separate "payloads" pipeline that routes gen_ai.content.* events
+#     to a dedicated exporter (filesystem or OTLP) for downstream storage
+#
+# Set LLMD_PAYLOAD_CAPTURE_ENABLED=true and choose a backend in your Helm
+# values before deploying this config.  See docs/proposals/genai-payload-events.md.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            keepalive:
+              enforcement_policy:
+                min_time: 10s
+                permit_without_stream: true
+            endpoint: "0.0.0.0:4317"
+          http:
+            endpoint: "0.0.0.0:4318"
+
+    processors:
+      filter/drop-metrics-scraping:
+        error_mode: ignore
+        traces:
+          span:
+            - 'attributes["url.path"] == "/metrics"'
+            - 'attributes["http.route"] == "/metrics"'
+            - name == "GET /metrics"
+            - name == "GET"
+
+      # Redact common PII patterns from all span attributes and event bodies
+      # before any exporter sees the data.  Add regexes matching your data
+      # classification policy under additional_patterns.
+      redaction:
+        allow_all_keys: true
+        blocked_values:
+          # US Social Security Numbers
+          - "\\b\\d{3}-\\d{2}-\\d{4}\\b"
+          # Credit card numbers (Luhn-format, 13–19 digits)
+          - "\\b(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|3[47][0-9]{13}|6(?:011|5[0-9]{2})[0-9]{12})\\b"
+          # Bearer tokens in Authorization header values
+          - "(?i)bearer\\s+[A-Za-z0-9\\-._~+/]+=*"
+        summary: redacted
+
+      # Keep only traces that contain gen_ai payload events; all other traces
+      # continue through the normal pipeline unaffected.
+      filter/payload-events-only:
+        error_mode: ignore
+        traces:
+          span_event:
+            - 'name != "gen_ai.content.prompt" and name != "gen_ai.content.completion"'
+
+      batch:
+        send_batch_size: 1024
+        timeout: 1s
+
+      batch/payload:
+        send_batch_size: 256
+        timeout: 2s
+
+    exporters:
+      otlp/jaeger:
+        endpoint: "jaeger-collector:4317"
+        tls:
+          insecure: true
+
+      # Payload exporter: writes gen_ai.content.* events to a local volume.
+      # Replace with an OTLP exporter pointing to your object-store proxy
+      # (e.g. a GCS OTLP bridge) for production use.
+      file/payloads:
+        path: /var/llm-d/payloads/traces.jsonl
+        rotation:
+          max_megabytes: 100
+          max_days: 7
+          max_backups: 5
+          localtime: false
+
+    extensions:
+      health_check:
+        endpoint: "0.0.0.0:13133"
+
+    service:
+      extensions: [health_check]
+      pipelines:
+        # Main traces pipeline — all spans, PII redacted, sent to Jaeger
+        traces:
+          receivers: [otlp]
+          processors: [filter/drop-metrics-scraping, redaction, batch]
+          exporters: [otlp/jaeger]
+
+        # Payload pipeline — only spans carrying gen_ai content events,
+        # written to the filesystem exporter for offline eval / QA workflows.
+        # Enable by deploying this config and setting payloadCapture.enabled=true.
+        traces/payloads:
+          receivers: [otlp]
+          processors: [filter/drop-metrics-scraping, redaction, filter/payload-events-only, batch/payload]
+          exporters: [file/payloads]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: otel-collector
+  template:
+    metadata:
+      labels:
+        app: otel-collector
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: otel-collector
+        image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.120.0
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
+        args:
+        - "--config=/etc/otel/config.yaml"
+        ports:
+        - containerPort: 4317
+          name: otlp-grpc
+        - containerPort: 4318
+          name: otlp-http
+        - containerPort: 13133
+          name: health-check
+        volumeMounts:
+        - name: config
+          mountPath: /etc/otel
+          readOnly: true
+        - name: payload-store
+          mountPath: /var/llm-d/payloads
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133
+          initialDelaySeconds: 5
+          periodSeconds: 10
+      volumes:
+      - name: config
+        configMap:
+          name: otel-collector-config
+      - name: payload-store
+        # Replace emptyDir with a PVC or cloud-backed volume for persistence.
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+spec:
+  selector:
+    app: otel-collector
+  ports:
+  - port: 4317
+    targetPort: 4317
+    name: otlp-grpc
+  - port: 4318
+    targetPort: 4318
+    name: otlp-http

--- a/docs/proposals/genai-payload-events.md
+++ b/docs/proposals/genai-payload-events.md
@@ -1,0 +1,307 @@
+# Capture GenAI Prompts and Completions as OTel Events
+
+## Summary
+
+Extend llm-d's existing OpenTelemetry distributed tracing to optionally capture full
+LLM prompts and completions as OTel span events, following the upstream
+[open-telemetry/semantic-conventions#2010](https://github.com/open-telemetry/semantic-conventions/issues/2010)
+specification. Payloads above a configurable size threshold are offloaded to an object
+storage backend (GCS, S3, or local filesystem) with only a reference URI stored on the
+span. The feature is disabled by default and requires explicit opt-in, preserving the
+existing metadata-only privacy posture for operators who do not need payload visibility.
+
+This proposal extends [distributed-tracing.md](distributed-tracing.md).
+
+## Motivation
+
+The existing tracing proposal deliberately excludes request/response payloads to protect
+privacy and keep span records small. However, several production use-cases require payload
+visibility that cannot be satisfied by token counts and latency metadata alone:
+
+- **Offline quality evaluation** — eval pipelines need exact prompts and completions to
+  run scoring models, compute BLEU/ROUGE, or detect prompt injection.
+- **Prompt debugging** — operators correlating unexpected outputs need the verbatim input,
+  not a summary.
+- **RAG pipeline validation** — confirming that retrieved context was injected correctly
+  requires inspecting the assembled prompt.
+- **Cost attribution** — understanding *what* drove high token usage requires the content,
+  not just the count.
+
+The upstream OTel semantic-conventions community chose an **event-based model** (not span
+attributes) specifically to decouple large payload data from the lightweight span record.
+Implementing against that spec makes llm-d payload data consumable by any OTel-native
+tooling without custom parsing.
+
+### Goals
+
+- Emit `gen_ai.content.prompt` and `gen_ai.content.completion` OTel events on the
+  relevant span following the upstream semantic convention.
+- Inline small payloads (≤ configurable threshold, default 4 KB) directly on the event
+  attribute; offload larger payloads to object storage and record only a reference URI.
+- Provide a pluggable storage interface with four built-in backends: `noop` (default),
+  `inline`, `gcs`, `s3`, and `filesystem`.
+- Expose an opt-in redaction pipeline (configurable regex patterns + optional external
+  DLP webhook) that runs before any payload reaches a backend.
+- Ensure zero overhead on the hot path when the feature is disabled.
+- Surface configuration through the existing Helm `tracing` / `payloadCapture` stanza
+  and through standard environment variables.
+
+### Non-Goals
+
+- This proposal does not modify or replace the latency, token-count, or routing
+  attributes defined in [distributed-tracing.md](distributed-tracing.md).
+- Real-time PII detection or alerting is out of scope; the redaction pipeline is
+  best-effort and advisory.
+- Streaming token-by-token event emission is out of scope for v1; completions are
+  buffered and emitted as a single event after the response is complete.
+- Guaranteed delivery of payload events to object storage (best-effort with
+  configurable timeout).
+- Breaking changes to the existing tracing configuration schema.
+
+## Proposal
+
+Operators who need payload visibility enable `payloadCapture.enabled: true` in their
+Helm values (or set `LLMD_PAYLOAD_CAPTURE_ENABLED=true`). All other operators see no
+change in behaviour or performance.
+
+When enabled, the relevant llm-d component:
+
+1. Serialises the request messages / prompt to JSON.
+2. Passes the JSON through the configured redaction pipeline.
+3. Compares the byte length against `inlineSizeThresholdBytes` (default 4 096).
+4. If within threshold → attaches the JSON as a `gen_ai.prompt` attribute on a
+   `gen_ai.content.prompt` OTel event on the active span.
+5. If above threshold → uploads to the configured `PayloadStore` backend and attaches
+   only the returned URI as `gen_ai.content.storage_uri`.
+6. Repeats steps 1–5 for the response completion after the full response is assembled.
+
+Success is measured by: (a) `gen_ai.content.prompt` / `gen_ai.content.completion` events
+appearing in Jaeger traces when enabled, (b) object-store objects appearing at the
+expected path, (c) no measurable latency increase on sampled requests when disabled.
+
+### User Stories
+
+#### Story 1 — Offline eval engineer
+
+As an eval engineer, I want to retrieve the exact prompt and completion for any sampled
+inference request so that I can run my scoring pipeline without maintaining a separate
+request-logging sidecar.
+
+#### Story 2 — Platform operator with PII constraints
+
+As a platform operator, I want to enable payload capture with built-in SSN and credit-card
+redaction patterns so that my audit team can inspect prompts without exposing raw PII,
+and without writing a custom logging proxy.
+
+#### Story 3 — RAG pipeline debugger
+
+As an ML engineer debugging a RAG pipeline, I want to open a Jaeger trace for a
+low-quality response and immediately see the assembled prompt (with retrieved context
+injected) so that I can confirm whether retrieval or generation was the failure point.
+
+## Design Details
+
+### OTel Event Specification
+
+Per [semconv#2010](https://github.com/open-telemetry/semantic-conventions/issues/2010),
+payload events are emitted on the **same span** that represents the LLM call.
+
+**Prompt event**
+
+| Field | Value |
+|---|---|
+| Event name | `gen_ai.content.prompt` |
+| `gen_ai.prompt` | Serialised messages / prompt JSON (omitted when offloaded) |
+| `gen_ai.content.storage_uri` | Object store URI (present only when offloaded) |
+
+**Completion event**
+
+| Field | Value |
+|---|---|
+| Event name | `gen_ai.content.completion` |
+| `gen_ai.completion` | Serialised choices JSON (omitted when offloaded) |
+| `gen_ai.content.storage_uri` | Object store URI (present only when offloaded) |
+
+When the payload is truncated due to `maxCompletionBufferBytes` being exceeded, the event
+additionally carries `gen_ai.content.truncated: true`.
+
+### Capture Layers
+
+Payload events are attached to spans at the following layers, with vLLM preferred when
+available:
+
+| Layer | Prompt capture | Completion capture | Span attached to |
+|---|---|---|---|
+| **vLLM** (preferred) | Decoded Python request object | `RequestOutput` choices | `vllm:llm_request` |
+| **Gateway (EPP)** | Raw HTTP request body (JSON parse) | Not available | `gateway.request` |
+| **P/D proxy sidecar** | Not available | Reassembled SSE stream | `llm_d.pd_proxy.request` |
+
+To avoid double-emission when vLLM tracing is active, the gateway and sidecar skip
+prompt/completion events when `payloadCapture.emitIfUpstreamTraced` is `false` (default).
+
+### PayloadStore Interface
+
+```go
+// PayloadStore persists a payload and returns a retrieval URI.
+// Implementations: NoopStore, InlineStore, GCSStore, S3Store, FilesystemStore.
+type PayloadStore interface {
+    Store(ctx context.Context, traceID, spanID string, kind PayloadKind, data []byte) (uri string, err error)
+}
+
+type PayloadKind string
+const (
+    KindPrompt     PayloadKind = "prompt"
+    KindCompletion PayloadKind = "completion"
+)
+```
+
+Backend selection via `payloadCapture.backend`:
+
+| Value | Behaviour |
+|---|---|
+| `noop` (default) | Drop silently; no event emitted |
+| `inline` | Attach to OTel event attribute; auto-offload if above threshold |
+| `gcs` | Upload to GCS, emit `gs://bucket/path` URI |
+| `s3` | Upload to S3-compatible store, emit `s3://bucket/path` URI |
+| `filesystem` | Write to mounted volume, emit `file:///path` URI |
+
+Object store path convention:
+```
+{prefix}/{YYYY}/{MM}/{DD}/{traceID}/{spanID}-{kind}.json
+```
+
+### Redaction Pipeline
+
+Runs before any backend sees the payload:
+
+```
+raw JSON → regex replacements → [optional webhook POST] → PayloadStore
+```
+
+Built-in patterns (active when `redaction.builtinPatterns: true`): US SSN, credit card
+numbers (Luhn-format), Bearer tokens in Authorization values. Custom patterns are a list
+of `{pattern, replacement}` objects. The webhook client enforces a configurable timeout;
+on error the payload is truncated rather than forwarded unredacted.
+
+### Streaming Completion Buffering
+
+SSE responses are buffered in memory up to `maxCompletionBufferBytes` (default 256 KB)
+before the completion event is emitted. If the buffer limit is reached, the event is
+emitted with the buffered content and `gen_ai.content.truncated: true`; the response
+stream continues unaffected.
+
+### Configuration
+
+Helm values (GAIE / EPP):
+
+```yaml
+inferenceExtension:
+  payloadCapture:
+    enabled: false                      # master switch; opt-in
+    backend: noop                       # noop | inline | gcs | s3 | filesystem
+    inlineSizeThresholdBytes: 4096
+    offloadBackend: ""                  # fallback when inline exceeds threshold
+    emitIfUpstreamTraced: false         # skip if vLLM tracing is active
+    maxCompletionBufferBytes: 262144
+    gcs:
+      bucket: ""
+      prefix: "llm-d/payloads"
+    s3:
+      bucket: ""
+      endpoint: ""
+      prefix: "llm-d/payloads"
+      region: "us-east-1"
+    filesystem:
+      mountPath: "/var/llm-d/payloads"
+    redaction:
+      enabled: false
+      builtinPatterns: true
+      patterns: []
+      webhookURL: ""
+```
+
+Equivalent environment variables: `LLMD_PAYLOAD_CAPTURE_ENABLED`, `LLMD_PAYLOAD_BACKEND`,
+`LLMD_PAYLOAD_INLINE_THRESHOLD`, `LLMD_PAYLOAD_GCS_BUCKET`, `LLMD_PAYLOAD_S3_BUCKET`,
+`LLMD_PAYLOAD_FS_PATH`, `LLMD_PAYLOAD_REDACTION_ENABLED`.
+
+### OTel Collector Pipeline
+
+A new `traces/payloads` pipeline filters for `gen_ai.content.*` events and routes them
+to a dedicated exporter (filesystem or OTLP bridge for GCS/S3). The existing
+`traces` pipeline is unchanged. The redaction processor can additionally be placed in
+the collector as a defence-in-depth layer.
+
+### Security
+
+Payload capture significantly raises the sensitivity of trace data. Operators must:
+
+1. Enable TLS on all OTLP gRPC endpoints.
+2. Restrict OTel collector access to the tracing namespace.
+3. Apply object-store bucket policies limiting read access to authorised principals.
+4. Treat captured payloads with the same classification as the underlying model's
+   training data or any user PII present in requests.
+5. Enable `redaction.enabled: true` when serving untrusted user inputs.
+
+Credentials for GCS/S3 are never embedded in Helm values — they must come from
+Workload Identity / IRSA bindings or Kubernetes Secrets mounted as environment variables.
+
+### Phased Implementation
+
+**Phase 1 — Interface and noop/inline backends (this proposal)**
+- `PayloadStore` interface in `pkg/telemetry/payload_store.go` (Go)
+- `NoopStore` and `InlineStore` implementations
+- Wire into gateway `server.go` `Process()` method behind the `enabled` flag
+- Helm values schema and documentation updates
+- Unit tests for interface and inline/noop backends
+
+**Phase 2 — Object store backends**
+- `GCSStore` (Workload Identity), `S3Store` (IRSA), `FilesystemStore`
+- Integration tests using fake-gcs-server / MinIO
+
+**Phase 3 — Redaction pipeline**
+- Regex replacement engine with built-in patterns
+- Webhook client with timeout and truncate-on-error fallback
+
+**Phase 4 — vLLM native integration**
+- Python `PayloadExporter` class mirroring Go interface
+- Hook into vLLM `AsyncLLMEngine` output processor
+- OTel event emission on `vllm:llm_request` span
+
+## Alternatives
+
+### Log-based payload capture (structured logs → Loki)
+
+Rejected. Requires correlating log lines with trace IDs out of band; no standard
+consumer understands the payload-to-span relationship the way OTel event consumers do.
+Adds a second observability pipeline with separate retention and access controls.
+
+### Span attributes instead of events
+
+Rejected. Large string attributes bloat the span record, degrade backend indexing
+performance, and are not aligned with the upstream semantic convention, which
+specifically chose the event model to keep span records lightweight.
+
+### Envoy / Istio sidecar capture
+
+Rejected. A service-mesh proxy captures raw TCP bytes without JSON context, making
+structured redaction and typed event emission significantly harder. It also captures
+all traffic regardless of sampling decisions, generating unbounded storage load.
+
+### Separate logging sidecar per pod
+
+Rejected. Duplicates the sampling and context-propagation work already done by the
+OTel instrumentation; requires operators to run and maintain an additional process per
+inference pod and correlate two separate data streams.
+
+---
+
+**Contributors and Reviewers:**
+
+* Nick Aggarwal <nick.aggarwal@gmail.com>
+
+Reviewers:
+* JeffLuoo <jeffluoo@google.com>
+* sallyom <somalley@redhat.com>
+* damemi <mike@odigos.io>
+* PierDipi <pdipilat@redhat.com>
+* ploffay <ploffay@odigos.io>

--- a/guides/inference-scheduling/gaie-inference-scheduling/values.yaml
+++ b/guides/inference-scheduling/gaie-inference-scheduling/values.yaml
@@ -22,6 +22,28 @@ inferenceExtension:
     # sampling:
     #   sampler: "parentbased_traceidratio"
     #   samplerArg: "0.1"
+  # GenAI payload capture — prompts and completions as OTel events (opt-in).
+  # See docs/proposals/genai-payload-events.md for security implications.
+  payloadCapture:
+    enabled: false
+    # backend: noop            # noop | inline | gcs | s3 | filesystem
+    # inlineSizeThresholdBytes: 4096
+    # offloadBackend: ""
+    # gcs:
+    #   bucket: ""
+    #   prefix: "llm-d/payloads"
+    # s3:
+    #   bucket: ""
+    #   endpoint: ""
+    #   prefix: "llm-d/payloads"
+    #   region: "us-east-1"
+    # filesystem:
+    #   mountPath: "/var/llm-d/payloads"
+    # redaction:
+    #   enabled: false
+    #   builtinPatterns: true
+    #   patterns: []
+    #   webhookURL: ""
   monitoring:
     interval: "10s"
     prometheus:

--- a/guides/inference-scheduling/ms-inference-scheduling/values.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values.yaml
@@ -7,6 +7,28 @@ multinode: false
 #   sampling:
 #     sampler: "parentbased_traceidratio"
 #     samplerArg: "0.1"
+#   # GenAI payload capture — prompts and completions as OTel events (opt-in).
+#   # See docs/proposals/genai-payload-events.md for security implications.
+#   payloadCapture:
+#     enabled: false
+#     backend: noop            # noop | inline | gcs | s3 | filesystem
+#     inlineSizeThresholdBytes: 4096
+#     offloadBackend: ""
+#     gcs:
+#       bucket: ""
+#       prefix: "llm-d/payloads"
+#     s3:
+#       bucket: ""
+#       endpoint: ""
+#       prefix: "llm-d/payloads"
+#       region: "us-east-1"
+#     filesystem:
+#       mountPath: "/var/llm-d/payloads"
+#     redaction:
+#       enabled: false
+#       builtinPatterns: true
+#       patterns: []
+#       webhookURL: ""
 
 modelArtifacts:
   uri: "hf://Qwen/Qwen3-32B"

--- a/guides/pd-disaggregation/gaie-pd/values.yaml
+++ b/guides/pd-disaggregation/gaie-pd/values.yaml
@@ -58,6 +58,28 @@ inferenceExtension:
     # sampling:
     #   sampler: "parentbased_traceidratio"
     #   samplerArg: "0.1"
+  # GenAI payload capture — prompts and completions as OTel events (opt-in).
+  # See docs/proposals/genai-payload-events.md for security implications.
+  payloadCapture:
+    enabled: false
+    # backend: noop            # noop | inline | gcs | s3 | filesystem
+    # inlineSizeThresholdBytes: 4096
+    # offloadBackend: ""
+    # gcs:
+    #   bucket: ""
+    #   prefix: "llm-d/payloads"
+    # s3:
+    #   bucket: ""
+    #   endpoint: ""
+    #   prefix: "llm-d/payloads"
+    #   region: "us-east-1"
+    # filesystem:
+    #   mountPath: "/var/llm-d/payloads"
+    # redaction:
+    #   enabled: false
+    #   builtinPatterns: true
+    #   patterns: []
+    #   webhookURL: ""
   # Monitoring configuration for EPP
   monitoring:
     interval: "10s"

--- a/guides/pd-disaggregation/ms-pd/values.yaml
+++ b/guides/pd-disaggregation/ms-pd/values.yaml
@@ -7,6 +7,28 @@ multinode: false
 #   sampling:
 #     sampler: "parentbased_traceidratio"
 #     samplerArg: "0.1"
+#   # GenAI payload capture — prompts and completions as OTel events (opt-in).
+#   # See docs/proposals/genai-payload-events.md for security implications.
+#   payloadCapture:
+#     enabled: false
+#     backend: noop            # noop | inline | gcs | s3 | filesystem
+#     inlineSizeThresholdBytes: 4096
+#     offloadBackend: ""
+#     gcs:
+#       bucket: ""
+#       prefix: "llm-d/payloads"
+#     s3:
+#       bucket: ""
+#       endpoint: ""
+#       prefix: "llm-d/payloads"
+#       region: "us-east-1"
+#     filesystem:
+#       mountPath: "/var/llm-d/payloads"
+#     redaction:
+#       enabled: false
+#       builtinPatterns: true
+#       patterns: []
+#       webhookURL: ""
 
 modelArtifacts:
   uri: "hf://openai/gpt-oss-120b"

--- a/guides/precise-prefix-cache-aware/gaie-kv-events/values.yaml
+++ b/guides/precise-prefix-cache-aware/gaie-kv-events/values.yaml
@@ -111,6 +111,28 @@ inferenceExtension:
     # sampling:
     #   sampler: "parentbased_traceidratio"
     #   samplerArg: "0.1"
+  # GenAI payload capture — prompts and completions as OTel events (opt-in).
+  # See docs/proposals/genai-payload-events.md for security implications.
+  payloadCapture:
+    enabled: false
+    # backend: noop            # noop | inline | gcs | s3 | filesystem
+    # inlineSizeThresholdBytes: 4096
+    # offloadBackend: ""
+    # gcs:
+    #   bucket: ""
+    #   prefix: "llm-d/payloads"
+    # s3:
+    #   bucket: ""
+    #   endpoint: ""
+    #   prefix: "llm-d/payloads"
+    #   region: "us-east-1"
+    # filesystem:
+    #   mountPath: "/var/llm-d/payloads"
+    # redaction:
+    #   enabled: false
+    #   builtinPatterns: true
+    #   patterns: []
+    #   webhookURL: ""
   # Monitoring configuration for EPP
   monitoring:
     interval: "10s"

--- a/guides/precise-prefix-cache-aware/ms-kv-events/values.yaml
+++ b/guides/precise-prefix-cache-aware/ms-kv-events/values.yaml
@@ -7,6 +7,28 @@ multinode: false
 #   sampling:
 #     sampler: "parentbased_traceidratio"
 #     samplerArg: "0.1"
+#   # GenAI payload capture — prompts and completions as OTel events (opt-in).
+#   # See docs/proposals/genai-payload-events.md for security implications.
+#   payloadCapture:
+#     enabled: false
+#     backend: noop            # noop | inline | gcs | s3 | filesystem
+#     inlineSizeThresholdBytes: 4096
+#     offloadBackend: ""
+#     gcs:
+#       bucket: ""
+#       prefix: "llm-d/payloads"
+#     s3:
+#       bucket: ""
+#       endpoint: ""
+#       prefix: "llm-d/payloads"
+#       region: "us-east-1"
+#     filesystem:
+#       mountPath: "/var/llm-d/payloads"
+#     redaction:
+#       enabled: false
+#       builtinPatterns: true
+#       patterns: []
+#       webhookURL: ""
 
 modelArtifacts:
   uri: "hf://Qwen/Qwen3-32B"

--- a/guides/simulated-accelerators/gaie-sim/values.yaml
+++ b/guides/simulated-accelerators/gaie-sim/values.yaml
@@ -23,6 +23,28 @@ inferenceExtension:
     # sampling:
     #   sampler: "parentbased_traceidratio"
     #   samplerArg: "0.1"
+  # GenAI payload capture — prompts and completions as OTel events (opt-in).
+  # See docs/proposals/genai-payload-events.md for security implications.
+  payloadCapture:
+    enabled: false
+    # backend: noop            # noop | inline | gcs | s3 | filesystem
+    # inlineSizeThresholdBytes: 4096
+    # offloadBackend: ""
+    # gcs:
+    #   bucket: ""
+    #   prefix: "llm-d/payloads"
+    # s3:
+    #   bucket: ""
+    #   endpoint: ""
+    #   prefix: "llm-d/payloads"
+    #   region: "us-east-1"
+    # filesystem:
+    #   mountPath: "/var/llm-d/payloads"
+    # redaction:
+    #   enabled: false
+    #   builtinPatterns: true
+    #   patterns: []
+    #   webhookURL: ""
   # Monitoring configuration for EPP
   monitoring:
     interval: "10s"

--- a/guides/simulated-accelerators/ms-sim/values.yaml
+++ b/guides/simulated-accelerators/ms-sim/values.yaml
@@ -7,6 +7,28 @@ multinode: false
 #   sampling:
 #     sampler: "parentbased_traceidratio"
 #     samplerArg: "0.1"
+#   # GenAI payload capture — prompts and completions as OTel events (opt-in).
+#   # See docs/proposals/genai-payload-events.md for security implications.
+#   payloadCapture:
+#     enabled: false
+#     backend: noop            # noop | inline | gcs | s3 | filesystem
+#     inlineSizeThresholdBytes: 4096
+#     offloadBackend: ""
+#     gcs:
+#       bucket: ""
+#       prefix: "llm-d/payloads"
+#     s3:
+#       bucket: ""
+#       endpoint: ""
+#       prefix: "llm-d/payloads"
+#       region: "us-east-1"
+#     filesystem:
+#       mountPath: "/var/llm-d/payloads"
+#     redaction:
+#       enabled: false
+#       builtinPatterns: true
+#       patterns: []
+#       webhookURL: ""
 
 modelArtifacts:
   uri: "hf://random"

--- a/guides/workload-autoscaling/gaie-workload-autoscaling/values.yaml
+++ b/guides/workload-autoscaling/gaie-workload-autoscaling/values.yaml
@@ -17,6 +17,28 @@ inferenceExtension:
     # sampling:
     #   sampler: "parentbased_traceidratio"
     #   samplerArg: "0.1"
+  # GenAI payload capture — prompts and completions as OTel events (opt-in).
+  # See docs/proposals/genai-payload-events.md for security implications.
+  payloadCapture:
+    enabled: false
+    # backend: noop            # noop | inline | gcs | s3 | filesystem
+    # inlineSizeThresholdBytes: 4096
+    # offloadBackend: ""
+    # gcs:
+    #   bucket: ""
+    #   prefix: "llm-d/payloads"
+    # s3:
+    #   bucket: ""
+    #   endpoint: ""
+    #   prefix: "llm-d/payloads"
+    #   region: "us-east-1"
+    # filesystem:
+    #   mountPath: "/var/llm-d/payloads"
+    # redaction:
+    #   enabled: false
+    #   builtinPatterns: true
+    #   patterns: []
+    #   webhookURL: ""
   monitoring:
     interval: "10s"
     # Prometheus ServiceMonitor will be created when enabled for EPP metrics collection

--- a/guides/workload-autoscaling/ms-workload-autoscaling/values.yaml
+++ b/guides/workload-autoscaling/ms-workload-autoscaling/values.yaml
@@ -7,6 +7,28 @@ multinode: false
 #   sampling:
 #     sampler: "parentbased_traceidratio"
 #     samplerArg: "0.1"
+#   # GenAI payload capture — prompts and completions as OTel events (opt-in).
+#   # See docs/proposals/genai-payload-events.md for security implications.
+#   payloadCapture:
+#     enabled: false
+#     backend: noop            # noop | inline | gcs | s3 | filesystem
+#     inlineSizeThresholdBytes: 4096
+#     offloadBackend: ""
+#     gcs:
+#       bucket: ""
+#       prefix: "llm-d/payloads"
+#     s3:
+#       bucket: ""
+#       endpoint: ""
+#       prefix: "llm-d/payloads"
+#       region: "us-east-1"
+#     filesystem:
+#       mountPath: "/var/llm-d/payloads"
+#     redaction:
+#       enabled: false
+#       builtinPatterns: true
+#       patterns: []
+#       webhookURL: ""
 
 modelArtifacts:
   uri: "hf://Qwen/Qwen3-0.6B"


### PR DESCRIPTION
## Summary

Adds a project proposal for capturing LLM prompts and completions as OpenTelemetry span events, following [open-telemetry/semantic-conventions#2010](https://github.com/open-telemetry/semantic-conventions/issues/2010).

Closes #1108.

---

### What's in this PR

| File | Purpose |
| --- | --- |
| `docs/proposals/genai-payload-events.md` | Full design proposal (template-compliant) covering event spec, capture layers, `PayloadStore` interface, redaction pipeline, security model, and phased implementation plan |
| `docs/monitoring/tracing/otel-collector-with-payload-capture.yaml` | Reference OTel Collector config with a `traces/payloads` pipeline and PII redaction processor |
| `guides/**/values.yaml` (10 files) | Commented-out `payloadCapture` Helm stanza in all GAIE and ModelService values files |

---

### Design decisions addressed from #1108

**1. Which component emits the events?**
Three-layer answer with vLLM as the preferred attachment point (direct access to decoded Python objects and the canonical `llm_request` span). Gateway (EPP) captures prompts as fallback when vLLM tracing is off; P/D proxy captures completions from reassembled SSE. `emitIfUpstreamTraced: false` prevents double-emission.

**2. Storage backend abstraction?**
`PayloadStore` interface with five backends: `noop` (default), `inline`, `gcs`, `s3` (covers MinIO/Ceph), `filesystem`. Inline payloads above `inlineSizeThresholdBytes` (default 4 KB) auto-offload.

**3. PII / redaction policy?**
Opt-in via `payloadCapture.redaction.enabled`. Built-in regex patterns (SSN, credit cards, Bearer tokens). Custom `{pattern, replacement}` list. Optional external DLP `webhookURL`. Runs before any backend sees the payload.

**4. Payload size threshold?**
4 KB inline, `maxCompletionBufferBytes: 256 KB` buffer for SSE completions, truncated with `gen_ai.content.truncated: true` on overflow.

---

`payloadCapture.enabled: false` by default — zero overhead until explicitly opted in.

## Test plan

- [ ] Proposal reviewed against `docs/proposals/PROPOSAL_TEMPLATE.md`
- [ ] OTel Collector config validates cleanly
- [ ] `yamllint guides/` passes on all updated values files
- [ ] Reviewed by impacted component maintainers (gateway, P/D sidecar, vLLM integration)