### PR TITLE
fix: Fix typos lint

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -506,11 +506,11 @@ RUN umask 002 && \
     chown vllm:root /home/vllm && \
     chmod g+rwx /home/vllm
 
-# default opinionated env var for HF_HOME, over-writeable
+# default opinionated env var for HF_HOME, over-writable
 ENV LLM_D_MODELS_DIR=/var/lib/llm-d/models \
     HF_HOME=/var/lib/llm-d/.hf
 
-# creates default models directory and makes path writeable for both root and default user, with symlink for convenience
+# creates default models directory and makes path writable for both root and default user, with symlink for convenience
 # find command keeps group=0 on all new subdirs created later
 RUN mkdir -p "$LLM_D_MODELS_DIR" "$HF_HOME" && \
     chown -R root:0 /var/lib/llm-d && \

--- a/docs/wip-docs-new/architecture/core/model-servers.md
+++ b/docs/wip-docs-new/architecture/core/model-servers.md
@@ -51,7 +51,7 @@ metric types and semantics MUST follow this doc.
 | [Optional] NumGPUBlocks| Labeled/Gauge     | The total number of blocks in the HBM KV cache, used by the prefix cache scorer. If this metric is not available, the NumGPUBlocks will be derived from the [prefix plugin config](https://gateway-api-inference-extension.sigs.k8s.io/guides/epp-configuration/prefix-aware/#customize-the-prefix-cache-plugin).| name: `vllm:cache_config_info`, label name: `num_gpu_blocks`| `nv_trt_llm_kv_cache_block_metrics{kv_cache_block_type=max}` | `trtllm_kv_cache_max_blocks` | name: `sglang:cache_config_info`, label name: `num_pages`
 
 
-To correctly map metrics names, model server Pods should be labeld with the model server type they are running as demonistrated below. Pods without the engine-type label will default to vLLM metrics names.
+To correctly map metrics names, model server Pods should be labeled with the model server type they are running as demonistrated below. Pods without the engine-type label will default to vLLM metrics names.
 
 
 ```yaml

--- a/guides/optimized-baseline/scheduler/README.md
+++ b/guides/optimized-baseline/scheduler/README.md
@@ -6,7 +6,7 @@ Layer this file on top of the shared [scheduler recipes](../../recipes/scheduler
 
 ## EPHEMERAL DOC
 
-We no longer want to have per guide docs explaing anything related to installation and verification. All of that should be abstracted into a few docs at the root of guide repo. This Document is kept around for reviews to understand the scoping and implementation of this refactor, as we will be refactoring guide by guide to cut down review overhead.
+We no longer want to have per guide docs explaining anything related to installation and verification. All of that should be abstracted into a few docs at the root of guide repo. This Document is kept around for reviews to understand the scoping and implementation of this refactor, as we will be refactoring guide by guide to cut down review overhead.
 
 ## Standalone (no gateway)
 


### PR DESCRIPTION
This PR fixes the nightly docs scan issue: https://github.com/llm-d/llm-d/issues/1240.   ~~I think it would be better to run lint checks on each PR and automatically add comments when typos are detected, rather than relying on ad hoc fixes later. Please let me know if you'd like me to submit a follow-up PR for the workflow.~~ The linter is already in place for PR.