### PR TITLE
[Guides Storage]: Align tiered-prefix-cache storage guide with optimized-baseline

### DIFF
--- a/guides/tiered-prefix-cache/storage/README.md
+++ b/guides/tiered-prefix-cache/storage/README.md
@@ -195,8 +195,8 @@ kubectl get httproute -n ${NAMESPACE}
 ```
 
 ```bash
-NAME          HOSTNAMES   AGE
-llm-d-route               17m
+NAME            HOSTNAMES   AGE
+llm-d-infpool               17m
 ```
 
 ### Check the PVC
@@ -208,8 +208,8 @@ kubectl get pvc -n ${NAMESPACE}
 Output should show the PVC as `Bound`:
 
 ```
-NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
-lustre-pvc   Bound    pvc-3c793698-XXXXXXX   36000Gi    RWX            lustre-class   <unset>                 6d
+NAME         STATUS   VOLUME                  CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
+<pvc-name>   Bound    pvc-3c793698-XXXXXXX    18000Gi    RWX            <storage-class>   <unset>              6d
 ```
 
 ### Check the InferencePool
@@ -232,10 +232,10 @@ kubectl get pods -n ${NAMESPACE}
 You should see the InferencePool's endpoint pod and the model server pods in a `Running` state.
 
 ```bash
-NAME                                  READY   STATUS    RESTARTS   AGE
-llm-d-infpool-epp-xxxxxxxx-xxxxx     1/1     Running   0          16m
-llm-d-model-server-xxxxxxxx-xxxxx   1/1     Running   0          11m
-llm-d-model-server-xxxxxxxx-xxxxx   1/1     Running   0          11m
+NAME                                READY   STATUS    RESTARTS   AGE
+llm-d-infpool-epp-xxxxxxxx-xxxxx    1/1     Running   0          16m
+llm-d-decode-xxxxxxxx-xxxxx         1/1     Running   0          11m
+llm-d-decode-xxxxxxxx-xxxxx         1/1     Running   0          11m
 ```
 
 ### Verify KV cache is offloaded to storage
@@ -250,7 +250,7 @@ You can verify if the KV cache is being offloaded to local storage by checking t
 ```
 export IP=localhost
 export PORT=8000
-export POD_NAME=llm-d-model-server-xxxx-xxxx
+export POD_NAME=llm-d-decode-xxxx-xxxx
 kubectl exec -it $POD_NAME -- curl -i http://${IP}:${PORT}/metrics | grep lmcache:local_storage_usage
 ```
 
@@ -262,6 +262,24 @@ kubectl exec -it $POD_NAME -- du -sh /mnt/files-storage
 ```
 
 <!-- TABS:END -->
+
+### Test inference through the Gateway
+
+The Gateway is a `ClusterIP` Service, so port-forward to call it from outside the cluster:
+
+```bash
+kubectl port-forward -n ${NAMESPACE} svc/llm-d-inference-gateway-istio 8000:80 &
+curl -s http://localhost:8000/v1/models
+curl -s http://localhost:8000/v1/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"Qwen/Qwen3-32B","prompt":"The capital of France is","max_tokens":15,"temperature":0}'
+```
+
+A successful response looks like:
+
+```json
+{"id":"cmpl-...","object":"text_completion","model":"Qwen/Qwen3-32B","choices":[{"index":0,"text":" Paris. ...","finish_reason":"length"}],"usage":{"prompt_tokens":5,"completion_tokens":15,"total_tokens":20}}
+```
 
 ## Cleanup
 

