### PR TITLE
Add missing details tag in docs

### DIFF
--- a/guides/optimized-baseline/README.md
+++ b/guides/optimized-baseline/README.md
@@ -139,6 +139,7 @@ kubectl apply -n ${NAMESPACE} -k guides/${GUIDE_NAME}/modelserver/cpu/vllm/
 
 </details>
 
+<details>
 <summary><h4>If you run into NCCL errors on GKE</h4></summary>
 
 Try applying the patch:


### PR DESCRIPTION
Missing beginning `<details>` tag in the file - causes the website build to fail.

Found this when this PR ran and tried a site deployment.  https://github.com/llm-d/llm-d.github.io/pull/259