### PR TITLE
[Docs] Recover precise prefix cache-aware well-lit-path

### DIFF
--- a/docs/wip-docs-new/outline.md
+++ b/docs/wip-docs-new/outline.md
@@ -29,6 +29,7 @@
 ├── well-lit-paths
 │   ├── README.md
 │   ├── optimized-baseline.md
+│   ├── precise-prefix-cache-aware.md
 │   ├── flow-control.md
 │   ├── prefill-decode-disaggregation.md
 │   ├── wide-expert-parallelism.md

--- a/docs/wip-docs-new/well-lit-paths/optimized-baseline.md
+++ b/docs/wip-docs-new/well-lit-paths/optimized-baseline.md
@@ -7,7 +7,7 @@ LLM requests break all three assumptions. They are:
 * **Slow** - a single request can take over a minute generating tokens
 * **Non-uniform** - range from 1000s of reasoning tokens to a 100k+ context tokens
 
-EPP injects awareness of the LLM-workload into the load-balancing layer considering **prefix-cache affinity** and **server load metrics**.
+The llm-d inference scheduler injects awareness of the LLM-workload into the load-balancing layer considering **prefix-cache affinity** and **server load metrics**.
 
 > [!NOTE]
 > This guide demonstrates one approach to prefix- and load-aware scheduling. Inference scheduler supports other options as well, including session affinity and active request based scheduling, which make no assumptions about the scheduler's ability to parse the request or probe the servers. See [configuration](../architecture/core/epp/configuration.md) for more details on the available scorers, or [precise prefix-cache-aware routing](precise-prefix-cache-aware.md) for KV-event-driven scoring.

--- a/docs/wip-docs-new/well-lit-paths/optimized-baseline.md
+++ b/docs/wip-docs-new/well-lit-paths/optimized-baseline.md
@@ -10,7 +10,7 @@ LLM requests break all three assumptions. They are:
 EPP injects awareness of the LLM-workload into the load-balancing layer considering **prefix-cache affinity** and **server load metrics**.
 
 > [!NOTE]
-> This guide demonstrates one approach to prefix- and load-aware scheduling. EPP supports other options as well, including session affinity and active request based scheduling, which make no assumptions about the scheduler's ability to parse the request or probe the servers. See [EPP configuration](../architecture/core/epp/configuration.md) for more details on the available scorers.
+> This guide demonstrates one approach to prefix- and load-aware scheduling. EPP supports other options as well, including session affinity and active request based scheduling, which make no assumptions about the scheduler's ability to parse the request or probe the servers. See [EPP configuration](../architecture/core/epp/configuration.md) for more details on the available scorers, or [precise prefix-cache-aware routing](precise-prefix-cache-aware.md) for KV-event-driven scoring.
 
 ## Deploy
 

--- a/docs/wip-docs-new/well-lit-paths/optimized-baseline.md
+++ b/docs/wip-docs-new/well-lit-paths/optimized-baseline.md
@@ -10,7 +10,7 @@ LLM requests break all three assumptions. They are:
 EPP injects awareness of the LLM-workload into the load-balancing layer considering **prefix-cache affinity** and **server load metrics**.
 
 > [!NOTE]
-> This guide demonstrates one approach to prefix- and load-aware scheduling. EPP supports other options as well, including session affinity and active request based scheduling, which make no assumptions about the scheduler's ability to parse the request or probe the servers. See [EPP configuration](../architecture/core/epp/configuration.md) for more details on the available scorers, or [precise prefix-cache-aware routing](precise-prefix-cache-aware.md) for KV-event-driven scoring.
+> This guide demonstrates one approach to prefix- and load-aware scheduling. Inference scheduler supports other options as well, including session affinity and active request based scheduling, which make no assumptions about the scheduler's ability to parse the request or probe the servers. See [configuration](../architecture/core/epp/configuration.md) for more details on the available scorers, or [precise prefix-cache-aware routing](precise-prefix-cache-aware.md) for KV-event-driven scoring.
 
 ## Deploy
 

