### PR TITLE
fix: remove unsupported description field to fix precise-prefix-cache…

### DIFF
--- a/guides/precise-prefix-cache-aware/scheduler/patches/uds-tokenizer/plugin.yaml
+++ b/guides/precise-prefix-cache-aware/scheduler/patches/uds-tokenizer/plugin.yaml
@@ -11,7 +11,6 @@ apiVersion: v1
 name: uds-tokenizer
 version: 0.1.0
 type: postrenderer/v1
-description: Adds the UDS tokenizer sidecar to the standalone chart's scheduler pod.
 runtime: subprocess
 runtimeConfig:
   platformCommand:


### PR DESCRIPTION
…-aware helm install

Remove the `description` field from the plugin manifest to prevent YAML parsing errors during the Helm plugin installation.
