### PR TITLE
feat(helpers): add multimedia and model caching service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ CLAUDE.md
 
 # helm chart directories via kustomize
 **/charts/
+
+*.pem

--- a/helpers/multimedia-downloader/README.md
+++ b/helpers/multimedia-downloader/README.md
@@ -1,0 +1,112 @@
+# Multimedia Downloader Proxy
+
+A pluggable caching proxy designed to speed up the fetching of large multimedia assets like videos, images, and optionally machine learning models.
+
+## Supported Implementations
+
+The proxy is designed to support different caching backends, which are maintained in the [`implementations/`](implementations/) directory. Each backend manages its own specific configuration and resource footprints.
+
+* **[Squid](https://github.com/squid-cache/squid) (Default):** A robust, high-performance HTTP/HTTPS caching proxy with two variants:
+  * **[http](implementations/squid/http/)** — HTTP caching proxy (port 8080).
+  * **[https-ssl-bump](implementations/squid/https-ssl-bump/)** — HTTPS caching proxy (port 3128). Requires a custom CA certificate.
+
+  For setup instructions see the [Squid Implementation Guide](implementations/squid/README.md).
+
+## Prerequisites
+
+* **[kind](https://kind.sigs.k8s.io/)**
+* **`kubectl`**
+
+## Quick Start
+
+### 1. Create a kind Cluster
+
+```bash
+kind create cluster --name multimedia-test --wait 90s
+```
+
+### 2. Deploy the Proxy
+Deploy the default implementation to the newly created cluster using Kustomize:
+
+```bash
+kubectl apply -k helpers/multimedia-downloader
+```
+
+### 3. Wait for the Deployment to Be Ready
+
+```bash
+kubectl rollout status deployment/multimedia-downloader
+```
+
+### 4. Verify It Works
+
+Send a request through the proxy and check the logs:
+
+```bash
+kubectl run curl-test --image=curlimages/curl:8.11.1 --restart=Never --rm -it -- \
+  curl -s -x http://multimedia-downloader:80 http://images.cocodataset.org/val2017/000000039769.jpg -o /dev/null -w "%{http_code}\n"
+```
+
+Check the cache log (run twice to see `TCP_MISS` → `TCP_HIT`):
+
+```bash
+kubectl logs -l app=multimedia-downloader --tail=5
+```
+
+> Note: For a detailed breakdown of what TCP_MISS, TCP_HIT, and other log statuses mean, see the [Squid Implementation Guide](implementations/squid/README.md).
+
+### 5. Cleanup
+
+```bash
+kind delete cluster --name multimedia-test
+```
+
+## Usage: Routing Application Traffic
+
+Once the proxy is running, you must configure your downstream applications to route their downloads through it. Set the standard proxy environment variables in your client deployments:
+
+```bash
+export HTTP_PROXY=http://multimedia-downloader:80
+export HTTPS_PROXY=http://multimedia-downloader:80
+export NO_PROXY=localhost,127.0.0.1,.svc,.cluster.local
+```
+
+- `HTTP_PROXY` — Routes unencrypted web traffic
+- `HTTPS_PROXY` — Routes secure, encrypted web traffic
+- `NO_PROXY` — Bypasses the proxy for specific internal hosts or domains
+
+For Python applications:
+```python
+import os
+os.environ['HTTP_PROXY'] = 'http://multimedia-downloader:80'
+os.environ['HTTPS_PROXY'] = 'http://multimedia-downloader:80'
+os.environ['NO_PROXY'] = 'localhost,127.0.0.1,.svc,.cluster.local'
+```
+
+## Configuration
+
+### Base Configuration
+
+The base directory contains:
+- [service.yaml](service.yaml) - Base service definition (port 80, `targetPort: http-proxy`)
+- [kustomization.yaml](kustomization.yaml) - References the service and selected implementation
+
+### Implementation-Specific Configuration
+
+Each implementation lives under `implementations/<name>/` and may contain one or more variant subdirectories. Each variant has its own:
+- `deployment.yaml` - Kubernetes deployment; must expose a container port named `http-proxy`
+- `kustomization.yaml` - Kustomize configuration
+
+The base service uses the named port `http-proxy` as its `targetPort`. Variants resolve this automatically by naming their container port `http-proxy` — no service patch is required.
+
+## Adding New Implementations
+
+To add a new cache implementation:
+
+1. Create a variant directory under `implementations/`
+
+2. Add variant-specific files:
+   - `deployment.yaml` - Your proxy deployment; name the container port `http-proxy` (the base service resolves `targetPort: http-proxy` automatically)
+   - `kustomization.yaml` - List resources and labels
+
+3. Modify the base `kustomization.yaml` to point to any new default implementation.

--- a/helpers/multimedia-downloader/README.md
+++ b/helpers/multimedia-downloader/README.md
@@ -2,22 +2,36 @@
 
 A pluggable caching proxy designed to speed up the fetching of large multimedia assets like videos, images, and optionally machine learning models.
 
+## Motivation
+
+Multimodal LLM inference workloads constantly fetch heavy assets (images, videos) from remote origins. These repeated "cold" downloads introduce significant latency, spike egress costs, and expose the system to external rate limits and network jitter.
+
+This is particularly impactful in llm-d's
+[disaggregated serving](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/docs/disaggregation.md)
+configurations (E/P/D). In an encode-prefill-decode split, dedicated encode
+workers, prefill pods, and decode pods are scheduled independently and may each
+fetch the same multimedia asset from the origin on the same request — amplifying
+egress costs and download latency proportionally to the number of disaggregated
+components. A shared cluster-local cache eliminates this redundancy: the first
+component to request an asset pays the origin fetch cost; every subsequent
+request across all components in the llm-d ecosystem is served from cache.
+
 ## Supported Implementations
 
 The proxy is designed to support different caching backends, which are maintained in the [`implementations/`](implementations/) directory. Each backend manages its own specific configuration and resource footprints.
 
 * **[Squid](https://github.com/squid-cache/squid) (Default):** A robust, high-performance HTTP/HTTPS caching proxy with two variants:
-  * **[http](implementations/squid/http/)** — HTTP caching proxy (port 8080).
-  * **[https-ssl-bump](implementations/squid/https-ssl-bump/)** — HTTPS caching proxy (port 3128). Requires a custom CA certificate.
+  * **[http](implementations/squid/http/)** — HTTP caching proxy. HTTPS requests are not cached; they are tunneled through an opaque `CONNECT` tunnel with no content inspection.
+  * **[https-ssl-bump](implementations/squid/https-ssl-bump/)** — HTTPS caching proxy. Requires a custom CA certificate and a custum docker image.
 
   For setup instructions see the [Squid Implementation Guide](implementations/squid/README.md).
 
-## Prerequisites
+## Quick Start
+
+### Prerequisites
 
 * **[kind](https://kind.sigs.k8s.io/)**
 * **`kubectl`**
-
-## Quick Start
 
 ### 1. Create a kind Cluster
 
@@ -90,6 +104,8 @@ os.environ['NO_PROXY'] = 'localhost,127.0.0.1,.svc,.cluster.local'
 The base directory contains:
 - [service.yaml](service.yaml) - Base service definition (port 80, `targetPort: http-proxy`)
 - [kustomization.yaml](kustomization.yaml) - References the service and selected implementation
+
+Regardless of the backend's internal port, the proxy always listens on port 80. Therefore, when configuring HTTP_PROXY or HTTPS_PROXY for clients, you must specify port 80.
 
 ### Implementation-Specific Configuration
 

--- a/helpers/multimedia-downloader/implementations/squid/README.md
+++ b/helpers/multimedia-downloader/implementations/squid/README.md
@@ -1,6 +1,19 @@
 # Squid Proxy: Multimedia Cache
 
-This Squid proxy implementation caches multimedia content (like images and videos) to optimize data retrieval speeds.
+[Squid](https://www.squid-cache.org/)  is a powerful, open-source caching proxy for HTTP, HTTPS, and FTP traffic, engineered to accelerate content delivery and minimize bandwidth consumption.
+
+Key Capabilities:
+
+📊 Intelligent Eviction - Advanced algorithms ensure optimal use of available cache space.
+
+🚀 Bandwidth Reduction - Utilizes collapsed forwarding to cut origin server load.
+
+💾 Versatile Storage - Supports memory-only, disk-based, or hybrid caching configurations.
+
+📈 Massive Scalability - Maximize single-node hardware with concurrent SMP workers, or distribute load globally via cache hierarchies and external load balancing.
+
+Deployment: Primarily operates as a forward proxy.
+
 
 ## 🚀 Automated Testing
 
@@ -60,8 +73,7 @@ By default, proxies cannot see inside encrypted HTTPS traffic. Here is how Squid
 * **Smart Inspection ([Peek & Splice](https://wiki.squid-cache.org/Features/SslPeekAndSplice)):** Inspects the unencrypted SNI (Server Name Indication) during the TLS handshake. 
     * *Trade-off:* Allows domain-based filtering without requiring full decryption.
 
-**Modern Constraints: TLS 1.3 & ECH**:
-While Squid supports TLS 1.3, new privacy standards like ECH (Encrypted Client Hello) and ESNI encrypt the destination domain itself. Since the proxy cannot see the target to apply policy, these connections must be spliced (passed through blindly) to prevent connection failure.
+> **Note:** While Squid supports TLS 1.3, new privacy standards like ECH (Encrypted Client Hello) and ESNI encrypt the destination domain itself. Since the proxy cannot see the target to apply policy, these connections must be spliced (passed through blindly) to prevent connection failure.
 
 > **Warning:**  SSL Bump breaks end-to-end trust. Always ensure you have legal and compliance approval before intercepting HTTPS traffic.
 

--- a/helpers/multimedia-downloader/implementations/squid/README.md
+++ b/helpers/multimedia-downloader/implementations/squid/README.md
@@ -1,0 +1,225 @@
+# Squid Proxy: Multimedia Cache
+
+This Squid proxy implementation caches multimedia content (like images and videos) to optimize data retrieval speeds.
+
+## 🚀 Automated Testing
+
+Execute the [test-squid.sh](test/test-squid.sh) script to run cache validations and inspect the resulting logs.
+
+### kind
+
+Run HTTP test (spins up a temporary kind cluster, tests, and tears it down):
+
+```bash
+./helpers/multimedia-downloader/implementations/squid/test/test-squid.sh
+```
+
+To retain resources after testing for manual review and debugging add `--skip-cleanup` flag:
+
+```bash
+./helpers/multimedia-downloader/implementations/squid/test/test-squid.sh --skip-cleanup
+```
+
+### OpenShift
+
+Target an OpenShift cluster (uses the openshift overlay):
+
+```bash
+./helpers/multimedia-downloader/implementations/squid/test/test-squid.sh --openshift
+```
+
+To target a specific OpenShift context (implies `--openshift`):
+
+```bash
+./helpers/multimedia-downloader/implementations/squid/test/test-squid.sh --context <ctx>
+```
+
+To leave OpenShift resources in place after testing for manual inspection add `--skip-cleanup` flag:
+
+```bash
+./helpers/multimedia-downloader/implementations/squid/test/test-squid.sh --openshift --skip-cleanup
+```
+
+### Understanding Log Results
+
+- **TCP_HIT:** Served fast from disk cache.
+- **TCP_MEM_HIT:** Served ultra-fast from memory cache.
+- **TCP_MISS:** Downloaded from the origin server (not in cache).
+- **TCP_TUNNEL:** Encrypted HTTPS traffic passed through blindly (not cached).
+
+For more detailed explanations of log statuses and monitoring cache hit rates, see the [Squid monitoring guide](https://oneuptime.com/blog/post/2026-03-20-squid-monitor-cache-hit-rates-ipv4/view).
+
+## 🔒 HTTPS Caching
+
+By default, proxies cannot see inside encrypted HTTPS traffic. Here is how Squid manages encrypted flows depending on your configuration:
+
+* **Blind Tunneling (CONNECT):** Passes encrypted TCP traffic through an opaque tunnel. 
+    * *Trade-off:* Zero visibility; no caching or granular filtering is possible.
+* **Full Decryption ([SSL Bump](https://wiki.squid-cache.org/Features/SslBump) MITM):** Intercepts, decrypts, and re-encrypts traffic using a custom Root CA. 
+    * *Trade-off:* Enables full inspection and caching, but requires complex certificate management and raises privacy/legal risks.
+* **Smart Inspection ([Peek & Splice](https://wiki.squid-cache.org/Features/SslPeekAndSplice)):** Inspects the unencrypted SNI (Server Name Indication) during the TLS handshake. 
+    * *Trade-off:* Allows domain-based filtering without requiring full decryption.
+
+**Modern Constraints: TLS 1.3 & ECH**:
+While Squid supports TLS 1.3, new privacy standards like ECH (Encrypted Client Hello) and ESNI encrypt the destination domain itself. Since the proxy cannot see the target to apply policy, these connections must be spliced (passed through blindly) to prevent connection failure.
+
+> **Warning:**  SSL Bump breaks end-to-end trust. Always ensure you have legal and compliance approval before intercepting HTTPS traffic.
+
+### 🚀 Automated Tests
+
+#### kind
+
+Run SSL Bump test (builds image, generates CA, deploys, and verifies cache):
+
+```bash
+./helpers/multimedia-downloader/implementations/squid/test/test-squid.sh --mode ssl-bump
+```
+
+To retain resources after testing for manual inspection add `--skip-cleanup` flag:
+
+```bash
+./helpers/multimedia-downloader/implementations/squid/test/test-squid.sh --mode ssl-bump --skip-cleanup
+```
+
+#### OpenShift
+
+The SSL Bump image must be pushed to a registry accessible by your cluster. Run these two steps once each.
+
+```bash
+export SQUID_IMAGE_REGISTRY="image-registry"
+```
+
+**Step 1 — build and push the image (run once per image change):**
+
+`--build-push` implies `--mode ssl-bump`:
+
+```bash
+./helpers/multimedia-downloader/implementations/squid/test/test-squid.sh --build-push
+```
+
+Make the pushed image accessible from your cluster, then proceed to step 2.
+
+**Step 2 — deploy and test:**
+
+```bash
+./helpers/multimedia-downloader/implementations/squid/test/test-squid.sh --mode ssl-bump --openshift
+```
+
+To leave OpenShift resources in place after testing for manual inspection add `--skip-cleanup` flag:
+
+```bash
+./helpers/multimedia-downloader/implementations/squid/test/test-squid.sh --mode ssl-bump --openshift --skip-cleanup
+```
+
+(Note: You can always pass --registry <url> manually if you prefer not to use the environment variable).
+
+## 🛠️ Manual Deployment
+
+> **Note:** The following steps assume your target cluster is already running and your active `kubectl` context is set correctly.
+
+### Standard HTTP Proxy
+
+**Step 1 — deploy:**
+
+#### kind
+
+```bash
+kubectl apply -k helpers/multimedia-downloader/implementations/squid/http/overlays/kind
+kubectl apply -f helpers/multimedia-downloader/service.yaml
+kubectl rollout status deployment/multimedia-downloader --timeout=120s
+```
+
+#### OpenShift
+
+```bash
+kubectl apply -k helpers/multimedia-downloader/implementations/squid/http/overlays/openshift
+kubectl apply -f helpers/multimedia-downloader/service.yaml
+kubectl rollout status deployment/multimedia-downloader --timeout=120s
+```
+
+**Step 2 — verify:**
+
+Run two requests through the proxy. The first should be a cache miss, the second a cache hit:
+
+```bash
+kubectl run curl-test --image=curlimages/curl:8.11.1 --restart=Never -- sleep 30
+kubectl wait --for=condition=Ready pod/curl-test --timeout=60s
+kubectl exec curl-test -- curl -sf -x http://multimedia-downloader:80 -o /dev/null -w "miss: %{http_code}\n" http://images.cocodataset.org/val2017/000000039769.jpg
+kubectl exec curl-test -- curl -sf -x http://multimedia-downloader:80 -o /dev/null -w "hit:  %{http_code}\n" http://images.cocodataset.org/val2017/000000039769.jpg
+```
+
+### SSL Bump Proxy (Advanced)
+
+Because SSL Bump intercepts encrypted traffic, it requires a custom CA certificate, a specialized container image, and platform-specific overlays.
+
+| Overlay | Path | Image |
+|---------|------|-------|
+| `kind` | `https-ssl-bump/overlays/kind` | `squid-ssl-bump:local` (locally built) |
+| `openshift` | `https-ssl-bump/overlays/openshift` | your registry — set `$SQUID_IMAGE_REGISTRY` or `--registry` |
+
+**Step 1 — generate the CA certificate** (must exist before deploying — the deployment mounts both secrets):
+
+| Secret | Contents | Mounted by |
+|--------|----------|------------|
+| `squid-ssl-certs` | CA cert + private key | Squid proxy (signs intercepted TLS) |
+| `squid-ca-public-cert` | CA cert only | Client pods (trust the proxy CA) |
+
+
+To automatically generate the secrets run:
+```bash
+./helpers/multimedia-downloader/implementations/squid/test/generate-ssl-certs.sh
+```
+
+**Step 2 — deploy:**
+
+Build the [Dockerfile](docker/Dockerfile.squid-ssl-bump) (required for both platforms):
+
+```bash
+docker build -t squid-ssl-bump:local \
+  -f helpers/multimedia-downloader/implementations/squid/docker/Dockerfile.squid-ssl-bump \
+  helpers/multimedia-downloader/implementations/squid/docker/
+```
+
+#### kind
+
+```bash
+kind load docker-image squid-ssl-bump:local
+kubectl apply -k helpers/multimedia-downloader/implementations/squid/https-ssl-bump/overlays/kind
+kubectl apply -f helpers/multimedia-downloader/service.yaml
+kubectl rollout status deployment/multimedia-downloader --timeout=120s
+```
+
+#### OpenShift
+
+```bash
+export SQUID_IMAGE_REGISTRY=<your-registry>
+docker tag squid-ssl-bump:local ${SQUID_IMAGE_REGISTRY}/squid-ssl-bump:dev
+docker push ${SQUID_IMAGE_REGISTRY}/squid-ssl-bump:dev
+kubectl apply -k helpers/multimedia-downloader/implementations/squid/https-ssl-bump/overlays/openshift
+kubectl set image deployment/multimedia-downloader squid=${SQUID_IMAGE_REGISTRY}/squid-ssl-bump:dev
+kubectl apply -f helpers/multimedia-downloader/service.yaml
+kubectl rollout status deployment/multimedia-downloader --timeout=120s
+```
+
+**Step 3 — verify:**
+
+Deploy the CA-trusting test pod and run two requests. The first should be a cache miss, the second a cache hit:
+
+```bash
+kubectl apply -f helpers/multimedia-downloader/implementations/squid/test/curl-test-pod.yaml
+kubectl wait --for=condition=Ready pod/curl-ssl-test-pod --timeout=120s
+kubectl exec curl-ssl-test-pod -- curl -sf -o /dev/null -w "miss: %{http_code}\n" https://images.dog.ceo/breeds/poodle-standard/n02113799_2280.jpg
+kubectl exec curl-ssl-test-pod -- curl -sf -o /dev/null -w "hit:  %{http_code}\n" https://images.dog.ceo/breeds/poodle-standard/n02113799_2280.jpg
+```
+
+#### Configuring Client Pods (Production)
+
+To route a real workload's traffic through the SSL Bump proxy, you must inject the Squid CA and proxy environment variables. Patch your client's Kustomize deployment:
+
+```yaml
+patches:
+  - path: path/to/https-ssl-bump/patch-client-deployment.yaml
+    target:
+      kind: Deployment
+      name: <your-client-deployment-name>
+```

--- a/helpers/multimedia-downloader/implementations/squid/README.md
+++ b/helpers/multimedia-downloader/implementations/squid/README.md
@@ -95,15 +95,17 @@ To retain resources after testing for manual inspection add `--skip-cleanup` fla
 
 #### OpenShift
 
-The SSL Bump image must be pushed to a registry accessible by your cluster. Run these two steps once each.
+To use the SSL Bump configuration, the custom Squid image must be hosted in a registry that your cluster can access.
+
+**Step 1 - Set your target registry**
 
 ```bash
 export SQUID_IMAGE_REGISTRY="image-registry"
 ```
 
-**Step 1 — build and push the image (run once per image change):**
+**Step 2 — Build and push the image**
 
-`--build-push` implies `--mode ssl-bump`:
+Run this step to build the image and push it to your registry. You only need to do this once, or whenever the image configuration changes. (Note: The --build-push flag automatically sets --mode ssl-bump).
 
 ```bash
 ./helpers/multimedia-downloader/implementations/squid/test/test-squid.sh --build-push
@@ -111,7 +113,7 @@ export SQUID_IMAGE_REGISTRY="image-registry"
 
 Make the pushed image accessible from your cluster, then proceed to step 2.
 
-**Step 2 — deploy and test:**
+**Step 3 — deploy and test**
 
 ```bash
 ./helpers/multimedia-downloader/implementations/squid/test/test-squid.sh --mode ssl-bump --openshift
@@ -131,7 +133,7 @@ To leave OpenShift resources in place after testing for manual inspection add `-
 
 ### Standard HTTP Proxy
 
-**Step 1 — deploy:**
+**Step 1 — deploy**
 
 #### kind
 
@@ -149,7 +151,7 @@ kubectl apply -f helpers/multimedia-downloader/service.yaml
 kubectl rollout status deployment/multimedia-downloader --timeout=120s
 ```
 
-**Step 2 — verify:**
+**Step 2 — verify**
 
 Run two requests through the proxy. The first should be a cache miss, the second a cache hit:
 
@@ -169,7 +171,9 @@ Because SSL Bump intercepts encrypted traffic, it requires a custom CA certifica
 | `kind` | `https-ssl-bump/overlays/kind` | `squid-ssl-bump:local` (locally built) |
 | `openshift` | `https-ssl-bump/overlays/openshift` | your registry — set `$SQUID_IMAGE_REGISTRY` or `--registry` |
 
-**Step 1 — generate the CA certificate** (must exist before deploying — the deployment mounts both secrets):
+**Step 1 — generate the CA certificate**
+
+Because the Squid deployment mounts the certificate secrets, they must exist in the cluster before the deployment process begins.
 
 | Secret | Contents | Mounted by |
 |--------|----------|------------|
@@ -182,15 +186,17 @@ To automatically generate the secrets run:
 ./helpers/multimedia-downloader/implementations/squid/test/generate-ssl-certs.sh
 ```
 
-**Step 2 — deploy:**
+**Step 2 — deploy**
 
-Build the [Dockerfile](docker/Dockerfile.squid-ssl-bump) (required for both platforms):
+First build the [Dockerfile](docker/Dockerfile.squid-ssl-bump) (required for both platforms):
 
 ```bash
 docker build -t squid-ssl-bump:local \
   -f helpers/multimedia-downloader/implementations/squid/docker/Dockerfile.squid-ssl-bump \
   helpers/multimedia-downloader/implementations/squid/docker/
 ```
+
+Next run the following commands depending on the platform:
 
 #### kind
 
@@ -205,6 +211,9 @@ kubectl rollout status deployment/multimedia-downloader --timeout=120s
 
 ```bash
 export SQUID_IMAGE_REGISTRY=<your-registry>
+```
+
+```bash
 docker tag squid-ssl-bump:local ${SQUID_IMAGE_REGISTRY}/squid-ssl-bump:dev
 docker push ${SQUID_IMAGE_REGISTRY}/squid-ssl-bump:dev
 kubectl apply -k helpers/multimedia-downloader/implementations/squid/https-ssl-bump/overlays/openshift
@@ -213,7 +222,7 @@ kubectl apply -f helpers/multimedia-downloader/service.yaml
 kubectl rollout status deployment/multimedia-downloader --timeout=120s
 ```
 
-**Step 3 — verify:**
+**Step 3 — verify**
 
 Deploy the CA-trusting test pod and run two requests. The first should be a cache miss, the second a cache hit:
 

--- a/helpers/multimedia-downloader/implementations/squid/components/kind-security/kustomization.yaml
+++ b/helpers/multimedia-downloader/implementations/squid/components/kind-security/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+- target:
+    kind: Deployment
+    name: multimedia-downloader
+  patch: |
+    - op: add
+      path: /spec/template/spec/securityContext
+      value:
+        runAsNonRoot: true
+        fsGroup: 13
+    - op: add
+      path: /spec/template/spec/containers/0/securityContext
+      value:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+        runAsUser: 13

--- a/helpers/multimedia-downloader/implementations/squid/components/openshift-security/kustomization.yaml
+++ b/helpers/multimedia-downloader/implementations/squid/components/openshift-security/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+- target:
+    kind: Deployment
+    name: multimedia-downloader
+  patch: |
+    - op: add
+      path: /spec/template/spec/securityContext
+      value:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    - op: add
+      path: /spec/template/spec/containers/0/securityContext
+      value:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]

--- a/helpers/multimedia-downloader/implementations/squid/docker/Dockerfile.squid-ssl-bump
+++ b/helpers/multimedia-downloader/implementations/squid/docker/Dockerfile.squid-ssl-bump
@@ -1,0 +1,42 @@
+ARG BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-micro:9.7
+
+# ==========================================
+# Stage 1: Builder
+# ==========================================
+FROM registry.access.redhat.com/ubi9/ubi:9.7 AS builder
+
+RUN mkdir -p /mnt/rootfs
+
+# Install packages and clean cache in a single layer
+RUN dnf install --installroot /mnt/rootfs --releasever=9 --setopt=install_weak_deps=False --nodocs -y \
+    squid \
+    openssl \
+    ca-certificates \
+    curl \
+    && dnf --installroot /mnt/rootfs clean all
+
+# ==========================================
+# Stage 2: Final Micro Image
+# ==========================================
+FROM ${BASE_IMAGE}
+
+LABEL description="Squid Proxy with SSL-Bump support"
+
+COPY --from=builder /mnt/rootfs /
+
+# Consolidate directory creation, cert generation, and permissions into a single layer
+RUN mkdir -p /var/lib/squid /var/log/squid /var/run/squid /etc/squid/certs /var/cache/squid \
+    && /usr/lib64/squid/security_file_certgen -c -s /var/lib/squid/ssl_db -M 4MB \
+    && chown -R squid:root /var/lib/squid /var/log/squid /var/run/squid /etc/squid/certs /var/cache/squid \
+    && chmod -R g+rwX /var/lib/squid /var/log/squid /var/run/squid /etc/squid/certs /var/cache/squid
+
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+EXPOSE 3128
+
+USER squid
+WORKDIR /var/cache/squid
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["squid", "-NYd", "1"]

--- a/helpers/multimedia-downloader/implementations/squid/docker/docker-entrypoint.sh
+++ b/helpers/multimedia-downloader/implementations/squid/docker/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -euo pipefail
+
+# Re-initialize SSL DB if missing (e.g., first start with an emptyDir volume mount)
+if [ ! -f "/var/lib/squid/ssl_db/size" ]; then
+    echo "Initializing SSL certificate database..."
+    /usr/lib64/squid/security_file_certgen -c -s /var/lib/squid/ssl_db -M 4MB
+fi
+
+echo "Starting Squid..."
+exec "$@"

--- a/helpers/multimedia-downloader/implementations/squid/http/base/deployment.yaml
+++ b/helpers/multimedia-downloader/implementations/squid/http/base/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: multimedia-downloader
+  labels:
+    app: multimedia-downloader
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: multimedia-downloader
+  template:
+    metadata:
+      labels:
+        app: multimedia-downloader
+    spec:
+      containers:
+      - name: squid
+        image: ubuntu/squid:6.1-23.10_beta
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "-c"]
+        args:
+        - exec squid -NYCd1
+        ports:
+        - name: http-proxy
+          containerPort: 8080
+          protocol: TCP
+        resources:
+          limits:
+            cpu: "1"
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        volumeMounts:
+        - name: squid-config
+          mountPath: /etc/squid/squid.conf
+          subPath: squid.conf
+        - name: cache-volume
+          mountPath: /var/cache/squid
+        livenessProbe:
+          exec:
+            command: ["/bin/sh", "-c", "test -f /var/cache/squid/squid.pid && kill -0 $(cat /var/cache/squid/squid.pid)"]
+          initialDelaySeconds: 15
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command: ["/bin/sh", "-c", "test -f /var/cache/squid/squid.pid && kill -0 $(cat /var/cache/squid/squid.pid)"]
+          initialDelaySeconds: 10
+          periodSeconds: 5
+      volumes:
+      - name: squid-config
+        configMap:
+          name: squid-multimedia-downloader-config
+      - name: cache-volume
+        emptyDir:
+          sizeLimit: 3Gi

--- a/helpers/multimedia-downloader/implementations/squid/http/base/kustomization.yaml
+++ b/helpers/multimedia-downloader/implementations/squid/http/base/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- squid-config.yaml
+- deployment.yaml
+
+labels:
+- pairs:
+    cache-implementation: squid
+
+images:
+- name: ubuntu/squid
+  newTag: 6.1-23.10_beta

--- a/helpers/multimedia-downloader/implementations/squid/http/base/squid-config.yaml
+++ b/helpers/multimedia-downloader/implementations/squid/http/base/squid-config.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: squid-multimedia-downloader-config
+  labels:
+    cache-implementation: squid
+    component: multimedia-downloader
+data:
+  squid.conf: |-
+    access_log stdio:/dev/stdout squid
+    cache_log /dev/stderr
+
+    # --- Listen Port ---
+    http_port 8080
+
+    # --- PID/Files for Non-Root Compliance ---
+    pid_filename /var/cache/squid/squid.pid
+    netdb_filename none
+
+    # --- Storage & Caching ---
+    cache_mem 256 MB
+
+    # --- Aggressive Caching for Images ---
+    refresh_pattern -i \.(jpg|jpeg|png|gif|webp|bmp|tiff)$ 10080 100% 43200
+
+    # --- Access Control ---
+    http_access allow all
+
+    # --- Performance & DNS ---
+    # Disable ICMP pinger: containers run without NET_RAW capability, so the
+    # pinger helper would fail to open raw sockets and produce FATAL log noise.
+    pinger_enable off
+    collapsed_forwarding on
+    # External DNS resolvers are used so that Squid can reach internet hosts.
+    # Squid does not resolve in-cluster service names, so keep NO_PROXY set
+    # for .svc and .cluster.local addresses in any client configuration.
+    dns_nameservers 8.8.8.8 8.8.4.4

--- a/helpers/multimedia-downloader/implementations/squid/http/kustomization.yaml
+++ b/helpers/multimedia-downloader/implementations/squid/http/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Default overlay — used by test-squid.sh.
+# For OpenShift, use: kubectl apply -k overlays/openshift
+resources:
+- ./overlays/kind

--- a/helpers/multimedia-downloader/implementations/squid/http/overlays/kind/kustomization.yaml
+++ b/helpers/multimedia-downloader/implementations/squid/http/overlays/kind/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+components:
+- ../../../components/kind-security

--- a/helpers/multimedia-downloader/implementations/squid/http/overlays/openshift/kustomization.yaml
+++ b/helpers/multimedia-downloader/implementations/squid/http/overlays/openshift/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+components:
+- ../../../components/openshift-security

--- a/helpers/multimedia-downloader/implementations/squid/https-ssl-bump/base/kustomization.yaml
+++ b/helpers/multimedia-downloader/implementations/squid/https-ssl-bump/base/kustomization.yaml
@@ -1,0 +1,40 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../http/base
+
+patches:
+# Replace squid.conf with the SSL Bump version
+- path: squid-config-ssl-bump.yaml
+
+# Common Deployment modifications required for SSL Bump (platform-agnostic)
+- target:
+    kind: Deployment
+    name: multimedia-downloader
+  patch: |
+    - op: replace
+      path: /spec/template/spec/containers/0/ports/0/containerPort
+      value: 3128
+    - op: add
+      path: /spec/template/spec/containers/0/volumeMounts/-
+      value:
+        name: squid-ssl-certs
+        mountPath: /etc/squid/certs
+        readOnly: true
+    - op: add
+      path: /spec/template/spec/volumes/-
+      value:
+        name: squid-ssl-certs
+        secret:
+          secretName: squid-ssl-certs
+    - op: replace
+      path: /spec/template/spec/containers/0/command
+      value: ["/usr/local/bin/docker-entrypoint.sh"]
+    - op: replace
+      path: /spec/template/spec/containers/0/args
+      value: ["squid", "-NYd", "1"]
+
+labels:
+- pairs:
+    cache-implementation: squid-ssl-bump

--- a/helpers/multimedia-downloader/implementations/squid/https-ssl-bump/base/squid-config-ssl-bump.yaml
+++ b/helpers/multimedia-downloader/implementations/squid/https-ssl-bump/base/squid-config-ssl-bump.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: squid-multimedia-downloader-config
+  labels:
+    app: multimedia-downloader
+    cache-implementation: squid-ssl-bump
+    component: multimedia-downloader
+data:
+  squid.conf: |
+    access_log stdio:/dev/stdout squid
+    cache_log /dev/stderr
+
+    http_port 3128 ssl-bump \
+      cert=/etc/squid/certs/squid-ca-cert.pem \
+      key=/etc/squid/certs/squid-ca-key.pem \
+      generate-host-certificates=on \
+      dynamic_cert_mem_cache_size=16MB
+
+    # --- SSL Certificate Generation ---
+    sslcrtd_program /usr/lib64/squid/security_file_certgen -s /var/lib/squid/ssl_db -M 16MB
+    sslcrtd_children 10 startup=5 idle=1
+
+    # --- SSL Bump Rules ---
+    # "bump all" decrypts every HTTPS connection — intentional for test/lab use.
+    # For production, replace with a peek-then-splice strategy to limit interception
+    # to specific domains and pass ECH/TLS-1.3 connections through blindly:
+    #
+    #   acl to_cache dstdomain .images.cocodataset.org .images.dog.ceo
+    #   ssl_bump peek all       # inspect SNI without decrypting
+    #   ssl_bump bump to_cache  # decrypt only the target domains
+    #   ssl_bump splice all     # pass everything else through untouched
+    ssl_bump bump all
+
+    # --- PID/Files for Non-Root ---
+    pid_filename /var/cache/squid/squid.pid
+    netdb_filename none
+
+    # --- Caching ---
+    cache_mem 256 MB
+    refresh_pattern -i \.(jpg|jpeg|png|gif|webp|bmp|tiff)$ 10080 100% 43200
+
+    # --- Performance ---
+    # Disable ICMP pinger: containers run without NET_RAW capability.
+    pinger_enable off
+
+    # --- Access Control ---
+    http_access allow all

--- a/helpers/multimedia-downloader/implementations/squid/https-ssl-bump/kustomization.yaml
+++ b/helpers/multimedia-downloader/implementations/squid/https-ssl-bump/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Default overlay — used by test-squid.sh.
+# For OpenShift, use: kubectl apply -k overlays/openshift
+resources:
+- ./overlays/kind

--- a/helpers/multimedia-downloader/implementations/squid/https-ssl-bump/overlays/kind/kustomization.yaml
+++ b/helpers/multimedia-downloader/implementations/squid/https-ssl-bump/overlays/kind/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+components:
+- ../../../components/kind-security
+
+images:
+- name: ubuntu/squid
+  newName: squid-ssl-bump
+  newTag: local

--- a/helpers/multimedia-downloader/implementations/squid/https-ssl-bump/overlays/openshift/kustomization.yaml
+++ b/helpers/multimedia-downloader/implementations/squid/https-ssl-bump/overlays/openshift/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+components:
+- ../../../components/openshift-security

--- a/helpers/multimedia-downloader/implementations/squid/https-ssl-bump/patch-client-deployment.yaml
+++ b/helpers/multimedia-downloader/implementations/squid/https-ssl-bump/patch-client-deployment.yaml
@@ -1,0 +1,56 @@
+# Strategic merge patch — adds Squid CA trust and proxy env vars to a client Deployment.
+#
+# Usage (kustomization.yaml of the client workload):
+#   patches:
+#     - path: patch-client-deployment.yaml
+#       target:
+#         kind: Deployment
+#         name: <your-client-deployment-name>
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: <your-client-deployment-name>   # replace with the actual deployment name
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: install-ca-cert
+        image: alpine:3.21
+        command:
+        - /bin/sh
+        - -c
+        - |
+          apk add --no-cache ca-certificates
+          cp -L /etc/ssl/certs/ca-certificates.crt /shared-certs/ca-certificates.crt
+          cat /squid-ca/squid-ca-cert.pem >> /shared-certs/ca-certificates.crt
+        volumeMounts:
+        - name: squid-ca-cert
+          mountPath: /squid-ca
+          readOnly: true
+        - name: shared-certs
+          mountPath: /shared-certs
+      containers:
+      - name: app                        # replace with your container name if different
+        env:
+        - name: HTTP_PROXY
+          value: "http://multimedia-downloader:80"
+        - name: HTTPS_PROXY
+          value: "http://multimedia-downloader:80"
+        - name: NO_PROXY
+          value: "localhost,127.0.0.1,.svc,.cluster.local"
+        - name: SSL_CERT_DIR
+          value: "/etc/ssl/certs"
+        - name: REQUESTS_CA_BUNDLE
+          value: "/etc/ssl/certs/ca-certificates.crt"
+        - name: CURL_CA_BUNDLE
+          value: "/etc/ssl/certs/ca-certificates.crt"
+        volumeMounts:
+        - name: shared-certs
+          mountPath: /etc/ssl/certs
+          readOnly: true
+      volumes:
+      - name: squid-ca-cert
+        secret:
+          secretName: squid-ca-public-cert
+      - name: shared-certs
+        emptyDir: {}

--- a/helpers/multimedia-downloader/implementations/squid/test/curl-test-pod.yaml
+++ b/helpers/multimedia-downloader/implementations/squid/test/curl-test-pod.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: curl-ssl-test-pod
+spec:
+  initContainers:
+  - name: install-ca-cert
+    image: alpine:3.21
+    command:
+    - /bin/sh
+    - -c
+    - |
+      apk add --no-cache ca-certificates
+      cp -L /etc/ssl/certs/ca-certificates.crt /shared-certs/ca-certificates.crt
+      cat /squid-ca/squid-ca-cert.pem >> /shared-certs/ca-certificates.crt
+    volumeMounts:
+    - name: squid-ca-cert
+      mountPath: /squid-ca
+      readOnly: true
+    - name: shared-certs
+      mountPath: /shared-certs
+  containers:
+  - name: app
+    image: curlimages/curl:8.11.1
+    command: ["sleep", "3600"]
+    env:
+    - name: HTTP_PROXY
+      value: "http://multimedia-downloader:80"
+    - name: HTTPS_PROXY
+      value: "http://multimedia-downloader:80"
+    - name: NO_PROXY
+      value: "localhost,127.0.0.1,.svc,.cluster.local"
+    - name: SSL_CERT_DIR
+      value: "/etc/ssl/certs"
+    - name: REQUESTS_CA_BUNDLE
+      value: "/etc/ssl/certs/ca-certificates.crt"
+    - name: CURL_CA_BUNDLE
+      value: "/etc/ssl/certs/ca-certificates.crt"
+    volumeMounts:
+    - name: shared-certs
+      mountPath: /etc/ssl/certs
+      readOnly: true
+  volumes:
+  - name: squid-ca-cert
+    secret:
+      secretName: squid-ca-public-cert
+  - name: shared-certs
+    emptyDir: {}

--- a/helpers/multimedia-downloader/implementations/squid/test/generate-ssl-certs.sh
+++ b/helpers/multimedia-downloader/implementations/squid/test/generate-ssl-certs.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Generates a Squid CA certificate and creates the corresponding Kubernetes secrets
+# for SSL Bump support.
+#
+# Usage: ./generate-ssl-certs.sh [--namespace <ns>] [--out-dir <dir>] [--org <org>]
+#
+# Defaults:
+#   --namespace  default
+#   --out-dir    squid-ssl-certs
+#   --org        YourOrganization
+
+set -euo pipefail
+
+NAMESPACE="default"
+OUT_DIR="squid-ssl-certs"
+ORG="YourOrganization"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --namespace) NAMESPACE="$2"; shift 2 ;;
+    --out-dir)   OUT_DIR="$2";   shift 2 ;;
+    --org)       ORG="$2";       shift 2 ;;
+    *) echo "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+KEY="$OUT_DIR/squid-ca-key.pem"
+CERT="$OUT_DIR/squid-ca-cert.pem"
+
+# ---------------------------------------------------------------------------
+# Step 1: Generate certificates
+# ---------------------------------------------------------------------------
+mkdir -p "$OUT_DIR"
+
+if [[ -f "$KEY" || -f "$CERT" ]]; then
+  echo "ERROR: Certificate files already exist in '$OUT_DIR/'. Delete them to regenerate." >&2
+  exit 1
+fi
+
+echo "Generating CA private key (4096-bit)..."
+openssl genrsa -out "$KEY" 4096
+
+echo "Generating CA certificate (valid 10 years)..."
+openssl req -new -x509 -days 3650 \
+  -key "$KEY" \
+  -out "$CERT" \
+  -subj "/C=US/ST=State/L=City/O=${ORG}/OU=IT/CN=Squid Proxy CA"
+
+# ---------------------------------------------------------------------------
+# Step 2: Verify the certificate matches the key
+# ---------------------------------------------------------------------------
+echo "Verifying certificate/key pair..."
+CERT_MOD=$(openssl x509 -noout -modulus -in "$CERT" | openssl md5)
+KEY_MOD=$(openssl rsa  -noout -modulus -in "$KEY"  | openssl md5)
+if [[ "$CERT_MOD" != "$KEY_MOD" ]]; then
+  echo "ERROR: certificate and key moduli do not match!" >&2
+  exit 1
+fi
+echo "Certificate/key pair verified."
+
+# ---------------------------------------------------------------------------
+# Step 3: Create Kubernetes secrets
+# ---------------------------------------------------------------------------
+echo "Applying Kubernetes secret 'squid-ssl-certs' (cert + key) in namespace '$NAMESPACE'..."
+kubectl create secret generic squid-ssl-certs \
+  --from-file=squid-ca-cert.pem="$CERT" \
+  --from-file=squid-ca-key.pem="$KEY" \
+  -n "$NAMESPACE" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo "Applying Kubernetes secret 'squid-ca-public-cert' (cert only) in namespace '$NAMESPACE'..."
+kubectl create secret generic squid-ca-public-cert \
+  --from-file=squid-ca-cert.pem="$CERT" \
+  -n "$NAMESPACE" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo ""
+echo "Done. Files written to '$OUT_DIR/'."
+echo "⚠️  Keep '$KEY' secure"

--- a/helpers/multimedia-downloader/implementations/squid/test/test-squid.sh
+++ b/helpers/multimedia-downloader/implementations/squid/test/test-squid.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# test-squid.sh — deploys and tests the Squid HTTP or SSL Bump implementation.
+# Usage details available via --help
+
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly HTTP_DIR="${SCRIPT_DIR}/../http"
+readonly SSL_BUMP_DIR="${SCRIPT_DIR}/../https-ssl-bump"
+readonly DOCKER_DIR="${SCRIPT_DIR}/../docker"
+readonly SERVICE_YAML="${SCRIPT_DIR}/../../../service.yaml"
+readonly LOCAL_IMAGE="squid-ssl-bump:local"
+readonly REMOTE_TAG="dev"
+readonly CURL_IMAGE="curlimages/curl:8.11.1"
+readonly HTTP_TEST_URL="http://images.cocodataset.org/val2017/000000039769.jpg"
+readonly HTTP_PROXY="http://multimedia-downloader:80"
+readonly SSL_TEST_URL="https://images.dog.ceo/breeds/poodle-standard/n02113799_2280.jpg"
+readonly SSL_CA_ORG="Squid Test CA"
+
+# Default configurations
+MODE="http"
+SKIP_CLEANUP=false
+USE_OPENSHIFT=false
+KUBE_CONTEXT=""
+NAMESPACE="default"
+REGISTRY="${SQUID_IMAGE_REGISTRY:-}" # Reads from ENV var if set
+BUILD_PUSH=false
+KUSTOMIZE_TMP=""
+
+# --- Logging Helpers -----------------------------------------------------------
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
+section() { echo -e "\n${YELLOW}==> $*${NC}"; }
+success() { echo -e "${GREEN}✓ $*${NC}"; }
+error()   { echo -e "${RED}✗ $*${NC}"; }
+
+# --- Argument Parsing ----------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --mode)             MODE="$2"; shift 2 ;;
+        --skip-cleanup)     SKIP_CLEANUP=true; shift ;;
+        --openshift)        USE_OPENSHIFT=true; shift ;;
+        --registry)         REGISTRY="$2"; shift 2 ;;
+        --build-push)       BUILD_PUSH=true; MODE="ssl-bump"; shift ;;
+        --context)          KUBE_CONTEXT="$2"; USE_OPENSHIFT=true; shift 2 ;;
+        --help|-h)
+            sed -n '2,/^# Requirements:/p' "$0" | grep '^#' | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) error "Unknown argument: $1"; exit 1 ;;
+    esac
+done
+
+# --- Validation & Dynamic Variables --------------------------------------------
+case "${MODE}" in
+    http)     
+        readonly CLUSTER_NAME="squid-smoke"
+        readonly TEST_POD="curl-test-pod"
+        readonly IMPL_DIR="${HTTP_DIR}" 
+        ;;
+    ssl-bump) 
+        readonly CLUSTER_NAME="squid-ssl-bump-smoke"
+        readonly TEST_POD="curl-ssl-test-pod"
+        readonly IMPL_DIR="${SSL_BUMP_DIR}" 
+        ;;
+    *) error "Invalid --mode '${MODE}'. Must be 'http' or 'ssl-bump'."; exit 1 ;;
+esac
+
+# Validate dependencies (using short-circuit evaluation for clean code)
+[[ "${MODE}" == "ssl-bump" && ${USE_OPENSHIFT} == true && -z "${REGISTRY}" ]] && { error "--mode ssl-bump --openshift requires a registry. Use --registry or export SQUID_IMAGE_REGISTRY"; exit 1; }
+[[ ${BUILD_PUSH} == true && -z "${REGISTRY}" ]] && { error "--build-push requires a registry. Use --registry or export SQUID_IMAGE_REGISTRY"; exit 1; }
+
+# --- Core Functions ------------------------------------------------------------
+
+cleanup() {
+    section "Cleaning up"
+
+    if [[ ${SKIP_CLEANUP} == true ]]; then
+        echo "  Resources left in place for inspection (--skip-cleanup)."
+    else
+        kubectl delete pod "${TEST_POD}" --ignore-not-found --wait=false 2>/dev/null || true
+
+        if [[ ${USE_OPENSHIFT} == true ]]; then
+            kubectl delete -f "${SERVICE_YAML}" --ignore-not-found 2>/dev/null || true
+            kubectl delete -k "${IMPL_DIR}/overlays/openshift" --ignore-not-found 2>/dev/null || true
+            echo "  OpenShift multimedia-downloader resources deleted."
+        else
+            kind delete cluster --name "${CLUSTER_NAME}" 2>/dev/null || true
+            echo "  Cluster '${CLUSTER_NAME}' deleted."
+        fi
+    fi
+
+    if [[ -d "${SCRIPT_DIR}/squid-ssl-certs" ]]; then
+        rm -rf "${SCRIPT_DIR}/squid-ssl-certs"
+        echo "  Generated certificates cleaned up."
+    fi
+    [[ -n "${KUSTOMIZE_TMP}" && -d "${KUSTOMIZE_TMP}" ]] && rm -rf "${KUSTOMIZE_TMP}"
+}
+trap cleanup EXIT
+
+build_and_push_image() {
+    section "Building Squid SSL Bump image"
+    docker build -t "${LOCAL_IMAGE}" -f "${DOCKER_DIR}/Dockerfile.squid-ssl-bump" "${DOCKER_DIR}"
+    success "Image built: ${LOCAL_IMAGE}"
+
+    if [[ ${BUILD_PUSH} == true && -n "${REGISTRY}" ]]; then
+        local remote_image="${REGISTRY}/squid-ssl-bump:${REMOTE_TAG}"
+        section "Pushing image to registry"
+        docker tag "${LOCAL_IMAGE}" "${remote_image}"
+        docker push "${remote_image}"
+        success "Image pushed: ${remote_image}"
+    fi
+}
+
+setup_cluster() {
+    if [[ -n "${KUBE_CONTEXT}" ]]; then
+        kubectl config use-context "${KUBE_CONTEXT}"
+        echo "  Switched to kubectl context: ${KUBE_CONTEXT}"
+    fi
+
+    if [[ ${USE_OPENSHIFT} == true ]]; then
+        NAMESPACE="$(kubectl config view --minify --output 'jsonpath={..namespace}' || echo 'default')"
+        echo "  Using OpenShift namespace: ${NAMESPACE}"
+        kubectl config set-context --current --namespace="${NAMESPACE}"
+    else
+        section "Setting up kind cluster '${CLUSTER_NAME}'"
+        if ! kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"; then
+            kind create cluster --name "${CLUSTER_NAME}" --wait 90s
+            echo "  Cluster created."
+        fi
+
+        if [[ "${MODE}" == "ssl-bump" ]]; then
+            section "Loading image into kind cluster"
+            kind load docker-image "${LOCAL_IMAGE}" --name "${CLUSTER_NAME}"
+            success "Image loaded into cluster"
+        fi
+    fi
+}
+
+deploy_squid() {
+    local kustomize_dir="${IMPL_DIR}/overlays/kind"
+
+    if [[ ${USE_OPENSHIFT} == true ]]; then
+        kustomize_dir="${IMPL_DIR}/overlays/openshift"
+        
+        if [[ "${MODE}" == "ssl-bump" && -n "${REGISTRY}" ]]; then
+            KUSTOMIZE_TMP="$(mktemp -d "${IMPL_DIR}/overlays/.tmp-kustomize-XXXXXX")"
+            cat > "${KUSTOMIZE_TMP}/kustomization.yaml" <<EOF
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../openshift
+images:
+- name: ubuntu/squid
+  newName: ${REGISTRY}/squid-ssl-bump
+  newTag: ${REMOTE_TAG}
+EOF
+            kustomize_dir="${KUSTOMIZE_TMP}"
+        fi
+    fi
+
+    section "Deploying squid (mode: ${MODE})"
+    kubectl apply -k "${kustomize_dir}"
+    
+    kubectl apply -f "${SERVICE_YAML}"
+    kubectl rollout status deployment/multimedia-downloader --timeout=120s
+    success "multimedia-downloader is ready."
+}
+
+# assert_squid_status <expected_pattern> <url> [curl_args...]
+# Sends one curl request and verifies the squid log contains expected_pattern for that URL.
+assert_squid_status() {
+    local expected="$1" url="$2"; shift 2
+
+    echo "  Requesting ${url} (expect ${expected})..."
+    if ! kubectl exec "${TEST_POD}" -- curl -sf -o /dev/null "$@" "${url}"; then
+        error "curl request failed: ${url}"
+        return 1
+    fi
+    sleep 3
+
+    local log_line
+    log_line=$(kubectl logs -l app=multimedia-downloader -c squid --tail=20 \
+               | grep -F "${url}" | tail -1 || true)
+    if ! echo "${log_line}" | grep -qE "${expected}"; then
+        error "Expected '${expected}' in squid log but got: ${log_line:-<no matching entry>}"
+        return 1
+    fi
+    success "${expected} confirmed for ${url}"
+}
+
+# run_cache_test <url> [curl_args...]
+# Sends a miss request then a hit request, asserting cache status for each.
+run_cache_test() {
+    local url="$1"; shift
+    assert_squid_status "TCP_MISS"  "${url}" "$@"
+    assert_squid_status "TCP_.*HIT" "${url}" "$@"
+}
+
+run_http_test() {
+    section "Testing HTTP Cache"
+    kubectl run "${TEST_POD}" --image="${CURL_IMAGE}" --restart=Never -- sleep 30
+    kubectl wait --for=condition=Ready pod/"${TEST_POD}" --timeout=60s
+
+    run_cache_test "${HTTP_TEST_URL}" -x "${HTTP_PROXY}"
+}
+
+run_ssl_bump_test() {
+    section "Generating SSL certificates"
+    rm -rf "${SCRIPT_DIR}/squid-ssl-certs" 2>/dev/null || true
+    "${SCRIPT_DIR}/generate-ssl-certs.sh" --namespace "${NAMESPACE}" --out-dir "${SCRIPT_DIR}/squid-ssl-certs" --org "${SSL_CA_ORG}"
+    success "SSL certificates generated"
+
+    # Must generate certs BEFORE deploying squid so the secret exists
+    deploy_squid
+
+    section "Deploying test client pod with CA trust"
+    kubectl delete pod "${TEST_POD}" --ignore-not-found --wait=true 2>/dev/null
+    kubectl apply -f "${SCRIPT_DIR}/curl-test-pod.yaml"
+    kubectl wait --for=condition=Ready pod/"${TEST_POD}" --timeout=120s
+
+    section "Testing SSL Bump Cache"
+    run_cache_test "${SSL_TEST_URL}"
+
+    section "Verifying SSL Bump interception"
+    kubectl exec "${TEST_POD}" -- curl -sfv "${SSL_TEST_URL}" -o /dev/null 2>&1 | grep -i "issuer" || echo "Could not verify issuer"
+}
+
+# --- Main Execution Flow -------------------------------------------------------
+
+if [[ ${BUILD_PUSH} == true ]]; then
+    build_and_push_image
+    echo -e "\nNOTE: Run the test with: $0 --mode ssl-bump --openshift --registry ${REGISTRY}"
+    
+    # Unregister the trap so we don't accidentally delete an active cluster
+    trap - EXIT
+    exit 0
+fi
+
+if [[ "${MODE}" == "ssl-bump" && ${USE_OPENSHIFT} == false ]]; then
+    build_and_push_image
+fi
+
+setup_cluster
+
+if [[ "${MODE}" == "http" ]]; then
+    deploy_squid
+    run_http_test
+else
+    run_ssl_bump_test
+fi
+
+section "Summary"
+success "Proxy deployed and tested (${MODE})"
+echo "To inspect manually: kubectl logs -l app=multimedia-downloader -c squid"

--- a/helpers/multimedia-downloader/kustomization.yaml
+++ b/helpers/multimedia-downloader/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+# Base service — implementations expose a port named http-proxy, which the service
+# resolves automatically via targetPort: http-proxy (no service patch needed).
+- service.yaml
+# Cache implementation
+- implementations/squid/http
+
+
+commonLabels:
+  component: multimedia-downloader
+

--- a/helpers/multimedia-downloader/service.yaml
+++ b/helpers/multimedia-downloader/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: multimedia-downloader
+  labels:
+    app: multimedia-downloader
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: http-proxy
+    protocol: TCP
+    name: http-proxy
+  selector:
+    app: multimedia-downloader
+


### PR DESCRIPTION
Adds helpers/multimedia-downloader/, a pluggable Kubernetes-native caching proxy for large multimedia assets fetched during LLM inference.

## What's included
Base service — a ClusterIP service on port 80 with a named-port contract (http-proxy) that decouples the service from backend implementation details
Squid HTTP variant — caches HTTP assets; HTTPS is tunneled via opaque CONNECT
Squid HTTPS SSL Bump variant — full HTTPS caching via MITM interception; includes cert generation helper and a custom container image
Kustomize overlays — for kind and openShift
Pluggable interface — new backends can be added under implementations/ without modifying the base service

closes #1182