### PR TITLE
Remove cron trigger from e2e gke tests

### DIFF
--- a/.github/workflows/e2e-inference-scheduling-gke.yaml
+++ b/.github/workflows/e2e-inference-scheduling-gke.yaml
@@ -4,8 +4,6 @@ on:
   # Runs with a PR comment /run-gke-inference-scheduling
   issue_comment:
     types: [created]
-  schedule:
-    - cron: '0 10 * * *'  # 3AM PST (10:00 UTC)
   workflow_dispatch:
     inputs:
       pr_or_branch:

--- a/.github/workflows/e2e-pd-disaggregation-gke.yaml
+++ b/.github/workflows/e2e-pd-disaggregation-gke.yaml
@@ -4,8 +4,6 @@ on:
   # Runs with a PR comment /run-gke-pd-disaggregation
   issue_comment:
     types: [created]
-  schedule:  # TODO: enable once validated functional
-    - cron: '0 11 * * *'  # 4AM PST (11:00 UTC)
   workflow_dispatch:
     inputs:
       pr_or_branch:

--- a/.github/workflows/e2e-wide-ep-accelerator-gke.yaml
+++ b/.github/workflows/e2e-wide-ep-accelerator-gke.yaml
@@ -4,8 +4,6 @@ on:
   # Runs with a PR comment /run-gke-wide-ep
   issue_comment:
     types: [created]
-  schedule:
-    - cron: '0 12 * * *'  # 5AM PST (12:00 UTC)
   workflow_dispatch:
     inputs:
       pr_or_branch:


### PR DESCRIPTION
Nightly tests running under 

* `.github/workflows/nightly-e2e-inference-scheduling-gke.yaml`
* `.github/workflows/nightly-e2e-pd-disaggregation-gke.yaml`
* `.github/workflows/nightly-e2e-wide-ep-lws-gke.yaml`