### PR TITLE
Prep v0.7.0

### DIFF
--- a/guides/optimized-baseline/modelserver/amd/vllm/kustomization.yaml
+++ b/guides/optimized-baseline/modelserver/amd/vllm/kustomization.yaml
@@ -8,7 +8,7 @@ namePrefix: optimized-baseline-rocm-vllm-
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: ghcr.io/llm-d/llm-d-rocm
-    newTag: v0.6.0
+    newTag: v0.7.0
 
 labels:
   - pairs:

--- a/guides/optimized-baseline/modelserver/hpu/vllm/kustomization.yaml
+++ b/guides/optimized-baseline/modelserver/hpu/vllm/kustomization.yaml
@@ -9,7 +9,7 @@ namePrefix: optimized-baseline-hpu-vllm-
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: ghcr.io/llm-d/llm-d-hpu
-    newTag: v0.6.0
+    newTag: v0.7.0
 
 labels:
   - pairs:

--- a/guides/optimized-baseline/modelserver/xpu/vllm/kustomization.yaml
+++ b/guides/optimized-baseline/modelserver/xpu/vllm/kustomization.yaml
@@ -9,7 +9,7 @@ namePrefix: optimized-baseline-xpu-vllm-
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: ghcr.io/llm-d/llm-d-xpu
-    newTag: v0.6.0
+    newTag: v0.7.0
 
 labels:
   - pairs:

--- a/guides/pd-disaggregation/modelserver/amd/vllm/base/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/vllm/base/kustomization.yaml
@@ -8,7 +8,7 @@ namePrefix: pd-disaggregation-rocm-vllm-
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: ghcr.io/llm-d/llm-d-rocm
-    newTag: v0.6.0
+    newTag: v0.7.0
 
 
 labels:

--- a/guides/pd-disaggregation/modelserver/hpu/vllm/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/hpu/vllm/kustomization.yaml
@@ -12,7 +12,7 @@ configurations:
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: ghcr.io/llm-d/llm-d-hpu
-    newTag: v0.6.0
+    newTag: v0.7.0
 
 
 labels:

--- a/guides/pd-disaggregation/modelserver/xpu/vllm/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/xpu/vllm/kustomization.yaml
@@ -12,7 +12,7 @@ configurations:
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: ghcr.io/llm-d/llm-d-xpu
-    newTag: v0.6.0
+    newTag: v0.7.0
 
 
 labels:

--- a/guides/precise-prefix-cache-aware/README.md
+++ b/guides/precise-prefix-cache-aware/README.md
@@ -132,7 +132,7 @@ The release name `${GUIDE_NAME}` is mandatory for standard deployments — the i
 <details>
 <summary><b>Why a helm post-renderer is required (chart limitation)</b></summary>
 
-The standalone chart's `sidecar.*` slot is occupied by its Envoy proxy — overriding it would lose HTTP serving — so the UDS tokenizer container is appended via a helm post-render hook instead. The post-renderer runs `kustomize build` on the chart's rendered manifests with a strategic merge patch that adds the `tokenizer-uds` container (image `ghcr.io/llm-d/llm-d-uds-tokenizer:v0.7.1`), two `emptyDir` volumes (`tokenizers`, `tokenizer-uds`), and a `/tmp/tokenizer` volumeMount on the existing `epp` container so the `tokenizer` plugin can reach the UDS socket. Tracking removal of this workaround upstream — once the chart supports multiple sidecars natively, the post-renderer goes away.
+The standalone chart's `sidecar.*` slot is occupied by its Envoy proxy — overriding it would lose HTTP serving — so the UDS tokenizer container is appended via a helm post-render hook instead. The post-renderer runs `kustomize build` on the chart's rendered manifests with a strategic merge patch that adds the `tokenizer-uds` container (image `ghcr.io/llm-d/llm-d-uds-tokenizer:vllm-v0.19.1`), two `emptyDir` volumes (`tokenizers`, `tokenizer-uds`), and a `/tmp/tokenizer` volumeMount on the existing `epp` container so the `tokenizer` plugin can reach the UDS socket. Tracking removal of this workaround upstream — once the chart supports multiple sidecars natively, the post-renderer goes away.
 
 </details>
 

