### PR TITLE
[Docs][AMD] Add MI355X (gfx950) to validated AMD platforms

### DIFF
--- a/guides/inference-scheduling/ms-inference-scheduling/values_amd.yaml
+++ b/guides/inference-scheduling/ms-inference-scheduling/values_amd.yaml
@@ -1,3 +1,12 @@
+# AMD GPU inference-scheduling values.
+#
+# Validated on:
+#   * MI300X (gfx942) -- original target, see PR #642
+#   * MI355X (gfx950) -- llm-d-rocm:v0.6.0 image works as-is on MI355X.
+#     Smoke + standalone vLLM verified on a single 8xMI355X node.
+#     PYTORCH_ROCM_ARCH in the v0.6.0 image already includes both gfx942
+#     and gfx950, so no image-level changes are required for MI355X.
+
 multinode: false
 
 # Distributed tracing configuration (OpenTelemetry)

--- a/guides/pd-disaggregation/README.amd.md
+++ b/guides/pd-disaggregation/README.amd.md
@@ -5,6 +5,7 @@
 This guide demonstrates how to deploy models using vLLM's P/D disaggregation support with RIXL. This guide has been validated on:
 
 * a cluster with 2 8xMI300x nodes connected with RoCE networking
+* `ghcr.io/llm-d/llm-d-rocm:v0.6.0` standalone container on a single 8xMI355X (gfx950) node — model load + smoke test only; full P/D disaggregation across MI355X nodes still needs validation
 
 > WARNING: We are still investigating and optimizing performance across hardware and networking configurations
 

--- a/guides/pd-disaggregation/ms-pd/values_amd.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_amd.yaml
@@ -1,3 +1,12 @@
+# AMD GPU P/D disaggregation values.
+#
+# Validated on:
+#   * MI300X (gfx942) -- original target, see PR #776 (Mar 2026)
+#   * MI355X (gfx950) -- llm-d-rocm:v0.6.0 standalone container verified to
+#     load amd/Llama-3.3-70B-Instruct-FP8-KV at TP=8 on a single 8xMI355X
+#     node and produce coherent output. Two-node P/D disaggregation across
+#     MI355X nodes still needs RoCE-fabric validation.
+
 multinode: false
 
 modelArtifacts:


### PR DESCRIPTION
## Summary

Add MI355X (gfx950) as a validated AMD platform in the AMD well-lit-paths guides. The published `ghcr.io/llm-d/llm-d-rocm:v0.6.0` image works as-is on MI355X — no code or container changes required, only documentation/values-comment updates.

## Validation

Tested on a single 8xMI355X (gfx950) node, `ghcr.io/llm-d/llm-d-rocm:v0.6.0` standalone (no Helm/K8s), against two configurations:

### 1. Qwen2.5-1.5B-Instruct, TP=1

```bash
docker run -d --name llmd-smoke \
  --device=/dev/kfd --device=/dev/dri --network=host --ipc=host --shm-size=128g \
  --group-add video --cap-add SYS_PTRACE --security-opt seccomp=unconfined \
  -v /path/to/models:/models:ro \
  ghcr.io/llm-d/llm-d-rocm:v0.6.0 \
    --model /models/Qwen2.5-1.5B-Instruct \
    --port 8000 --tensor-parallel-size 1 \
    --gpu-memory-utilization 0.85 --max-model-len 4096
```
- Server ready in ~60s
- `/v1/completions` returns coherent text

### 2. amd/Llama-3.3-70B-Instruct-FP8-KV, TP=8 (matches `values_amd.yaml`)

```bash
docker run -d --name llmd-smoke \
  --device=/dev/kfd --device=/dev/dri --network=host --ipc=host --shm-size=128g \
  --group-add video --cap-add SYS_PTRACE --security-opt seccomp=unconfined \
  -v /path/to/models:/models:ro \
  ghcr.io/llm-d/llm-d-rocm:v0.6.0 \
    --model /models/Llama-3.3-70B-Instruct-FP8-KV \
    --port 8000 --tensor-parallel-size 8 \
    --gpu-memory-utilization 0.85 \
    --max-model-len 32000 --block-size 128 \
    --disable-uvicorn-access-log
```
- Server ready in ~135s
- Smoke test returns coherent text:
  > "Hello, my name is Alvin and I am a 3rd year student at the University of California, Berkeley, studying Computer Science. I am excited to be a part of the Google Summer of Code program"

**Quick perf** (`vllm bench serve --backend vllm --dataset-name random --random-input-len 1024 --random-output-len 256 --num-prompts 32 --max-concurrency 8`):

| Metric | Value |
|---|---|
| Output throughput | 735 tok/s |
| Total throughput | 3674 tok/s |
| Mean TTFT | 222 ms |
| Median TPOT / ITL | 9.97 ms |

## Why this works without code changes

The base image's PyTorch is built with `PYTORCH_ROCM_ARCH=gfx90a;gfx942;gfx950;...`, so MI355X (gfx950) is already a first-class build target:

```
$ docker exec llmd-smoke python3 -c "import os; print(os.environ.get('PYTORCH_ROCM_ARCH'))"
gfx90a;gfx942;gfx950;gfx1100;gfx1101;gfx1200;gfx1201;gfx1150;gfx1151

$ docker exec llmd-smoke python3 -c "import torch; print(torch.cuda.get_device_properties(0).gcnArchName)"
gfx950:sramecc+:xnack-
```

## What's NOT covered (follow-up)

- Two-node P/D disaggregation across MI355X nodes via RoCE — needs a paired MI355X topology with a working RoCE fabric, which I didn't have access to during this validation. Single-node functional + perf only.
- Helm/K8s deployment of the well-lit-paths on MI355X — single-node container only.
- Other models in the AMD ecosystem (DeepSeek, Kimi, GLM-5) — only the documented `Llama-3.3-70B-FP8-KV` was exercised.

Happy to extend this to a P/D run if a maintainer can point at suitable test infrastructure.

## Refs

- Closes a sub-question of #139 (community asking about AMD/MI300 support — MI300X already supported via PR #642 / #776; MI355X now also documented)
