### PR TITLE
fix: restore tiered-prefix-cache base deployment after recipes/vllm removal

### DIFF
--- a/docs/monitoring/tracing/README.md
+++ b/docs/monitoring/tracing/README.md
@@ -80,7 +80,7 @@ inferenceExtension:
 
 ### Kustomize / Raw Manifests
 
-For guides that use raw manifests (e.g., `wide-ep-lws`, `recipes/vllm`), add tracing flags to your `vllm serve` command and OTEL env vars to the container:
+For guides that use raw manifests (e.g., `wide-ep-lws`, `recipes/modelserver`), add tracing flags to your `vllm serve` command and OTEL env vars to the container:
 
 ```yaml
 # Add to your vllm serve command:

--- a/guides/tiered-prefix-cache/cpu/manifests/vllm/base/deployment.yaml
+++ b/guides/tiered-prefix-cache/cpu/manifests/vllm/base/deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm-d-model-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      llm-d.ai/inference-serving: "true"
+  template:
+    metadata:
+      labels:
+        llm-d.ai/inference-serving: "true"
+    spec:
+      containers:
+        - name: vllm
+          image: vllm/vllm-openai:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - exec vllm serve --port 8000
+          env:
+            - name: HUGGING_FACE_HUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
+          ports:
+            - containerPort: 8000
+              name: http
+              protocol: TCP
+          lifecycle:
+            preStop:
+              sleep:
+                seconds: 30
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+              scheme: HTTP
+            periodSeconds: 1
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+              scheme: HTTP
+            periodSeconds: 1
+            successThreshold: 1
+            failureThreshold: 1
+            timeoutSeconds: 1
+          startupProbe:
+            failureThreshold: 600
+            initialDelaySeconds: 2
+            periodSeconds: 1
+            httpGet:
+              path: /health
+              port: http
+              scheme: HTTP
+          volumeMounts:
+            - mountPath: /data
+              name: data
+            - mountPath: /dev/shm
+              name: shm
+      restartPolicy: Always
+      enableServiceLinks: false
+      terminationGracePeriodSeconds: 130
+      volumes:
+        - name: data
+          emptyDir: {}
+        - name: shm
+          emptyDir:
+            medium: Memory

--- a/guides/tiered-prefix-cache/cpu/manifests/vllm/base/kustomization.yaml
+++ b/guides/tiered-prefix-cache/cpu/manifests/vllm/base/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../../../../recipes/vllm/standard
+  - deployment.yaml

--- a/guides/tiered-prefix-cache/storage/manifests/vllm/llm-d-fs-connector/kustomization.yaml
+++ b/guides/tiered-prefix-cache/storage/manifests/vllm/llm-d-fs-connector/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../../../../recipes/vllm/standard
+  - ../../../../cpu/manifests/vllm/base
 patches:
   - target:
       kind: Deployment


### PR DESCRIPTION
## Summary

PR #1131 refactored model server deployment from Helm to Kustomize, removing the `recipes/vllm/` directory. However, the **tiered-prefix-cache** guide kustomization files still referenced `recipes/vllm/standard`, breaking all five guide variants with:

```
error: accumulating resources: ... lstat .../guides/recipes/vllm: no such file or directory
```

### Approach

The new `recipes/modelserver/base/single-host/default` uses fundamentally different naming (`decode` deployment, `modelserver` container, empty arrays) compared to the old `recipes/vllm/standard` (`llm-d-model-server` deployment, `vllm` container, pre-populated fields). All tiered-prefix-cache downstream patches (offloading-connector, lmcache-connector, fs-connector) target the old names via JSON patches.

Rather than rewriting all downstream patches, this PR **inlines the original deployment manifest** into the tiered-prefix-cache base directory, preserving the `llm-d-model-server` structure that all patches depend on.

### Changes

| File | Change |
|------|--------|
| `guides/tiered-prefix-cache/cpu/manifests/vllm/base/deployment.yaml` | **New** — inlined `llm-d-model-server` deployment (from deleted `recipes/vllm/base/deployment.yaml`) |
| `guides/tiered-prefix-cache/cpu/manifests/vllm/base/kustomization.yaml` | `recipes/vllm/standard` → `deployment.yaml` (local) |
| `guides/tiered-prefix-cache/storage/manifests/vllm/llm-d-fs-connector/kustomization.yaml` | `recipes/vllm/standard` → `../../../../cpu/manifests/vllm/base` |
| `docs/monitoring/tracing/README.md` | Stale `recipes/vllm` mention → `recipes/modelserver` |

No changes to any downstream patch files — they continue to work unchanged.

### Testing

All five tiered-prefix-cache kustomization targets build with patches correctly applied:

```
guides/tiered-prefix-cache/cpu/manifests/vllm/base                 ... OK
guides/tiered-prefix-cache/cpu/manifests/vllm/offloading-connector ... OK
guides/tiered-prefix-cache/cpu/manifests/vllm/lmcache-connector    ... OK
guides/tiered-prefix-cache/storage/manifests/vllm/llm-d-fs-connector ... OK
guides/tiered-prefix-cache/storage/manifests/vllm/lmcache-connector  ... OK
```

Full `kustomize build` dry-run over all 48 guide targets confirms zero regressions.

Fixes #1243

Signed-off-by: Milind waykole <mwaykole@redhat.com>