### PR TITLE
[CI]: nightly security events

### DIFF
--- a/.github/workflows/nightly-build-image.yaml
+++ b/.github/workflows/nightly-build-image.yaml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
   packages: write
+  security-events: write
 
 concurrency:
   group: nightly-build-image


### PR DESCRIPTION

root cause:

nightly-build-image.yaml calls the reusable workflow .github/workflows/build-image.yml, but it does not grant all permissions
  required by the called workflow. The reusable workflow needs security-events: write because it uploads SARIF results from Trivy-based  security scanning. This is not unusual in this repository: the same permission is already granted in other workflows such as  ci-pr-test.yaml and ci-release.yaml for the same kind of security reporting. Since the nightly caller only declared contents: read and  packages: write, GitHub rejected the workflow call due to the missing security-events permission.
  
  
 fix  https://github.com/llm-d/llm-d/issues/1306