### PR TITLE
ci: migrate e2e-pd-xpu from helmfile to kustomize

### DIFF
--- a/.github/workflows/e2e-pd-xpu.yaml
+++ b/.github/workflows/e2e-pd-xpu.yaml
@@ -2,7 +2,7 @@ name: XPU PD Test
 
 on:
   schedule:
-    - cron: '0 10 * * *'  # 3AM PST (10:00 UTC)
+    - cron: '30 10 * * *'  # 3:30 AM PST (10:30 UTC), staggered from other XPU nightlies
   workflow_dispatch:
     inputs:
       pr_or_branch:
@@ -27,18 +27,15 @@ on:
         required: false
         default: ''
         type: string
-
 jobs:
   deploy_and_validate:
     if: github.repository == 'llm-d/llm-d'
     runs-on: xpu
     env:
       NAMESPACE: "llm-d-xpu-pd"
-      GATEWAY_TYPE: "istio"
-      RELEASE_NAME_POSTFIX: "pd-xpu"
-      INFRA_RELEASE_NAME: "infra-pd-xpu"
-      GAIE_RELEASE_NAME: "gaie-pd-xpu"
-      MS_RELEASE_NAME: "ms-pd-xpu"
+      GAIE_VERSION: "v1.4.0"
+      GUIDE_NAME: "pd-disaggregation"
+      SCHEDULER_RELEASE_NAME: "pd-disaggregation"
 
     steps:
       - name: Checkout
@@ -79,11 +76,9 @@ jobs:
         run: |
           ./helpers/client-setup/install-deps.sh | tee ~/install-deps.log
 
-      - name: Install chart dependencies (CRDs and Istio)
+      - name: Install Gateway API Inference Extension CRDs
         run: |
-          cd guides/prereq/gateway-provider
-          ./install-gateway-provider-dependencies.sh
-          helmfile apply -f istio.helmfile.yaml
+          kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
 
       - name: Install monitoring stack
         run: |
@@ -106,53 +101,44 @@ jobs:
         run: |
           CUSTOM_TAG="${{ inputs.custom_image_tag }}"
           if [ -n "${CUSTOM_TAG}" ]; then
-            # Check if it's a full image address (contains '/') or just a tag
+            # If input contains '/' it is a full image reference; otherwise treat as a tag
             if [[ "${CUSTOM_TAG}" == *"/"* ]]; then
-              echo "Using custom full image address: ${CUSTOM_TAG}"
-              FULL_IMAGE="${CUSTOM_TAG}"
+              echo "Using custom image reference: ${CUSTOM_TAG}"
+              echo "CUSTOM_IMAGE_REF=${CUSTOM_TAG}" >> $GITHUB_ENV
             else
               echo "Using custom image tag: ${CUSTOM_TAG}"
-              FULL_IMAGE="ghcr.io/${{ github.repository }}-xpu-dev:${CUSTOM_TAG}"
+              echo "CUSTOM_IMAGE_REF=ghcr.io/${{ github.repository }}-xpu-dev:${CUSTOM_TAG}" >> $GITHUB_ENV
             fi
-            echo "IMAGE_TAG=${CUSTOM_TAG}" >> $GITHUB_ENV
-            echo "HELM_SET_IMAGE=--set decode.containers[0].image=${FULL_IMAGE} --set decode.containers[0].imagePullPolicy=Always --set prefill.containers[0].image=${FULL_IMAGE} --set prefill.containers[0].imagePullPolicy=Always" >> $GITHUB_ENV
+            echo "HAS_CUSTOM_IMAGE=true" >> $GITHUB_ENV
           else
-            echo "Using default image tag from values file"
-            echo "HELM_SET_IMAGE=" >> $GITHUB_ENV
+            echo "Using default image from kustomization.yaml"
+            echo "HAS_CUSTOM_IMAGE=false" >> $GITHUB_ENV
           fi
 
-      - name: Deploy guide
+      - name: Deploy scheduler via helm (standalone)
         run: |
-          cd guides/pd-disaggregation
-          RELEASE_NAME_POSTFIX=${RELEASE_NAME_POSTFIX} \
-          helmfile apply -e xpu -n "${NAMESPACE}" ${HELM_SET_IMAGE} \
-            --skip-schema-validation \
+          echo "Installing scheduler (standalone chart) via helm..."
+          helm install "${SCHEDULER_RELEASE_NAME}" \
+            oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
+            -f guides/recipes/scheduler/base.values.yaml \
+            -f guides/${GUIDE_NAME}/scheduler/${GUIDE_NAME}.values.yaml \
+            -n "${NAMESPACE}" \
+            --version "${GAIE_VERSION}" \
             | tee ~/pd-xpu-deployment.log
-          echo "---------------------------------------" >> ~/pd-xpu-deployment.log
 
-      - name: Deploy HTTPRoute
+      - name: Deploy model server via kustomize
         run: |
