### PR TITLE
Bump deprecated kgateway path to v2.2.3

### DIFF
--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -46,7 +46,7 @@ Pinned in `guides/prereq/gateway-provider/`:
 | **Gateway API CRDs** | `v1.5.1` | `install-gateway-provider-dependencies.sh` line 39 | [kubernetes-sigs/gateway-api](https://github.com/kubernetes-sigs/gateway-api) |
 | **Gateway API Inference Extension CRDs** | `v1.4.0` | `install-gateway-provider-dependencies.sh` line 46 | [kubernetes-sigs/gateway-api-inference-extension](https://github.com/kubernetes-sigs/gateway-api-inference-extension) |
 | **Istio** | `1.29.1` | `istio.helmfile.yaml` | [istio/istio](https://github.com/istio/istio) |
-| **kgateway (deprecated llm-d install path)** | `v2.2.1` | `kgateway.helmfile.yaml` | [kgateway-dev/kgateway](https://github.com/kgateway-dev/kgateway) (`ghcr.io/kgateway-dev/charts/agentgateway*`) |
+| **kgateway (deprecated llm-d install path)** | `v2.2.3` | `kgateway.helmfile.yaml` | [kgateway-dev/kgateway](https://github.com/kgateway-dev/kgateway) (`ghcr.io/kgateway-dev/charts/agentgateway*`) |
 | **agentgateway (preferred path)** | `v1.0.0` | `agentgateway.helmfile.yaml` | [agentgateway/agentgateway](https://github.com/agentgateway/agentgateway) |
 
 ## CI Workflow Dependencies

--- a/guides/prereq/gateway-provider/README.md
+++ b/guides/prereq/gateway-provider/README.md
@@ -75,7 +75,7 @@ llm-d provides helmfiles that install and configure `istio`, `kgateway`, and `ag
 The two self-installed inference modes are:
 
 * `agentgateway`: installs the `agentgateway` v1.0.0 control plane and data plane. This is the preferred self-installed inference path.
-* `kgateway`: installs the deprecated llm-d `kgateway` path using the `ghcr.io/kgateway-dev/charts/agentgateway*` charts at `v2.2.1`, with `inferenceExtension.enabled=true`. This path is retained only to support migrations.
+* `kgateway`: installs the deprecated llm-d `kgateway` path using the `ghcr.io/kgateway-dev/charts/agentgateway*` charts at `v2.2.3`, with `inferenceExtension.enabled=true`. This path is retained only to support migrations.
 
 Both self-installed inference modes use the `agentgateway` GatewayClass in llm-d guide manifests.
 
@@ -112,7 +112,7 @@ To install the gateway control plane:
 For the self-installed inference modes:
 
     helmfile apply -f agentgateway.helmfile.yaml  # preferred: agentgateway
-    helmfile apply -f kgateway.helmfile.yaml      # deprecated: kgateway path via the kgateway-dev agentgateway v2.2.1 charts
+    helmfile apply -f kgateway.helmfile.yaml      # deprecated: kgateway path via the kgateway-dev agentgateway v2.2.3 charts
 
 ##### Targeted install
 

--- a/guides/prereq/gateway-provider/common-configurations/README.md
+++ b/guides/prereq/gateway-provider/common-configurations/README.md
@@ -5,5 +5,5 @@ Each guide pulls in these gateway configurations. They are meant to abstract all
 For llm-d inference guides, both the deprecated `kgateway` mode and the preferred `agentgateway` mode currently set `gateway.gatewayClassName: agentgateway`.
 The difference between those modes is how the gateway provider stack is installed:
 
-* `kgateway` installs the deprecated llm-d `kgateway` path via the `ghcr.io/kgateway-dev/charts/agentgateway*` charts at `v2.2.1`. This mode is deprecated in llm-d and will be removed in the next release.
+* `kgateway` installs the deprecated llm-d `kgateway` path via the `ghcr.io/kgateway-dev/charts/agentgateway*` charts at `v2.2.3`. This mode is deprecated in llm-d and will be removed in the next release.
 * `agentgateway` installs the `agentgateway` control plane and data plane. This is the preferred self-installed inference path.

--- a/guides/prereq/gateway-provider/common-configurations/kgateway.yaml
+++ b/guides/prereq/gateway-provider/common-configurations/kgateway.yaml
@@ -1,5 +1,5 @@
 gateway:
   # Deprecated in llm-d and retained only for migration. Prefer agentgateway.
-  # This mode uses the kgateway-dev agentgateway v2.2.1 charts, not the agentgateway charts.
+  # This mode uses the kgateway-dev agentgateway v2.2.3 charts, not the agentgateway charts.
   provider: kgateway
   gatewayClassName: agentgateway

--- a/guides/prereq/gateway-provider/kgateway.helmfile.yaml
+++ b/guides/prereq/gateway-provider/kgateway.helmfile.yaml
@@ -4,7 +4,7 @@ releases:
   - name: agentgateway-crds
     chart: oci://ghcr.io/kgateway-dev/charts/agentgateway-crds
     namespace: agentgateway-system
-    version: v2.2.1
+    version: v2.2.3
     installed: true
     labels:
       type: gateway-provider
@@ -12,7 +12,7 @@ releases:
 
   - name: agentgateway
     chart: oci://ghcr.io/kgateway-dev/charts/agentgateway
-    version: v2.2.1
+    version: v2.2.3
     namespace: agentgateway-system
     installed: true
     values:


### PR DESCRIPTION
## Summary
- bump the deprecated kgateway helmfile from v2.2.1 to v2.2.3
- update the gateway-provider docs and upstream version tracking to match

## Testing
- `git diff --check`
- `helmfile -f guides/prereq/gateway-provider/kgateway.helmfile.yaml build`

Fixes: #1218
