### PR TITLE
fix(make): xpu-prepare must check out VLLM_XPU_COMMIT_SHA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ xpu-prepare: ## Prepare vLLM XPU build context and upstream Dockerfile
 	@rm -rf $(XPU_BUILD_DIR)
 	@mkdir -p $(dir $(XPU_BUILD_DIR))
 	@git clone $(VLLM_REPO) $(XPU_BUILD_DIR)
-	@git -C $(XPU_BUILD_DIR) checkout $(VLLM_COMMIT_SHA)
+	@git -C $(XPU_BUILD_DIR) checkout $(VLLM_XPU_COMMIT_SHA)
 	@curl -fsSL $(XPU_DOCKERFILE_URL) -o $(XPU_BUILD_DIR)/docker/Dockerfile.xpu
 
 .PHONY: image-push


### PR DESCRIPTION
## Summary

`make xpu-prepare` clones vLLM and then runs `git checkout $(VLLM_COMMIT_SHA)`, but `VLLM_COMMIT_SHA` is the **CUDA** commit:

- [`docker/common-versions:5`](https://github.com/llm-d/llm-d/blob/main/docker/common-versions#L5) — \`VLLM_COMMIT_SHA=95c0f928... # maps to v0.17.1 tag\`
- [`docker/common-versions:35`](https://github.com/llm-d/llm-d/blob/main/docker/common-versions#L35) — \`VLLM_XPU_COMMIT_SHA=9dd656f0... # maps to v0.18.0rc2 tag for XPU RDMA support\`

The XPU SHA is defined separately and explicitly labelled as required for XPU RDMA support, but the Makefile target ignores it and checks out the CUDA SHA instead. The result is that `make xpu-prepare` produces an XPU build context from the wrong upstream commit.

## Fix

```diff
-	@git -C $(XPU_BUILD_DIR) checkout $(VLLM_COMMIT_SHA)
+	@git -C $(XPU_BUILD_DIR) checkout $(VLLM_XPU_COMMIT_SHA)
```

## Verification

\`make -n xpu-prepare DEVICE=xpu\` before/after:

**Before** — checks out the CUDA commit:
\`\`\`
git -C .cache/vllm-src checkout 95c0f928cdeeaa21c4906e73cee6a156e1b3b995
\`\`\`

**After** — checks out the XPU commit:
\`\`\`
git -C .cache/vllm-src checkout 9dd656f0ea06ba452e1f26666c111ea4909cd488
\`\`\`

## Note (out of scope for this PR)

\`XPU_VLLM_TAG\` in the Makefile is still pinned to \`v0.17.0\` and is used to fetch \`docker/Dockerfile.xpu\` from upstream vLLM (line 10 / 161). After this PR the source checkout is \`v0.18.0rc2\` while the Dockerfile is fetched from the \`v0.17.0\` tag — these may also be intentionally misaligned, or may be a related issue. Happy to follow up in a separate PR if maintainers confirm \`XPU_VLLM_TAG\` should track the XPU SHA.

## Test plan

- [x] \`make -n xpu-prepare DEVICE=xpu\` shows the checkout line resolves to the XPU SHA from \`docker/common-versions:35\`
- [ ] (Maintainer) End-to-end \`make image-build DEVICE=xpu\` on an XPU host