-          cd guides/pd-disaggregation
-          echo "Deploying HTTPRoute with RELEASE_NAME_POSTFIX=${RELEASE_NAME_POSTFIX}..."
-          # Create a temporary HTTPRoute file with the correct names
-          sed -e "s/infra-pd-inference-gateway/${INFRA_RELEASE_NAME}-inference-gateway/g" \
-              -e "s/gaie-pd/${GAIE_RELEASE_NAME}/g" \
-              -e "s/name: llm-d-pd-disaggregation/name: llm-d-xpu-pd-${RELEASE_NAME_POSTFIX}/g" \
-              httproute.yaml > httproute-xpu.yaml
-          echo "Generated HTTPRoute configuration:"
-          cat httproute-xpu.yaml
-          kubectl apply -f httproute-xpu.yaml -n "${NAMESPACE}" \
+          cd guides/${GUIDE_NAME}/modelserver/xpu/vllm
+
+          # Override image if custom reference is provided (applies to both decode and prefill Deployments)
+          if [[ "${HAS_CUSTOM_IMAGE}" == "true" ]]; then
+            echo "Overriding image to ${CUSTOM_IMAGE_REF}"
+            kustomize edit set image "REPLACE_MODEL_SERVER_IMAGE=${CUSTOM_IMAGE_REF}"
+          fi
+
+          echo "Building and applying kustomize manifests..."
+          kubectl apply -n "${NAMESPACE}" -k ./ \
             | tee -a ~/pd-xpu-deployment.log
-          echo "---------------------------------------" >> ~/pd-xpu-deployment.log
-
-      - name: fetch helm manifests - prepare for upload
-        run: |
-          for release_name in "${INFRA_RELEASE_NAME}" "${GAIE_RELEASE_NAME}" "${MS_RELEASE_NAME}"; do
-            bash .github/scripts/e2e/helm-get-all.sh \
-              ~/pd-xpu-deployment.log \
-              "$release_name" \
-              "$NAMESPACE"
-          done
 
       - name: Wait for all pods to be ready
         id: wait_pods
@@ -162,7 +148,7 @@ jobs:
             --for=condition=Ready \
             --all \
             -n "${NAMESPACE}" \
-            --timeout=10m; then
+            --timeout=15m; then
             echo "✅ All pods are ready."
             kubectl get pods -n "${NAMESPACE}"
           else
@@ -174,24 +160,11 @@ jobs:
             exit 1
           fi
 
-      - name: Check gateway pod is up
-        if: always()
-        run: |
-          GATEWAY_POD_READY=$(kubectl get pods -n "${NAMESPACE}" | grep "inference-gateway" | awk '{print $2}')
-          if [ "${GATEWAY_POD_READY}" = "1/1" ]; then
-              echo "✅ Gateway pod ready."
-          else
-              echo "❌ Missing gateway pod"
-          fi
-
       - name: Show deployment status
         if: always()
         run: |
           echo "=== Deployments ==="
           kubectl get deployments -n "${NAMESPACE}"
-          echo ""
-          echo "=== Replica Sets ==="
-          kubectl get replicasets -n "${NAMESPACE}"
           echo ""
           echo "=== Pods ==="
           kubectl get pods -n "${NAMESPACE}"
@@ -203,20 +176,15 @@ jobs:
           helm list -n "${NAMESPACE}" || true
           echo ""
           echo "=== Inference Pools ==="
-          kubectl get InferencePool.inference.networking.k8s.io -n "${NAMESPACE}" || true
-          echo ""
-          echo "=== HTTPRoutes ==="
-          kubectl get httproutes -n "${NAMESPACE}" || true
-          echo ""
-          echo "=== Gateway ==="
-          kubectl get Gateway -n "${NAMESPACE}" || true
-          echo ""
-          echo "=== Destination Rule ==="
-          kubectl get destinationrule -n "${NAMESPACE}" || true
+          kubectl get inferencepools -n "${NAMESPACE}" || true
           echo ""
 
       - name: Verify installation and run inference tests
         if: steps.wait_pods.outcome == 'success'
+        env:
+          # Standalone mode: no Gateway resource exists; point e2e-validate.sh
+          # at the EPP service's ClusterIP DNS name directly.
+          GATEWAY_HOST: "${{ env.SCHEDULER_RELEASE_NAME }}-epp.${{ env.NAMESPACE }}.svc.cluster.local"
         run: |
           cd .github/scripts/e2e
           ./e2e-validate.sh -n "${NAMESPACE}" -v
@@ -226,10 +194,15 @@ jobs:
         run: |
             mkdir -p pod-logs-pd-xpu
             cd pod-logs-pd-xpu
