### PR TITLE
docs: reorganize predicted latency docs and fix broken links

### DIFF
--- a/docs/wip-docs-new/architecture/advanced/latency-predictor.md
+++ b/docs/wip-docs-new/architecture/advanced/latency-predictor.md
@@ -2,7 +2,7 @@
 
 The Latency Predictor is the llm-d component behind predicted latency-based scheduling. Instead of scoring pods by coarse utilization signals alone, the EPP asks an online-trained ML model to predict **Time To First Token (TTFT)** and **Time Per Output Token (TPOT)** for each candidate pod, then routes on those predictions — optionally gated by per-request Service Level Objectives (SLOs).
 
-This page is a reference for the component: its design, EPP plugins, ML model, failure modes, and scaling characteristics. For step-by-step adoption — Helm enablement, SLO header usage, verification, troubleshooting — see the [Predicted Latency well-lit path](../../well-lit-paths/experimental/predicted-latency.md). Design rationale and benchmarks are in the blog [Predicted Latency-Based Scheduling for LLMs](https://llm-d.ai/blog/predicted-latency-based-scheduling-for-llms).
+This page is a reference for the component: its design, EPP plugins, ML model, failure modes, and scaling characteristics. For step-by-step adoption — Helm enablement, SLO header usage, verification, troubleshooting — see the [Predicted Latency well-lit path](../../well-lit-paths/predicted-latency.md). Design rationale and benchmarks are in the blog [Predicted Latency-Based Scheduling for LLMs](https://llm-d.ai/blog/predicted-latency-based-scheduling-for-llms).
 
 ## Why Predicted Latency?
 
@@ -152,6 +152,6 @@ All latency and prediction-duration series are Prometheus **histograms**, so das
 
 ## Further Reading
 
-- [Predicted Latency Well-Lit Path](../../well-lit-paths/experimental/predicted-latency.md) — how to adopt this path: Helm enablement, request headers, verification, troubleshooting.
+- [Predicted Latency Well-Lit Path](../../well-lit-paths/predicted-latency.md) — how to adopt this path: Helm enablement, request headers, verification, troubleshooting.
 - [Predicted Latency-Based Scheduling for LLMs](https://llm-d.ai/blog/predicted-latency-based-scheduling-for-llms) — design rationale and benchmark results.
 - [EPP Scheduling](../core/epp/scheduling.md) — how the plugins fits into EPP request handling.

--- a/docs/wip-docs-new/getting-started/README.md
+++ b/docs/wip-docs-new/getting-started/README.md
@@ -25,9 +25,12 @@ LLM-aware load balancing that goes beyond naive round-robin. The LLM-aware load 
 - **Prefix cache locality** — route to replicas that already have relevant KV-cache entries
 - **KV-cache utilization** — prefer replicas with more available memory
 - **Queue depth** — avoid overloading busy replicas
-- **Predicted latency** — SLO-aware routing based on live traffic patterns (experimental)
 
 This alone can deliver order-of-magnitude latency reductions vs. round-robin baselines.
+
+### Predicted Latency-Based Scheduling
+
+Route each request to the replica predicted to serve it fastest, using an XGBoost model trained online on live traffic. Optionally enforce per-request SLOs via `x-slo-ttft-ms` / `x-slo-tpot-ms` headers — requests that no replica can meet within budget are shed at admission rather than routed to a guaranteed miss. Useful when workload variance makes queue-depth a poor proxy for true load, or when clients need to express interactive vs. batch latency budgets.
 
 ### Prefill/Decode Disaggregation
 

--- a/docs/wip-docs-new/outline.md
+++ b/docs/wip-docs-new/outline.md
@@ -29,6 +29,7 @@
 ├── well-lit-paths
 │   ├── README.md
 │   ├── optimized-baseline.md
+│   ├── predicted-latency.md
 │   ├── precise-prefix-cache-aware.md
 │   ├── flow-control.md
 │   ├── prefill-decode-disaggregation.md

--- a/docs/wip-docs-new/well-lit-paths/predicted-latency.md
+++ b/docs/wip-docs-new/well-lit-paths/predicted-latency.md
@@ -1,6 +1,6 @@
 # Predicted Latency-Based Scheduling
 
-llm-d's [optimized baseline guide](../intelligent-inference-scheduling.md) leverages load signals and prefix-cache affinity to schedule requests, combining the signals together with heuristics.
+llm-d's [optimized baseline guide](./optimized-baseline.md) leverages load signals and prefix-cache affinity to schedule requests, combining the signals together with heuristics.
 
 This path is for operators who want to adopt predicted latency-based scheduling - which uses an XGBoost model trained online - to make scheduling decisions. This strategy is useful when:
 - Your workload has **high variance in prompt and completion length**, and queue depth alone is a poor proxy for true load.
@@ -16,7 +16,7 @@ See the [Predicted Latency guide](https://github.com/llm-d/llm-d/tree/main/guide
 
 ## Architecture
 
-![Latency Predictor](../../../assets/latency-predictor.svg)
+![Latency Predictor](../../assets/latency-predictor.svg)
 
 The setup deploys an EPP with the predicted latency sidecar containers:
 * **Training Server** - trains the XGBoost model to predict TPOT and TTFT based on observed traffic
@@ -32,6 +32,6 @@ During the standard request flow:
 
 ## Further Reading
 
-- [Latency Predictor Architecture](../../architecture/advanced/latency-predictor.md) — plugin pipeline, ML model, scaling characteristics, metric reference.
+- [Latency Predictor Architecture](../architecture/advanced/latency-predictor.md) — plugin pipeline, ML model, scaling characteristics, metric reference.
 - [llm-d/llm-d-latency-predictor](https://github.com/llm-d/llm-d-latency-predictor) — source for the training and prediction server Python code.
 - [Predicted Latency-Based Scheduling for LLMs - Blog](https://llm-d.ai/blog/predicted-latency-based-scheduling-for-llms) — design rationale and benchmark results.

--- a/guides/README.md
+++ b/guides/README.md
@@ -5,16 +5,16 @@ Our well-lit path guides are documented, tested, and benchmarked recipes to serv
 We currently offer the following:
 1. [optimized baseline](./optimized-baseline/README.md) - Deploy vLLM with prefix-cache and load-aware routing enabled by the llm-d EPP. 
 2. [optimized baseline - Precise Prefix Cache Routing](./precise-prefix-cache-aware/README.md) - Enhance optimized baseline with precise global indexing of the vLLM KV cache state.
-3. [Prefill/Decode Disaggregation](./pd-disaggregation/README.md) - Split inference into specialized prefill and decode instances, improving throughput and quality of service stability for medium and large models like `openai/gpt-oss-120b`.
-3. [Wide Expert-Parallelism](./wide-ep-lws/README.md) - Deploy large Mixture-of-Experts (MoE) models like `deepseek-ai/DeepSeek-R1` over mulple nodes via DP/EP configuration, increasing available KV cache space and throughput.
-4. [Tiered Prefix Cache](./tiered-prefix-cache/README.md) - Offload KV caches beyond accelerator memory (e.g. to CPU or disk), increasing the "KV-working set size" for multi-turn inference request patterns.
+3. [optimized baseline - Predicted Latency](./predicted-latency-based-scheduling/README.md) - Enhance optimized baseline with real-time predictions of request latency (via a live-trained XGBoost model) rather than heuristic-based combinations of utilization metrics like queue depth or KV-cache utilization.
+4. [Prefill/Decode Disaggregation](./pd-disaggregation/README.md) - Split inference into specialized prefill and decode instances, improving throughput and quality of service stability for medium and large models like `openai/gpt-oss-120b`.
+5. [Wide Expert-Parallelism](./wide-ep-lws/README.md) - Deploy large Mixture-of-Experts (MoE) models like `deepseek-ai/DeepSeek-R1` over mulple nodes via DP/EP configuration, increasing available KV cache space and throughput.
+6. [Tiered Prefix Cache](./tiered-prefix-cache/README.md) - Offload KV caches beyond accelerator memory (e.g. to CPU or disk), increasing the "KV-working set size" for multi-turn inference request patterns.
 
 > [!IMPORTANT]
 > These guides are intended to be a starting point for your own configuration and deployment of model servers. Our Helm charts provide basic reusable building blocks for vLLM deployments and inference scheduler configuration within these guides but will not support the full range of all possible configurations.
 
 ## Experimental Guides
 
-* [Predicted Latency](./predicted-latency-based-scheduling/README.md) - enhance optimized baseline with real-time predictions of request latency (via an live-trained XGBoost model) rather than heuristic-based combinations of utilization metrics like queue depth or KV-cache utilization.
 * [Workload Autoscaling](./workload-autoscaling/README.md) - autoscale the LLM service via proactive, SLO-aware signals that reflect the true state of the inference system — queue depth, in-flight request counts, and KV cache pressure — so that capacity can be added before end-user latency is impacted.
 * [Asynchronous Processing](./asynchronous-processing/README.md) - process inference requests asynchronously using a queue-based architecture. This is ideal for latency-insensitive batch workloads or for filling "slack" capacity in your inference pool.
 

--- a/guides/predicted-latency-based-scheduling/README.md
+++ b/guides/predicted-latency-based-scheduling/README.md
@@ -1,338 +1,186 @@
-# Experimental Feature: Predicted Latency based Load Balancing
+# Predicted Latency-Based Scheduling
 
-## Overview
+Route each inference request to the model server predicted to serve it fastest — and, optionally, only to a server predicted to meet its TTFT/TPOT SLO.
 
-This experimental feature introduces **predicted latency based load balancing**, where scheduling decisions are guided by real-time predictions of request latency rather than only utilization metrics like queue depth or KV-cache utilization.
+This path is for operators who want to **adopt** predicted latency-based scheduling in an existing llm-d deployment. For what the component is and how it works internally — the plugin pipeline, the ML model, scaling characteristics, the full metric list — see [architecture/advanced/latency-predictor.md](../../docs/wip-docs-new/architecture/advanced/latency-predictor.md).
 
-- **Problem:** Utilization-based load balancing misses some distinct characteristics of LLM workloads, leading to requests missing SLO targets or leads to overly conservative routing that wastes capacity.
-- **Approach:** The Endpoint Picker (EPP) integrates with **in-pod latency predictor sidecars** that continuously learn from live traffic. These sidecars estimate **p90 TTFT** and **p90 TPOT** for each candidate pod given current load, prefix cache state, and request features.
-- **Outcome:** The **SLO scorer** compares predictions against per-request SLOs and directs traffic to pods with some headroom. If none exist, requests are shed (priority < 0) or sent to a weighted pool favoring lower latency pods.
+## When to Pick This Path
 
-### Tradeoffs & Gaps
+Pick it when:
 
-- **Homogeneous InferencePool**
-  Current predictors assume that all model server pods are identical (same GPU type, model weights, and serving configuration). Heterogeneous pools are not yet modeled.
+- Your workload has **high variance in prompt and completion length**, and queue depth alone is a poor proxy for true load.
+- Your clients can express **per-request latency SLOs** (interactive vs. batch) and you want the gateway to enforce them.
+- Static weight tuning between cache affinity and load has become **fragile** as traffic shifts.
 
-- **Scaling limits**
-  Each prediction sidecar can sustain ~300 QPS on a c4-standard-192 Google cloud machine (**≈ 192 vCPUs, 720 GB RAM, Up to 100 Gbps network, Up to 200 Gbps aggregate throughput**). Because the EPP makes one prediction call per candidate pod, total prediction load grows with both **cluster QPS** and **pod count**. If traffic or pod count increases, prediction servers must be scaled horizontally.
-
-- **Training mode**
-  Only streaming workloads (set **"stream": "true"** in the request body as per openAI protocol) are supported.
-
-- **Percentiles**
-  The predictor currently estimates only **p90** TTFT and TPOT. Other percentiles (p95, p99) or a mix of percentiles are not yet available.
-
-- **Prefill/Decode disaggregation**
-  Current routing does **not support prefill/decode disaggregation** (where one pod performs prefill and another performs decode). Prediction and SLO scoring assume a pod executes the entire request lifecycle. Support for disaggregated serving is a **work in progress**.
-
-- **Unvalidated against advanced inference features**
-  Predictions have not yet been tested with advanced serving strategies such as LoRA adapters, speculative decoding, or beam search. Each of these may shift latency characteristics (e.g., speculative decoding may reduce TTFT but increase TPOT variance), and models may need to be extended to remain accurate in these contexts.
-
-### What is Tested
-
-This feature has been validated against the scenarios described in the [original design doc](https://docs.google.com/document/d/1q56wr3N5XGx0B21MzHu5oBsCiGi9VrbZAvyhP2VFG_c/edit?tab=t.0#heading=h.ob7j9esmcyd3) — including **short-prompt/long-completion**, **long-prompt/short-completion**, and **mixed workloads** — to compare baseline inference gateway routing versus prediction-based SLO routing. The benchmarking results are included in this doc.
-
-This guide explains how to deploy EPP with latency predictor sidecars, configure profiles and scorers, and enable **SLO-aware routing** via headers.
-
----
+Skip it when your pool is **heterogeneous** — mixed GPU types, model variants, or serving configurations in the same pool will produce inaccurate predictions, because the predictor assumes a single pod shape.
 
 ## Prerequisites
 
-- **Install the Inference Gateway extension**
-  Follow the official installation steps here:
-  <https://gateway-api-inference-extension.sigs.k8s.io/guides/>
+- Have the [proper client tools installed on your local system](../../helpers/client-setup/README.md) to use this guide.
+- Checkout llm-d repo:
 
-- **Build your EPP image** from the experimental branch:
+  ```bash
+    export branch="main" # branch, tag, or commit hash
+    git clone https://github.com/llm-d/llm-d.git && cd llm-d && git checkout ${branch}
+  ```
+- Set the following environment variables:
 
-    ***Prerequisites***
-  - Docker/BuildKit installed
-  - Access to a container registry (e.g., GCP Artifact Registry, Docker Hub, ECR)
+  ```bash
+    export GAIE_VERSION=v1.5.0
+    export GUIDE_NAME="predicted-latency-based-scheduling"
+    export NAMESPACE=llm-d-predicted-latency
+    export MODEL_NAME="Qwen/Qwen3-32B"
+  ```
+- Install the Gateway API Inference Extension CRDs:
 
-    ***Clone & checkout***
+  ```bash
+    kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+  ```
+- Create a target namespace for the installation:
 
-    ```bash
-    git clone https://github.com/kubernetes-sigs/gateway-api-inference-extension.git
-    cd gateway-api-inference-extension
-    git checkout slo-prediction-experimental
-    ```
+  ```bash
+    kubectl create namespace ${NAMESPACE}
+  ```
 
-    ***Set your target registry and tag***
+## Installation Instructions
 
-    ```bash
-    export IMG="<your-registry>/epp:slo-prediction-$(git rev-parse --short HEAD)"
-    ```
+### 1. Deploy the Inference Scheduler
 
-    ***Build the image***
+Two ready-to-use values files ship with this guide:
 
-    ```bash
-    docker build -t "$IMG" -f Dockerfile .
-    ```
+| File | When to use |
+|---|---|
+| [`scheduler/predicted-latency.values.yaml`](./scheduler/predicted-latency.values.yaml) | Default — predictor trains on end-to-end latency. Routing-only, no SLO header support. |
+| [`scheduler/predicted-latency-slo.values.yaml`](./scheduler/predicted-latency-slo.values.yaml) | SLO-aware — Assumes `x-slo-ttft-ms` / `x-slo-tpot-ms` are set on requests. Every request must be sent with `"stream": true`. |
 
-    ***Push the image***
+Both target model server pods labeled `llm-d.ai/guide=optimized-baseline` since in the next step we will simply reuse the model server manifests from the [optimized-baseline guide](../optimized-baseline).
 
-    ```bash
-    docker push "$IMG"
-    ```
+#### Standalone Mode
 
-- **Build your EPP Sidecars** from the same experimental branch as described here:
-  <https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/slo-prediction-experimental/latencypredictor-v1>
+This deploys the inference scheduler with an Envoy sidecar, it doesn't set up a Kubernetes Gateway.
 
----
-
-## Testing Predicted Latency based Scheduling
-
-Once prerequisites are met, you can validate predicted latency based scheduling:
-
-1. **Apply your InferencePool/EPP manifest**
-   - Consult the [example manifest in the gateway-api-inference-extension repository](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/slo-prediction-experimental/config/manifests/inferencepool-resources-lp.yaml)
-   - Update the EPP container and sidecar images to the ones you built.
-   - Confirm that the `Deployment` includes the EPP container, training sidecar, and three prediction sidecars, each with their own volumes.
-   - Ensure the `plugins-config` ConfigMap defines both `default` and `slo` profiles.
-
-2. **Check readiness**
-   - Verify pod status: `kubectl get pods` → all containers `Running/Ready`.
-   - Training sidecar health: `curl http://<pod-ip>:8000/readyz`
-   - Prediction sidecar health: `curl http://<pod-ip>:8001/readyz` (and 8002, 8003).
-   - EPP gRPC health: port `9003` (liveness/readiness probes).
-
-3. **Send traffic**
-   - **Baseline:** run requests using the **`default`** profile (no prediction headers).
-   - **SLO-aware:** run requests with the **`slo`** profile and set
-     `x-prediction-based-scheduling: true`, optionally adding SLO headers like `x-slo-ttft-ms` and `x-slo-tpot-ms`.
-
-   Example request:
-
-   ```bash
-   curl -v $GW_IP/v1/completions \
-     -H 'Content-Type: application/json' \
-     -H 'x-prediction-based-scheduling: true' \
-     -H 'x-slo-ttft-ms: 200' \
-     -H 'x-slo-tpot-ms: 50' \
-     -d '{
-       "model": "meta-llama/Llama-3.1-8B-Instruct",
-       "prompt": "what is the difference between Franz and Apache Kafka?",
-       "max_tokens": 200,
-       "temperature": 0,
-       "stream_options": {"include_usage": "true"},
-       "stream": "true"
-     }'
-   ```
-
-   Example response (abridged SSE):
-
-   ```text
-   < HTTP/1.1 200 OK
-   < content-type: text/event-stream; charset=utf-8
-   ...
-   data: {"choices":[{"index":0,"text":" Apache"}], "object":"text_completion", ...}
-   data: {"choices":[{"index":0,"text":" Kafka"}],  "object":"text_completion", ...}
-   ... (many streamed tokens) ...
-   data: {
-     "object":"text_completion",
-     "usage": {
-       "prompt_tokens": 12,
-       "completion_tokens": 200,
-       "total_tokens": 212,
-       "ttft_ms": 59,
-       "tpot_observations_ms": [9, 6],
-       "avg_tpot_ms": 7.5,
-       "predicted_ttft_ms": 273.23,
-       "predicted_tpot_observations_ms": [176.22, 18.17],
-       "avg_predicted_tpot_ms": 97.19
-     }
-   }
-   data: [DONE]
-   ```
-
-   - The final SSE frame includes both **predictions and actuals** so you can validate accuracy (e.g., `predicted_ttft_ms` vs `ttft_ms`).
-   - TPOTs are sampled every 200th token and surfaced in the arrays like `tpot_observations_ms`.
-
-4. **Validate predictions in logs**
-   Tail EPP logs at verbosity `-v=4`. For each request you should see:
-
-   - **Profile selection**
-
-     ```text
-     msg:"Running profile handler, Pick profiles"
-     plugin:"slo-aware-profile-handler/slo-aware-profile-handler"
-     ```
-
-   - **Candidate pods**
-
-     ```text
-     msg:"Before running scorer plugins"
-     pods:[{... "pod_name":"...-5k7qr" ...}, {... "pod_name":"...-9lp5g" ...}]
-     ```
-
-   - **SLO scorer pod scores**
-
-     ```text
-     msg:"Pod score"
-     scorer_type:"slo-scorer"
-     pod_name:"vllm-llama3-8b-instruct-7b584dd595-9b4wt"
-     score:0.82
-     ```
-
-   - **Final pick**
-
-     ```text
-     msg:"Picked endpoint"
-     scorer_type:"slo-scorer"
-     selected_pod:"vllm-llama3-8b-instruct-7b584dd595-9b4wt"
-     ```
-
-   These logs confirm:
-   - The request entered the SLO-aware path.
-   - All candidate pods were evaluated.
-   - Scores reflect predicted headroom vs SLOs.
-   - The final pod was chosen based on SLO scorer output.
-
-5. **Confirm request shedding (optional)**
-   If you send requests with **priority < 0** and no pod can meet both TTFT & TPOT SLOs, logs should show the request being **shed** instead of placed in the negative bucket.
-
----
-
-## Configuration
-
-This section details the container setup, ConfigMaps, and profile configuration needed to enable prediction-based scheduling.
-
-### Sidecars & EPP containers in the Deployment
-
-#### EPP container
-
-- **Image**: `epp`
-- **Args**
-  - `--config-file=/config/default-plugins.yaml`
-  - `--enable-latency-predictor`
-- **Env**
-  - `PREDICTION_SERVER_URL`: CSV of in-pod predictor endpoints
-  - `TRAINING_SERVER_URL`: `http://localhost:8000`
-  - `LATENCY_MAX_SAMPLE_SIZE`
-  - `NEG_HEADROOM_TTFT_WEIGHT`, `NEG_HEADROOM_TPOT_WEIGHT`
-  - `HEADROOM_TTFT_WEIGHT`, `HEADROOM_TPOT_WEIGHT`
-  - `HEADROOM_SELECTION_STRATEGY`
-  - `SLO_BUFFER_FACTOR`
-
-**Training sidecar (`training-server`)**
-
-- **Port**: 8000
-- **EnvFrom**: `latency-predictor-config`
-- **Volume**: `/models`
-
-**Prediction sidecars (`prediction-server-1/2/3`)**
-
-- **Ports**: 8001, 8002, 8003
-- **EnvFrom**: `prediction-server-config`
-- **Volumes**: `/server_models`
-
----
-
-### ConfigMaps
-
-**1. `latency-predictor-config` (training)**
-
-```yaml
-data:
-  LATENCY_RETRAINING_INTERVAL_SEC: "1"
-  LATENCY_MIN_SAMPLES_FOR_RETRAIN: "100"
-  LATENCY_TTFT_MODEL_PATH: "/models/ttft.joblib"
-  LATENCY_TPOT_MODEL_PATH: "/models/tpot.joblib"
-  LATENCY_TTFT_SCALER_PATH: "/models/ttft_scaler.joblib"
-  LATENCY_TPOT_SCALER_PATH: "/models/tpot_scaler.joblib"
-  LATENCY_MODEL_TYPE: "xgboost"
-  LATENCY_MAX_TRAINING_DATA_SIZE_PER_BUCKET: "5000"
+```bash
+helm install ${GUIDE_NAME} \
+    oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
+    -f guides/${GUIDE_NAME}/scheduler/predicted-latency.values.yaml \
+    -n ${NAMESPACE} --version ${GAIE_VERSION}
 ```
 
-**2. `prediction-server-config` (predictors)**
+For SLO-aware scheduling, swap the values file: `-f guides/${GUIDE_NAME}/scheduler/predicted-latency-slo.values.yaml`.
 
-```yaml
-data:
-  LATENCY_MODEL_TYPE: "xgboost"
-  PREDICT_HOST: "0.0.0.0"
-  LOCAL_TTFT_MODEL_PATH: "/server_models/ttft.joblib"
-  LOCAL_TPOT_MODEL_PATH: "/server_models/tpot.joblib"
-  LOCAL_TTFT_SCALER_PATH: "/server_models/ttft_scaler.joblib"
-  LOCAL_TPOT_SCALER_PATH: "/server_models/tpot_scaler.joblib"
+<details>
+<summary><h4>Gateway Mode</h4></summary>
+
+To use a Kubernetes Gateway managed proxy rather than the standalone version, follow these steps instead of applying the previous Helm chart:
+
+1. *Deploy a Kubernetes Gateway* by following one of [the gateway guides](../prereq/gateways).
+2. *Deploy the inference scheduler and an HTTPRoute* that connects it to the Gateway as follows:
+
+```bash
+export PROVIDER_NAME=gke # options: none, gke, agentgateway, istio
+helm install ${GUIDE_NAME} \
+    oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool \
+    -f guides/${GUIDE_NAME}/scheduler/predicted-latency.values.yaml \
+    --set provider.name=${PROVIDER_NAME} \
+    --set experimentalHttpRoute.enabled=true \
+    --set experimentalHttpRoute.inferenceGatewayName=llm-d-inference-gateway \
+    -n ${NAMESPACE} --version ${GAIE_VERSION}
 ```
 
----
+</details>
 
-### Profiles & Plugins
+### 2. Deploy the Model Server
 
-`plugins-config` ConfigMap (`default-plugins.yaml`):
+This guide reuses the model server manifests from the optimized-baseline guide (the values files above already select pods labeled `llm-d.ai/guide=optimized-baseline`). Apply the default NVIDIA GPU / vLLM overlay:
 
-```yaml
-apiVersion: inference.networking.x-k8s.io/v1alpha1
-kind: EndpointPickerConfig
-plugins:
-  - type: queue-scorer
-  - type: kv-cache-utilization-scorer
-  - type: prefix-cache-scorer
-  - type: slo-request-tracker
-  - type: slo-scorer
-  - type: slo-aware-profile-handler
-  - type: max-score-picker
-
-schedulingProfiles:
-  - name: default
-    plugins:
-      - pluginRef: slo-request-tracker
-      - pluginRef: prefix-cache-scorer
-      - pluginRef: queue-scorer
-      - pluginRef: kv-cache-utilization-scorer
-      - pluginRef: max-score-picker
-
-  - name: slo
-    plugins:
-      - pluginRef: prefix-cache-scorer
-        weight: 0
-      - pluginRef: slo-request-tracker
-      - pluginRef: slo-scorer
-      - pluginRef: max-score-picker
+```bash
+kubectl apply -n ${NAMESPACE} -k guides/optimized-baseline/modelserver/gpu/vllm/
 ```
 
-#### What they do
+For other backends (AMD GPU, Intel XPU, Gaudi, TPU, CPU), see [optimized-baseline → Deploy the Model Server](../optimized-baseline/README.md#2-deploy-the-model-server).
 
-- `slo-request-tracker` — captures per-request SLOs and tracks them.
-- `slo-scorer` — uses predicted TTFT/TPOT to compare against SLOs and classify into positive/negative buckets.
-- `slo-aware-profile-handler` — switches requests into the `slo` profile when SLO headers are present.
-- `queue-scorer`, `kv-cache-utilization-scorer`, `prefix-cache-scorer` — baseline scoring plugins.
+### 3. Enable monitoring (optional)
 
----
+Follow [optimized-baseline → Enable monitoring](../optimized-baseline/README.md#3-enable-monitoring-optional) — the same steps apply since this guide reuses the same model server manifests.
 
-### Headroom strategies
+## Send Requests
 
-Tune positive vs negative headroom scoring with env vars:
+Once enabled, latency-based scheduling works on every request — no header changes needed. The proxy picks the endpoint with the lowest predicted latency.
 
-- `HEADROOM_SELECTION_STRATEGY` — `least` (compact) or `most` (spread)
-- `HEADROOM_TTFT_WEIGHT` / `HEADROOM_TPOT_WEIGHT` — blend weights for positive headroom
-- `NEG_HEADROOM_TTFT_WEIGHT` / `NEG_HEADROOM_TPOT_WEIGHT` — blend weights for deficits
-- `SLO_BUFFER_FACTOR` — safety multiplier on TPOT SLOs
+To opt an individual request into SLO-aware routing, add one or both headers:
 
----
+- `x-slo-ttft-ms` — Time-to-first-token SLO in milliseconds.
+- `x-slo-tpot-ms` — Time-per-output-token SLO in milliseconds.
 
-### Enable prediction-based scheduling
+### 1. Get the IP of the Proxy
 
-Turn on SLO-aware routing per request with the header:
+**Standalone Mode**
 
-```text
-x-prediction-based-scheduling: true
+```bash
+export IP=$(kubectl get service ${GUIDE_NAME}-epp -n ${NAMESPACE} -o jsonpath='{.spec.clusterIP}')
 ```
 
-- If **SLO headers are present**: predictions are compared against thresholds.
-- If **no SLOs** are provided: treated as SLO=0 → lowest latency pod is chosen.
-- If **priority < 0** and **no pod can meet SLOs**: request is **shed** instead of placed in the negative bucket.
+<details>
+<summary> <b>Gateway Mode</b> </summary>
 
-#### Current limitations
+```bash
+export IP=$(kubectl get gateway llm-d-inference-gateway -n ${NAMESPACE} -o jsonpath='{.status.addresses[0].value}')
+```
+</details>
 
-- Percentile: only **p90** supported.
-- Training: only **streaming mode** supported.
-- TPOT sampling: for obsevability, every 200th token is logged and compared with predictions.
+### 2. Send a Test Request
 
----
+**Open a temporary interactive shell inside the cluster:**
 
-## Cleanup
+```bash
+kubectl run curl-debug --rm -it \
+    --image=cfmanteiga/alpine-bash-curl-jq \
+    --env="IP=$IP" \
+    --env="NAMESPACE=$NAMESPACE" \
+    --env="MODEL_NAME=$MODEL_NAME" \
+    -- /bin/bash
+```
 
-To remove the resources you created in this walkthrough, follow the same cleanup instructions from the [Inference Gateway Extension guide](https://gateway-api-inference-extension.sigs.k8s.io/guides/#cleanup).
+**Send a completion request:**
 
-That section covers how to delete the InferencePool, ConfigMaps, and supporting resources you applied here. The steps are identical — only the EPP image and sidecar configuration differ.
+```bash
+curl -X POST http://${IP}/v1/completions \
+    -H 'Content-Type: application/json' \
+    -H 'x-slo-ttft-ms: 200' \
+    -H 'x-slo-tpot-ms: 50' \
+    -d '{
+        "model": "'${MODEL_NAME}'",
+        "prompt": "Explain the difference between prefill and decode.",
+        "max_tokens": 200,
+        "temperature": 0,
+        "stream": true,
+        "stream_options": {"include_usage": true}
+    }'
+```
+
+Sheddable requests (priority < 0) are rejected at admission when no endpoint can meet the SLO, rather than routed to a guaranteed miss.
+
+## Verify
+
+Once traffic is flowing, confirm three things in Prometheus (see the [architecture doc](../../docs/wip-docs-new/architecture/advanced/latency-predictor.md#observability) for the metric reference):
+
+1. **Predictions are being produced.** `inference_objective_request_ttft_prediction_duration_seconds` has non-zero samples. If it stays empty, the predictor sidecar is not being called — tail the EPP logs for `predicted-latency-producer` errors.
+2. **Predictions track reality.** Compare `inference_objective_request_predicted_ttft_seconds` against `inference_objective_request_ttft_seconds` over a rolling window. A healthy deployment converges to within a few percent after warmup.
+3. **SLOs are being honored.** If you're sending SLO-annotated traffic, `inference_objective_request_ttft_slo_violation_total` and `..._tpot_slo_violation_total` should increment only under genuine saturation.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| Prediction duration metrics empty | Predictor sidecar unreachable — EPP falls back to composite heuristic scoring. Check sidecar readiness and `PREDICTION_SERVER_URL`. |
+| Large, persistent drift between predicted and actual TTFT | `streamingMode` mismatch (set to `false` on a streaming workload, or vice versa), or workload drifted outside the training window. |
+| High TPOT SLO violation rate at low QPS | `streamingMode: false` — TPOT is not being trained. Flip it to `true` and restart. |
+| SLO violations cluster on a few pods during spikes | Scoring strategy is `least`; try `most` for more headroom at the cost of utilization. |
+| Prediction-based routing degrades to baseline | Predictor error or sidecar restart — expected fallback, not a failure. Investigate sidecar logs. |
+
+## Related
+
+- [Latency Predictor Architecture](../../docs/wip-docs-new/architecture/advanced/latency-predictor.md) — plugin pipeline, ML model, scaling characteristics, metric reference.
+- [llm-d/llm-d-inference-scheduler](https://github.com/llm-d/llm-d-inference-scheduler) — source for the EPP plugins and per-plugin configuration references.
+- [llm-d/llm-d-latency-predictor](https://github.com/llm-d/llm-d-latency-predictor) — source for the training and prediction server Python code.
+- [Predicted Latency-Based Scheduling for LLMs](https://llm-d.ai/blog/predicted-latency-based-scheduling-for-llms) — design rationale and benchmark results.

--- a/guides/predicted-latency-based-scheduling/scheduler/predicted-latency-slo.values.yaml
+++ b/guides/predicted-latency-based-scheduling/scheduler/predicted-latency-slo.values.yaml
@@ -1,0 +1,65 @@
+## Predicted Latency-Based Scheduling — SLO-aware setup (streamingMode: true).
+##
+## Overrides the chart's default plugin pipeline so predicted-latency-producer
+## trains on streaming TPOT samples. Required for x-slo-ttft-ms / x-slo-tpot-ms
+## request headers to be honored. Every request must be sent with
+## "stream": true in the body.
+##
+## For routing-only (no SLO headers), use predicted-latency.values.yaml.
+
+inferenceExtension:
+  image:
+    registry: ghcr.io
+    repository: llm-d/llm-d-inference-scheduler
+    tag: v0.8.0
+  latencyPredictor:
+    enabled: true
+  extraServicePorts:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8081
+  pluginsConfigFile: "predicted-latency-slo-plugins.yaml"
+  pluginsCustomConfig:
+    predicted-latency-slo-plugins.yaml: |
+      apiVersion: inference.networking.x-k8s.io/v1alpha1
+      kind: EndpointPickerConfig
+      plugins:
+      - type: queue-scorer
+      - type: kv-cache-utilization-scorer
+      - type: prefix-cache-scorer
+      - type: metrics-data-source
+        parameters:
+          insecureSkipVerify: true
+          path: /metrics
+          scheme: http
+      - type: core-metrics-extractor
+      - type: predicted-latency-producer
+        parameters:
+          streamingMode: true
+      - type: prefix-cache-affinity-filter
+        name: strict-affinity-filter
+        parameters:
+          affinityThreshold: 0.99
+      - type: prefix-cache-affinity-filter
+        name: loose-affinity-filter
+        parameters:
+          affinityThreshold: 0.8
+      - type: latency-scorer
+      - type: weighted-random-picker
+      - type: slo-headroom-tier-filter
+      - type: latency-slo-admitter
+      schedulingProfiles:
+      - name: default
+        plugins:
+        - pluginRef: predicted-latency-producer
+        - pluginRef: strict-affinity-filter
+        - pluginRef: slo-headroom-tier-filter
+        - pluginRef: loose-affinity-filter
+        - pluginRef: latency-scorer
+        - pluginRef: weighted-random-picker
+
+inferencePool:
+  modelServers:
+    matchLabels:
+      llm-d.ai/guide: "optimized-baseline"

--- a/guides/predicted-latency-based-scheduling/scheduler/predicted-latency.values.yaml
+++ b/guides/predicted-latency-based-scheduling/scheduler/predicted-latency.values.yaml
@@ -1,0 +1,23 @@
+## Predicted Latency-Based Scheduling — default (routing-only) setup.
+##
+## The predictor trains on end-to-end latency. Suitable for non-SLO traffic.
+## For SLO header support (x-slo-ttft-ms / x-slo-tpot-ms), use
+## predicted-latency-slo.values.yaml instead.
+
+inferenceExtension:
+  image:
+    registry: ghcr.io
+    repository: llm-d/llm-d-inference-scheduler
+    tag: v0.8.0
+  latencyPredictor:
+    enabled: true
+  extraServicePorts:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8081
+
+inferencePool:
+  modelServers:
+    matchLabels:
+      llm-d.ai/guide: "optimized-baseline"


### PR DESCRIPTION
- guides/predicted-latency-based-scheduling/README.md: replace the old experimental-feature doc with the concise "adopt this path" version copied from the well-lit-paths folder (see https://github.com/llm-d/llm-d/pull/1166). Rewrite ../../architecture/... and ../../getting-started/... to ../../docs/wip-docs-new/... so links resolve from the guide location.
- docs/wip-docs-new/guides/experimental/predicted-latency.md → docs/wip-docs-new/guides/predicted-latency.md: move the WLP page out of the experimental subfolder (now empty). Adjust its internal relative links for the new depth and update the stale reference to intelligent-optimized-baseline.md after the rename to intelligent-inference-scheduling.md.
- docs/wip-docs-new/architecture/advanced/latency-predictor.md: repoint the two incoming links to the new WLP path.