### PR TITLE
Add kustomize to prerequisite in client-setup/README.md

### DIFF
--- a/helpers/client-setup/README.md
+++ b/helpers/client-setup/README.md
@@ -11,6 +11,7 @@
 | `helm`      | v3.12.0+                 | [Helm – quick-start install](https://helm.sh/docs/intro/install/)                               |
 | `helmfile`  | v1.1.0+                  | [Helmfile - installation](https://github.com/helmfile/helmfile?tab=readme-ov-file#installation) |
 | `kubectl`   | v1.28.0+                 | [kubectl – install & setup](https://kubernetes.io/docs/tasks/tools/install-kubectl/)            |
+| `kustomize` | v5.0.0+                  | [Kustomize – installation](https://kubectl.docs.kubernetes.io/installation/kustomize/)          |
 
 ### Optional Tools
 


### PR DESCRIPTION
Helm installation of precise-prefix-cache-aware in guides/precise-prefix-cache-aware/README.md fails without kustomize installed.