--- a/guides/precise-prefix-cache-aware/modelserver/amd/vllm/kustomization.yaml
+++ b/guides/precise-prefix-cache-aware/modelserver/amd/vllm/kustomization.yaml
@@ -9,7 +9,7 @@ namePrefix: precise-prefix-cache-aware-amd-vllm-
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: ghcr.io/llm-d/llm-d-rocm
-    newTag: v0.6.0
+    newTag: v0.7.0
 
 labels:
   - pairs:

--- a/guides/precise-prefix-cache-aware/modelserver/hpu/vllm/kustomization.yaml
+++ b/guides/precise-prefix-cache-aware/modelserver/hpu/vllm/kustomization.yaml
@@ -10,7 +10,7 @@ namePrefix: precise-prefix-cache-aware-hpu-vllm-
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: ghcr.io/llm-d/llm-d-hpu
-    newTag: v0.6.0
+    newTag: v0.7.0
 
 labels:
   - pairs:

--- a/guides/precise-prefix-cache-aware/modelserver/xpu/vllm/kustomization.yaml
+++ b/guides/precise-prefix-cache-aware/modelserver/xpu/vllm/kustomization.yaml
@@ -10,7 +10,7 @@ namePrefix: precise-prefix-cache-aware-xpu-vllm-
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: ghcr.io/llm-d/llm-d-xpu
-    newTag: v0.6.0
+    newTag: v0.7.0
 
 labels:
   - pairs:

--- a/guides/recipes/modelserver/base/single-host/pd/sglang/patch-sidecar.yaml
+++ b/guides/recipes/modelserver/base/single-host/pd/sglang/patch-sidecar.yaml
@@ -13,7 +13,7 @@ spec:
             - --connector=sglang
             - --zap-log-level=1
             - --secure-proxy=false
-          image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
+          image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
           imagePullPolicy: Always
           ports:
             - containerPort: 8000

--- a/guides/recipes/modelserver/base/single-host/pd/vllm/patch-sidecar.yaml
+++ b/guides/recipes/modelserver/base/single-host/pd/vllm/patch-sidecar.yaml
@@ -13,7 +13,7 @@ spec:
             - --connector=nixlv2
             - --zap-log-level=1
             - --secure-proxy=false
-          image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
+          image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
           imagePullPolicy: Always
           ports:
             - containerPort: 8000

--- a/guides/wide-ep-lws/experimental-dp-aware/manifests/modelserver/base/decode.yaml
+++ b/guides/wide-ep-lws/experimental-dp-aware/manifests/modelserver/base/decode.yaml
@@ -47,7 +47,7 @@ spec:
               #   value: "parentbased_traceidratio"
               # - name: OTEL_TRACES_SAMPLER_ARG
               #   value: "0.1"
-            image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
+            image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
             imagePullPolicy: Always
             ports:
               - containerPort: 8000

--- a/guides/wide-ep-lws/modelserver/gpu/vllm/base/decode.yaml
+++ b/guides/wide-ep-lws/modelserver/gpu/vllm/base/decode.yaml
@@ -29,7 +29,7 @@ spec:
               - --zap-log-level=1
               - --secure-proxy=false
               - --enable-prefiller-sampling
-            image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
+            image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
             imagePullPolicy: Always
             # To enable tracing, uncomment:
             # env:

--- a/guides/wide-ep-lws/modelserver/gpu/vllm/base/decode.yaml
+++ b/guides/wide-ep-lws/modelserver/gpu/vllm/base/decode.yaml
@@ -29,7 +29,7 @@ spec:
               - --zap-log-level=1
               - --secure-proxy=false
               - --enable-prefiller-sampling
-            image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
+            image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
             imagePullPolicy: Always
             # To enable tracing, uncomment:
             # env:

--- a/guides/workload-autoscaling/README.wva.md
+++ b/guides/workload-autoscaling/README.wva.md
@@ -224,7 +224,7 @@ Choose your platform and follow the corresponding section:
 # Setup
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
-export VERSION=${VERSION:-v0.6.0}
+export VERSION=${VERSION:-v0.7.0}
 export MON_NS=openshift-user-workload-monitoring
 
 # Download OpenShift-specific values