--- a/docs/wip-docs-new/well-lit-paths/precise-prefix-cache-aware.md
+++ b/docs/wip-docs-new/well-lit-paths/precise-prefix-cache-aware.md
@@ -16,13 +16,13 @@ See the [precise prefix cache-aware guide](https://github.com/llm-d/llm-d/tree/m
 
 ## Architecture
 
-The split is straightforward: **model servers** produce KV-events on every cache change; the **EPP** consumes them to score routing decisions. The two sides are decoupled — pods and EPP replicas scale independently.
+The split is straightforward: **model servers** produce KV-events on every cache change; the **inference scheduler** consumes them to score pods for better routing decisions. The two sides are decoupled — model server and inference scheduler replicas scale independently.
 
-Inside the EPP:
+Inside the inference scheduler:
 - An **indexer** consumes the event stream and maintains a `block key → pods` mapping for every block resident across the fleet.
 - A **scorer** derives block keys deterministically from the input and queries the index. It returns the longest consecutive prefix each candidate pod has cached, weighted by tier.
 
-Events flow from model-server pods to the EPP over ZMQ. The default mode is **centralized** — every pod publishes to a single EPP endpoint, fitting a single replica. For multi-replica deployments, **pod discovery** has each EPP replica subscribe to every pod independently; all replicas converge to the same index, enabling active-active HA across schedulers.
+Events flow from model-server pods to the inference scheduler over ZMQ. The default mode is **centralized** — every pod publishes to a single inference scheduler endpoint, fitting a single replica. For multi-replica deployments, **pod discovery** has each inference scheduler replica subscribe to every model server pod independently; all replicas converge to the same index, enabling active-active HA across schedulers.
 
 ## Further Reading
 

--- a/docs/wip-docs-new/well-lit-paths/precise-prefix-cache-aware.md
+++ b/docs/wip-docs-new/well-lit-paths/precise-prefix-cache-aware.md
@@ -1,8 +1,8 @@
 # Precise Prefix Cache Aware Routing
 
-The model server is the most accurate source of truth for what's cached on its own GPUs and memory mediums. vLLM, SGLang and NVIDIA TensorRT-LLM publish every cache change as an event; llm-d subscribes to that stream, builds a near-real-time view of resident blocks across the fleet, and scores requests against it. The prefix-affinity score is combined with the standard load-aware scorers, similarly to the [Optimized Baseline](optimized-baseline.md) path.
+The model server is the most accurate source of truth for what's cached on its own GPUs and memory tiers. vLLM, SGLang and NVIDIA TensorRT-LLM publish every cache change as an event; llm-d subscribes to that stream, builds a near-real-time view of resident blocks across the fleet, and scores requests against it. The prefix-affinity score is combined with the standard load-aware scorers, similarly to the [Optimized Baseline](optimized-baseline.md) path.
 
-KV-events have become the ecosystem-standard substrate for exposing accurate cache state - where reusable inference state lives and how it changes over time. 
+KV-events have become the ecosystem-standard substrate for exposing accurate cache state — where reusable inference state lives and how it changes over time.
 As KV-cache orchestration grows more sophisticated and agentic workloads stretch prefixes longer, cache state becomes something the control plane needs to observe and act on. The same view scales naturally to:
 - tier-aware cache tracking across GPU HBM, CPU DRAM, local NVMe, and shared storage;
 - policies that account for explicit prompt-cache placement and dynamic KV-offloading;

--- a/docs/wip-docs-new/well-lit-paths/precise-prefix-cache-aware.md
+++ b/docs/wip-docs-new/well-lit-paths/precise-prefix-cache-aware.md
@@ -1,0 +1,29 @@
+# Precise Prefix Cache Aware Routing
+
+The model server is the most accurate source of truth for what's cached on its own GPUs and memory mediums. vLLM, SGLang and NVIDIA TensorRT-LLM publish every cache change as an event; llm-d subscribes to that stream, builds a near-real-time view of resident blocks across the fleet, and scores requests against it. The prefix-affinity score is combined with the standard load-aware scorers, similarly to the [Optimized Baseline](optimized-baseline.md) path.
+
+KV-events have become the ecosystem-standard substrate for exposing accurate cache state - where reusable inference state lives and how it changes over time. 
+As KV-cache orchestration grows more sophisticated and agentic workloads stretch prefixes longer, cache state becomes something the control plane needs to observe and act on. The same view scales naturally to:
+- tier-aware cache tracking across GPU HBM, CPU DRAM, local NVMe, and shared storage;
+- policies that account for explicit prompt-cache placement and dynamic KV-offloading;
+- cache movement and prefetching workflows for fleet-wide KV reuse;
+- advanced KV retention and eviction policies for agentic patterns;
+- hybrid-attention models where layer groups (full, sliding-window, linear) evict independently.
+
+## Deploy
+
+See the [precise prefix cache-aware guide](https://github.com/llm-d/llm-d/tree/main/guides/precise-prefix-cache-aware) for manifests and step-by-step deployment.
+
+## Architecture
+
+The split is straightforward: **model servers** produce KV-events on every cache change; the **EPP** consumes them to score routing decisions. The two sides are decoupled — pods and EPP replicas scale independently.
+
+Inside the EPP:
+- An **indexer** consumes the event stream and maintains a `block key → pods` mapping for every block resident across the fleet.
+- A **scorer** derives block keys deterministically from the input and queries the index. It returns the longest consecutive prefix each candidate pod has cached, weighted by tier.
+
+Events flow from model-server pods to the EPP over ZMQ. The default mode is **centralized** — every pod publishes to a single EPP endpoint, fitting a single replica. For multi-replica deployments, **pod discovery** has each EPP replica subscribe to every pod independently; all replicas converge to the same index, enabling active-active HA across schedulers.
+
+## Further Reading
+
+See [KV-Cache Indexer](../architecture/advanced/kv-indexer.md) for the full architecture


### PR DESCRIPTION
Recover the precise prefix cache-aware well-lit-path to the rendered docs.