### PR TITLE
fix: correct argument order in test-dockerfile-lint.sh

### DIFF
--- a/scripts/test-dockerfile-lint.sh
+++ b/scripts/test-dockerfile-lint.sh
@@ -30,7 +30,7 @@ cp /tmp/test-script.sh /tmp/test-scripts/
 
 echo ""
 echo "Test 1: Dockerfile missing required variable (should FAIL)"
-if ./scripts/lint-dockerfile-envvars.py /tmp/test-Dockerfile /tmp/test-scripts 2>&1; then
+if ./scripts/lint-dockerfile-envvars.py /tmp/test-scripts /tmp/test-Dockerfile 2>&1; then
     echo "✗ Test failed: should have detected missing TEST_VAR2"
     exit 1
 else
@@ -49,7 +49,7 @@ EOF
 
 echo ""
 echo "Test 2: Dockerfile with all required variables (should PASS)"
-if ./scripts/lint-dockerfile-envvars.py /tmp/test-Dockerfile-fixed /tmp/test-scripts 2>&1; then
+if ./scripts/lint-dockerfile-envvars.py /tmp/test-scripts /tmp/test-Dockerfile-fixed 2>&1; then
     echo "✓ Test passed: all variables declared"
 else
     echo "✗ Test failed: should have passed with all variables declared"


### PR DESCRIPTION
## Summary

`scripts/test-dockerfile-lint.sh` invokes the linter with reversed arguments. The linter signature is `lint-dockerfile-envvars.py <scripts-dir> <Dockerfile> [...]` (per its own usage banner), but both test calls pass `<Dockerfile> <scripts-dir>`.

With the args reversed, the linter raises `IsADirectoryError` trying to `read_text()` the scripts directory as if it were a Dockerfile. Test 1 is wrapped in `if ... ; then "expected fail" else "passed"`, so the crash gets misread as the expected detection of a missing variable — the test silently passes for the wrong reason. Test 2 fails outright with the same crash.

The script is not currently wired into a CI workflow, which is why this has gone unnoticed since [#324](https://github.com/llm-d/llm-d/pull/324).

## Repro (before fix)

```
$ bash scripts/test-dockerfile-lint.sh
Test 1: Dockerfile missing required variable (should FAIL)
Traceback (most recent call last):
  ...
  IsADirectoryError: [Errno 21] Is a directory: '/tmp/test-scripts'
✓ Test passed: correctly detected missing variable     # ← false positive, was a crash

Test 2: Dockerfile with all required variables (should PASS)
Traceback (most recent call last):
  ...
✗ Test failed: should have passed with all variables declared
exit=1
```

## After fix

```
$ bash scripts/test-dockerfile-lint.sh
Test 1: Dockerfile missing required variable (should FAIL)
/tmp/test-Dockerfile:5: Script 'test-script.sh' in stage 'test' requires:
  - TEST_VAR2 (not declared as ARG or ENV)
✗ 1 error(s) found
✓ Test passed: correctly detected missing variable

Test 2: Dockerfile with all required variables (should PASS)
✓ All Dockerfiles validated successfully
✓ Test passed: all variables declared

All tests passed!
exit=0
```

## Test plan

- [x] Run `bash scripts/test-dockerfile-lint.sh` — both tests now pass for the right reason (Test 1 sees the linter actually flag the missing var, Test 2 sees it accept the fixed Dockerfile)