--- a/guides/tiered-prefix-cache/storage/README.md
+++ b/guides/tiered-prefix-cache/storage/README.md
@@ -238,9 +238,57 @@ llm-d-decode-xxxxxxxx-xxxxx         1/1     Running   0          11m
 llm-d-decode-xxxxxxxx-xxxxx         1/1     Running   0          11m
 ```
 
+### Test inference through the Gateway
+
+The Gateway is a `ClusterIP` Service, so port-forward to call it from outside the cluster:
+
+```bash
+kubectl port-forward -n ${NAMESPACE} svc/llm-d-inference-gateway-istio 8000:80 &
+curl -s http://localhost:8000/v1/models
+curl -s http://localhost:8000/v1/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"Qwen/Qwen3-32B","prompt":"The capital of France is","max_tokens":15,"temperature":0}'
+```
+
+A successful response looks like:
+
+```json
+{"id":"cmpl-...","object":"text_completion","model":"Qwen/Qwen3-32B","choices":[{"index":0,"text":" Paris. ...","finish_reason":"length"}],"usage":{"prompt_tokens":5,"completion_tokens":15,"total_tokens":20}}
+```
+
 ### Verify KV cache is offloaded to storage
 
 <!-- TABS:START -->
+
+<!-- TAB:llm-d FS Connector -->
+#### llm-d FS Connector
+
+Send a long prompt (one that crosses several `block_size` boundaries) to trigger offload, then inspect the PVC:
+
+```bash
+# Long prompt (~3K tokens)
+PROMPT=$(printf 'Story: '; for i in $(seq 1 800); do printf 'alice met bob and they walked together. '; done)
+curl -s http://localhost:8000/v1/completions \
+  -H 'Content-Type: application/json' \
+  -d "$(printf '{"model":"Qwen/Qwen3-32B","prompt":%s,"max_tokens":3,"temperature":0}' \
+        "$(printf '%s' "$PROMPT" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))')")"
+
+# Check the shared PVC for written blocks
+POD=$(kubectl get pod -n ${NAMESPACE} -l llm-d.ai/role=decode -o jsonpath='{.items[0].metadata.name}')
+kubectl exec -n ${NAMESPACE} ${POD} -- du -sh /mnt/files-storage/kv-cache
+kubectl exec -n ${NAMESPACE} ${POD} -- find /mnt/files-storage/kv-cache -maxdepth 5 -type d
+```
+
+Expected output: `du -sh` shows hundreds of MB to several GB, and `find` lists a path like
+`/mnt/files-storage/kv-cache/<model>/<block-config>/<tp-config>/...`.
+
+You can also confirm via vLLM's offload metrics (exposed at `/metrics` on each pod):
+
+```bash
+kubectl exec -n ${NAMESPACE} ${POD} -- curl -s http://localhost:8000/metrics | grep '^vllm:kv_offload_total_bytes'
+```
+
+A successful offload increments `vllm:kv_offload_total_bytes{transfer_type="GPU_to_SHARED_STORAGE"}`.
 
 <!-- TAB:LMCache Connector -->
 #### LMCache Connector
@@ -262,24 +310,6 @@ kubectl exec -it $POD_NAME -- du -sh /mnt/files-storage
 ```
 
 <!-- TABS:END -->
-
-### Test inference through the Gateway
-
-The Gateway is a `ClusterIP` Service, so port-forward to call it from outside the cluster:
-
-```bash
-kubectl port-forward -n ${NAMESPACE} svc/llm-d-inference-gateway-istio 8000:80 &
-curl -s http://localhost:8000/v1/models
-curl -s http://localhost:8000/v1/completions \
-  -H 'Content-Type: application/json' \
-  -d '{"model":"Qwen/Qwen3-32B","prompt":"The capital of France is","max_tokens":15,"temperature":0}'
-```
-
-A successful response looks like:
-
-```json
-{"id":"cmpl-...","object":"text_completion","model":"Qwen/Qwen3-32B","choices":[{"index":0,"text":" Paris. ...","finish_reason":"length"}],"usage":{"prompt_tokens":5,"completion_tokens":15,"total_tokens":20}}
-```
 
 ## Cleanup
 

--- a/guides/tiered-prefix-cache/storage/manifests/vllm/llm-d-fs-connector/deployment-patch.yaml
+++ b/guides/tiered-prefix-cache/storage/manifests/vllm/llm-d-fs-connector/deployment-patch.yaml
@@ -10,6 +10,8 @@ spec:
         - name: modelserver
           command: ["/bin/sh", "-c"]
           args:
