### PR TITLE
Remove tokenizer plugin and enable speculativeIndexing in precise-prefix-cache guide

### DIFF
--- a/guides/precise-prefix-cache-aware/scheduler/features/active-active.values.yaml
+++ b/guides/precise-prefix-cache-aware/scheduler/features/active-active.values.yaml
@@ -67,11 +67,6 @@ inferenceExtension:
       apiVersion: inference.networking.x-k8s.io/v1alpha1
       kind: EndpointPickerConfig
       plugins:
-        - type: tokenizer
-          parameters:
-            modelName: Qwen/Qwen3-32B
-            udsTokenizerConfig:
-              socketFile: /tmp/tokenizer/tokenizer-uds.socket
         - type: endpoint-notification-source
         - type: metrics-data-source
         - type: core-metrics-extractor
@@ -110,7 +105,6 @@ inferenceExtension:
         - name: default
           plugins:
             - pluginRef: decode-filter
-            - pluginRef: tokenizer
             - pluginRef: precise-prefix-cache-scorer
               weight: 2.0
             - pluginRef: kv-cache-utilization-scorer

--- a/guides/precise-prefix-cache-aware/scheduler/precise-prefix-cache-aware.values.yaml
+++ b/guides/precise-prefix-cache-aware/scheduler/precise-prefix-cache-aware.values.yaml
@@ -68,11 +68,6 @@ inferenceExtension:
       apiVersion: inference.networking.x-k8s.io/v1alpha1
       kind: EndpointPickerConfig
       plugins:
-        - type: tokenizer
-          parameters:
-            modelName: Qwen/Qwen3-32B
-            udsTokenizerConfig:
-              socketFile: /tmp/tokenizer/tokenizer-uds.socket
         - type: single-profile-handler
         - type: decode-filter
         - type: precise-prefix-cache-scorer
@@ -99,7 +94,6 @@ inferenceExtension:
         - name: default
           plugins:
             - pluginRef: decode-filter
-            - pluginRef: tokenizer
             - pluginRef: precise-prefix-cache-scorer
               weight: 2.0
             - pluginRef: kv-cache-utilization-scorer


### PR DESCRIPTION
## Summary
- Remove `type: tokenizer` plugin from both scheduler configs
- Enable `speculativeIndexing: true` in `precise-prefix-cache-scorer`
- Remove `tokenizer` pluginRef from schedulingProfiles

## Why
The tokenizer plugin and speculative indexing cause double tokenization when both are enabled:
1. `PrepareRequestData` (speculative) runs **before** the tokenizer plugin's `Score()`
2. At that point CycleState is empty, so the scorer tokenizes independently via its own `tokenizersPoolConfig.uds`
3. Then the tokenizer plugin also tokenizes → UDS tokenizer called twice per request

Since `precise-prefix-cache-scorer` has its own tokenizer pool, the tokenizer plugin is redundant for this guide.
