### PR TITLE
Fix precise-prefix-cache guide: remove tokenizer plugin, fix speculativeIndexing placement

### DIFF
--- a/guides/precise-prefix-cache-aware/scheduler/features/active-active.values.yaml
+++ b/guides/precise-prefix-cache-aware/scheduler/features/active-active.values.yaml
@@ -81,8 +81,8 @@ inferenceExtension:
           parameters:
             tokenProcessorConfig:
               blockSize: 64
+            speculativeIndexing: true
             indexerConfig:
-              speculativeIndexing: true
               tokenizersPoolConfig:
                 modelName: Qwen/Qwen3-32B
                 uds:
@@ -110,7 +110,6 @@ inferenceExtension:
         - name: default
           plugins:
             - pluginRef: decode-filter
-            - pluginRef: tokenizer
             - pluginRef: precise-prefix-cache-scorer
               weight: 2.0
             - pluginRef: kv-cache-utilization-scorer

--- a/guides/precise-prefix-cache-aware/scheduler/precise-prefix-cache-aware.values.yaml
+++ b/guides/precise-prefix-cache-aware/scheduler/precise-prefix-cache-aware.values.yaml
@@ -79,8 +79,8 @@ inferenceExtension:
           parameters:
             tokenProcessorConfig:
               blockSize: 64           # must match vLLM --block-size
+            speculativeIndexing: true
             indexerConfig:
-              speculativeIndexing: true
               tokenizersPoolConfig:
                 modelName: Qwen/Qwen3-32B
                 uds:
@@ -99,7 +99,6 @@ inferenceExtension:
         - name: default
           plugins:
             - pluginRef: decode-filter
-            - pluginRef: tokenizer
             - pluginRef: precise-prefix-cache-scorer
               weight: 2.0
             - pluginRef: kv-cache-utilization-scorer


### PR DESCRIPTION
## Summary
1. Remove `type: tokenizer` plugin and `pluginRef: tokenizer` from scheduling profiles in both central and active-active configs. In v0.8.0 the tokenizer plugin is a Scorer — without a `pluginRef` in the scheduling profile it never executes. The `precise-prefix-cache-scorer` has its own tokenizer pool (`tokenizersPoolConfig.uds`) and does not need the external plugin.

2. Fix `speculativeIndexing` placement — move from inside `indexerConfig` (where it was silently ignored as an unknown field on `kvcache.Config`) to the correct position under `parameters` (`PluginConfig` level).

## Files changed
- `scheduler/precise-prefix-cache-aware.values.yaml`
- `scheduler/features/active-active.values.yaml`