### PR TITLE
Remove workflow permit

### DIFF
--- a/.github/workflows/slash-test-nightly.yaml
+++ b/.github/workflows/slash-test-nightly.yaml
@@ -34,7 +34,6 @@ permissions:
   contents: write
   pull-requests: write
   actions: write
-  workflows: write
 
 # Use comment ID in concurrency group so different /test-nightly
 # commands on the same PR can run in parallel.


### PR DESCRIPTION
I was wrong. `workflows` is not a valid permission for the permissions: block in GitHub Actions. The `GITHUB_TOKEN` cannot be granted the workflows scope. That's only available on Personal Access Tokens (PATs).