@@ -273,7 +273,7 @@ YAML
 # Setup
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
-export VERSION=${VERSION:-v0.6.0}
+export VERSION=${VERSION:-v0.7.0}
 export MON_NS=${MON_NS:-llm-d-monitoring}
 
 # Download values
@@ -297,7 +297,7 @@ For Kind clusters with HTTPS Prometheus (configured in Platform-Specific Configu
 # Setup
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
-export VERSION=${VERSION:-v0.6.0}
+export VERSION=${VERSION:-v0.7.0}
 export MON_NS=${MON_NS:-llm-d-monitoring}
 
 # Download values

--- a/guides/workload-autoscaling/wva-config/base/kustomization.yaml
+++ b/guides/workload-autoscaling/wva-config/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: llm-d-autoscaler
 resources:
-  - github.com/llm-d/llm-d-workload-variant-autoscaler/config/default?ref=v0.6.0
+  - github.com/llm-d/llm-d-workload-variant-autoscaler/config/default?ref=v0.7.0
   - controller-manager-token-secret.yaml
   - metrics-reader-rolebinding.yaml
 patches:


### PR DESCRIPTION
## Core Image Version Updates (v0.6.0 → v0.7.0)

| Image | Previous | New | Files |
|---|---|---|---|
| llm-d-cuda | v0.5.0 / v0.6.0 / dev:latest | v0.7.0 | `wide-ep-lws/modelserver/gpu/vllm/base/decode.yaml`, `prefill.yaml`; `wide-ep-lws/experimental-dp-aware/manifests/modelserver/base/decode.yaml`, `prefill.yaml`; `workload-autoscaling/ms-workload-autoscaling/values.yaml`; `tiered-prefix-cache/cpu/manifests/vllm/lmcache-connector/kustomization.yaml` |
| llm-d-rocm | v0.6.0 | v0.7.0 | `optimized-baseline/modelserver/amd/vllm/kustomization.yaml`; `precise-prefix-cache-aware/modelserver/amd/vllm/kustomization.yaml`; `pd-disaggregation/modelserver/amd/vllm/base/kustomization.yaml` |
| llm-d-xpu | v0.6.0 | v0.7.0 | `optimized-baseline/modelserver/xpu/vllm/kustomization.yaml`; `precise-prefix-cache-aware/modelserver/xpu/vllm/kustomization.yaml`; `pd-disaggregation/modelserver/xpu/vllm/kustomization.yaml` |
| llm-d-hpu | v0.6.0 | v0.7.0 | `optimized-baseline/modelserver/hpu/vllm/kustomization.yaml`; `precise-prefix-cache-aware/modelserver/hpu/vllm/kustomization.yaml`; `pd-disaggregation/modelserver/hpu/vllm/kustomization.yaml` |

## Sidecar & Scheduler Component Updates

| Image | Previous | New | Files |
|---|---|---|---|
| llm-d-routing-sidecar | v0.7.1 | v0.8.0 | `recipes/modelserver/base/single-host/pd/vllm/patch-sidecar.yaml`, `sglang/patch-sidecar.yaml`; `simulated-accelerators/ms-sim/values.yaml`; `wide-ep-lws/modelserver/gpu/vllm/base/decode.yaml`; `wide-ep-lws/experimental-dp-aware/manifests/modelserver/base/decode.yaml` |
| llm-d-uds-tokenizer | v0.7.1 | vllm-v0.19.1 | `precise-prefix-cache-aware/scheduler/patches/uds-tokenizer/patch-uds-sidecar.yaml`; `precise-prefix-cache-aware/README.md`; `simulated-accelerators/ms-sim/values.yaml` |
| llm-d-inference-scheduler | v0.8.0-rc.1 | v0.8.0 | `precise-prefix-cache-aware/scheduler/precise-prefix-cache-aware.values.yaml` |

## Other Component Updates

| Component | Previous | New | Files |
|---|---|---|---|
| llm-d-workload-variant-autoscaler | v0.6.0 | v0.7.0 | `workload-autoscaling/wva-config/base/kustomization.yaml`; `workload-autoscaling/README.wva.md` (×3) |

## Intentionally NOT bumped

| Image | Reason |
|---|---|
| llm-d-cpu | Omitted from this release |

@llm-d/release-crew 