### PR TITLE
Remove hashSeed/PYTHONHASHSEED and enable speculativeIndexing in precise-prefix-cache guide

### DIFF
--- a/guides/precise-prefix-cache-aware/README.md
+++ b/guides/precise-prefix-cache-aware/README.md
@@ -226,8 +226,7 @@ kubectl delete -n ${NAMESPACE} -k guides/precise-prefix-cache-aware/modelserver/
 
 1. **vLLM pods publish KV-cache events** — each pod runs `vllm serve ... --kv-events-config '{...,"publisher":"zmq","endpoint":"$(KV_EVENTS_ENDPOINT)","topic":"kv@$(POD_IP):$(POD_PORT)@<model>"}'`. On every KV block allocation/eviction, vLLM emits a ZMQ message.
 2. **Scheduler subscribes** — in central mode the scheduler's scorer binds `tcp://*:5556` and all vLLM publishers connect in. A single `kv@`-prefixed topic filter passes all events through.
-3. **Index is keyed by block hash** — the scorer hashes tokens using `blockSize=64` (must match vLLM's `--block-size`) to produce the same block IDs vLLM emits. Incoming requests are tokenized via the UDS tokenizer sidecar, hashed with the same parameters, and looked up in the index.
-4. **Scoring** — the `precise-prefix-cache-scorer` returns the fraction of the request's prefix blocks that are resident on each candidate pod. The `max-score-picker` routes to the highest-scoring pod.
+3. **Scoring** — the `precise-prefix-cache-scorer` returns the fraction of the request's prefix blocks that are resident on each candidate pod. The `max-score-picker` routes to the highest-scoring pod.
 
 The `tokenizer` plugin and the scorer's internal `tokenizersPoolConfig` both point at `/tmp/tokenizer/tokenizer-uds.socket` — a UDS tokenizer sidecar (`ghcr.io/llm-d/llm-d-uds-tokenizer`) owns tokenizer model downloads and caching, keeping tokenization out of the EPP main container.
 

--- a/guides/precise-prefix-cache-aware/README.md
+++ b/guides/precise-prefix-cache-aware/README.md
@@ -226,7 +226,7 @@ kubectl delete -n ${NAMESPACE} -k guides/precise-prefix-cache-aware/modelserver/
 
 1. **vLLM pods publish KV-cache events** — each pod runs `vllm serve ... --kv-events-config '{...,"publisher":"zmq","endpoint":"$(KV_EVENTS_ENDPOINT)","topic":"kv@$(POD_IP):$(POD_PORT)@<model>"}'`. On every KV block allocation/eviction, vLLM emits a ZMQ message.
 2. **Scheduler subscribes** — in central mode the scheduler's scorer binds `tcp://*:5556` and all vLLM publishers connect in. A single `kv@`-prefixed topic filter passes all events through.
-3. **Index is keyed by block hash** — the scorer hashes tokens using `blockSize=64` + `hashSeed="42"` (must match vLLM's `PYTHONHASHSEED=42` env var) to produce the same block IDs vLLM emits. Incoming requests are tokenized via the UDS tokenizer sidecar, hashed with the same parameters, and looked up in the index.
+3. **Index is keyed by block hash** — the scorer hashes tokens using `blockSize=64` (must match vLLM's `--block-size`) to produce the same block IDs vLLM emits. Incoming requests are tokenized via the UDS tokenizer sidecar, hashed with the same parameters, and looked up in the index.
 4. **Scoring** — the `precise-prefix-cache-scorer` returns the fraction of the request's prefix blocks that are resident on each candidate pod. The `max-score-picker` routes to the highest-scoring pod.
 
 The `tokenizer` plugin and the scorer's internal `tokenizersPoolConfig` both point at `/tmp/tokenizer/tokenizer-uds.socket` — a UDS tokenizer sidecar (`ghcr.io/llm-d/llm-d-uds-tokenizer`) owns tokenizer model downloads and caching, keeping tokenization out of the EPP main container.

--- a/guides/precise-prefix-cache-aware/modelserver/amd/vllm/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-aware/modelserver/amd/vllm/patch-vllm.yaml
@@ -32,8 +32,6 @@ spec:
               value: "8000"
             - name: KV_EVENTS_ENDPOINT
               value: "tcp://precise-prefix-cache-aware-epp.$(NAMESPACE).svc.cluster.local:5556"
-            - name: PYTHONHASHSEED
-              value: "42"
             # Disable vLLM usage telemetry — its writes to /.config fail
             # under restricted SecurityContexts (e.g. OpenShift).
             - name: DO_NOT_TRACK

--- a/guides/precise-prefix-cache-aware/modelserver/cpu/vllm/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-aware/modelserver/cpu/vllm/patch-vllm.yaml
@@ -38,8 +38,6 @@ spec:
               value: "8000"
             - name: KV_EVENTS_ENDPOINT
               value: "tcp://precise-prefix-cache-aware-epp.$(NAMESPACE).svc.cluster.local:5556"
-            - name: PYTHONHASHSEED
-              value: "42"
             # Disable vLLM usage telemetry — its writes to /.config fail
             # under restricted SecurityContexts (e.g. OpenShift).
             - name: DO_NOT_TRACK

--- a/guides/precise-prefix-cache-aware/modelserver/gpu/vllm/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-aware/modelserver/gpu/vllm/patch-vllm.yaml
@@ -39,10 +39,6 @@ spec:
             # patch this value to `<release-name>-epp`.
             - name: KV_EVENTS_ENDPOINT
               value: "tcp://precise-prefix-cache-aware-epp.$(NAMESPACE).svc.cluster.local:5556"
-            # Must match precise-prefix-cache-scorer tokenProcessorConfig.hashSeed
-            # so the in-EPP tokenizer produces the same block hashes that vLLM emits.
-            - name: PYTHONHASHSEED
-              value: "42"
             # Disable vLLM usage telemetry — its writes to /.config fail
             # under restricted SecurityContexts (e.g. OpenShift).
             - name: DO_NOT_TRACK

--- a/guides/precise-prefix-cache-aware/modelserver/hpu/vllm/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-aware/modelserver/hpu/vllm/patch-vllm.yaml
@@ -39,8 +39,6 @@ spec:
               value: "8000"
             - name: KV_EVENTS_ENDPOINT
               value: "tcp://precise-prefix-cache-aware-epp.$(NAMESPACE).svc.cluster.local:5556"
-            - name: PYTHONHASHSEED
-              value: "42"
             - name: HF_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/guides/precise-prefix-cache-aware/modelserver/tpu-v6/vllm/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-aware/modelserver/tpu-v6/vllm/patch-vllm.yaml
@@ -41,8 +41,6 @@ spec:
               value: "8000"
             - name: KV_EVENTS_ENDPOINT
               value: "tcp://precise-prefix-cache-aware-epp.$(NAMESPACE).svc.cluster.local:5556"
-            - name: PYTHONHASHSEED
-              value: "42"
             # Disable vLLM usage telemetry — its writes to /.config fail
             # under restricted SecurityContexts (e.g. OpenShift).
             - name: DO_NOT_TRACK

--- a/guides/precise-prefix-cache-aware/modelserver/tpu-v7/vllm/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-aware/modelserver/tpu-v7/vllm/patch-vllm.yaml
@@ -43,8 +43,6 @@ spec:
               value: "8000"
             - name: KV_EVENTS_ENDPOINT
               value: "tcp://precise-prefix-cache-aware-epp.$(NAMESPACE).svc.cluster.local:5556"
-            - name: PYTHONHASHSEED
-              value: "42"
             # Disable vLLM usage telemetry — its writes to /.config fail
             # under restricted SecurityContexts (e.g. OpenShift).
             - name: DO_NOT_TRACK

--- a/guides/precise-prefix-cache-aware/modelserver/xpu/vllm/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-aware/modelserver/xpu/vllm/patch-vllm.yaml
@@ -41,8 +41,6 @@ spec:
               value: "8000"
             - name: KV_EVENTS_ENDPOINT
               value: "tcp://precise-prefix-cache-aware-epp.$(NAMESPACE).svc.cluster.local:5556"
-            - name: PYTHONHASHSEED
-              value: "42"
             # Disable vLLM usage telemetry — its writes to /.config fail
             # under restricted SecurityContexts (e.g. OpenShift).
             - name: DO_NOT_TRACK

--- a/guides/precise-prefix-cache-aware/scheduler/features/active-active.values.yaml
+++ b/guides/precise-prefix-cache-aware/scheduler/features/active-active.values.yaml
@@ -81,8 +81,8 @@ inferenceExtension:
           parameters:
             tokenProcessorConfig:
               blockSize: 64
-              hashSeed: "42"
             indexerConfig:
+              speculativeIndexing: true
               tokenizersPoolConfig:
                 modelName: Qwen/Qwen3-32B
                 uds:

--- a/guides/precise-prefix-cache-aware/scheduler/precise-prefix-cache-aware.values.yaml
+++ b/guides/precise-prefix-cache-aware/scheduler/precise-prefix-cache-aware.values.yaml
@@ -79,8 +79,8 @@ inferenceExtension:
           parameters:
             tokenProcessorConfig:
               blockSize: 64           # must match vLLM --block-size
-              hashSeed: "42"          # must match vLLM PYTHONHASHSEED env var
             indexerConfig:
+              speculativeIndexing: true
               tokenizersPoolConfig:
                 modelName: Qwen/Qwen3-32B
                 uds:


### PR DESCRIPTION
## Summary
- Remove `hashSeed` from scheduler configs — engine keys and request keys are decoupled, no alignment with vLLM's hash seed is needed
- Remove `PYTHONHASHSEED` env var from all 7 modelserver patches (gpu, cpu, xpu, amd, tpu-v6, tpu-v7, hpu)
- Enable `speculativeIndexing: true` by default in both scheduler configs
- Update README to remove hashSeed/PYTHONHASHSEED references