-            echo "Fetching ${NAMESPACE} pods log..."
-            kubectl get pods -n "${NAMESPACE}" -l "llm-d.ai/inferenceServing" -o yaml > ./inference-pods.yaml || true
-            kubectl logs -n "${NAMESPACE}" -l "llm-d.ai/inferenceServing" 2>&1 | grep -v "waiting for vLLM to be ready" > ./inference-pod-logs.log || true
-            kubectl describe pod -n "${NAMESPACE}" -l "llm-d.ai/inferenceServing" > ./inference-describe-pod-logs.log || true
+            echo "Fetching ${NAMESPACE} decode pods log..."
+            kubectl get pods -n "${NAMESPACE}" -l "llm-d.ai/role=decode" -o yaml > ./decode-pods.yaml || true
+            kubectl logs -n "${NAMESPACE}" -l "llm-d.ai/role=decode" --all-containers=true 2>&1 > ./decode-pod-logs.log || true
+            kubectl describe pod -n "${NAMESPACE}" -l "llm-d.ai/role=decode" > ./decode-describe-pod-logs.log || true
+
+            echo "Fetching ${NAMESPACE} prefill pods log..."
+            kubectl get pods -n "${NAMESPACE}" -l "llm-d.ai/role=prefill" -o yaml > ./prefill-pods.yaml || true
+            kubectl logs -n "${NAMESPACE}" -l "llm-d.ai/role=prefill" --all-containers=true 2>&1 > ./prefill-pod-logs.log || true
+            kubectl describe pod -n "${NAMESPACE}" -l "llm-d.ai/role=prefill" > ./prefill-describe-pod-logs.log || true
 
             echo "Collecting logs from all pods..."
             kubectl get pods -n "${NAMESPACE}" --no-headers -o custom-columns=":metadata.name" \
@@ -244,9 +217,6 @@ jobs:
 
             mv ~/pd-xpu-deployment.log . || true
             mv ~/install-deps.log . || true
-            
-            echo "Log collection completed."
-            ls -la
 
             echo "Log collection completed."
             ls -la
@@ -261,6 +231,10 @@ jobs:
       - name: Cleanup deployment
         if: always()
         run: |
-          cd guides/pd-disaggregation
-          helmfile destroy -e xpu -n "${NAMESPACE}"
-          kubectl delete ns ${NAMESPACE}
+          echo "Cleaning up helm release..."
+          helm uninstall "${SCHEDULER_RELEASE_NAME}" -n "${NAMESPACE}" || true
+          echo "Cleaning up model server..."
+          kustomize build guides/${GUIDE_NAME}/modelserver/xpu/vllm/ \
+            | kubectl delete -n "${NAMESPACE}" -f - || true
+          echo "Deleting namespace..."
+          kubectl delete ns "${NAMESPACE}" || true


### PR DESCRIPTION
## Summary

Follow-up to #1238 (merged). That PR migrated the `pd-disaggregation` guide from helmfile to kustomize, but did not update the XPU workflow — `.github/workflows/e2e-pd-xpu.yaml` is still wired for the pre-migration shape and now fails on every nightly run.

> [!IMPORTANT]
> **#1319 must merge first.** This workflow calls `kustomize` directly, and `helpers/client-setup/install-deps.sh` does not install it today. #1319 adds the `kustomize` install step.  If don't install kustomize in install-deps.sh, the alternative is to explicitly install kustomize via a separate step, like [reusable openshift e2e](https://github.com/llm-d/llm-d-infra/blob/main/.github/workflows/reusable-nightly-e2e-openshift.yaml#L247-L248).

## What's changed

Rewrites `.github/workflows/e2e-pd-xpu.yaml` to the kustomize + helm-standalone pattern used by the other XPU workflows:

- `helm install pd-disaggregation oci://.../standalone -f base.values.yaml -f pd-disaggregation.values.yaml --version v1.4.0`
- `kubectl apply -k guides/pd-disaggregation/modelserver/xpu/vllm` (with `kustomize edit set image` for the `custom_image_tag` override path, covering both decode and prefill via the shared `REPLACE_MODEL_SERVER_IMAGE` placeholder)
- `GATEWAY_HOST=pd-disaggregation-epp.<ns>.svc.cluster.local` for `e2e-validate.sh` (standalone mode, no Gateway/HTTPRoute)
- Drops the helmfile install step, the `sed`-ed `httproute.yaml` step, and the `helmfile destroy` teardown
- Role-labelled (`decode` / `prefill`) log buckets, pod-wait timeout 10m→15m, cron offset to 10:30 UTC


## Test plan

- [x] `kustomize build guides/pd-disaggregation/modelserver/xpu/vllm/` renders cleanly
- [x] `helm template pd-disaggregation oci://.../standalone -f base.values.yaml -f pd-disaggregation.values.yaml --version v1.4.0` renders cleanly
- [x] Full workflow run on a self-hosted XPU runner — 20/20 steps green: https://github.com/xiaojun-zhang/llm-d/actions/runs/25147136922

cc @robertgshaw2-redhat (#1238), 
