### PR TITLE
Add workflow write

### DIFF
--- a/.github/workflows/slash-test-nightly.yaml
+++ b/.github/workflows/slash-test-nightly.yaml
@@ -34,6 +34,7 @@ permissions:
   contents: write
   pull-requests: write
   actions: write
+  workflows: write
 
 # Use comment ID in concurrency group so different /test-nightly
 # commands on the same PR can run in parallel.


### PR DESCRIPTION
This PR: https://github.com/llm-d/llm-d/pull/1244  always runs the workflow from the default branch, regardless of which PR you comment on. So the `workflows: write` permission we added won't take effect until it's merged to main. Therefore I need to merge just the `workflows: write` permission to main first to avoid a chicken-and-egg problem.