### PR TITLE
fix: align pod label selector to kebab-case inference-serving

### DIFF
--- a/.github/workflows/e2e-pd-hpu.yaml
+++ b/.github/workflows/e2e-pd-hpu.yaml
@@ -219,9 +219,9 @@ jobs:
             mkdir -p pod-logs-pd-hpu
             cd pod-logs-pd-hpu
             echo "Fetching ${NAMESPACE} pods log..."
-            kubectl get pods -n "${NAMESPACE}" -l "llm-d.ai/inferenceServing" -o yaml > ./inference-pods.yaml
-            kubectl logs -n "${NAMESPACE}" -l "llm-d.ai/inferenceServing" | grep -v "waiting for vLLM to be ready" > ./inference-pod-logs.log || true
-            kubectl describe pod -n "${NAMESPACE}" -l "llm-d.ai/inferenceServing" > ./inference-describe-pod-logs.log
+            kubectl get pods -n "${NAMESPACE}" -l "llm-d.ai/inference-serving" -o yaml > ./inference-pods.yaml
+            kubectl logs -n "${NAMESPACE}" -l "llm-d.ai/inference-serving" | grep -v "waiting for vLLM to be ready" > ./inference-pod-logs.log || true
+            kubectl describe pod -n "${NAMESPACE}" -l "llm-d.ai/inference-serving" > ./inference-describe-pod-logs.log
             kubectl get pods -n "${NAMESPACE}" --no-headers -o custom-columns=":metadata.name" \
             | xargs -I{} sh -c 'kubectl logs --all-containers=true -n "${NAMESPACE}" {} > "{}.log" 2>&1' || true
             echo "Fetching ${NAMESPACE} pods descriptions..."

--- a/docs/infra-providers/openshift/README.md
+++ b/docs/infra-providers/openshift/README.md
@@ -256,7 +256,7 @@ oc create configmap grafana-dashboard-llm-performance --from-file=monitoring/gra
 ### Add Prometheus annotations to model service pods for metrics discovery
 
 ```
-for pod in $(oc get pods -n llm-d -l llm-d.ai/inferenceServing=true -o name); do
+for pod in $(oc get pods -n llm-d -l llm-d.ai/inference-serving=true -o name); do
   oc annotate $pod prometheus.io/scrape=true prometheus.io/port=8000 prometheus.io/path=/metrics -n llm-d
 done
 ```


### PR DESCRIPTION
## Summary

- Replace camelCase `llm-d.ai/inferenceServing` with kebab-case `llm-d.ai/inference-serving` across CI e2e workflows and the OpenShift infra provider README.
- Aligns this repo with the canonical label used in the llm-d org deployment guides and Pod manifests.

## Context

Follow-up to llm-d/llm-d-kv-cache#525, which switched the default `podLabelSelector` in `llm-d-kv-cache` from camelCase to kebab-case. That PR called out the remaining camelCase usages in this repo that should be aligned.

## Changes

- `.github/workflows/e2e-pd-hpu.yaml`
- `.github/workflows/e2e-pd-xpu.yaml`
- `.github/workflows/e2e-prefix-cache-xpu.yaml`
- `docs/infra-providers/openshift/README.md`

All of them only reference the label in `kubectl get/logs/describe -l ...` filters (or the equivalent `oc` command), so the change is a pure selector rename to match the canonical Pod label.

## Test plan

- [x] `rg 'inferenceServing'` in the repo returns no matches after the change.
- [ ] CI e2e jobs (`e2e-pd-hpu`, `e2e-pd-xpu`, `e2e-prefix-cache-xpu`) still collect pod logs correctly (they now match the Pods labeled with `llm-d.ai/inference-serving`, which is what the deployment manifests actually set).