### PR TITLE
[Proposal]: Add GenAI payload events proposal

### DIFF
--- a/docs/proposals/genai-payload-events.md
+++ b/docs/proposals/genai-payload-events.md
@@ -1,0 +1,313 @@
+# Capture GenAI Prompts and Completions as OTel Events
+
+## Summary
+
+Extend llm-d's existing OpenTelemetry distributed tracing to optionally capture full
+LLM prompts and completions as OTel span events, following the upstream
+[open-telemetry/semantic-conventions#2010](https://github.com/open-telemetry/semantic-conventions/issues/2010)
+specification. Payloads above a configurable size threshold are offloaded to an object
+storage backend (GCS, S3, or local filesystem) with only a reference URI stored on the
+span. The feature is disabled by default and requires explicit opt-in, preserving the
+existing metadata-only privacy posture for operators who do not need payload visibility.
+
+This proposal extends [distributed-tracing.md](distributed-tracing.md).
+
+## Motivation
+
+The existing tracing proposal deliberately excludes request/response payloads to protect
+privacy and keep span records small. However, several production use-cases require payload
+visibility that cannot be satisfied by token counts and latency metadata alone:
+
+- **Offline quality evaluation** — eval pipelines need exact prompts and completions to
+  run scoring models, compute BLEU/ROUGE, or detect prompt injection.
+- **Prompt debugging** — operators correlating unexpected outputs need the verbatim input,
+  not a summary.
+- **RAG pipeline validation** — confirming that retrieved context was injected correctly
+  requires inspecting the assembled prompt.
+- **Cost attribution** — understanding *what* drove high token usage requires the content,
+  not just the count.
+
+The upstream OTel semantic-conventions community chose an **event-based model** (not span
+attributes) specifically to decouple large payload data from the lightweight span record.
+Implementing against that spec makes llm-d payload data consumable by any OTel-native
+tooling without custom parsing.
+
+### Goals
+
+- Emit `gen_ai.content.prompt` and `gen_ai.content.completion` OTel events on the
+  relevant span following the upstream semantic convention.
+- Inline small payloads (≤ configurable threshold, default 4 KB) directly on the event
+  attribute; offload larger payloads to object storage and record only a reference URI.
+- Provide a pluggable storage interface with four built-in backends: `noop` (default),
+  `inline`, `gcs`, `s3`, and `filesystem`.
+- Expose an opt-in redaction pipeline (configurable regex patterns + optional external
+  DLP webhook) that runs before any payload reaches a backend.
+- Ensure zero overhead on the hot path when the feature is disabled.
+- Surface configuration through the deployment overlay (Kustomize, once the in-flight
+  migration of model server deployments away from Helm lands) and through standard
+  environment variables.
+
+### Non-Goals
+
+- This proposal does not modify or replace the latency, token-count, or routing
+  attributes defined in [distributed-tracing.md](distributed-tracing.md).
+- Real-time PII detection or alerting is out of scope; the redaction pipeline is
+  best-effort and advisory.
+- Streaming token-by-token event emission is out of scope for v1; completions are
+  buffered and emitted as a single event after the response is complete.
+- Guaranteed delivery of payload events to object storage (best-effort with
+  configurable timeout).
+- Breaking changes to the existing tracing configuration schema.
+
+## Proposal
+
+Operators who need payload visibility enable `payloadCapture.enabled: true` in their
+deployment overlay (or set `LLMD_PAYLOAD_CAPTURE_ENABLED=true`). All other operators
+see no change in behaviour or performance.
+
+When enabled, the relevant llm-d component:
+
+1. Serialises the request messages / prompt to JSON.
+2. Passes the JSON through the configured redaction pipeline.
+3. Compares the byte length against `inlineSizeThresholdBytes` (default 4 096).
+4. If within threshold → attaches the JSON as a `gen_ai.prompt` attribute on a
+   `gen_ai.content.prompt` OTel event on the active span.
+5. If above threshold → uploads to the configured `PayloadStore` backend and attaches
+   only the returned URI as `gen_ai.content.storage_uri`.
+6. Repeats steps 1–5 for the response completion after the full response is assembled.
+
+Success is measured by: (a) `gen_ai.content.prompt` / `gen_ai.content.completion` events
+appearing in Jaeger traces when enabled, (b) object-store objects appearing at the
+expected path, (c) no measurable latency increase on sampled requests when disabled.
+
+### User Stories
+
+#### Story 1 — Offline eval engineer
+
+As an eval engineer, I want to retrieve the exact prompt and completion for any sampled
+inference request so that I can run my scoring pipeline without maintaining a separate
+request-logging sidecar.
+
+#### Story 2 — Platform operator with PII constraints
+
+As a platform operator, I want to enable payload capture with built-in SSN and credit-card
+redaction patterns so that my audit team can inspect prompts without exposing raw PII,
+and without writing a custom logging proxy.
+
+#### Story 3 — RAG pipeline debugger
+
+As an ML engineer debugging a RAG pipeline, I want to open a Jaeger trace for a
+low-quality response and immediately see the assembled prompt (with retrieved context
+injected) so that I can confirm whether retrieval or generation was the failure point.
+
+## Design Details
+
+### OTel Event Specification
+
+Per [semconv#2010](https://github.com/open-telemetry/semantic-conventions/issues/2010),
+payload events are emitted on the **same span** that represents the LLM call.
+
+**Prompt event**
+
+| Field | Value |
+|---|---|
+| Event name | `gen_ai.content.prompt` |
+| `gen_ai.prompt` | Serialised messages / prompt JSON (omitted when offloaded) |
+| `gen_ai.content.storage_uri` | Object store URI (present only when offloaded) |
+
+**Completion event**
+
+| Field | Value |
+|---|---|
+| Event name | `gen_ai.content.completion` |
+| `gen_ai.completion` | Serialised choices JSON (omitted when offloaded) |
+| `gen_ai.content.storage_uri` | Object store URI (present only when offloaded) |
+
+When the payload is truncated due to `maxCompletionBufferBytes` being exceeded, the event
+additionally carries `gen_ai.content.truncated: true`.
+
+### Capture Layers
+
+Payload events are attached to spans at the following layers, with vLLM preferred when
+available:
+
+| Layer | Prompt capture | Completion capture | Span attached to |
+|---|---|---|---|
+| **vLLM** (preferred) | Decoded Python request object | `RequestOutput` choices | `vllm:llm_request` |
+| **Gateway (EPP)** | Raw HTTP request body (JSON parse) | Not available | `gateway.request` |
+| **P/D proxy sidecar** | Not available | Reassembled SSE stream | `llm_d.pd_proxy.request` |
+
+To avoid double-emission when vLLM tracing is active, the gateway and sidecar skip
+prompt/completion events when `payloadCapture.emitIfUpstreamTraced` is `false` (default).
+
+### PayloadStore Interface
+
+```go
+// PayloadStore persists a payload and returns a retrieval URI.
+// Implementations: NoopStore, InlineStore, GCSStore, S3Store, FilesystemStore.
+type PayloadStore interface {
+    Store(ctx context.Context, traceID, spanID string, kind PayloadKind, data []byte) (uri string, err error)
+}
+
+type PayloadKind string
+const (
+    KindPrompt     PayloadKind = "prompt"
+    KindCompletion PayloadKind = "completion"
+)
+```
+
+Backend selection via `payloadCapture.backend`:
+
+| Value | Behaviour |
+|---|---|
+| `noop` (default) | Drop silently; no event emitted |
+| `inline` | Attach to OTel event attribute; auto-offload if above threshold |
+| `gcs` | Upload to GCS, emit `gs://bucket/path` URI |
+| `s3` | Upload to S3-compatible store, emit `s3://bucket/path` URI |
+| `filesystem` | Write to mounted volume, emit `file:///path` URI |
+
+Object store path convention:
+```
+{prefix}/{YYYY}/{MM}/{DD}/{traceID}/{spanID}-{kind}.json
+```
+
+### Redaction Pipeline
+
+Runs before any backend sees the payload:
+
+```
+raw JSON → regex replacements → [optional webhook POST] → PayloadStore
+```
+
+Built-in patterns (active when `redaction.builtinPatterns: true`): US SSN, credit card
+numbers (Luhn-format), Bearer tokens in Authorization values. Custom patterns are a list
+of `{pattern, replacement}` objects. The webhook client enforces a configurable timeout;
+on error the payload is truncated rather than forwarded unredacted.
+
+### Streaming Completion Buffering
+
+SSE responses are buffered in memory up to `maxCompletionBufferBytes` (default 256 KB)
+before the completion event is emitted. If the buffer limit is reached, the event is
+emitted with the buffered content and `gen_ai.content.truncated: true`; the response
+stream continues unaffected.
+
+### Configuration
+
+The configuration schema below is the canonical shape; the concrete operator surface
+(currently Helm `values.yaml`, transitioning to Kustomize patches as the model server
+deployments are migrated) will adopt the same field names and defaults. The example
+shows the GAIE / EPP component:
+
+```yaml
+inferenceExtension:
+  payloadCapture:
+    enabled: false                      # master switch; opt-in
+    backend: noop                       # noop | inline | gcs | s3 | filesystem
+    inlineSizeThresholdBytes: 4096
+    offloadBackend: ""                  # fallback when inline exceeds threshold
+    emitIfUpstreamTraced: false         # skip if vLLM tracing is active
+    maxCompletionBufferBytes: 262144
+    gcs:
+      bucket: ""
+      prefix: "llm-d/payloads"
+    s3:
+      bucket: ""
+      endpoint: ""
+      prefix: "llm-d/payloads"
+      region: "us-east-1"
+    filesystem:
+      mountPath: "/var/llm-d/payloads"
+    redaction:
+      enabled: false
+      builtinPatterns: true
+      patterns: []
+      webhookURL: ""
+```
+
+Equivalent environment variables: `LLMD_PAYLOAD_CAPTURE_ENABLED`, `LLMD_PAYLOAD_BACKEND`,
+`LLMD_PAYLOAD_INLINE_THRESHOLD`, `LLMD_PAYLOAD_GCS_BUCKET`, `LLMD_PAYLOAD_S3_BUCKET`,
+`LLMD_PAYLOAD_FS_PATH`, `LLMD_PAYLOAD_REDACTION_ENABLED`.
+
+### OTel Collector Pipeline
+
+A new `traces/payloads` pipeline filters for `gen_ai.content.*` events and routes them
+to a dedicated exporter (filesystem or OTLP bridge for GCS/S3). The existing
+`traces` pipeline is unchanged. The redaction processor can additionally be placed in
+the collector as a defence-in-depth layer.
+
+### Security
+
+Payload capture significantly raises the sensitivity of trace data. Operators must:
+
+1. Enable TLS on all OTLP gRPC endpoints.
+2. Restrict OTel collector access to the tracing namespace.
+3. Apply object-store bucket policies limiting read access to authorised principals.
+4. Treat captured payloads with the same classification as the underlying model's
+   training data or any user PII present in requests.
+5. Enable `redaction.enabled: true` when serving untrusted user inputs.
+
+Credentials for GCS/S3 are never embedded in deployment values — they must come from
+Workload Identity / IRSA bindings or Kubernetes Secrets mounted as environment variables.
+
+### Phased Implementation
+
+**Phase 1 — Interface and noop/inline backends (this proposal)**
+- `PayloadStore` interface in `pkg/telemetry/payload_store.go` (Go)
+- `NoopStore` and `InlineStore` implementations
+- Wire into gateway `server.go` `Process()` method behind the `enabled` flag
+- Operator-surface schema (Kustomize patch / overlay aligned with the in-flight
+  migration; equivalent env-var aliases for components that retain Helm short-term)
+  and documentation updates
+- Unit tests for interface and inline/noop backends
+
+**Phase 2 — Object store backends**
+- `GCSStore` (Workload Identity), `S3Store` (IRSA), `FilesystemStore`
+- Integration tests using fake-gcs-server / MinIO
+
+**Phase 3 — Redaction pipeline**
+- Regex replacement engine with built-in patterns
+- Webhook client with timeout and truncate-on-error fallback
+
+**Phase 4 — vLLM native integration**
+- Python `PayloadExporter` class mirroring Go interface
+- Hook into vLLM `AsyncLLMEngine` output processor
+- OTel event emission on `vllm:llm_request` span
+
+## Alternatives
+
+### Log-based payload capture (structured logs → Loki)
+
+Rejected. Requires correlating log lines with trace IDs out of band; no standard
+consumer understands the payload-to-span relationship the way OTel event consumers do.
+Adds a second observability pipeline with separate retention and access controls.
+
+### Span attributes instead of events
+
+Rejected. Large string attributes bloat the span record, degrade backend indexing
+performance, and are not aligned with the upstream semantic convention, which
+specifically chose the event model to keep span records lightweight.
+
+### Envoy / Istio sidecar capture
+
+Rejected. A service-mesh proxy captures raw TCP bytes without JSON context, making
+structured redaction and typed event emission significantly harder. It also captures
+all traffic regardless of sampling decisions, generating unbounded storage load.
+
+### Separate logging sidecar per pod
+
+Rejected. Duplicates the sampling and context-propagation work already done by the
+OTel instrumentation; requires operators to run and maintain an additional process per
+inference pod and correlate two separate data streams.
+
+---
+
+**Contributors and Reviewers:**
+
+* Nick Aggarwal <nick.aggarwal@gmail.com>
+
+Reviewers:
+* JeffLuoo <jeffluoo@google.com>
+* sallyom <somalley@redhat.com>
+* damemi <mike@odigos.io>
+* PierDipi <pdipilat@redhat.com>
+* ploffay <ploffay@odigos.io>

--- a/docs/proposals/genai-payload-events.md
+++ b/docs/proposals/genai-payload-events.md
@@ -6,11 +6,13 @@ Extend llm-d's existing OpenTelemetry distributed tracing to optionally capture 
 LLM prompts and completions, following the upstream
 [GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) —
 specifically the `gen_ai.input.messages`, `gen_ai.output.messages`, and
-`gen_ai.system_instructions` attributes, recorded in structured form on a span event
-(per the convention, message content is recorded on events/logs and serialised to a JSON
-string when attached to a span). These attributes are `Opt-In` and at `Development`
-stability upstream, and are flagged as likely to contain sensitive data — they are never
-captured by default. Payloads above a configurable size threshold are offloaded to an
+`gen_ai.system_instructions` attributes. The convention allows these to be recorded
+either as Opt-In span attributes (serialised to a JSON string) or on the log-based
+event `gen_ai.client.inference.operation.details`; llm-d attaches them to a dedicated
+**span event** on the LLM span (serialised to a JSON string) as an explicit design
+decision — see [Design Details](#otel-attribute-specification) for the rationale and
+migration plan. These attributes are `Opt-In` and at `Development` stability upstream,
+and are flagged as likely to contain sensitive data — they are never captured by default. Payloads above a configurable size threshold are offloaded to an
 object storage backend (GCS, S3, or local filesystem) with only a reference URI stored on
 the span. Non-text content parts (images, audio, and other binary media in multimodal
 requests) are always offloaded — they cannot be carried as OTel attributes — and are
@@ -38,20 +40,22 @@ visibility that cannot be satisfied by token counts and latency metadata alone:
   multimodal requests are increasingly common drivers of latency and quality issues,
   and cannot be reconstructed from token metadata alone.
 
-The upstream GenAI conventions record message content as **structured attributes on a
-span event or log record** (`gen_ai.input.messages` / `gen_ai.output.messages`), rather
-than as attributes on the span itself, specifically to decouple large payload data from
-the lightweight span record. Even so, these attributes are typed as
-strings/numbers/bools/arrays and cannot carry opaque bytes; non-text payloads (images,
-audio) can be carried **neither on a span nor in a log record** and must therefore be
-offloaded to object storage and referenced by URI. Implementing against the upstream spec
+The upstream GenAI conventions record message content in one of two carriers:
+Opt-In **span attributes** on the LLM span (`gen_ai.input.messages` /
+`gen_ai.output.messages`, serialised to a JSON string), or on the log-based event
+`gen_ai.client.inference.operation.details` (an OTel Log Event, not a span event). Either
+way the attribute type system permits only strings, numbers, bools, and arrays of those;
+non-text payloads (images, audio) can be carried **neither on a span nor in a log record**
+and must therefore be offloaded to object storage and referenced by URI. Implementing against the upstream spec
 makes llm-d payload data consumable by any OTel-native tooling without custom parsing.
 
 ### Goals
 
 - Record `gen_ai.input.messages`, `gen_ai.output.messages`, and
-  `gen_ai.system_instructions` on a span event for the LLM call, following the upstream
-  GenAI semantic convention.
+  `gen_ai.system_instructions` for each LLM call using the upstream GenAI attribute
+  names. Carrier is a dedicated **span event** on the LLM span — see
+  [OTel Attribute Specification](#otel-attribute-specification) for why this deviates
+  from the semconv's span-attribute / log-event carriers.
 - Inline small text payloads (≤ configurable threshold, default 4 KB) directly on the
   event attribute; offload larger text payloads to object storage and record only a
   reference URI.
@@ -92,10 +96,11 @@ When enabled, the relevant llm-d component:
    (an array of role/parts messages; system content is split out to
    `gen_ai.system_instructions`).
 2. Passes the JSON through the configured redaction pipeline.
-3. Compares the byte length against `inlineSizeThresholdBytes` (default 4 096).
+3. Compares the byte length against `inlineSizeThresholdBytes` (default 4096).
 4. If within threshold → attaches the structured messages as the `gen_ai.input.messages`
-   attribute on a span event for the active LLM span (serialised to a JSON string, per the
-   convention's rule for recording messages on spans).
+   attribute on a dedicated span event of the active LLM span, serialised to a JSON string
+   (span-event attributes share the type system of span attributes; the JSON-string
+   encoding matches the semconv rule for message content on spans).
 5. If above threshold → uploads to the configured `PayloadStore` backend and attaches
    only the returned URI as `llm_d.payload.storage_uri` (llm-d extension).
 6. Repeats steps 1–5 for the response completion (`gen_ai.output.messages`) after the full
@@ -134,10 +139,34 @@ Payload content is recorded using the current upstream
 `gen_ai.input.messages`, `gen_ai.output.messages`, and `gen_ai.system_instructions`
 ([attribute registry](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/)).
 These attributes are `Opt-In` and at `Development` stability upstream; they may still
-change, so this proposal tracks them rather than pinning a frozen copy. Per the
-convention, message content is recorded **in structured form on a span event or log
-record** attached to the LLM span; when recorded on the span itself it is serialised to a
-JSON string. Each message is `{role, parts: [...]}`, where each part has a `type`
+change, so this proposal tracks them rather than pinning a frozen copy.
+
+**Upstream carriers.** The convention allows message content to be recorded via
+(a) Opt-In **span attributes** on the LLM span, serialised to a JSON string, or
+(b) the log-based event `gen_ai.client.inference.operation.details` — an OTel
+Log-based Event, not a span event. Span-event attributes are typed identically to
+span attributes, so on either a span or a span event the content is a JSON string;
+there is no fully-structured attribute carrier at the OTel type layer.
+
+**llm-d carrier — design decision.** This proposal records payload attributes on a
+dedicated **span event** attached to the LLM span. This is an explicit llm-d choice,
+not what the convention prescribes; the convention prefers span attributes or its
+log-based event, and the OTel community is moving away from Span Events toward
+Log-based Events. We use span events because:
+
+- they give the reference OTel Collector recipe a clean event-scoped routing surface
+  (see the `spanevent`-scoped OTTL filter in
+  `guides/recipes/observability/tracing/otel-collector.yaml`) without introducing a
+  logs pipeline in llm-d's default observability stack, and
+- they let operators tail-sample or drop the payload carrier separately from the parent
+  LLM span, preserving the existing lightweight-span posture for consumers that don't
+  opt in.
+
+If the upstream convention firms up around log records or Opt-In span attributes, a
+future revision of this proposal will migrate the carrier without changing the
+attribute names.
+
+Each message is `{role, parts: [...]}`, where each part has a `type`
 (`text`, `tool_call`, `tool_call_response`, …); output messages additionally carry a
 `finish_reason`. See [Non-Text and Multimodal Payloads](#non-text-and-multimodal-payloads)
 for how media parts are represented.

--- a/docs/proposals/genai-payload-events.md
+++ b/docs/proposals/genai-payload-events.md
@@ -149,8 +149,11 @@ attributes (`gen_ai.prompt`, `gen_ai.completion`) follow the upstream spec.
 | `gen_ai.content.media_uris` *(llm-d extension)* | Array of object store URIs for non-text content parts (present when the completion contains any non-text media) |
 
 When the payload is truncated due to `maxCompletionBufferBytes` being exceeded, or when
-a non-text part is dropped because the configured backend cannot return a resolvable URI
-(e.g. `noop`), the event additionally carries `gen_ai.content.truncated: true`.
+a non-text part is dropped because the configured offload target cannot return a
+resolvable URI (see [Non-Text and Multimodal Payloads](#non-text-and-multimodal-payloads)
+for the cases that produce this), the event additionally carries
+`gen_ai.content.truncated: true`. `backend: noop` is distinct: it is the
+no-event-at-all kill switch and emits no `gen_ai.content.*` events of any kind.
 
 ### Non-Text and Multimodal Payloads
 
@@ -182,17 +185,20 @@ The capture pipeline handles non-text content as follows:
 5. URL-reference parts (e.g. `image_url` pointing to a public CDN) are recorded in
    `gen_ai.content.media_uris` as-is and are **not** re-fetched by llm-d; the redaction
    pipeline still runs against the URL string itself.
-6. When the backend is `noop` — or any backend that cannot return a resolvable URI —
-   non-text parts are dropped, `gen_ai.content.truncated: true` is set on the event,
-   and the text skeleton is still emitted so that text-based debugging continues to
-   work.
+6. `backend: noop` short-circuits the entire payload pipeline: no
+   `gen_ai.content.*` events are emitted at all, and steps 1–5 above are skipped.
+   Operators who want capture *disabled* should leave `payloadCapture.enabled: false`;
+   `backend: noop` exists as a secondary kill switch for the case where `enabled` must
+   stay `true` for other reasons (e.g. shared overlay) but this particular component
+   should produce nothing.
 7. When the primary `backend` is `inline` (which cannot store binary), the non-text
    part is routed to the backend named in `offloadBackend`. If `offloadBackend` is
-   empty or unset, the part is dropped with `gen_ai.content.truncated: true` rather
-   than failing the request. Operators selecting `backend: inline` while expecting
-   multimodal capture must therefore configure a non-empty `offloadBackend` (one of
-   `gcs`, `s3`, or `filesystem`); startup configuration validation logs a warning
-   when this combination would silently drop media.
+   empty or unset, the part is dropped with `gen_ai.content.truncated: true` on the
+   emitted event, the text skeleton is still emitted so text-based debugging continues
+   to work, and the request itself is not failed. Operators selecting `backend: inline`
+   while expecting multimodal capture must therefore configure a non-empty
+   `offloadBackend` (one of `gcs`, `s3`, or `filesystem`); startup configuration
+   validation logs a warning when this combination would silently drop media.
 
 The object-store path convention is extended to encode part index and media type so
 that text and non-text payloads for the same span do not collide:

--- a/docs/proposals/genai-payload-events.md
+++ b/docs/proposals/genai-payload-events.md
@@ -97,7 +97,7 @@ When enabled, the relevant llm-d component:
    attribute on a span event for the active LLM span (serialised to a JSON string, per the
    convention's rule for recording messages on spans).
 5. If above threshold → uploads to the configured `PayloadStore` backend and attaches
-   only the returned URI as `gen_ai.content.storage_uri` (llm-d extension).
+   only the returned URI as `llm_d.payload.storage_uri` (llm-d extension).
 6. Repeats steps 1–5 for the response completion (`gen_ai.output.messages`) after the full
    response is assembled.
 
@@ -142,25 +142,27 @@ JSON string. Each message is `{role, parts: [...]}`, where each part has a `type
 `finish_reason`. See [Non-Text and Multimodal Payloads](#non-text-and-multimodal-payloads)
 for how media parts are represented.
 
-The offload and truncation markers below have **no upstream equivalent** and are explicit
-llm-d extensions, prefixed `gen_ai.content.*`. We will adopt standard names if and when
-the GenAI conventions define them.
+The offload and truncation markers below have **no upstream equivalent** — the GenAI
+registry defines no `gen_ai.content.*` namespace and no storage/offload attribute of any
+kind. To avoid squatting on OTel's reserved `gen_ai.*` namespace, they are namespaced as
+explicit llm-d extensions under `llm_d.payload.*`. We will migrate to standard names if
+and when the GenAI conventions define equivalents.
 
 | Attribute | Source | Value |
 |---|---|---|
-| `gen_ai.input.messages` | upstream | Structured request messages (role/parts), text-only skeleton with non-text parts replaced by `$ref` markers (omitted when the whole payload is offloaded) |
-| `gen_ai.output.messages` | upstream | Structured response messages (role/parts/finish_reason), same skeleton treatment |
+| `gen_ai.input.messages` | upstream | Structured request messages (role/parts); offloaded `blob` parts are rewritten in place as standard `uri` parts (omitted when the whole payload is offloaded) |
+| `gen_ai.output.messages` | upstream | Structured response messages (role/parts/finish_reason), same `blob`→`uri` rewrite |
 | `gen_ai.system_instructions` | upstream | System message(s) supplied separately from the chat history |
-| `gen_ai.content.storage_uri` | **llm-d extension** | Object store URI for the full text payload (present only when offloaded) |
-| `gen_ai.content.media_uris` | **llm-d extension** | Array of object store URIs for non-text content parts (present when the payload contains any non-text media) |
-| `gen_ai.content.truncated` | **llm-d extension** | `true` when content was dropped/truncated (see below) |
+| `llm_d.payload.storage_uri` | **llm-d extension** | Object store URI for the full text payload (present only when offloaded) |
+| `llm_d.payload.media_uris` | **llm-d extension** | Array of object store URIs for non-text content parts (present when the payload contains any non-text media) |
+| `llm_d.payload.truncated` | **llm-d extension** | `true` when content was dropped/truncated (see below) |
 
 `gen_ai.input.messages` (with `gen_ai.system_instructions`) is recorded on the input span
 event; `gen_ai.output.messages` on the output span event. When the payload is truncated
-due to `maxCompletionBufferBytes` being exceeded, or when a non-text part is dropped
+due to `maxCompletionBufferBytes` being exceeded, or when a `blob` part is dropped
 because the configured offload target cannot return a resolvable URI (see
 [Non-Text and Multimodal Payloads](#non-text-and-multimodal-payloads) for the cases that
-produce this), the event additionally carries `gen_ai.content.truncated: true`.
+produce this), the event additionally carries `llm_d.payload.truncated: true`.
 `backend: noop` is distinct: it is the no-event-at-all kill switch and records none of
 these attributes.
 
@@ -170,42 +172,54 @@ Modern chat APIs accept multimodal content parts within a single request — Ope
 Chat Completions `image_url` and `input_audio` parts, vLLM `multi_modal_data`, and
 similar shapes from other engines. The upstream GenAI convention models these as typed
 parts inside each message's `parts[]` array (see the
-[input-messages JSON schema](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-input-messages.json)),
-so llm-d maps engine-native multimodal parts onto that structure. The OTel attribute type
-system permits strings, numbers, bools, and arrays of those — it does **not** permit
-opaque bytes, and span backends do not tolerate multi-megabyte attribute strings. Log
-records are unsuitable for the same reason and lack a standard span-to-payload linking
-convention. Non-text parts must therefore live in object storage and be referenced by
-URI; this section specifies how.
+[input-messages JSON schema](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-input-messages.json)).
+The schema defines three media-bearing part types, each carrying a `mime_type` (IANA
+media type) and a `modality` (`image` | `video` | `audio`):
+
+| `type` | Carries | llm-d handling |
+|---|---|---|
+| `blob` | Raw bytes inline (`content`) | **Offloaded** — see below |
+| `file` | A provider pre-upload reference (`file_id`) | Recorded as-is (no bytes to offload) |
+| `uri` | An external reference (`uri`) | Recorded as-is; not re-fetched |
+
+llm-d maps engine-native multimodal parts onto these types (e.g. OpenAI `image_url`
+with a data-URL → `blob`; `image_url` with an `https://` URL → `uri`). The OTel
+attribute type system permits strings, numbers, bools, and arrays of those — it does
+**not** permit the opaque bytes a `blob` part carries, and span backends do not tolerate
+multi-megabyte attribute strings. Log records are unsuitable for the same reason and lack
+a standard span-to-payload linking convention. `blob` parts must therefore live in object
+storage and be referenced by URI; this section specifies how.
 
 The capture pipeline handles non-text content as follows:
 
-1. The serialiser walks the request / response structure and identifies content parts
-   whose `type` is not `text` (or, in engine-native shapes, parts that carry binary
-   media regardless of declared type).
-2. Each non-text part is **always offloaded** to the configured `PayloadStore`,
+1. The serialiser walks the request / response `parts[]` and classifies each part by its
+   `type`. `text` (and `reasoning`) parts stay inline; `blob` parts are offload
+   candidates; `file` and `uri` parts are already references and are kept as-is.
+2. Each `blob` part is **always offloaded** to the configured `PayloadStore`,
    regardless of `inlineSizeThresholdBytes`. The inline threshold continues to apply
    only to the text portion.
-3. In the serialised payload that the span event carries, every non-text part is
-   replaced by a `$ref` marker of the form
-   `{"$ref": "<storage_uri>", "media_type": "image/png", "size_bytes": 12345}`.
-   The resulting text-only skeleton is then subject to the normal inline-vs-offload
-   decision against `inlineSizeThresholdBytes`.
-4. The event additionally carries `gen_ai.content.media_uris`: an ordered array of the
-   storage URIs produced for that request or completion. Consumers that only need to
-   locate media can read this attribute without re-parsing the skeleton.
-5. URL-reference parts (e.g. `image_url` pointing to a public CDN) are recorded in
-   `gen_ai.content.media_uris` as-is and are **not** re-fetched by llm-d; the redaction
-   pipeline still runs against the URL string itself.
+3. In the serialised payload that the span event carries, every offloaded `blob` part is
+   **rewritten in place as a standard `uri` part** — its `content` (raw bytes) is
+   replaced by the object-store `uri`, while the original `mime_type` and `modality` are
+   preserved. The result is therefore still a schema-valid `parts[]` array that any
+   OTel-native consumer can read without understanding an llm-d-specific marker. The
+   resulting text-only skeleton is then subject to the normal inline-vs-offload decision
+   against `inlineSizeThresholdBytes`.
+4. As a convenience, the event additionally carries `llm_d.payload.media_uris`: a flat,
+   ordered array mirroring the object-store URIs of the rewritten parts, so consumers
+   that only need to locate media can read one attribute without walking `parts[]`.
+5. `file` parts (`file_id`) and `uri` parts pointing at an external store (e.g. a public
+   CDN) are recorded as-is and are **not** re-fetched or re-uploaded by llm-d; the
+   redaction pipeline still runs against the `file_id` / `uri` string itself.
 6. `backend: noop` short-circuits the entire payload pipeline: no
-   `gen_ai.content.*` events are emitted at all, and steps 1–5 above are skipped.
+   `llm_d.payload.*` events are emitted at all, and steps 1–5 above are skipped.
    Operators who want capture *disabled* should leave `payloadCapture.enabled: false`;
    `backend: noop` exists as a secondary kill switch for the case where `enabled` must
    stay `true` for other reasons (e.g. shared overlay) but this particular component
    should produce nothing.
-7. When the primary `backend` is `inline` (which cannot store binary), the non-text
+7. When the primary `backend` is `inline` (which cannot store binary), the `blob`
    part is routed to the backend named in `offloadBackend`. If `offloadBackend` is
-   empty or unset, the part is dropped with `gen_ai.content.truncated: true` on the
+   empty or unset, the part is dropped with `llm_d.payload.truncated: true` on the
    emitted event, the text skeleton is still emitted so text-based debugging continues
    to work, and the request itself is not failed. Operators selecting `backend: inline`
    while expecting multimodal capture must therefore configure a non-empty
@@ -213,18 +227,18 @@ The capture pipeline handles non-text content as follows:
    validation logs a warning when this combination would silently drop media.
 
 The object-store path convention is extended to encode part index and media type so
-that text and non-text payloads for the same span do not collide:
+that text and `blob` payloads for the same span do not collide:
 
 ```
 {prefix}/{YYYY}/{MM}/{DD}/{traceID}/{spanID}-{kind}.json                 # full text payload
-{prefix}/{YYYY}/{MM}/{DD}/{traceID}/{spanID}-{kind}-{partIndex}.{ext}    # non-text part
+{prefix}/{YYYY}/{MM}/{DD}/{traceID}/{spanID}-{kind}-{partIndex}.{ext}    # offloaded blob part
 ```
 
-`{ext}` is derived from the part's declared media type (`png`, `jpg`, `webp`, `wav`,
-`mp3`, `pcm`, …) with `bin` as the fallback when the type is unknown. The redaction
-pipeline runs against the text skeleton only; binary parts are stored as received,
-and operators relying on redaction for compliance should either disable multimodal
-capture or apply DLP at the object-store layer.
+`{ext}` is derived from the part's `mime_type` (`image/png`→`png`, `audio/wav`→`wav`,
+…) with `bin` as the fallback when the type is unknown. The redaction pipeline runs
+against the text skeleton only; `blob` bytes are stored as received, and operators
+relying on redaction for compliance should either disable multimodal capture or apply
+DLP at the object-store layer.
 
 **Per-part size cap (`maxNonTextPartBytes`).** Defaults to 8 MiB (`8388608`). The
 value is chosen to sit comfortably above the per-image caps of common hosted APIs
@@ -235,7 +249,7 @@ request with several 4 MiB images is fully captured under the default. Operators
 should tune this for their workload: lower it (e.g. 2 MiB) when the dominant media
 type is photos at moderate resolution and storage cost matters, or raise it (up to
 ~25 MiB) when serving audio clips or large image inputs through Gemini/OpenAI
-upstreams. Parts exceeding the cap are dropped with `gen_ai.content.truncated: true`
+upstreams. Parts exceeding the cap are dropped with `llm_d.payload.truncated: true`
 rather than truncated mid-stream, since binary truncation produces undecodable artifacts.
 
 ### Capture Layers
@@ -284,7 +298,7 @@ Backend selection via `payloadCapture.backend`:
 
 | Value | Behaviour |
 |---|---|
-| `noop` (default) | Drop silently. No `gen_ai.content.*` events of any kind are emitted on the span — neither for text nor for non-text parts, and `gen_ai.content.truncated` is never set. This is the secondary kill switch and short-circuits the entire capture pipeline (see step 6 of [Non-Text and Multimodal Payloads](#non-text-and-multimodal-payloads)) |
+| `noop` (default) | Drop silently. No `llm_d.payload.*` events of any kind are emitted on the span — neither for text nor for non-text parts, and `llm_d.payload.truncated` is never set. This is the secondary kill switch and short-circuits the entire capture pipeline (see step 6 of [Non-Text and Multimodal Payloads](#non-text-and-multimodal-payloads)) |
 | `inline` | Attach to OTel event attribute; auto-offload if above threshold |
 | `gcs` | Upload to GCS, emit `gs://bucket/path` URI |
 | `s3` | Upload to S3-compatible store, emit `s3://bucket/path` URI |
@@ -315,7 +329,7 @@ on error the payload is truncated rather than forwarded unredacted.
 
 SSE responses are buffered in memory up to `maxCompletionBufferBytes` (default 256 KB)
 before the completion event is emitted. If the buffer limit is reached, the event is
-emitted with the buffered content and `gen_ai.content.truncated: true`; the response
+emitted with the buffered content and `llm_d.payload.truncated: true`; the response
 stream continues unaffected.
 
 ### Configuration

--- a/docs/proposals/genai-payload-events.md
+++ b/docs/proposals/genai-payload-events.md
@@ -52,7 +52,7 @@ custom parsing.
   multimodal requests) to object storage regardless of the inline threshold, and expose
   the resulting URIs via a dedicated event attribute so consumers can locate media
   without parsing the payload skeleton.
-- Provide a pluggable storage interface with four built-in backends: `noop` (default),
+- Provide a pluggable storage interface with five built-in backends: `noop` (default),
   `inline`, `gcs`, `s3`, and `filesystem`.
 - Expose an opt-in redaction pipeline (configurable regex patterns + optional external
   DLP webhook) that runs before any payload reaches a backend.
@@ -118,8 +118,17 @@ injected) so that I can confirm whether retrieval or generation was the failure 
 
 ### OTel Event Specification
 
-Per [semconv#2010](https://github.com/open-telemetry/semantic-conventions/issues/2010),
-payload events are emitted on the **same span** that represents the LLM call.
+Per [semconv#2010](https://github.com/open-telemetry/semantic-conventions/issues/2010)
+(now closed; GenAI conventions have moved to the dedicated
+[semantic-conventions-genai](https://github.com/open-telemetry/semantic-conventions-genai)
+repository), payload events are emitted on the **same span** that represents the LLM
+call. Attribute names prefixed `gen_ai.content.*` that are **not yet defined** in the
+upstream GenAI semantic conventions are marked below as *(llm-d extension)*; we will
+track upstream as the GenAI conventions stabilise and rename these attributes to match
+once standard names exist. This includes `gen_ai.content.media_uris`,
+`gen_ai.content.storage_uri`, and `gen_ai.content.truncated`. The base event names
+(`gen_ai.content.prompt`, `gen_ai.content.completion`) and the inlined-text payload
+attributes (`gen_ai.prompt`, `gen_ai.completion`) follow the upstream spec.
 
 **Prompt event**
 
@@ -127,8 +136,8 @@ payload events are emitted on the **same span** that represents the LLM call.
 |---|---|
 | Event name | `gen_ai.content.prompt` |
 | `gen_ai.prompt` | Serialised messages / prompt JSON, text-only skeleton with non-text parts replaced by `$ref` markers (omitted when the whole payload is offloaded) |
-| `gen_ai.content.storage_uri` | Object store URI for the full text payload (present only when offloaded) |
-| `gen_ai.content.media_uris` | Array of object store URIs for non-text content parts (present when the request contains any non-text media) |
+| `gen_ai.content.storage_uri` *(llm-d extension)* | Object store URI for the full text payload (present only when offloaded) |
+| `gen_ai.content.media_uris` *(llm-d extension)* | Array of object store URIs for non-text content parts (present when the request contains any non-text media) |
 
 **Completion event**
 
@@ -136,8 +145,8 @@ payload events are emitted on the **same span** that represents the LLM call.
 |---|---|
 | Event name | `gen_ai.content.completion` |
 | `gen_ai.completion` | Serialised choices JSON, text-only skeleton with non-text parts replaced by `$ref` markers (omitted when the whole payload is offloaded) |
-| `gen_ai.content.storage_uri` | Object store URI for the full text payload (present only when offloaded) |
-| `gen_ai.content.media_uris` | Array of object store URIs for non-text content parts (present when the completion contains any non-text media) |
+| `gen_ai.content.storage_uri` *(llm-d extension)* | Object store URI for the full text payload (present only when offloaded) |
+| `gen_ai.content.media_uris` *(llm-d extension)* | Array of object store URIs for non-text content parts (present when the completion contains any non-text media) |
 
 When the payload is truncated due to `maxCompletionBufferBytes` being exceeded, or when
 a non-text part is dropped because the configured backend cannot return a resolvable URI
@@ -177,6 +186,13 @@ The capture pipeline handles non-text content as follows:
    non-text parts are dropped, `gen_ai.content.truncated: true` is set on the event,
    and the text skeleton is still emitted so that text-based debugging continues to
    work.
+7. When the primary `backend` is `inline` (which cannot store binary), the non-text
+   part is routed to the backend named in `offloadBackend`. If `offloadBackend` is
+   empty or unset, the part is dropped with `gen_ai.content.truncated: true` rather
+   than failing the request. Operators selecting `backend: inline` while expecting
+   multimodal capture must therefore configure a non-empty `offloadBackend` (one of
+   `gcs`, `s3`, or `filesystem`); startup configuration validation logs a warning
+   when this combination would silently drop media.
 
 The object-store path convention is extended to encode part index and media type so
 that text and non-text payloads for the same span do not collide:

--- a/docs/proposals/genai-payload-events.md
+++ b/docs/proposals/genai-payload-events.md
@@ -272,7 +272,7 @@ Backend selection via `payloadCapture.backend`:
 
 | Value | Behaviour |
 |---|---|
-| `noop` (default) | Drop silently; no event emitted |
+| `noop` (default) | Drop silently. No `gen_ai.content.*` events of any kind are emitted on the span — neither for text nor for non-text parts, and `gen_ai.content.truncated` is never set. This is the secondary kill switch and short-circuits the entire capture pipeline (see step 6 of [Non-Text and Multimodal Payloads](#non-text-and-multimodal-payloads)) |
 | `inline` | Attach to OTel event attribute; auto-offload if above threshold |
 | `gcs` | Upload to GCS, emit `gs://bucket/path` URI |
 | `s3` | Upload to S3-compatible store, emit `s3://bucket/path` URI |

--- a/docs/proposals/genai-payload-events.md
+++ b/docs/proposals/genai-payload-events.md
@@ -3,11 +3,16 @@
 ## Summary
 
 Extend llm-d's existing OpenTelemetry distributed tracing to optionally capture full
-LLM prompts and completions as OTel span events, following the upstream
-[open-telemetry/semantic-conventions#2010](https://github.com/open-telemetry/semantic-conventions/issues/2010)
-specification. Payloads above a configurable size threshold are offloaded to an object
-storage backend (GCS, S3, or local filesystem) with only a reference URI stored on the
-span. Non-text content parts (images, audio, and other binary media in multimodal
+LLM prompts and completions, following the upstream
+[GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) —
+specifically the `gen_ai.input.messages`, `gen_ai.output.messages`, and
+`gen_ai.system_instructions` attributes, recorded in structured form on a span event
+(per the convention, message content is recorded on events/logs and serialised to a JSON
+string when attached to a span). These attributes are `Opt-In` and at `Development`
+stability upstream, and are flagged as likely to contain sensitive data — they are never
+captured by default. Payloads above a configurable size threshold are offloaded to an
+object storage backend (GCS, S3, or local filesystem) with only a reference URI stored on
+the span. Non-text content parts (images, audio, and other binary media in multimodal
 requests) are always offloaded — they cannot be carried as OTel attributes — and are
 referenced from the span by URI regardless of the inline threshold. The feature is
 disabled by default and requires explicit opt-in, preserving the existing metadata-only
@@ -33,18 +38,20 @@ visibility that cannot be satisfied by token counts and latency metadata alone:
   multimodal requests are increasingly common drivers of latency and quality issues,
   and cannot be reconstructed from token metadata alone.
 
-The upstream OTel semantic-conventions community chose an **event-based model** (not span
-attributes) specifically to decouple large payload data from the lightweight span record.
-Even so, event attributes are typed as strings/numbers/bools/arrays and cannot carry
-opaque bytes; non-text payloads must therefore be offloaded to object storage and
-referenced by URI, never inlined in a span or a log record. Implementing against the
-upstream spec makes llm-d payload data consumable by any OTel-native tooling without
-custom parsing.
+The upstream GenAI conventions record message content as **structured attributes on a
+span event or log record** (`gen_ai.input.messages` / `gen_ai.output.messages`), rather
+than as attributes on the span itself, specifically to decouple large payload data from
+the lightweight span record. Even so, these attributes are typed as
+strings/numbers/bools/arrays and cannot carry opaque bytes; non-text payloads (images,
+audio) can be carried **neither on a span nor in a log record** and must therefore be
+offloaded to object storage and referenced by URI. Implementing against the upstream spec
+makes llm-d payload data consumable by any OTel-native tooling without custom parsing.
 
 ### Goals
 
-- Emit `gen_ai.content.prompt` and `gen_ai.content.completion` OTel events on the
-  relevant span following the upstream semantic convention.
+- Record `gen_ai.input.messages`, `gen_ai.output.messages`, and
+  `gen_ai.system_instructions` on a span event for the LLM call, following the upstream
+  GenAI semantic convention.
 - Inline small text payloads (≤ configurable threshold, default 4 KB) directly on the
   event attribute; offload larger text payloads to object storage and record only a
   reference URI.
@@ -81,18 +88,22 @@ see no change in behaviour or performance.
 
 When enabled, the relevant llm-d component:
 
-1. Serialises the request messages / prompt to JSON.
+1. Serialises the request messages into the upstream `gen_ai.input.messages` structure
+   (an array of role/parts messages; system content is split out to
+   `gen_ai.system_instructions`).
 2. Passes the JSON through the configured redaction pipeline.
 3. Compares the byte length against `inlineSizeThresholdBytes` (default 4 096).
-4. If within threshold → attaches the JSON as a `gen_ai.prompt` attribute on a
-   `gen_ai.content.prompt` OTel event on the active span.
+4. If within threshold → attaches the structured messages as the `gen_ai.input.messages`
+   attribute on a span event for the active LLM span (serialised to a JSON string, per the
+   convention's rule for recording messages on spans).
 5. If above threshold → uploads to the configured `PayloadStore` backend and attaches
-   only the returned URI as `gen_ai.content.storage_uri`.
-6. Repeats steps 1–5 for the response completion after the full response is assembled.
+   only the returned URI as `gen_ai.content.storage_uri` (llm-d extension).
+6. Repeats steps 1–5 for the response completion (`gen_ai.output.messages`) after the full
+   response is assembled.
 
-Success is measured by: (a) `gen_ai.content.prompt` / `gen_ai.content.completion` events
-appearing in Jaeger traces when enabled, (b) object-store objects appearing at the
-expected path, (c) no measurable latency increase on sampled requests when disabled.
+Success is measured by: (a) `gen_ai.input.messages` / `gen_ai.output.messages` attributes
+appearing on span events in Jaeger traces when enabled, (b) object-store objects appearing
+at the expected path, (c) no measurable latency increase on sampled requests when disabled.
 
 ### User Stories
 
@@ -116,55 +127,56 @@ injected) so that I can confirm whether retrieval or generation was the failure 
 
 ## Design Details
 
-### OTel Event Specification
+### OTel Attribute Specification
 
-Per [semconv#2010](https://github.com/open-telemetry/semantic-conventions/issues/2010)
-(now closed; GenAI conventions have moved to the dedicated
-[semantic-conventions-genai](https://github.com/open-telemetry/semantic-conventions-genai)
-repository), payload events are emitted on the **same span** that represents the LLM
-call. Attribute names prefixed `gen_ai.content.*` that are **not yet defined** in the
-upstream GenAI semantic conventions are marked below as *(llm-d extension)*; we will
-track upstream as the GenAI conventions stabilise and rename these attributes to match
-once standard names exist. This includes `gen_ai.content.media_uris`,
-`gen_ai.content.storage_uri`, and `gen_ai.content.truncated`. The base event names
-(`gen_ai.content.prompt`, `gen_ai.content.completion`) and the inlined-text payload
-attributes (`gen_ai.prompt`, `gen_ai.completion`) follow the upstream spec.
+Payload content is recorded using the current upstream
+[GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) —
+`gen_ai.input.messages`, `gen_ai.output.messages`, and `gen_ai.system_instructions`
+([attribute registry](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/)).
+These attributes are `Opt-In` and at `Development` stability upstream; they may still
+change, so this proposal tracks them rather than pinning a frozen copy. Per the
+convention, message content is recorded **in structured form on a span event or log
+record** attached to the LLM span; when recorded on the span itself it is serialised to a
+JSON string. Each message is `{role, parts: [...]}`, where each part has a `type`
+(`text`, `tool_call`, `tool_call_response`, …); output messages additionally carry a
+`finish_reason`. See [Non-Text and Multimodal Payloads](#non-text-and-multimodal-payloads)
+for how media parts are represented.
 
-**Prompt event**
+The offload and truncation markers below have **no upstream equivalent** and are explicit
+llm-d extensions, prefixed `gen_ai.content.*`. We will adopt standard names if and when
+the GenAI conventions define them.
 
-| Field | Value |
-|---|---|
-| Event name | `gen_ai.content.prompt` |
-| `gen_ai.prompt` | Serialised messages / prompt JSON, text-only skeleton with non-text parts replaced by `$ref` markers (omitted when the whole payload is offloaded) |
-| `gen_ai.content.storage_uri` *(llm-d extension)* | Object store URI for the full text payload (present only when offloaded) |
-| `gen_ai.content.media_uris` *(llm-d extension)* | Array of object store URIs for non-text content parts (present when the request contains any non-text media) |
+| Attribute | Source | Value |
+|---|---|---|
+| `gen_ai.input.messages` | upstream | Structured request messages (role/parts), text-only skeleton with non-text parts replaced by `$ref` markers (omitted when the whole payload is offloaded) |
+| `gen_ai.output.messages` | upstream | Structured response messages (role/parts/finish_reason), same skeleton treatment |
+| `gen_ai.system_instructions` | upstream | System message(s) supplied separately from the chat history |
+| `gen_ai.content.storage_uri` | **llm-d extension** | Object store URI for the full text payload (present only when offloaded) |
+| `gen_ai.content.media_uris` | **llm-d extension** | Array of object store URIs for non-text content parts (present when the payload contains any non-text media) |
+| `gen_ai.content.truncated` | **llm-d extension** | `true` when content was dropped/truncated (see below) |
 
-**Completion event**
-
-| Field | Value |
-|---|---|
-| Event name | `gen_ai.content.completion` |
-| `gen_ai.completion` | Serialised choices JSON, text-only skeleton with non-text parts replaced by `$ref` markers (omitted when the whole payload is offloaded) |
-| `gen_ai.content.storage_uri` *(llm-d extension)* | Object store URI for the full text payload (present only when offloaded) |
-| `gen_ai.content.media_uris` *(llm-d extension)* | Array of object store URIs for non-text content parts (present when the completion contains any non-text media) |
-
-When the payload is truncated due to `maxCompletionBufferBytes` being exceeded, or when
-a non-text part is dropped because the configured offload target cannot return a
-resolvable URI (see [Non-Text and Multimodal Payloads](#non-text-and-multimodal-payloads)
-for the cases that produce this), the event additionally carries
-`gen_ai.content.truncated: true`. `backend: noop` is distinct: it is the
-no-event-at-all kill switch and emits no `gen_ai.content.*` events of any kind.
+`gen_ai.input.messages` (with `gen_ai.system_instructions`) is recorded on the input span
+event; `gen_ai.output.messages` on the output span event. When the payload is truncated
+due to `maxCompletionBufferBytes` being exceeded, or when a non-text part is dropped
+because the configured offload target cannot return a resolvable URI (see
+[Non-Text and Multimodal Payloads](#non-text-and-multimodal-payloads) for the cases that
+produce this), the event additionally carries `gen_ai.content.truncated: true`.
+`backend: noop` is distinct: it is the no-event-at-all kill switch and records none of
+these attributes.
 
 ### Non-Text and Multimodal Payloads
 
 Modern chat APIs accept multimodal content parts within a single request — OpenAI
 Chat Completions `image_url` and `input_audio` parts, vLLM `multi_modal_data`, and
-similar shapes from other engines. The OTel attribute type system permits strings,
-numbers, bools, and arrays of those — it does **not** permit opaque bytes, and span
-backends do not tolerate multi-megabyte attribute strings. Log records are unsuitable
-for the same reason and lack a standard span-to-payload linking convention. Non-text
-parts must therefore live in object storage and be referenced by URI; this section
-specifies how.
+similar shapes from other engines. The upstream GenAI convention models these as typed
+parts inside each message's `parts[]` array (see the
+[input-messages JSON schema](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-input-messages.json)),
+so llm-d maps engine-native multimodal parts onto that structure. The OTel attribute type
+system permits strings, numbers, bools, and arrays of those — it does **not** permit
+opaque bytes, and span backends do not tolerate multi-megabyte attribute strings. Log
+records are unsuitable for the same reason and lack a standard span-to-payload linking
+convention. Non-text parts must therefore live in object storage and be referenced by
+URI; this section specifies how.
 
 The capture pipeline handles non-text content as follows:
 
@@ -350,10 +362,14 @@ Equivalent environment variables: `LLMD_PAYLOAD_CAPTURE_ENABLED`, `LLMD_PAYLOAD_
 
 ### OTel Collector Pipeline
 
-A new `traces/payloads` pipeline filters for `gen_ai.content.*` events and routes them
-to a dedicated exporter (filesystem or OTLP bridge for GCS/S3). The existing
-`traces` pipeline is unchanged. The redaction processor can additionally be placed in
-the collector as a defence-in-depth layer.
+An optional `traces/payloads` pipeline keeps only the span events that carry
+`gen_ai.input.messages` / `gen_ai.output.messages` (an event-level filter — it drops
+non-payload span events, not whole spans) and routes them to a dedicated exporter
+(filesystem or OTLP bridge for GCS/S3). It is added to the existing collector recipe at
+[`guides/recipes/observability/tracing/otel-collector.yaml`](../../guides/recipes/observability/tracing/otel-collector.yaml)
+as commented, opt-in blocks — the default `traces` pipeline is unchanged, so operators
+who do not enable payload capture see identical behaviour. The `redaction` processor can
+additionally be placed in the collector as a defence-in-depth layer.
 
 ### Security
 
@@ -376,7 +392,21 @@ Workload Identity / IRSA bindings or Kubernetes Secrets mounted as environment v
 
 ### Phased Implementation
 
-**Phase 1 — Interface and noop/inline backends (this proposal)**
+**Ownership.** The Go `PayloadStore` interface and the `noop`/`inline`/`gcs`/`s3`/
+`filesystem` backends are owned by the **gateway / EPP** (`inferenceExtension`), where the
+request body is already parsed and the active span is in scope — this is the component
+that implements the interface for Phases 1–3. The vLLM native integration (Phase 4) is a
+**Python mirror** of the same interface owned by the model-server / vLLM integration, not
+a second Go implementation; it reuses the same attribute spec and object-store path
+convention so consumers see one format regardless of capture layer.
+
+**Concrete next steps** (assuming the design is approved): land Phase 1 as the first
+implementation PR — the `PayloadStore` interface, `NoopStore` + `InlineStore`, the
+`enabled` wiring in the gateway, the Kustomize opt-in surface, and unit tests — then
+proceed through Phases 2–4 in order. Each phase is independently shippable behind the
+default-off `payloadCapture.enabled` flag.
+
+**Phase 1 — Interface and noop/inline backends (first implementation PR)**
 - `PayloadStore` interface in `pkg/telemetry/payload_store.go` (Go)
 - `NoopStore` and `InlineStore` implementations
 - Wire into gateway `server.go` `Process()` method behind the `enabled` flag

--- a/docs/proposals/genai-payload-events.md
+++ b/docs/proposals/genai-payload-events.md
@@ -208,6 +208,18 @@ pipeline runs against the text skeleton only; binary parts are stored as receive
 and operators relying on redaction for compliance should either disable multimodal
 capture or apply DLP at the object-store layer.
 
+**Per-part size cap (`maxNonTextPartBytes`).** Defaults to 8 MiB (`8388608`). The
+value is chosen to sit comfortably above the per-image caps of common hosted APIs
+that llm-d typically fronts (Anthropic Claude vision: 5 MiB inline; OpenAI and Google
+Gemini: 20 MiB inline) while still bounding worst-case object-store write amplification
+for high-volume inference traffic. The cap is per part, not per request, so a multi-image
+request with several 4 MiB images is fully captured under the default. Operators
+should tune this for their workload: lower it (e.g. 2 MiB) when the dominant media
+type is photos at moderate resolution and storage cost matters, or raise it (up to
+~25 MiB) when serving audio clips or large image inputs through Gemini/OpenAI
+upstreams. Parts exceeding the cap are dropped with `gen_ai.content.truncated: true`
+rather than truncated mid-stream, since binary truncation produces undecodable artifacts.
+
 ### Capture Layers
 
 Payload events are attached to spans at the following layers, with vLLM preferred when
@@ -306,7 +318,9 @@ inferenceExtension:
     maxCompletionBufferBytes: 262144
     captureNonTextParts: true           # set false to drop non-text media instead of
                                         # storing it (text skeleton + truncated:true)
-    maxNonTextPartBytes: 8388608        # per-part cap for image/audio/binary uploads
+    maxNonTextPartBytes: 8388608        # 8 MiB per-part cap; tune per deployment —
+                                        # see "Non-Text and Multimodal Payloads" for
+                                        # the rationale behind the default
     gcs:
       bucket: ""
       prefix: "llm-d/payloads"

--- a/docs/proposals/genai-payload-events.md
+++ b/docs/proposals/genai-payload-events.md
@@ -7,8 +7,11 @@ LLM prompts and completions as OTel span events, following the upstream
 [open-telemetry/semantic-conventions#2010](https://github.com/open-telemetry/semantic-conventions/issues/2010)
 specification. Payloads above a configurable size threshold are offloaded to an object
 storage backend (GCS, S3, or local filesystem) with only a reference URI stored on the
-span. The feature is disabled by default and requires explicit opt-in, preserving the
-existing metadata-only privacy posture for operators who do not need payload visibility.
+span. Non-text content parts (images, audio, and other binary media in multimodal
+requests) are always offloaded — they cannot be carried as OTel attributes — and are
+referenced from the span by URI regardless of the inline threshold. The feature is
+disabled by default and requires explicit opt-in, preserving the existing metadata-only
+privacy posture for operators who do not need payload visibility.
 
 This proposal extends [distributed-tracing.md](distributed-tracing.md).
 
@@ -26,18 +29,29 @@ visibility that cannot be satisfied by token counts and latency metadata alone:
   requires inspecting the assembled prompt.
 - **Cost attribution** — understanding *what* drove high token usage requires the content,
   not just the count.
+- **Multimodal request inspection** — image, audio, and other non-text parts in
+  multimodal requests are increasingly common drivers of latency and quality issues,
+  and cannot be reconstructed from token metadata alone.
 
 The upstream OTel semantic-conventions community chose an **event-based model** (not span
 attributes) specifically to decouple large payload data from the lightweight span record.
-Implementing against that spec makes llm-d payload data consumable by any OTel-native
-tooling without custom parsing.
+Even so, event attributes are typed as strings/numbers/bools/arrays and cannot carry
+opaque bytes; non-text payloads must therefore be offloaded to object storage and
+referenced by URI, never inlined in a span or a log record. Implementing against the
+upstream spec makes llm-d payload data consumable by any OTel-native tooling without
+custom parsing.
 
 ### Goals
 
 - Emit `gen_ai.content.prompt` and `gen_ai.content.completion` OTel events on the
   relevant span following the upstream semantic convention.
-- Inline small payloads (≤ configurable threshold, default 4 KB) directly on the event
-  attribute; offload larger payloads to object storage and record only a reference URI.
+- Inline small text payloads (≤ configurable threshold, default 4 KB) directly on the
+  event attribute; offload larger text payloads to object storage and record only a
+  reference URI.
+- Always offload non-text content parts (image / audio / other binary media in
+  multimodal requests) to object storage regardless of the inline threshold, and expose
+  the resulting URIs via a dedicated event attribute so consumers can locate media
+  without parsing the payload skeleton.
 - Provide a pluggable storage interface with four built-in backends: `noop` (default),
   `inline`, `gcs`, `s3`, and `filesystem`.
 - Expose an opt-in redaction pipeline (configurable regex patterns + optional external
@@ -112,19 +126,71 @@ payload events are emitted on the **same span** that represents the LLM call.
 | Field | Value |
 |---|---|
 | Event name | `gen_ai.content.prompt` |
-| `gen_ai.prompt` | Serialised messages / prompt JSON (omitted when offloaded) |
-| `gen_ai.content.storage_uri` | Object store URI (present only when offloaded) |
+| `gen_ai.prompt` | Serialised messages / prompt JSON, text-only skeleton with non-text parts replaced by `$ref` markers (omitted when the whole payload is offloaded) |
+| `gen_ai.content.storage_uri` | Object store URI for the full text payload (present only when offloaded) |
+| `gen_ai.content.media_uris` | Array of object store URIs for non-text content parts (present when the request contains any non-text media) |
 
 **Completion event**
 
 | Field | Value |
 |---|---|
 | Event name | `gen_ai.content.completion` |
-| `gen_ai.completion` | Serialised choices JSON (omitted when offloaded) |
-| `gen_ai.content.storage_uri` | Object store URI (present only when offloaded) |
+| `gen_ai.completion` | Serialised choices JSON, text-only skeleton with non-text parts replaced by `$ref` markers (omitted when the whole payload is offloaded) |
+| `gen_ai.content.storage_uri` | Object store URI for the full text payload (present only when offloaded) |
+| `gen_ai.content.media_uris` | Array of object store URIs for non-text content parts (present when the completion contains any non-text media) |
 
-When the payload is truncated due to `maxCompletionBufferBytes` being exceeded, the event
-additionally carries `gen_ai.content.truncated: true`.
+When the payload is truncated due to `maxCompletionBufferBytes` being exceeded, or when
+a non-text part is dropped because the configured backend cannot return a resolvable URI
+(e.g. `noop`), the event additionally carries `gen_ai.content.truncated: true`.
+
+### Non-Text and Multimodal Payloads
+
+Modern chat APIs accept multimodal content parts within a single request — OpenAI
+Chat Completions `image_url` and `input_audio` parts, vLLM `multi_modal_data`, and
+similar shapes from other engines. The OTel attribute type system permits strings,
+numbers, bools, and arrays of those — it does **not** permit opaque bytes, and span
+backends do not tolerate multi-megabyte attribute strings. Log records are unsuitable
+for the same reason and lack a standard span-to-payload linking convention. Non-text
+parts must therefore live in object storage and be referenced by URI; this section
+specifies how.
+
+The capture pipeline handles non-text content as follows:
+
+1. The serialiser walks the request / response structure and identifies content parts
+   whose `type` is not `text` (or, in engine-native shapes, parts that carry binary
+   media regardless of declared type).
+2. Each non-text part is **always offloaded** to the configured `PayloadStore`,
+   regardless of `inlineSizeThresholdBytes`. The inline threshold continues to apply
+   only to the text portion.
+3. In the serialised payload that the span event carries, every non-text part is
+   replaced by a `$ref` marker of the form
+   `{"$ref": "<storage_uri>", "media_type": "image/png", "size_bytes": 12345}`.
+   The resulting text-only skeleton is then subject to the normal inline-vs-offload
+   decision against `inlineSizeThresholdBytes`.
+4. The event additionally carries `gen_ai.content.media_uris`: an ordered array of the
+   storage URIs produced for that request or completion. Consumers that only need to
+   locate media can read this attribute without re-parsing the skeleton.
+5. URL-reference parts (e.g. `image_url` pointing to a public CDN) are recorded in
+   `gen_ai.content.media_uris` as-is and are **not** re-fetched by llm-d; the redaction
+   pipeline still runs against the URL string itself.
+6. When the backend is `noop` — or any backend that cannot return a resolvable URI —
+   non-text parts are dropped, `gen_ai.content.truncated: true` is set on the event,
+   and the text skeleton is still emitted so that text-based debugging continues to
+   work.
+
+The object-store path convention is extended to encode part index and media type so
+that text and non-text payloads for the same span do not collide:
+
+```
+{prefix}/{YYYY}/{MM}/{DD}/{traceID}/{spanID}-{kind}.json                 # full text payload
+{prefix}/{YYYY}/{MM}/{DD}/{traceID}/{spanID}-{kind}-{partIndex}.{ext}    # non-text part
+```
+
+`{ext}` is derived from the part's declared media type (`png`, `jpg`, `webp`, `wav`,
+`mp3`, `pcm`, …) with `bin` as the fallback when the type is unknown. The redaction
+pipeline runs against the text skeleton only; binary parts are stored as received,
+and operators relying on redaction for compliance should either disable multimodal
+capture or apply DLP at the object-store layer.
 
 ### Capture Layers
 
@@ -146,7 +212,19 @@ prompt/completion events when `payloadCapture.emitIfUpstreamTraced` is `false` (
 // PayloadStore persists a payload and returns a retrieval URI.
 // Implementations: NoopStore, InlineStore, GCSStore, S3Store, FilesystemStore.
 type PayloadStore interface {
-    Store(ctx context.Context, traceID, spanID string, kind PayloadKind, data []byte) (uri string, err error)
+    Store(ctx context.Context, ref PayloadRef, data []byte) (uri string, err error)
+}
+
+// PayloadRef identifies one payload part. PartIndex is zero for the text payload
+// itself and >= 1 for each non-text content part associated with the same span.
+// MediaType is an IANA media type (e.g. "application/json", "image/png") and
+// drives both the storage-path extension and Content-Type on uploads.
+type PayloadRef struct {
+    TraceID   string
+    SpanID    string
+    Kind      PayloadKind
+    PartIndex int
+    MediaType string
 }
 
 type PayloadKind string
@@ -166,9 +244,12 @@ Backend selection via `payloadCapture.backend`:
 | `s3` | Upload to S3-compatible store, emit `s3://bucket/path` URI |
 | `filesystem` | Write to mounted volume, emit `file:///path` URI |
 
-Object store path convention:
+Object store path convention (text payloads use `.json`; non-text parts append a
+part index and a media-type-derived extension — see
+[Non-Text and Multimodal Payloads](#non-text-and-multimodal-payloads)):
 ```
 {prefix}/{YYYY}/{MM}/{DD}/{traceID}/{spanID}-{kind}.json
+{prefix}/{YYYY}/{MM}/{DD}/{traceID}/{spanID}-{kind}-{partIndex}.{ext}
 ```
 
 ### Redaction Pipeline
@@ -207,6 +288,9 @@ inferenceExtension:
     offloadBackend: ""                  # fallback when inline exceeds threshold
     emitIfUpstreamTraced: false         # skip if vLLM tracing is active
     maxCompletionBufferBytes: 262144
+    captureNonTextParts: true           # set false to drop non-text media instead of
+                                        # storing it (text skeleton + truncated:true)
+    maxNonTextPartBytes: 8388608        # per-part cap for image/audio/binary uploads
     gcs:
       bucket: ""
       prefix: "llm-d/payloads"
@@ -245,6 +329,11 @@ Payload capture significantly raises the sensitivity of trace data. Operators mu
 4. Treat captured payloads with the same classification as the underlying model's
    training data or any user PII present in requests.
 5. Enable `redaction.enabled: true` when serving untrusted user inputs.
+6. Recognise that the redaction pipeline operates only on the text skeleton — non-text
+   parts (images, audio) are written to the configured store as received. For
+   workloads where multimodal content can carry sensitive data, either disable
+   non-text capture (`captureNonTextParts: false`) or apply a DLP pass at the
+   object-store layer (e.g. GCS DLP inspection, S3 Object Lambda).
 
 Credentials for GCS/S3 are never embedded in deployment values — they must come from
 Workload Identity / IRSA bindings or Kubernetes Secrets mounted as environment variables.

--- a/guides/recipes/observability/tracing/otel-collector.yaml
+++ b/guides/recipes/observability/tracing/otel-collector.yaml
@@ -27,17 +27,55 @@ data:
       batch:
         send_batch_size: 1024
         timeout: 1s
+      # --- Optional: GenAI payload capture processors (opt-in) ----------------
+      # Defence-in-depth PII redaction applied before any payload exporter sees
+      # the data. The redaction processor masks attribute *values* that match any
+      # regex listed in `blocked_values` (it does not validate checksums). Add
+      # patterns for your data-classification policy under `blocked_values`.
+      # See docs/proposals/genai-payload-events.md.
+      # redaction/payloads:
+      #   allow_all_keys: true
+      #   blocked_values:
+      #     - "\\b\\d{3}-\\d{2}-\\d{4}\\b"                # US SSN
+      #     # Credit-card brand prefix + length only (NOT Luhn-validated)
+      #     - "\\b(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|3[47][0-9]{13}|6(?:011|5[0-9]{2})[0-9]{12})\\b"
+      #     - "(?i)bearer\\s+[a-z0-9._\\-]+"             # Bearer tokens
+      #   summary: debug
+      # Keep only span events that carry gen_ai payload attributes. NOTE: this is
+      # an event-level filter — it drops non-payload span *events*, not whole
+      # spans or traces. Parent spans still flow through the `traces` pipeline
+      # above unchanged.
+      # filter/payload-events-only:
+      #   error_mode: ignore
+      #   traces:
+      #     spanevent:
+      #       - 'attributes["gen_ai.input.messages"] == nil and attributes["gen_ai.output.messages"] == nil'
     exporters:
       otlp/jaeger:
         endpoint: "jaeger-collector:4317"
         tls:
           insecure: true
+      # --- Optional: GenAI payload capture exporter (opt-in) ------------------
+      # Dedicated, redacted sink for payload-bearing span events. The `file`
+      # exporter writes to a mounted volume (filesystem backend); for GCS/S3,
+      # bridge via an OTLP exporter to a collector with the object-store
+      # exporter, or offload at the application layer per the proposal.
+      # file/payloads:
+      #   path: /var/llm-d/payloads/payload-spans.json
     service:
       pipelines:
         traces:
           receivers: [otlp]
           processors: [filter/drop-metrics-scraping, batch]
           exporters: [otlp/jaeger]
+        # --- Optional: GenAI payload capture pipeline (opt-in) --------------
+        # Uncomment together with the processors + exporter above to route
+        # payload-bearing span events to a dedicated, redacted sink. The default
+        # `traces` pipeline is unaffected.
+        # traces/payloads:
+        #   receivers: [otlp]
+        #   processors: [filter/payload-events-only, redaction/payloads, batch]
+        #   exporters: [file/payloads]
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/guides/recipes/observability/tracing/otel-collector.yaml
+++ b/guides/recipes/observability/tracing/otel-collector.yaml
@@ -41,15 +41,22 @@ data:
       #     - "\\b(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|3[47][0-9]{13}|6(?:011|5[0-9]{2})[0-9]{12})\\b"
       #     - "(?i)bearer\\s+[a-z0-9._\\-]+"             # Bearer tokens
       #   summary: debug
-      # Keep only span events that carry gen_ai payload attributes. NOTE: this is
-      # an event-level filter — it drops non-payload span *events*, not whole
-      # spans or traces. Parent spans still flow through the `traces` pipeline
-      # above unchanged.
+      # Keep only span events that carry gen_ai payload attributes OR the
+      # llm-d offload/media pointers. NOTE: this is an event-level filter — it
+      # drops non-payload span *events*, not whole spans or traces. Parent
+      # spans still flow through the `traces` pipeline above unchanged.
+      #
+      # The `llm_d.payload.storage_uri` and `llm_d.payload.media_uris` clauses
+      # matter for the offload case: when a payload exceeds
+      # `inlineSizeThresholdBytes`, `gen_ai.input.messages` /
+      # `gen_ai.output.messages` are omitted and the event carries only the
+      # storage_uri (and, for multimodal payloads, media_uris). Dropping such
+      # events would silently lose the sole pointer to the offloaded object.
       # filter/payload-events-only:
       #   error_mode: ignore
       #   traces:
       #     spanevent:
-      #       - 'attributes["gen_ai.input.messages"] == nil and attributes["gen_ai.output.messages"] == nil'
+      #       - 'attributes["gen_ai.input.messages"] == nil and attributes["gen_ai.output.messages"] == nil and attributes["llm_d.payload.storage_uri"] == nil and attributes["llm_d.payload.media_uris"] == nil'
     exporters:
       otlp/jaeger:
         endpoint: "jaeger-collector:4317"


### PR DESCRIPTION
## Summary

Design proposal for capturing LLM prompts and completions as OpenTelemetry payload
attributes, following the upstream
[GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) —
specifically `gen_ai.input.messages`, `gen_ai.output.messages`, and
`gen_ai.system_instructions` (these are `Opt-In` / `Development` stability upstream and
are tracked as attribute names stabilise).

Closes #1108.

---

### What's in this PR

| File | Purpose |
| --- | --- |
| `docs/proposals/genai-payload-events.md` | Full proposal following `PROPOSAL_TEMPLATE.md`: summary, motivation, proposal, design details, alternatives. Covers attribute spec, multimodal/non-text payload handling, capture layers, `PayloadStore` interface (ownership + execution plan), redaction pipeline, threat model, and phased implementation plan |
| `guides/recipes/observability/tracing/otel-collector.yaml` | The existing OTel Collector recipe, extended with an **opt-in, commented** `traces/payloads` pipeline (filter + redaction processors). The default `traces` pipeline is unchanged |

This is a **design-only** PR — no implementation, no `values.yaml` stanzas. The
operator opt-in surface (canonical field names defined in the proposal) will land
alongside the in-flight Helm → Kustomize migration in a follow-up Phase-1 implementation
PR. No `guides/**/values.yaml` files are touched here.

> **Update (review feedback):** Migrated off the now-deprecated `gen_ai.content.prompt` /
> `gen_ai.content.completion` events to the current `gen_ai.input.messages` /
> `gen_ai.output.messages` / `gen_ai.system_instructions` attributes; offload markers
> (`storage_uri`, `media_uris`, `truncated`) are marked explicitly as llm-d extensions.
> The standalone `otel-collector-with-payload-capture.yaml` has been **removed** and its
> payload pipeline folded into the existing `otel-collector.yaml` recipe per review.

---

### Design decisions addressed from #1108

**1. Which component emits the events?**
Three-layer answer with vLLM as the preferred attachment point (direct access to decoded
Python objects and the canonical `vllm:llm_request` span). Gateway (EPP) captures prompts
as fallback when vLLM tracing is off; P/D proxy captures completions from reassembled SSE.
`emitIfUpstreamTraced: false` prevents double-emission.

**2. Storage backend abstraction?**
`PayloadStore` interface with five backends: `noop` (default), `inline`, `gcs`, `s3`
(covers MinIO/Ceph), `filesystem`. The Go interface and backends are owned by the
**gateway / EPP**; the vLLM integration is a Python mirror of the same interface. Text
payloads above `inlineSizeThresholdBytes` (default 4 KB) auto-offload to the configured
`offloadBackend`. GCS uses Workload Identity; S3 uses IRSA.

**3. Non-text / multimodal payloads?**
Binary content (images, audio) cannot be carried as OTel attributes — the attribute type
system permits strings/numbers/bools/arrays only, on neither spans nor log records.
Non-text parts are therefore **always offloaded** to the configured `PayloadStore`,
mapped onto the upstream input-messages `parts[]` schema, replaced in the text skeleton
with a `$ref` marker, and surfaced via the `gen_ai.content.media_uris` attribute (llm-d
extension).

**4. PII / redaction policy?**
Opt-in via `payloadCapture.redaction.enabled`. Built-in regex patterns (SSN, credit
cards, Bearer tokens). Custom `{pattern, replacement}` list. Optional external DLP
`webhookURL`. Runs before any backend sees the payload. Redaction operates on the text
skeleton only; operators relying on redaction for compliance on multimodal workloads
should disable non-text capture or apply DLP at the object-store layer.

**5. Payload size threshold?**
4 KB inline for text; `maxCompletionBufferBytes: 256 KB` buffer for SSE completions,
truncated with `gen_ai.content.truncated: true` on overflow. `maxNonTextPartBytes: 8 MiB`
per non-text part by default; tunable per deployment.

---

`payloadCapture.enabled: false` by default — zero overhead on the hot path until
explicitly opted in. `backend: noop` is a secondary kill switch that records no
payload attributes even when the master switch is enabled.

## Test plan

- [ ] Proposal reviewed against `docs/proposals/PROPOSAL_TEMPLATE.md`
- [ ] OTel Collector recipe validates cleanly
- [ ] Reviewed by impacted component maintainers (gateway, P/D sidecar, vLLM integration)
- [ ] Multimodal/non-text handling reviewed against current OpenAI / Anthropic / Gemini request shapes

---

Proposal-only PR — no implementation code per CONTRIBUTING.md. Implementation will land in
follow-up PRs once the design is approved.
