### PR TITLE
ci: install kustomize in client-setup install-deps.sh

### DIFF
--- a/helpers/client-setup/install-deps.sh
+++ b/helpers/client-setup/install-deps.sh
@@ -12,6 +12,8 @@ HELM_VER="v3.19.0"
 HELMDIFF_VERSION="v3.13.0"
 # Helmfile version
 HELMFILE_VERSION="1.2.1"
+# Kustomize version
+KUSTOMIZE_VERSION="v5.7.1"
 # chart-testing version
 CT_VERSION="3.14.0"
 
@@ -41,6 +43,7 @@ TOOLS INSTALLED:
     - helm (Helm package manager)
     - helm diff plugin (optional but highly recommended)
     - helmfile (Helm deployment tool)
+    - kustomize
 
   Development tools (with --dev):
     - chart-testing (Helm chart testing tool)
@@ -198,6 +201,15 @@ if ! command -v helmfile &> /dev/null; then
   ARCHIVE="helmfile_${HELMFILE_VERSION}_${OS}_${ARCH}.tar.gz"
   HELMFILE_URL="https://github.com/helmfile/helmfile/releases/download/v${HELMFILE_VERSION}/${ARCHIVE}"
   install_from_tarball "${HELMFILE_URL}" "helmfile"
+fi
+
+########################################
+#  kustomize
+########################################
+if ! command -v kustomize &> /dev/null; then
+  ARCHIVE="kustomize_${KUSTOMIZE_VERSION}_${OS}_${ARCH}.tar.gz"
+  KUSTOMIZE_URL="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/${ARCHIVE}"
+  install_from_tarball "${KUSTOMIZE_URL}" "kustomize"
 fi
 
 ########################################


### PR DESCRIPTION
## Why

Failing nightly: https://github.com/llm-d/llm-d/actions/runs/25162029331/job/73758656422

`helpers/client-setup/install-deps.sh` doesn't install `kustomize`, even though [helpers/client-setup/README.md](../tree/main/helpers/client-setup/README.md#L14) lists it as a required tool. 

For other reusable workflows, they explicitly install kustomize via a separate step, [reusable openshift e2e as an example](https://github.com/llm-d/llm-d-infra/blob/main/.github/workflows/reusable-nightly-e2e-openshift.yaml#L247-L248).

I think it's better to have it covered in install-deps.sh.

## Fix

Add a `kustomize` install block to `install-deps.sh`, matching the existing `install_from_tarball` pattern used for helm/helmfile. Pinned to v5.7.1 (matches the `v5.0.0+` baseline in the client-setup README).

## Test plan

- [x] Reproduced the failure on a self-hosted XPU runner with kustomize deliberately absent (run [25189916493](https://github.com/xiaojun-zhang/llm-d/actions/runs/25189916493), same root-cause error).
- [x] Workflow passes end-to-end with this fix on the same runner (run [25191320767](https://github.com/xiaojun-zhang/llm-d/actions/runs/25191320767), 3m54s). Install log shows `Installing kustomize...` followed by `✅ All tools installed successfully.`, helm post-renderer succeeds, all 21 steps green.

