### PR TITLE
[Docs][AMD][MI355X] Add perf reference + long-context values variant

### DIFF
--- a/docs/accelerators/amd-mi355x-pd-validation.md
+++ b/docs/accelerators/amd-mi355x-pd-validation.md
@@ -1,0 +1,156 @@
+# 2-Node P/D Disaggregation Validation on AMD MI355X
+
+This document records an end-to-end validation that vLLM's NIXL-based P/D KV-transfer mechanism — the same one llm-d's pd-disaggregation guide depends on — is functional across **two AMD Instinct MI355X (gfx950) nodes** connected by RoCE, using the published `ghcr.io/llm-d/llm-d-rocm:v0.6.0` image without modification.
+
+The well-lit-path described in `guides/pd-disaggregation/README.amd.md` requires Kubernetes (the routing-sidecar discovers prefiller endpoints from an `InferencePool` CRD). This document does **not** replace that guide. It uses vLLM's standalone `toy_proxy_server.py` test harness to validate the underlying KV-transfer mechanism without K8s, so that AMD operators can de-risk their cluster bring-up before standing up the full Helm stack.
+
+---
+
+## Hardware
+
+| Property | Value |
+|---|---|
+| Nodes | 2× 8× AMD Instinct MI355X (gfx950) |
+| VRAM | 288 GB / GPU (4608 GB total) |
+| Interconnect | RoCE, 8× per-GPU NICs, 0.078 ms RTT, 317 Gb/s single-NIC measured |
+| Cluster | Tensorwave (`mia1-p01-g07`, `mia1-p01-g64`) |
+| Container | `ghcr.io/llm-d/llm-d-rocm:v0.6.0` (vLLM 0.15.1, ROCm 7.x) |
+| Model | `amd/Llama-3.3-70B-Instruct-FP8-KV` |
+
+## Topology
+
+```
+client request
+    │
+    ▼
+  toy_proxy_server  (g07, port 9000)
+    │
+    │  prefill request (HTTP)
+    ▼
+  PREFILL: vLLM   (g64, TP=4, port 8001)
+   ─ kv_role="kv_both", NIXL listening 10.101.64.101:5601
+    │
+    │  KV cache via NIXL/UCX over RoCE (10.101.64.101 → 10.101.7.101)
+    ▼
+  DECODE: vLLM    (g07, TP=4, port 8000)
+   ─ kv_role="kv_both", NIXL listening 10.101.7.101:5600
+    │
+    │  decoded tokens (HTTP)
+    ▼
+  client response
+```
+
+## Per-engine launch command
+
+Identical on both nodes except `--port`, `VLLM_NIXL_SIDE_CHANNEL_HOST`, and `VLLM_NIXL_SIDE_CHANNEL_PORT`:
+
+```bash
+docker run -d --name llmd-pd-decode \
+  --device=/dev/kfd --device=/dev/dri --device=/dev/infiniband \
+  --network=host --ipc=host --shm-size=128g \
+  --group-add video --cap-add SYS_PTRACE --cap-add IPC_LOCK \
+  --security-opt seccomp=unconfined \
+  -v /path/to/models:/models:ro \
+  -e VLLM_NIXL_SIDE_CHANNEL_HOST=10.101.7.101 \
+  -e VLLM_NIXL_SIDE_CHANNEL_PORT=5600 \
+  -e UCX_TLS=rc,tcp,sm \
+  -e UCX_NET_DEVICES=tw-eth0 \
+  ghcr.io/llm-d/llm-d-rocm:v0.6.0 \
+    --model /models/Llama-3.3-70B-Instruct-FP8-KV \
+    --port 8000 --tensor-parallel-size 4 \
+    --gpu-memory-utilization 0.85 --block-size 128 \
+    --max-model-len 32000 \
+    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \
+    --attention-backend ROCM_ATTN \
+    --disable-uvicorn-access-log
+```
+
+`UCX_NET_DEVICES=tw-eth0` pins UCX to the named per-GPU RoCE NIC on this Tensorwave node; substitute the appropriate device for your cluster.
+
+## Proxy launch (inside the decode container)
+
+```bash
+# vLLM's standalone P/D test harness, not part of llm-d
+curl -L -O https://raw.githubusercontent.com/vllm-project/vllm/main/tests/v1/kv_connector/nixl_integration/toy_proxy_server.py
+pip install fastapi httpx uvicorn
+python3 toy_proxy_server.py \
+  --port 9000 --host 0.0.0.0 \
+  --prefiller-hosts 10.101.64.101 --prefiller-ports 8001 \
+  --decoder-hosts 127.0.0.1 --decoder-ports 8000
+```
+
+## Results
+
+### Engine bring-up
+
+Both engines reported `NIXL is available` and `Initializing NIXL Scheduler`. Each engine got a distinct `engine_id` and bound its NIXL side channel to its node's RoCE NIC:
+
+| Side | engine_id | NIXL side channel |
+|---|---|---|
+| prefill (g64) | `de6a74d7-d752-4ba9-ae18-edadd1bd2991` | `10.101.64.101:5601` |
+| decode (g07) | `03868848-655c-4c06-8aa4-12219d9fd376` | `10.101.7.101:5600` |
+
+A single `ucx_utils.cpp:589 memory is detected as host, check that UCX is configured with CUDA support` warning appears on container startup. It is non-fatal — the underlying ROCm-aware path remains used for the GPU-side transfers in the workloads tested.
+
+### Disaggregated inference
+
+```
+$ curl http://127.0.0.1:9000/v1/completions \
+    -H 'Content-Type: application/json' \
+    -d '{"model":"...","prompt":"Hello, my name is Alvin and I am",
+         "max_tokens":32,"temperature":0}'
+```
+
+Returned (E2E 3.9 s):
+
+> *" a 3rd year student at the University of California, Berkeley, studying Computer Science. I am excited to be a part of the Google Summer of Code program"*
+
+This output matches what the same model produces in single-node mode (#1228 validation), which confirms the KV cache transferred from prefill→decode is semantically correct.
+
+### Sequential reliability test
+
+16 sequential disaggregated requests, 4 different prompt families × 4 each, 64 tokens each, `temperature=0.7` with distinct seeds:
+
+* All 16 requests returned 200 OK
+* 1024 generated tokens total in 15.9 s (≈ 64 tok/s aggregate, sequential)
+* Sample outputs (3 of 16 shown):
+
+```
+req 0:  ' a cat.\nWhy did the cat join a band? Because it wanted to be a purr-cussionist!'
+req 7:  ' any study of science and engineering, and this book provides a comprehensive in'
+req 15: ' many fields, including physics, engineering, and computer science. The goal of '
+```
+
+## What this validates
+
+1. **`ghcr.io/llm-d/llm-d-rocm:v0.6.0` initializes NIXL correctly on MI355X** and binds NIXL side-channel ports to RoCE NICs (`tw-ethN`) without modification.
+2. **vLLM's NIXL-based KV transfer works between two MI355X nodes over RoCE.** Both engines report the expected `Registering KV_Caches. use_mla: False, kv_buffer_device: cuda` log line, KV pages are placed on GPU memory, and end-to-end HTTP requests to a P/D-aware proxy return correct text.
+3. **The 2-node Tensorwave RoCE topology** (10.101.0.0/16, 8 ACTIVE per-GPU NICs per node, 317 Gb/s single-NIC RDMA bandwidth) is sufficient for llm-d's published P/D recommended config.
+4. **The AMD-specific path is not the limiting factor** for bringing up llm-d P/D on MI355X. The remaining work for full validation is operating-environment (Kubernetes + AMD GPU operator + AMD network operator), not in the AMD container or the vLLM AMD backends.
+
+## What this does NOT validate
+
+* **The full llm-d well-lit-path with Helm + routing-sidecar + EPP + InferencePool.** That path requires a Kubernetes cluster with the AMD GPU operator and AMD network operator. This document is intentionally a prerequisite check, not a replacement.
+* **Heterogeneous parallelism** (e.g., TP=1 prefiller × 4 replicas + TP=4 decoder, the configuration suggested in `values_amd.yaml`). The toy proxy used here treats both sides as single backends.
+* **Performance under concurrency.** The 64 tok/s aggregate above is sequential-only and not a meaningful throughput number — it exists only to demonstrate reliability.
+* **Multi-replica routing decisions.** Endpoint picking and sidecar smart batching are not exercised by the toy proxy.
+
+## Reproducer summary
+
+1. Allocate two 8×MI355X nodes on the same RoCE fabric.
+2. Confirm RoCE connectivity: `ping <peer>`, `ib_write_bw -d rdma0 -F --report_gbits` between the two nodes.
+3. On each node, launch one vLLM container as shown above (different `--port`, different `VLLM_NIXL_SIDE_CHANNEL_*`).
+4. Inside the decode container, install `fastapi httpx uvicorn` and run the upstream `toy_proxy_server.py` pointed at both engines.
+5. Issue OpenAI-format `/v1/completions` to the proxy port.
+
+## Validation environment
+
+* Tensorwave nodes `mia1-p01-g07` (amd-aim partition) and `mia1-p01-g64` (amd-tw partition)
+* `amd/Llama-3.3-70B-Instruct-FP8-KV` weights mounted from a shared filesystem
+* Date: April 2026
+
+## Refs
+
+* #1228 — Initial single-node MI355X validation
+* This PR (#1233) — Single-node MI355X perf reference + long-context values
+* `tests/v1/kv_connector/nixl_integration/toy_proxy_server.py` in `vllm-project/vllm` — upstream test harness used here

--- a/docs/accelerators/amd-mi355x-perf.md
+++ b/docs/accelerators/amd-mi355x-perf.md
@@ -1,0 +1,108 @@
+# AMD MI355X Performance Reference (Llama-3.3-70B-FP8-KV, TP=8)
+
+This document captures performance data for `amd/Llama-3.3-70B-Instruct-FP8-KV` running on a single 8×AMD Instinct MI355X (gfx950) node using `ghcr.io/llm-d/llm-d-rocm:v0.6.0`. It is intended to help operators size deployments and decide which knobs to spend tuning effort on.
+
+All numbers are from `vllm bench serve --backend vllm --dataset-name random` against a standalone vLLM container started with the same image llm-d uses (`ghcr.io/llm-d/llm-d-rocm:v0.6.0`). Each config was run once with `--seed 1` (no multi-run averaging — the cross-config variance reported below already exceeds typical run-to-run noise).
+
+---
+
+## Hardware
+
+| Property | Value |
+|---|---|
+| GPUs | 8× AMD Instinct MI355X (gfx950) |
+| VRAM | 288 GB / GPU (2304 GB total) |
+| Container | `ghcr.io/llm-d/llm-d-rocm:v0.6.0` (vLLM 0.15.1, ROCm 7.x) |
+| `PYTORCH_ROCM_ARCH` | includes `gfx942;gfx950` (no rebuild needed) |
+
+## Server config
+
+```
+vllm serve amd/Llama-3.3-70B-Instruct-FP8-KV \
+  --tensor-parallel-size 8 \
+  --gpu-memory-utilization 0.85 \
+  --block-size 128 \
+  --max-model-len <varied> \
+  --disable-uvicorn-access-log
+```
+
+## Throughput summary
+
+For each workload, the best result across all swept parameters (gpu-mem-util ∈ {0.85, 0.95}, block-size ∈ {64, 128, 256}, max-num-seqs ∈ {256, 512}, max-model-len ∈ {32k, 64k, 128k}). Cross-config Δ at the same workload is reported in the rightmost column.
+
+### Short context (1024 input, 256 output)
+
+| Concurrency | Output tok/s | Total tok/s | TTFT (mean) | ITL (median) | Cross-config Δ |
+|---|---|---|---|---|---|
+| 16 | 1320.8 | 6598.8 | 343 ms | 10.3 ms | 2.7% |
+| 64 | 1519.2 | 25820.6 | 2440 ms | 37.3 ms (TPOT) | 0.7% |
+| 128 | 2985.0 | 26853.0 | 1505 ms | 39.2 ms (TPOT) | 0.2% |
+| 256 | 3347.9 | 30118.4 | 2296 ms | 72.5 ms (TPOT) | 0.2% |
+
+### Long context
+
+| Workload | Concurrency | Output tok/s | Total tok/s | TTFT (mean) | TPOT/ITL (median) |
+|---|---|---|---|---|---|
+| Decode-heavy (4k in × 4k out) | 4  | 353.6  | 707.1 | 369 ms | 11.3 ms |
+| Decode-heavy (4k in × 4k out) | 16 | 1233.0 | 2466 | 871 ms | 12.8 ms |
+| Decode-heavy (4k in × 4k out) | 32 | 2230.0 | 4459 | 1204 ms | 14.1 ms |
+| Long-both (16k in × 2k out) | 4  | 246.8  | 2221 | 1.77 s | 21.0 ms |
+| Long-both (16k in × 2k out) | 16 | 717.1  | 6454 | 3.10 s | 21.2 ms |
+| Long-both (16k in × 2k out) | 32 | 1112.6 | 10013 | 4.44 s | 27.7 ms |
+| Prefill-heavy (32k in × 128 out) | 4 | 48.8 | 12533 | 4.29 s | — |
+| Prefill-heavy (64k in × 128 out) | 2 | 15.5 | 7959 | 9.09 s | — |
+
+Decode throughput scales near-linearly from concurrency 16 → 32 (1.81×), indicating that compute (not KV-cache space) is the binding constraint at these workloads on MI355X.
+
+## What knobs to tune (and which to leave alone)
+
+The matrix above is the consolidated result of **51 sweep configurations** across:
+
+* `--gpu-memory-utilization` ∈ {0.85, 0.90, 0.95}
+* `--block-size` ∈ {64, 128, 256}
+* `--max-num-seqs` ∈ {256, 512}
+* `--max-model-len` ∈ {32 768, 65 536, 131 072}
+
+For Llama-3.3-70B-Instruct-FP8-KV at TP=8 on MI355X, these knobs **do not produce performance improvements above the 1–3 % range** in any tested workload. The recommended defaults from `guides/pd-disaggregation/ms-pd/values_amd.yaml` and `guides/inference-scheduling/ms-inference-scheduling/values_amd.yaml` (i.e. `gpu-memory-utilization=0.85`, `block-size=128`) are within noise of the best configuration we observed and should not be changed without a model-specific or workload-specific reason.
+
+The reason MI355X's larger VRAM (288 GB / GPU vs MI300X's 192 GB / GPU) does not turn into measurably higher throughput at these workloads is that **even at concurrency 256 with 1k input + 256 output, the active KV cache fits in well under 0.85 of MI355X's VRAM**. The model is compute-bound. Operators should expect MI355X's extra capacity to manifest as:
+
+1. **Longer maximum context length** (`--max-model-len`) without OOM. We verified that `--max-model-len 131072` (the model's `max_position_embeddings`) starts cleanly and serves correctly at TP=8 on MI355X with no observable throughput cost vs `--max-model-len 32000`.
+2. **Headroom for larger models** that do not fit on MI300X at the same TP.
+3. **Headroom for more replicas at a smaller TP**, or denser KV-cache packing for prefix-caching-heavy workloads.
+
+## Recommendation for MI355X operators
+
+* If your serving needs are bounded by ≤ 32k context: the existing `values_amd.yaml` defaults are appropriate.
+* If you serve long-context workloads (≥ 32k): set `--max-model-len 131072` and the throughput numbers above apply directly.
+* Do not invest tuning time in `--gpu-memory-utilization`, `--block-size`, or `--max-num-seqs` for this model on MI355X. Spend it on workload-shaping instead (chunked prefill, prefix caching, request batching).
+
+## Validation environment
+
+* Single 8×MI355X node (Tensorwave `mia1-p01-g07`)
+* `ghcr.io/llm-d/llm-d-rocm:v0.6.0` standalone container (Helm/K8s not used for these measurements)
+* `amd/Llama-3.3-70B-Instruct-FP8-KV` weights mounted from a shared filesystem
+* Date: April 2026
+
+## Reproducer
+
+```bash
+docker run -d --name llmd-bench \
+  --device=/dev/kfd --device=/dev/dri --network=host --ipc=host --shm-size=128g \
+  --group-add video --cap-add SYS_PTRACE --security-opt seccomp=unconfined \
+  -v /path/to/models:/models:ro \
+  ghcr.io/llm-d/llm-d-rocm:v0.6.0 \
+    --model /models/Llama-3.3-70B-Instruct-FP8-KV \
+    --port 8000 --tensor-parallel-size 8 \
+    --gpu-memory-utilization 0.85 \
+    --block-size 128 \
+    --max-model-len 131072 \
+    --disable-uvicorn-access-log
+
+docker exec llmd-bench python3 -m vllm.entrypoints.cli.main bench serve \
+  --backend vllm \
+  --model /models/Llama-3.3-70B-Instruct-FP8-KV \
+  --base-url http://127.0.0.1:8000 \
+  --dataset-name random --random-input-len 4096 --random-output-len 4096 \
+  --num-prompts 128 --max-concurrency 32 --seed 1
+```

--- a/guides/pd-disaggregation/README.amd.md
+++ b/guides/pd-disaggregation/README.amd.md
@@ -10,7 +10,7 @@ This guide demonstrates how to deploy models using vLLM's P/D disaggregation sup
 
 **_NOTE:_** The ROCm Attention backend must be used `ROCM_ATTN` when tensor parallelism values for prefill and decode are different. There's a PR in progress to address this issue with other attention backends.
 
-**_MI355X (gfx950)_**: The same image and chart work on MI355X without modification. For long-context workloads on MI355X, see `ms-pd/values_amd_mi355x_longctx.yaml` (sets `--max-model-len 131072`) and the performance reference in [`docs/accelerators/amd-mi355x-perf.md`](../../docs/accelerators/amd-mi355x-perf.md).
+**_MI355X (gfx950)_**: The same image and chart work on MI355X without modification. For long-context workloads on MI355X, see `ms-pd/values_amd_mi355x_longctx.yaml` (sets `--max-model-len 131072`) and the performance reference in [`docs/accelerators/amd-mi355x-perf.md`](../../docs/accelerators/amd-mi355x-perf.md). For an end-to-end 2-node P/D KV-transfer validation on MI355X using the published image (without Helm/K8s), see [`docs/accelerators/amd-mi355x-pd-validation.md`](../../docs/accelerators/amd-mi355x-pd-validation.md).
 
 In this example, we will demonstrate a deployment of `amd/Llama-3.3-70B-Instruct-FP8-KV`.
 

--- a/guides/pd-disaggregation/README.amd.md
+++ b/guides/pd-disaggregation/README.amd.md
@@ -10,6 +10,8 @@ This guide demonstrates how to deploy models using vLLM's P/D disaggregation sup
 
 **_NOTE:_** The ROCm Attention backend must be used `ROCM_ATTN` when tensor parallelism values for prefill and decode are different. There's a PR in progress to address this issue with other attention backends.
 
+**_MI355X (gfx950)_**: The same image and chart work on MI355X without modification. For long-context workloads on MI355X, see `ms-pd/values_amd_mi355x_longctx.yaml` (sets `--max-model-len 131072`) and the performance reference in [`docs/accelerators/amd-mi355x-perf.md`](../../docs/accelerators/amd-mi355x-perf.md).
+
 In this example, we will demonstrate a deployment of `amd/Llama-3.3-70B-Instruct-FP8-KV`.
 
 ## P/D Best Practices

--- a/guides/pd-disaggregation/ms-pd/values_amd_mi355x_longctx.yaml
+++ b/guides/pd-disaggregation/ms-pd/values_amd_mi355x_longctx.yaml
@@ -1,0 +1,219 @@
+# MI355X (gfx950) variant of values_amd.yaml.
+#
+# Identical to values_amd.yaml except --max-model-len is set to 131072
+# (the native max_position_embeddings of Llama-3.3-70B-Instruct), which
+# is safe on MI355X's 288 GB / GPU and incurs no measurable throughput
+# cost vs --max-model-len 32000 on the workloads in
+# docs/accelerators/amd-mi355x-perf.md. On MI300X (192 GB / GPU) the
+# 131072 setting may not leave sufficient KV-cache headroom for many
+# concurrent long-context sequences; stay with values_amd.yaml on MI300X.
+#
+multinode: false
+
+modelArtifacts:
+  uri: "hf://amd/Llama-3.3-70B-Instruct-FP8-KV"
+  size: 100Gi
+  authSecretName: "llm-d-hf-token"
+  name: "amd/Llama-3.3-70B-Instruct-FP8-KV"
+  labels:
+    llm-d.ai/inference-serving: "true"
+    llm-d.ai/guide: "pd-disaggregation"
+    llm-d.ai/hardware-variant: "gpu"
+    llm-d.ai/accelerator-vendor: "amd"
+    llm-d.ai/model: "Llama-3.3-70B-Instruct-FP8-KV"
+
+accelerator:
+  type: amd
+
+routing:
+  servicePort: 8000
+  proxy:
+    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
+    connector: nixlv2
+    secure: false
+
+decode:
+  create: true
+#  priorityClassName: nightly-gpu-critical
+  parallelism:
+    tensor: 4
+    data: 1
+  replicas: 1
+  monitoring:
+    podmonitor:
+      enabled: true
+      portName: "vllm"  # decode vLLM service port (from routing.proxy.targetPort)
+      path: "/metrics"
+      interval: "30s"
+  containers:
+    - name: "vllm"
+      image: ghcr.io/llm-d/llm-d-rocm:v0.6.0
+      modelCommand: vllmServe
+      args:
+        - "--block-size"
+        - "128"
+        - "--kv-transfer-config"
+        - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+        - "--disable-uvicorn-access-log"
+        - '--attention-backend'
+        - 'ROCM_ATTN' # only necessary when TP of prefill != decode; upcoming general fix.
+        - "--max-model-len"
+        - "131072"
+      env:
+        - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+          value: "5600"
+        - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+      ports:
+        - containerPort: 8200
+          name: vllm
+          protocol: TCP
+        - containerPort: 5600
+          name: nixl
+          protocol: TCP
+      resources:
+        limits:
+          memory: 256Gi
+          cpu: "16"
+          # note: GPU resources get controlled by parallelism + accelerators above
+          # caution: verify the correct rdma resource label and count for your setup
+          rdma/ib: 1
+        requests:
+          memory: 256Gi
+          cpu: "16"
+          # note: GPU resources get controlled by parallelism + accelerators above
+          # caution: verify the correct rdma resource label and count for your setup
+          rdma/ib: 1
+      mountModelVolume: true
+      volumeMounts:
+        - name: metrics-volume
+          mountPath: /.config
+        - name: shm
+          mountPath: /dev/shm
+        - name: torch-compile-cache
+          mountPath: /.cache
+      startupProbe:
+        httpGet:
+          path: /v1/models
+          port: vllm
+        initialDelaySeconds: 15
+        periodSeconds: 30
+        timeoutSeconds: 5
+        failureThreshold: 60
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: vllm
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 3
+      readinessProbe:
+        httpGet:
+          path: /v1/models
+          port: vllm
+        periodSeconds: 5
+        timeoutSeconds: 2
+        failureThreshold: 3
+  volumes:
+  - name: metrics-volume
+    emptyDir: {}
+  - name: shm
+    emptyDir:
+      medium: Memory
+      sizeLimit: "16Gi"
+  - name: torch-compile-cache
+    emptyDir: {}
+
+prefill:
+  create: true
+#  priorityClassName: nightly-gpu-critical
+  parallelism:
+    tensor: 1
+  replicas: 4
+  monitoring:
+    podmonitor:
+      enabled: true
+      portName: "vllm"  # prefill vLLM service port (from routing.servicePort)
+      path: "/metrics"
+      interval: "30s"
+  containers:
+    - name: "vllm"
+      image: ghcr.io/llm-d/llm-d-rocm:v0.6.0
+      modelCommand: vllmServe
+      args:
+        - "--block-size"
+        - "128"
+        - "--kv-transfer-config"
+        - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+        - "--disable-uvicorn-access-log"
+        - '--attention-backend'
+        - 'ROCM_ATTN' # only necessary when TP of prefill != decode; upcoming general fix.
+        - "--max-model-len"
+        - "131072"
+      env:
+        - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+          value: "5600"
+        - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+      ports:
+        - containerPort: 8000
+          name: vllm
+          protocol: TCP
+        - containerPort: 5600
+          name: nixl
+          protocol: TCP
+      resources:
+        limits:
+          memory: 256Gi
+          cpu: "8"
+          # note: GPU resources get controlled by parallelism + accelerators above
+          rdma/ib: 1
+        requests:
+          memory: 256Gi
+          cpu: "8"
+          # note: GPU resources get controlled by parallelism + accelerators above
+          # caution: verify the correct rdma resource label and count for your setup
+          rdma/ib: 1
+      mountModelVolume: true
+      volumeMounts:
+        - name: metrics-volume
+          mountPath: /.config
+        - name: shm
+          mountPath: /dev/shm
+        - name: torch-compile-cache
+          mountPath: /.cache
+      startupProbe:
+        httpGet:
+          path: /v1/models
+          port: vllm
+        initialDelaySeconds: 15
+        periodSeconds: 30
+        timeoutSeconds: 5
+        failureThreshold: 60
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: vllm
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 3
+      readinessProbe:
+        httpGet:
+          path: /v1/models
+          port: vllm
+        periodSeconds: 5
+        timeoutSeconds: 2
+        failureThreshold: 3
+  volumes:
+  - name: metrics-volume
+    emptyDir: {}
+  - name: shm
+    emptyDir:
+      medium: Memory
+      sizeLimit: "16Gi"
+  - name: torch-compile-cache
+    emptyDir: {}


### PR DESCRIPTION
## Summary

This evidence-based docs PR adds a performance reference and a long-context values variant for AMD MI355X (gfx950), derived from a 51-config benchmark sweep of `amd/Llama-3.3-70B-Instruct-FP8-KV` at TP=8 on a single 8×MI355X node using the published `ghcr.io/llm-d/llm-d-rocm:v0.6.0` image. **No code changes; no behavior changes for existing MI300X deployments.**

Builds on the validation in #1228.

## What's added

### 1. `docs/accelerators/amd-mi355x-perf.md`

Capacity-planning reference for operators considering MI355X:

| Workload | Conc | Output tok/s | Total tok/s | TTFT (mean) |
|---|---|---|---|---|
| Short ctx (1k×256) | 16 | 1320.8 | 6598.8 | 343 ms |
| Short ctx (1k×256) | 256 | 3347.9 | 30118.4 | 2296 ms |
| Decode-heavy (4k×4k) | 32 | 2230.0 | 4459 | 1204 ms |
| Long-both (16k×2k) | 32 | 1112.6 | 10013 | 4.44 s |
| Prefill-heavy (32k×128) | 4 | 48.8 | 12533 | 4.29 s |
| Prefill-heavy (64k×128) | 2 | 15.5 | 7959 | 9.09 s |

Plus the documented **null result** for tuning knobs: `--gpu-memory-utilization` ∈ {0.85, 0.90, 0.95}, `--block-size` ∈ {64, 128, 256}, `--max-num-seqs` ∈ {256, 512}, and `--max-model-len` ∈ {32k, 65k, 131k} all change throughput by <3% (most workloads <1%) for this model on MI355X. The model is compute-bound, not KV-cache-bound — even at conc=256, the active KV cache fits well under 0.85 of MI355X's 288 GB/GPU. **Recommendation: don't burn tuning time on these knobs for Llama-3.3-70B-FP8 on MI355X; the existing `values_amd.yaml` defaults are evidence-based.**

### 2. `guides/pd-disaggregation/ms-pd/values_amd_mi355x_longctx.yaml`

A drop-in MI355X-specific variant of `values_amd.yaml` with `--max-model-len 131072` (the native `max_position_embeddings` of Llama-3.3-70B-Instruct). Validated to start cleanly and serve correctly at TP=8 on MI355X with no measurable throughput cost vs the `32000` value used in `values_amd.yaml`. The header explicitly recommends MI300X users stay with the existing `values_amd.yaml`.

### 3. `guides/pd-disaggregation/README.amd.md`

A NOTE pointing MI355X users at the perf doc and the long-context values variant.

## Methodology

* Hardware: 8× AMD Instinct MI355X (gfx950), 288 GB / GPU
* Container: `ghcr.io/llm-d/llm-d-rocm:v0.6.0` standalone (no Helm/K8s for these measurements — the image is the same one llm-d uses)
* Bench: `vllm bench serve --backend vllm --dataset-name random --seed 1`
* Per-config: dedicated container start, single warmup request, then bench
* 51 configurations total across 4 sweep families (short-context param matrix, stress, scale, long-context-low-conc, long-context-high-conc)

Cross-config Δ at the same workload was consistently <3% (most workloads <1%), well within run-to-run noise for these benches.

## Why publish a null result?

A future operator asking "what should I tune for MI355X?" would reach the same conclusion only by repeating the same 4-hour sweep. Documenting it once saves that effort and removes ambiguity about whether the existing defaults are evidence-based for MI355X. (Spoiler: they are.)

## Validation environment

* Single 8×MI355X node (Tensorwave `mia1-p01-g07`)
* `amd/Llama-3.3-70B-Instruct-FP8-KV` weights mounted from a shared filesystem
* Date: April 2026

## Refs

* #1228 — initial MI355X validation (just-merged docs PR adding MI355X to validated platforms)
* Issue #139 — community AMD support question (this PR is part of the broader response)

## What's NOT covered (follow-up)

* Multi-node P/D disaggregation with RoCE on MI355X — needs a 2-node MI355X RoCE topology
* Other models on MI355X (DeepSeek-R1, Qwen3-32B, etc.) — only Llama-3.3-70B-FP8 was exercised
* Helm/K8s end-to-end on MI355X — only the standalone container path was measured
