### PR TITLE
[CI] build-image.yml use wrong github.event_name

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1143,7 +1143,7 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ github.repository }}-cuda-gb200-dev:${{ steps.set-tag.outputs.tag }}
             ${{ steps.set-tag.outputs.pr_tag != '' && format('{0}/{1}-cuda-gb200-dev:{2}', env.REGISTRY, github.repository, steps.set-tag.outputs.pr_tag) || '' }}
-            ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event_name != 'pull_request' && format('{0}/{1}-cuda-gb200-dev:latest', env.REGISTRY, github.repository) || '' }}
+            ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event_name != 'pull_request_target' && format('{0}/{1}-cuda-gb200-dev:latest', env.REGISTRY, github.repository) || '' }}
           github-token: ${{ secrets.GHCR_TOKEN }}
         env:
           DOCKER_BUILDKIT: "1"


### PR DESCRIPTION
 .github/workflows/ci-pr-test.yaml  states that all PRs use pull_request_target, and the same file invokes build-image.yml under that model. Within build-image.yml itself, the equivalent latest tag guards for other image jobs already use github.event_name != 'pull_request_target'. 
 The GB200 condition was the only remaining outlier, so this change simply aligns it with both the external trigger model and the existing in-file pattern.