+            # llmd-fs-connector pin must match the vLLM line set in kustomization.yaml's image tag.
+            # For vLLM 0.X.x use llmd-fs-connector==0.X.
             - |
               pip install 'llmd-fs-connector==0.19' --extra-index-url https://llm-d.github.io/llm-d-kv-cache/simple/
               exec vllm serve \

--- a/guides/tiered-prefix-cache/storage/manifests/vllm/llm-d-fs-connector/deployment-patch.yaml
+++ b/guides/tiered-prefix-cache/storage/manifests/vllm/llm-d-fs-connector/deployment-patch.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: modelserver
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              pip install 'llmd-fs-connector==0.19' --extra-index-url https://llm-d.github.io/llm-d-kv-cache/simple/
+              exec vllm serve \
+                Qwen/Qwen3-32B \
+                --tensor-parallel-size 2 \
+                --max-num-seq 1024 \
+                --kv-transfer-config '{
+                  "kv_connector": "OffloadingConnector",
+                  "kv_role": "kv_both",
+                  "kv_connector_extra_config": {
+                    "spec_name": "SharedStorageOffloadingSpec",
+                    "shared_storage_path": "/mnt/files-storage/kv-cache/",
+                    "block_size": 256,
+                    "threads_per_gpu": 64,
+                    "spec_module_path": "llmd_fs_backend.spec"
+                  }
+                }'
+          env:
+            - name: PYTHONHASHSEED
+              value: "42"
+          resources:
+            limits:
+              cpu: '16'
+              memory: 400Gi
+              nvidia.com/gpu: 2
+            requests:
+              cpu: '8'
+              memory: 400Gi
+              nvidia.com/gpu: 2
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /.cache
+              name: torch-compile-cache
+            - mountPath: /.triton
+              name: triton-cache
+            - mountPath: /.local
+              name: pip-user-site
+            - mountPath: /mnt/files-storage
+              name: files-storage
+          startupProbe:
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 120
+          livenessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 20Gi
+        - name: torch-compile-cache
+          emptyDir: {}
+        - name: triton-cache
+          emptyDir: {}
+        - name: pip-user-site
+          emptyDir: {}
+        - name: files-storage
+          persistentVolumeClaim:
+            claimName: llm-d-kv-cache-storage

--- a/guides/tiered-prefix-cache/storage/manifests/vllm/llm-d-fs-connector/kustomization.yaml
+++ b/guides/tiered-prefix-cache/storage/manifests/vllm/llm-d-fs-connector/kustomization.yaml
@@ -1,92 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../../../../recipes/vllm/standard
+  - ../../../../../recipes/modelserver/base/single-host/default
+
+namePrefix: llm-d-
+
+images:
+  - name: REPLACE_MODEL_SERVER_IMAGE
+    newName: vllm/vllm-openai
+    newTag: v0.19.1
+
 patches:
-  - target:
-      kind: Deployment
-      name: llm-d-model-server
-    patch: |-
-      - op: replace
-        path: /spec/template/spec/containers/0/image
-        value: vllm/vllm-openai:v0.19.1
-
-  # Add Offloading Connector with llm-d FS Backend
-  - target:
-      kind: Deployment
-      name: llm-d-model-server
-    patch: |-
-      - op: replace
-        path: /spec/template/spec/containers/0/command
-        value: ["/bin/sh", "-c"]
-      - op: replace
-        path: /spec/template/spec/containers/0/args
-        value:
-          - |-
-            pip install --target /tmp/llmd-packages 'llmd-fs-connector==0.19' \
-              --extra-index-url https://llm-d.github.io/llm-d-kv-cache/simple/
-            export PYTHONPATH="/tmp/llmd-packages:${PYTHONPATH:-}"
-            exec vllm serve \
-              Qwen/Qwen3-32B \
-              --tensor-parallel-size 2 \
-              --port 8000 \
-              --max-num-seq 1024 \
-              --kv-transfer-config '{
-                "kv_connector": "OffloadingConnector",
-                "kv_role": "kv_both",
-                "kv_connector_extra_config": {
-                  "spec_name": "SharedStorageOffloadingSpec",
-                  "shared_storage_path": "/mnt/files-storage/kv-cache/",
-                  "block_size": 256,
-                  "threads_per_gpu": 64,
-                  "spec_module_path": "llmd_fs_backend.spec"
-                }
-              }'
-
-  # Add GPU + memory resources
-  - target:
-      kind: Deployment
-      name: llm-d-model-server
-    patch: |-
-      - op: add
-        path: /spec/template/spec/containers/0/resources
-        value:
-          limits:
-            nvidia.com/gpu: 2
-          requests:
-            nvidia.com/gpu: 2
-            memory: 400G
-
-  # Add PVC volume
-  - target:
-      kind: Deployment
-      name: llm-d-model-server
-    patch: |-
-      - op: add
-        path: /spec/template/spec/volumes/-
-        value:
-          name: files-storage
-          persistentVolumeClaim:
-            claimName: llm-d-kv-cache-storage
-
-  # Mount PVC into container
-  - target:
-      kind: Deployment
-      name: llm-d-model-server
-    patch: |-
-      - op: add
-        path: /spec/template/spec/containers/0/volumeMounts/-
-        value:
-          name: files-storage
-          mountPath: /mnt/files-storage
-
-  # Add PYTHONHASHSEED env var
-  - target:
-      kind: Deployment
-      name: llm-d-model-server
-    patch: |-
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: PYTHONHASHSEED
-          value: "42"
+  - path: deployment-patch.yaml

--- a/guides/tiered-prefix-cache/storage/manifests/vllm/llm-d-fs-connector/kustomization.yaml
+++ b/guides/tiered-prefix-cache/storage/manifests/vllm/llm-d-fs-connector/kustomization.yaml
@@ -8,6 +8,7 @@ namePrefix: llm-d-
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: vllm/vllm-openai
+    # Keep in sync with deployment-patch.yaml: llmd-fs-connector==0.X must match vLLM 0.X.x.
     newTag: v0.19.1
 
 patches:


### PR DESCRIPTION
## Summary

The storage kustomization referenced \`recipes/vllm/standard\` (removed in #1131), so \`kubectl kustomize\` errored out before any apply. This PR aligns the guide with the [optimized-baseline](https://github.com/llm-d/llm-d/tree/main/guides/optimized-baseline) pattern that's already CI-tested.

- Switch base to \`recipes/modelserver/base/single-host/default\`, use kustomize \`namePrefix\`/\`images\`, and replace JSON patches with a strategic-merge \`deployment-patch.yaml\`.
- Bump vLLM to v0.19.1 and install \`llmd-fs-connector==0.19\` from the pip index (matching the connector's [README](https://github.com/llm-d/llm-d-kv-cache/blob/main/kv_connectors/llmd_fs_backend/README.md)).
- Add the volume mounts the model server needs under restricted SCC (\`/.cache\`, \`/.triton\`, \`/.local\`, \`/dev/shm\`) and a longer \`startupProbe\` so Qwen3-32B has time to load before kubelet kills the pod.
- README: fix stale resource names users would see when verifying (\`llm-d-route\` → \`llm-d-infpool\`, \`llm-d-model-server-*\` → \`llm-d-decode-*\`, PVC and storage class shown as placeholders) and add a port-forward curl example to test inference end-to-end through the Gateway.

## Test plan

- [x] Deployed end-to-end on OpenShift (IBM Spectrum Scale RWX PVC) 
- [x] Verified KV cache write to shared PVC (\`/mnt/files-storage/kv-cache/Qwen/Qwen3-32B/...\`).
- [x] Verified cross-pod prefix cache hit (pod 2 reads cached blocks pod 1 wrote — \`External prefix cache hit rate: 99.9%\`).