### PR TITLE
update the llm-d-fs-connector kustomizations for v0.8

### DIFF
--- a/guides/tiered-prefix-cache/storage/manifests/vllm/llm-d-fs-connector/kustomization.yaml
+++ b/guides/tiered-prefix-cache/storage/manifests/vllm/llm-d-fs-connector/kustomization.yaml
@@ -9,7 +9,7 @@ patches:
     patch: |-
       - op: replace
         path: /spec/template/spec/containers/0/image
-        value: vllm/vllm-openai:v0.15.1
+        value: vllm/vllm-openai:v0.19.1
 
   # Add Offloading Connector with llm-d FS Backend
   - target:
@@ -17,25 +17,31 @@ patches:
       name: llm-d-model-server
     patch: |-
       - op: replace
-        path: /spec/template/spec/containers/0/args/0
-        value: |-
-          pip install https://raw.githubusercontent.com/llm-d/llm-d-kv-cache/main/kv_connectors/llmd_fs_backend/wheels/llmd_fs_connector-0.1.0-cp312-cp312-linux_x86_64.whl
-          exec vllm serve \
-            Qwen/Qwen3-32B \
-            --tensor-parallel-size 2 \
-            --port 8000 \
-            --max-num-seq 1024 \
-            --kv-transfer-config '{
-              "kv_connector": "OffloadingConnector",
-              "kv_role": "kv_both",
-              "kv_connector_extra_config": {
-                "spec_name": "SharedStorageOffloadingSpec",
-                "shared_storage_path": "/mnt/files-storage/kv-cache/",
-                "block_size": 256,
-                "threads_per_gpu": 64,
-                "spec_module_path": "llmd_fs_backend.spec"
-              }
-            }'
+        path: /spec/template/spec/containers/0/command
+        value: ["/bin/sh", "-c"]
+      - op: replace
+        path: /spec/template/spec/containers/0/args
+        value:
+          - |-
+            pip install --target /tmp/llmd-packages 'llmd-fs-connector==0.19' \
+              --extra-index-url https://llm-d.github.io/llm-d-kv-cache/simple/
+            export PYTHONPATH="/tmp/llmd-packages:${PYTHONPATH:-}"
+            exec vllm serve \
+              Qwen/Qwen3-32B \
+              --tensor-parallel-size 2 \
+              --port 8000 \
+              --max-num-seq 1024 \
+              --kv-transfer-config '{
+                "kv_connector": "OffloadingConnector",
+                "kv_role": "kv_both",
+                "kv_connector_extra_config": {
+                  "spec_name": "SharedStorageOffloadingSpec",
+                  "shared_storage_path": "/mnt/files-storage/kv-cache/",
+                  "block_size": 256,
+                  "threads_per_gpu": 64,
+                  "spec_module_path": "llmd_fs_backend.spec"
+                }
+              }'
 
   # Add GPU + memory resources
   - target:
@@ -61,7 +67,7 @@ patches:
         value:
           name: files-storage
           persistentVolumeClaim:
-            claimName: pvc-storage-files
+            claimName: llm-d-kv-cache-storage
 
   # Mount PVC into container
   - target:


### PR DESCRIPTION
1. Updated the wheel release
2. pip install fails because it doesn't have access to the global install dir, and the local directory is not in the python path.  There are multiple ways of fixing this, I picked installing into /tmp and updating the path to reference it.
3. the pvc is different than the one created in guides/tiered-prefix-cache/storage/manifests/pvc.yaml which is used by the lmcache kustomizations.  