### PR TITLE
[CI] Add release readiness board automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-readiness.yml
+++ b/.github/ISSUE_TEMPLATE/release-readiness.yml
@@ -1,0 +1,287 @@
+name: "Release Readiness Request"
+description: "Request your repository's inclusion in the next llm-d release"
+title: "[Release Readiness] {repo} — {version}"
+labels:
+  - release-readiness
+body:
+  # ── Identity ──────────────────────────────────────────────────────
+  - type: markdown
+    attributes:
+      value: |
+        ## Repository Identity
+
+        Tell us which repo is requesting release inclusion and what version you're targeting.
+        The release team uses this to coordinate cross-repo dependencies and build the release manifest.
+
+  - type: dropdown
+    id: repo
+    attributes:
+      label: Which repo is requesting release inclusion?
+      description: >
+        Select the repository you want included in the next llm-d release.
+        The validation workflow will run automated checks against this repo as soon as you submit.
+      options:
+        - llm-d
+        - llm-d-benchmark
+        - llm-d-inference-payload-processor
+        - llm-d-inference-scheduler
+        - llm-d-inference-sim
+        - llm-d-kv-cache
+        - llm-d-latency-predictor
+        - llm-d-model-service
+        - llm-d-pd-utils
+        - llm-d-prism
+        - llm-d-routing-sidecar
+        - llm-d-workload-variant-autoscaler
+        - batch-gateway (incubation)
+        - coordinator (incubation)
+        - hermes (incubation)
+        - ig-wva (incubation)
+        - llm-d-async (incubation)
+        - llm-d-fast-model-actuation (incubation)
+        - llm-d-modelservice (incubation)
+        - llm-d-planner (incubation)
+        - llm-d-resiliency-operator (incubation)
+        - llm-d-rl (incubation)
+        - llm-d-skills (incubation)
+        - py-inference-scheduler (incubation)
+        - secure-inference (incubation)
+        - weight-propagation-interface (incubation)
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: What version/tag are you releasing?
+      description: >
+        Enter the exact semver tag you plan to release (e.g., `v0.8.0`, `v1.0.0-rc.1`).
+        The workflow will validate that this follows the org's `vX.Y.Z` naming convention
+        and that RC tags use lowercase `-rc.N` format. Release type (major/minor/patch/RC)
+        is inferred from the version — no separate field needed.
+      placeholder: "v0.8.0"
+    validations:
+      required: true
+
+  # ── Prerequisites ─────────────────────────────────────────────────
+  - type: markdown
+    attributes:
+      value: |
+        ## Prerequisites
+
+        These questions confirm that your change has community support and has been tested.
+        The release team reviews these answers to decide whether the change is ready for inclusion.
+
+  - type: dropdown
+    id: maintainer_approval
+    attributes:
+      label: Do maintainers want your change?
+      description: >
+        Has at least one repo maintainer (listed in OWNERS) reviewed and approved the PR(s)
+        that make up this release? The workflow will check for `lgtm` and `approved` labels
+        on recent merged PRs. If maintainers haven't reviewed, the release team may block inclusion.
+      options:
+        - "Yes — PRs have lgtm + approved"
+        - "Partially — some PRs still need review"
+        - "No — requesting expedited review"
+    validations:
+      required: true
+
+  - type: textarea
+    id: tests_run
+    attributes:
+      label: What tests have you run on your feature?
+      description: >
+        Describe the testing you've done — unit tests, integration tests, manual validation,
+        performance benchmarks, etc. Tests must be easily reproducible by the community.
+        The release team needs confidence that your change won't break other components.
+        Include links to CI runs or test reports if available.
+      placeholder: |
+        - Unit tests: all passing (link to CI run)
+        - Integration tests: tested against inference-scheduler v0.8.0
+        - Manual validation: deployed to staging cluster, ran 100 inference requests
+    validations:
+      required: true
+
+  - type: textarea
+    id: hardware_guides
+    attributes:
+      label: What hardware / guides are affected by this change?
+      description: >
+        List any specific hardware platforms (GPU types, accelerators) or deployment guides
+        that your change touches. The release team uses this to schedule hardware-specific
+        validation and update documentation. If none, write "N/A".
+      placeholder: |
+        - NVIDIA A100/H100 (CUDA 12.x)
+        - Guide: "Getting Started with vLLM on OpenShift"
+    validations:
+      required: true
+
+  # ── Documentation ─────────────────────────────────────────────────
+  - type: markdown
+    attributes:
+      value: |
+        ## Documentation
+
+        Documentation gaps are the #1 source of post-release support burden.
+        The release team will block inclusion if affected guides haven't been updated.
+
+  - type: dropdown
+    id: guides_tested
+    attributes:
+      label: Have affected guides been tested on target platform?
+      description: >
+        If your change affects any deployment guide (install steps, config options, CLI flags),
+        have you actually walked through the guide end-to-end on the target hardware?
+        "Tested" means you followed the guide from scratch and it works — not just that CI passed.
+      options:
+        - "Yes — tested end-to-end on target platform"
+        - "Partially — some guides still need testing"
+        - "No guides affected"
+        - "No — guides need updating before release"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: docs_current
+    attributes:
+      label: Are docs up to date with code changes?
+      description: >
+        Have you updated README, API docs, configuration references, and any affected guides
+        to reflect your changes? The workflow will cross-reference your repo name against
+        the llm-d docs site to identify which guides mention your component.
+      options:
+        - "Yes — all docs updated"
+        - "PR open for doc updates"
+        - "No — docs need updating"
+        - "No docs affected"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: platforms
+    attributes:
+      label: What platforms are affected?
+      description: >
+        Check all hardware platforms your change has been validated on.
+        The release team needs this to know which platform-specific nightly tests to monitor
+        and which hardware labs need to re-validate after your change lands.
+      options:
+        - label: CPU only
+        - label: GPU / CUDA (NVIDIA)
+        - label: Intel Gaudi
+        - label: Intel XPU
+        - label: Google TPU
+        - label: AMD ROCm
+
+  # ── Risk Assessment ───────────────────────────────────────────────
+  - type: markdown
+    attributes:
+      value: |
+        ## Risk Assessment
+
+        Help the release team understand what could go wrong.
+        Be honest — hidden risk discovered post-release is far more expensive than a delayed inclusion.
+
+  - type: dropdown
+    id: breaking_changes
+    attributes:
+      label: Breaking changes?
+      description: >
+        Does this release include any backward-incompatible changes to APIs, CRD schemas,
+        CLI flags, configuration files, or environment variables? Breaking changes require
+        a migration guide and bump the major or minor version. The release team will reject
+        a patch release that contains breaking changes.
+      options:
+        - "No breaking changes"
+        - "Yes — migration guide included"
+        - "Yes — migration guide needed"
+    validations:
+      required: true
+
+  - type: textarea
+    id: cross_repo_deps
+    attributes:
+      label: Dependencies on other llm-d repos releasing simultaneously?
+      description: >
+        List any repos that MUST release at the same time as yours for the feature to work.
+        Select all that apply. For example, if you added a new API in inference-scheduler
+        that kv-cache depends on, both must ship together. The release team uses this to
+        sequence the release order and identify potential deadlocks.
+      placeholder: |
+        - Requires llm-d-kv-cache >= v0.8.0 (new cache eviction API)
+        - No dependency on other repos
+    validations:
+      required: true
+
+  # ── Attestation ───────────────────────────────────────────────────
+  - type: markdown
+    attributes:
+      value: |
+        ## Attestation
+
+        These are commitments from the submitter. The release team takes these at face value —
+        inaccurate attestations that cause post-release incidents will be flagged in the retrospective.
+
+  - type: dropdown
+    id: hardware_verified
+    attributes:
+      label: Has the submitter verified the feature works on target hardware?
+      description: >
+        "Verified" means you (or someone on your team) deployed this exact code to real hardware
+        and confirmed it works — not just that CI passed on a simulator. If your repo doesn't
+        require hardware (e.g., pure library/SDK), select "N/A — no hardware required".
+      options:
+        - "Yes — verified on target hardware"
+        - "Partially — some platforms not yet tested"
+        - "No — hardware testing pending"
+        - "N/A — no hardware required"
+    validations:
+      required: true
+
+  - type: textarea
+    id: rollback_plan
+    attributes:
+      label: Rollback plan
+      description: >
+        What happens if this release causes a production incident? Describe the specific steps
+        to revert — pin to previous version, feature flag, config change, etc. The release team
+        will not approve inclusion without a concrete rollback strategy. "Revert the PR" is
+        not sufficient — describe how operators in the field can recover.
+      placeholder: |
+        1. Pin to previous version v0.7.1 in Helm values
+        2. No schema migration — rollback is clean
+        3. Feature flag `ENABLE_NEW_SCHEDULER=false` disables new behavior
+    validations:
+      required: true
+
+  - type: dropdown
+    id: release_notes
+    attributes:
+      label: Release notes draft provided?
+      description: >
+        Have you prepared a draft of the release notes for your component? Release notes should
+        list new features, bug fixes, breaking changes, and deprecations. The workflow will check
+        if a CHANGELOG.md exists and has been updated. Without release notes, users can't evaluate
+        whether to upgrade.
+      options:
+        - "Yes — release notes / CHANGELOG updated"
+        - "Draft in progress"
+        - "No — need help writing release notes"
+    validations:
+      required: true
+
+  # ── Automated Checks (filled by workflow) ─────────────────────────
+  - type: markdown
+    attributes:
+      value: |
+        ---
+
+        ## Automated Checks
+
+        > **You do not need to fill in anything below this line.**
+        >
+        > A validation workflow runs automatically when you submit this issue.
+        > It checks CI health, governance files, artifact validity, test status,
+        > and release hygiene for the repo you selected above. Results appear
+        > as a comment within a few minutes.

--- a/.github/workflows/release-readiness-board.yml
+++ b/.github/workflows/release-readiness-board.yml
@@ -313,8 +313,8 @@ jobs:
               console.log(`Set Release = ${releaseOption.name}`);
             }
 
-            // Set Repo
-            const repoField = findField('Repo');
+            // Set Target Repo
+            const repoField = findField('Target Repo');
             const repoOption = findOption(repoField, repo);
             if (repoField && repoOption) {
               await github.graphql(updateMutation, {
@@ -323,7 +323,7 @@ jobs:
                 fieldId: repoField.id,
                 value: { singleSelectOptionId: repoOption.id },
               });
-              console.log(`Set Repo = ${repo}`);
+              console.log(`Set Target Repo = ${repo}`);
             }
 
             // Set Repo Tier

--- a/.github/workflows/release-readiness-board.yml
+++ b/.github/workflows/release-readiness-board.yml
@@ -1,0 +1,395 @@
+name: Release Readiness — Board Sync
+
+on:
+  issues:
+    types: [opened, labeled, unlabeled, closed, reopened]
+
+env:
+  PROJECT_TITLE: "llm-d Release Readiness"
+  ORG: "llm-d"
+
+jobs:
+  sync-board:
+    if: contains(github.event.issue.labels.*.name, 'release-readiness')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Parse issue body
+        id: parse
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.issue.body || '';
+
+            // GitHub renders form fields as: ### Label\n\nValue\n\n
+            function parseField(label) {
+              const regex = new RegExp(`### ${label}\\s*\\n\\n([^\\n]+)`, 'i');
+              const match = body.match(regex);
+              return match ? match[1].trim() : '';
+            }
+
+            const repoRaw = parseField('Which repo is requesting release inclusion\\?');
+            const version = parseField('What version/tag are you releasing\\?');
+
+            // Strip " (incubation)" suffix to get bare repo name
+            const repo = repoRaw.replace(/\s*\(incubation\)$/, '');
+            const tier = repoRaw.includes('(incubation)') ? 'incubation' : 'production';
+
+            // Derive release from version: v0.8.0 → v0.8, v1.0.0-rc.1 → v1.0
+            const releaseMatch = version.match(/^v?(\d+\.\d+)/);
+            const release = releaseMatch ? `v${releaseMatch[1]}` : '';
+
+            core.setOutput('repo', repo);
+            core.setOutput('version', version);
+            core.setOutput('tier', tier);
+            core.setOutput('release', release);
+
+            console.log(`Parsed: repo=${repo}, version=${version}, tier=${tier}, release=${release}`);
+
+      - name: Determine status from labels
+        id: status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.issue.labels.map(l => l.name);
+            const event = context.payload.action;
+
+            // Priority order for readiness labels (last match wins)
+            const statusMap = {
+              'readiness/filed': 'Filed',
+              'readiness/validating': 'Validating',
+              'readiness/passing': 'Passing',
+              'readiness/failing': 'Blocked',
+              'readiness/blocked': 'Blocked',
+              'readiness/validated': 'Validated',
+              'readiness/released': 'Released',
+            };
+
+            let status = 'Filed';
+            for (const [label, s] of Object.entries(statusMap)) {
+              if (labels.includes(label)) {
+                status = s;
+              }
+            }
+
+            if (event === 'closed') {
+              status = 'Released';
+            }
+
+            core.setOutput('status', status);
+            console.log(`Status: ${status} (event=${event}, labels=${labels.join(', ')})`);
+
+      - name: Ensure labels exist
+        if: github.event.action == 'opened'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const release = '${{ steps.parse.outputs.release }}';
+            const tier = '${{ steps.parse.outputs.tier }}';
+
+            const labelsToEnsure = [
+              { name: 'readiness/filed', color: 'C5DEF5', description: 'Submitted, awaiting validation' },
+              { name: `release/${release}`, color: '0E8A16', description: `${release} release` },
+              { name: `tier/${tier}`, color: tier === 'production' ? '1D76DB' : 'BFD4F2', description: `${tier} tier` },
+            ];
+
+            for (const label of labelsToEnsure) {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                });
+              } catch {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ...label,
+                });
+                console.log(`Created label: ${label.name}`);
+              }
+            }
+
+            // Add labels to the issue
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['readiness/filed', `release/${release}`, `tier/${tier}`],
+            });
+
+      - name: Add issue to project board
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            // Find the project
+            const projectQuery = `
+              query($org: String!) {
+                organization(login: $org) {
+                  projectsV2(first: 20) {
+                    nodes {
+                      id
+                      title
+                      number
+                    }
+                  }
+                }
+              }
+            `;
+
+            const projectResult = await github.graphql(projectQuery, { org: '${{ env.ORG }}' });
+            const project = projectResult.organization.projectsV2.nodes
+              .find(p => p.title === '${{ env.PROJECT_TITLE }}');
+
+            if (!project) {
+              core.setFailed('Project board not found: ${{ env.PROJECT_TITLE }}');
+              return;
+            }
+
+            // Add issue to project
+            const addMutation = `
+              mutation($projectId: ID!, $contentId: ID!) {
+                addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+                  item { id }
+                }
+              }
+            `;
+
+            const addResult = await github.graphql(addMutation, {
+              projectId: project.id,
+              contentId: context.payload.issue.node_id,
+            });
+
+            const itemId = addResult.addProjectV2ItemById.item.id;
+            core.setOutput('item_id', itemId);
+            core.setOutput('project_id', project.id);
+
+            console.log(`Added issue to project. Item ID: ${itemId}`);
+
+      - name: Set project fields
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const projectId = '${{ steps.parse.outputs.project_id || '' }}';
+            const itemId = '${{ steps.parse.outputs.item_id || '' }}';
+
+            // Re-fetch project info to get field definitions
+            const fieldsQuery = `
+              query($org: String!) {
+                organization(login: $org) {
+                  projectsV2(first: 20) {
+                    nodes {
+                      id
+                      title
+                      fields(first: 30) {
+                        nodes {
+                          ... on ProjectV2Field {
+                            id
+                            name
+                            dataType
+                          }
+                          ... on ProjectV2SingleSelectField {
+                            id
+                            name
+                            dataType
+                            options { id name }
+                          }
+                          ... on ProjectV2IterationField {
+                            id
+                            name
+                            dataType
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const result = await github.graphql(fieldsQuery, { org: '${{ env.ORG }}' });
+            const project = result.organization.projectsV2.nodes
+              .find(p => p.title === '${{ env.PROJECT_TITLE }}');
+
+            if (!project) {
+              core.setFailed('Project not found');
+              return;
+            }
+
+            // Get the item ID from the project
+            const itemsQuery = `
+              query($projectId: ID!, $issueId: ID!) {
+                node(id: $projectId) {
+                  ... on ProjectV2 {
+                    items(first: 100) {
+                      nodes {
+                        id
+                        content {
+                          ... on Issue {
+                            id
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const itemsResult = await github.graphql(itemsQuery, {
+              projectId: project.id,
+              issueId: context.payload.issue.node_id,
+            });
+
+            const item = itemsResult.node.items.nodes.find(
+              i => i.content && i.content.id === context.payload.issue.node_id
+            );
+
+            if (!item) {
+              console.log('Issue not found on board — may not have been added yet');
+              return;
+            }
+
+            const fields = project.fields.nodes;
+
+            function findField(name) {
+              return fields.find(f => f.name === name);
+            }
+
+            function findOption(field, optionName) {
+              if (!field || !field.options) return null;
+              return field.options.find(o => o.name === optionName);
+            }
+
+            const updateMutation = `
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: ProjectV2FieldValue!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $projectId
+                  itemId: $itemId
+                  fieldId: $fieldId
+                  value: $value
+                }) {
+                  projectV2Item { id }
+                }
+              }
+            `;
+
+            const repo = '${{ steps.parse.outputs.repo }}';
+            const tier = '${{ steps.parse.outputs.tier }}';
+            const release = '${{ steps.parse.outputs.release }}';
+            const status = '${{ steps.status.outputs.status }}';
+
+            // Set Status
+            const statusField = findField('Status');
+            const statusOption = findOption(statusField, status);
+            if (statusField && statusOption) {
+              await github.graphql(updateMutation, {
+                projectId: project.id,
+                itemId: item.id,
+                fieldId: statusField.id,
+                value: { singleSelectOptionId: statusOption.id },
+              });
+              console.log(`Set Status = ${status}`);
+            }
+
+            // Set Release
+            const releaseField = findField('Release');
+            // Find best matching release option
+            const releaseOption = releaseField?.options?.find(o => o.name.startsWith(release));
+            if (releaseField && releaseOption) {
+              await github.graphql(updateMutation, {
+                projectId: project.id,
+                itemId: item.id,
+                fieldId: releaseField.id,
+                value: { singleSelectOptionId: releaseOption.id },
+              });
+              console.log(`Set Release = ${releaseOption.name}`);
+            }
+
+            // Set Repo
+            const repoField = findField('Repo');
+            const repoOption = findOption(repoField, repo);
+            if (repoField && repoOption) {
+              await github.graphql(updateMutation, {
+                projectId: project.id,
+                itemId: item.id,
+                fieldId: repoField.id,
+                value: { singleSelectOptionId: repoOption.id },
+              });
+              console.log(`Set Repo = ${repo}`);
+            }
+
+            // Set Repo Tier
+            const tierField = findField('Repo Tier');
+            const tierOption = findOption(tierField, tier);
+            if (tierField && tierOption) {
+              await github.graphql(updateMutation, {
+                projectId: project.id,
+                itemId: item.id,
+                fieldId: tierField.id,
+                value: { singleSelectOptionId: tierOption.id },
+              });
+              console.log(`Set Repo Tier = ${tier}`);
+            }
+
+            // Set Validation Status = pending on new issues
+            if ('${{ github.event.action }}' === 'opened') {
+              const valStatusField = findField('Validation Status');
+              const pendingOption = findOption(valStatusField, 'pending');
+              if (valStatusField && pendingOption) {
+                await github.graphql(updateMutation, {
+                  projectId: project.id,
+                  itemId: item.id,
+                  fieldId: valStatusField.id,
+                  value: { singleSelectOptionId: pendingOption.id },
+                });
+                console.log('Set Validation Status = pending');
+              }
+            }
+
+            // Set Filed Date
+            const filedDateField = findField('Filed Date');
+            if (filedDateField) {
+              const filedDate = context.payload.issue.created_at.split('T')[0];
+              await github.graphql(updateMutation, {
+                projectId: project.id,
+                itemId: item.id,
+                fieldId: filedDateField.id,
+                value: { date: filedDate },
+              });
+              console.log(`Set Filed Date = ${filedDate}`);
+            }
+
+            // Set Target Date (1st of release month)
+            const targetDateField = findField('Target Date');
+            if (targetDateField && release) {
+              // release = "v0.7" → May 2026, "v0.8" → Jun 2026, etc.
+              // v0.7 = May 2026 (month 5), v0.8 = Jun 2026 (month 6), ...
+              // Base: v0.7 = 2026-05-01
+              const minor = parseInt(release.split('.')[1], 10);
+              const baseMinor = 7;
+              const baseMonth = 5;
+              const baseYear = 2026;
+              const monthOffset = minor - baseMinor;
+              const targetMonth = baseMonth + monthOffset;
+              const targetYear = baseYear + Math.floor((targetMonth - 1) / 12);
+              const targetMonthNorm = ((targetMonth - 1) % 12) + 1;
+              const targetDate = `${targetYear}-${String(targetMonthNorm).padStart(2, '0')}-01`;
+
+              await github.graphql(updateMutation, {
+                projectId: project.id,
+                itemId: item.id,
+                fieldId: targetDateField.id,
+                value: { date: targetDate },
+              });
+              console.log(`Set Target Date = ${targetDate}`);
+            }
+
+            console.log('Board sync complete');

--- a/.github/workflows/release-readiness-board.yml
+++ b/.github/workflows/release-readiness-board.yml
@@ -367,21 +367,22 @@ jobs:
               console.log(`Set Filed Date = ${filedDate}`);
             }
 
-            // Set Target Date (1st of release month)
+            // Set Target Date (23rd of month before release — code freeze deadline)
+            // v0.7 releases May 1st → code freeze April 23rd
             const targetDateField = findField('Target Date');
             if (targetDateField && release) {
-              // release = "v0.7" → May 2026, "v0.8" → Jun 2026, etc.
-              // v0.7 = May 2026 (month 5), v0.8 = Jun 2026 (month 6), ...
-              // Base: v0.7 = 2026-05-01
               const minor = parseInt(release.split('.')[1], 10);
               const baseMinor = 7;
               const baseMonth = 5;
               const baseYear = 2026;
               const monthOffset = minor - baseMinor;
-              const targetMonth = baseMonth + monthOffset;
-              const targetYear = baseYear + Math.floor((targetMonth - 1) / 12);
-              const targetMonthNorm = ((targetMonth - 1) % 12) + 1;
-              const targetDate = `${targetYear}-${String(targetMonthNorm).padStart(2, '0')}-01`;
+              const releaseMonth = baseMonth + monthOffset;
+              const CODE_FREEZE_MONTH_OFFSET = -1;
+              const CODE_FREEZE_DAY = 23;
+              const freezeMonth = releaseMonth + CODE_FREEZE_MONTH_OFFSET;
+              const targetYear = baseYear + Math.floor((freezeMonth - 1) / 12);
+              const targetMonthNorm = ((freezeMonth - 1) % 12) + 1;
+              const targetDate = `${targetYear}-${String(targetMonthNorm).padStart(2, '0')}-${CODE_FREEZE_DAY}`;
 
               await github.graphql(updateMutation, {
                 projectId: project.id,

--- a/.github/workflows/release-readiness-lifecycle.yml
+++ b/.github/workflows/release-readiness-lifecycle.yml
@@ -84,8 +84,11 @@ jobs:
 
       - name: Open cycle
         if: steps.config.outputs.action == 'open-cycle'
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
           script: |
             const release = '${{ steps.config.outputs.release }}';
             const displayMonth = '${{ steps.config.outputs.display_month }}';
@@ -128,7 +131,84 @@ jobs:
               console.log(`Created label: ${releaseLabel}`);
             }
 
-            // 2. File tracking meta-issue
+            // 2. Add Release field option to project board
+            const releaseOptionName = `${release} (${displayMonth})`;
+            const projectQuery = `
+              query($org: String!) {
+                organization(login: $org) {
+                  projectsV2(first: 20) {
+                    nodes {
+                      id
+                      title
+                      fields(first: 30) {
+                        nodes {
+                          ... on ProjectV2SingleSelectField {
+                            id
+                            name
+                            options { id name }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+            const projResult = await github.graphql(projectQuery, { org: '${{ env.ORG }}' });
+            const proj = projResult.organization.projectsV2.nodes
+              .find(p => p.title === '${{ env.PROJECT_TITLE }}');
+
+            if (proj) {
+              const releaseField = proj.fields.nodes.find(f => f.name === 'Release');
+              if (releaseField) {
+                const existing = releaseField.options.find(o => o.name === releaseOptionName);
+                if (existing) {
+                  console.log(`Release option "${releaseOptionName}" already exists`);
+                } else {
+                  const addOptionMutation = `
+                    mutation($projectId: ID!, $fieldId: ID!, $value: ProjectV2SingleSelectFieldOptionInput!) {
+                      updateProjectV2Field(input: {
+                        projectId: $projectId
+                        fieldId: $fieldId
+                        singleSelectOptions: [$value]
+                      }) {
+                        projectV2Field { ... on ProjectV2SingleSelectField { id } }
+                      }
+                    }
+                  `;
+
+                  // Preserve existing options and append new one
+                  const existingOptions = releaseField.options.map(o => ({
+                    name: o.name,
+                    description: '',
+                    color: 'GREEN',
+                  }));
+                  existingOptions.push({
+                    name: releaseOptionName,
+                    description: `${release} release (${displayMonth})`,
+                    color: 'GREEN',
+                  });
+
+                  await github.graphql(`
+                    mutation($projectId: ID!, $fieldId: ID!) {
+                      updateProjectV2Field(input: {
+                        projectId: $projectId
+                        fieldId: $fieldId
+                        singleSelectOptions: [${existingOptions.map(o =>
+                          `{name: ${JSON.stringify(o.name)}, description: ${JSON.stringify(o.description)}, color: GREEN}`
+                        ).join(', ')}]
+                      }) {
+                        projectV2Field { ... on ProjectV2SingleSelectField { id } }
+                      }
+                    }
+                  `, { projectId: proj.id, fieldId: releaseField.id });
+
+                  console.log(`Added Release option: ${releaseOptionName}`);
+                }
+              }
+            }
+
+            // 3. File tracking meta-issue
             const templateBaseUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/issues/new?template=release-readiness.yml`;
 
             let checklist = '## Repo Checklist\n\n';

--- a/.github/workflows/release-readiness-lifecycle.yml
+++ b/.github/workflows/release-readiness-lifecycle.yml
@@ -1,0 +1,340 @@
+name: Release Readiness — Lifecycle
+
+on:
+  schedule:
+    - cron: "0 12 25 * *"
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "Lifecycle action to run"
+        required: true
+        type: choice
+        options:
+          - open-cycle
+          - status-report
+          - close-cycle
+      release_version:
+        description: "Release version override (e.g., v0.8). Defaults to next month's release."
+        required: false
+        type: string
+
+env:
+  PROJECT_TITLE: "llm-d Release Readiness"
+  ORG: "llm-d"
+
+jobs:
+  lifecycle:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Determine release version and action
+        id: config
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let action = '${{ github.event.inputs.action }}' || 'open-cycle';
+            let release = '${{ github.event.inputs.release_version }}';
+
+            if (!release) {
+              // Auto-compute: on the 25th, open next month's release
+              // Base: v0.7 = May 2026
+              const now = new Date();
+              const BASE_YEAR = 2026;
+              const BASE_MONTH = 5;
+              const BASE_MINOR = 7;
+              const nextMonth = now.getMonth() + 2; // getMonth() is 0-indexed, +1 for next month, +1 for 1-indexed
+              const nextYear = now.getFullYear() + (nextMonth > 12 ? 1 : 0);
+              const normalizedMonth = ((nextMonth - 1) % 12) + 1;
+              const monthsFromBase = (nextYear - BASE_YEAR) * 12 + normalizedMonth - BASE_MONTH;
+              const minor = BASE_MINOR + monthsFromBase;
+              release = `v0.${minor}`;
+            }
+
+            core.setOutput('action', action);
+            core.setOutput('release', release);
+
+            // Compute display month for the release
+            const minor = parseInt(release.split('.')[1], 10);
+            const BASE_MINOR = 7;
+            const BASE_MONTH = 5;
+            const BASE_YEAR = 2026;
+            const monthOffset = minor - BASE_MINOR;
+            const targetMonth = BASE_MONTH + monthOffset;
+            const targetYear = BASE_YEAR + Math.floor((targetMonth - 1) / 12);
+            const targetMonthNorm = ((targetMonth - 1) % 12) + 1;
+            const months = ['', 'January', 'February', 'March', 'April', 'May', 'June',
+                           'July', 'August', 'September', 'October', 'November', 'December'];
+            const displayMonth = `${months[targetMonthNorm]} ${targetYear}`;
+
+            core.setOutput('display_month', displayMonth);
+            core.setOutput('target_date', `${targetYear}-${String(targetMonthNorm).padStart(2, '0')}-01`);
+
+            console.log(`Action: ${action}, Release: ${release}, Month: ${displayMonth}`);
+
+      - name: Open cycle
+        if: steps.config.outputs.action == 'open-cycle'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const release = '${{ steps.config.outputs.release }}';
+            const displayMonth = '${{ steps.config.outputs.display_month }}';
+
+            // All shipping repos (excludes llm-d-infra, .github, docs — internal only)
+            const PRODUCTION_REPOS = [
+              'llm-d', 'llm-d-benchmark', 'llm-d-inference-payload-processor',
+              'llm-d-inference-scheduler', 'llm-d-inference-sim', 'llm-d-kv-cache',
+              'llm-d-latency-predictor', 'llm-d-model-service', 'llm-d-pd-utils',
+              'llm-d-prism', 'llm-d-routing-sidecar', 'llm-d-workload-variant-autoscaler',
+            ];
+
+            const INCUBATION_REPOS = [
+              'batch-gateway', 'coordinator', 'hermes', 'ig-wva',
+              'llm-d-async', 'llm-d-fast-model-actuation', 'llm-d-modelservice',
+              'llm-d-planner', 'llm-d-resiliency-operator', 'llm-d-rl',
+              'llm-d-skills', 'py-inference-scheduler', 'secure-inference',
+              'weight-propagation-interface',
+            ];
+
+            const ALL_REPOS = [...PRODUCTION_REPOS, ...INCUBATION_REPOS];
+
+            // 1. Create release label
+            const releaseLabel = `release/${release}`;
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: releaseLabel,
+              });
+              console.log(`Label ${releaseLabel} already exists`);
+            } catch {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: releaseLabel,
+                color: '0E8A16',
+                description: `${release} release (${displayMonth})`,
+              });
+              console.log(`Created label: ${releaseLabel}`);
+            }
+
+            // 2. File tracking meta-issue
+            const templateBaseUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/issues/new?template=release-readiness.yml`;
+
+            let checklist = '## Repo Checklist\n\n';
+            checklist += '### Production\n\n';
+            for (const repo of PRODUCTION_REPOS) {
+              const prefillUrl = `${templateBaseUrl}&title=${encodeURIComponent(`[Release Readiness] ${repo} — ${release}`)}&labels=release-readiness`;
+              checklist += `- [ ] **${repo}** — [File readiness issue](${prefillUrl})\n`;
+            }
+            checklist += '\n### Incubation\n\n';
+            for (const repo of INCUBATION_REPOS) {
+              const prefillUrl = `${templateBaseUrl}&title=${encodeURIComponent(`[Release Readiness] ${repo} — ${release}`)}&labels=release-readiness`;
+              checklist += `- [ ] **${repo}** — [File readiness issue](${prefillUrl})\n`;
+            }
+
+            const trackingBody = `# Release Tracking: ${release} — ${displayMonth}
+
+            **Release date**: ${displayMonth} 1st
+            **Total repos**: ${ALL_REPOS.length} (${PRODUCTION_REPOS.length} production + ${INCUBATION_REPOS.length} incubation)
+
+            ## Status Summary
+
+            | Status | Count |
+            |---|---|
+            | Validated | 0 |
+            | Passing | 0 |
+            | Filed | 0 |
+            | Blocked | 0 |
+            | Not filed | ${ALL_REPOS.length} |
+
+            ${checklist}
+
+            ---
+            _This issue is auto-generated by the release readiness lifecycle workflow._
+            _Use \`/revalidate\` on individual readiness issues to re-run checks._
+            _Run the lifecycle workflow with \`status-report\` action for an updated summary._
+            `.replace(/^            /gm, '');
+
+            const trackingIssue = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[Release Tracking] ${release} — ${displayMonth}`,
+              body: trackingBody,
+              labels: ['release-readiness', releaseLabel],
+            });
+
+            console.log(`Created tracking issue: #${trackingIssue.data.number}`);
+
+      - name: Status report
+        if: steps.config.outputs.action == 'status-report'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const release = '${{ steps.config.outputs.release }}';
+            const releaseLabel = `release/${release}`;
+
+            // Find all readiness issues for this release
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'all',
+              labels: `release-readiness,${releaseLabel}`,
+              per_page: 100,
+            });
+
+            // Filter out tracking issues
+            const readinessIssues = issues.data.filter(i =>
+              !i.title.startsWith('[Release Tracking]')
+            );
+
+            const statusCounts = {
+              validated: 0,
+              passing: 0,
+              failing: 0,
+              validating: 0,
+              filed: 0,
+              blocked: 0,
+              released: 0,
+            };
+
+            const issueDetails = [];
+
+            for (const issue of readinessIssues) {
+              const labels = issue.labels.map(l => l.name);
+              let status = 'filed';
+              for (const [label, s] of Object.entries({
+                'readiness/filed': 'filed',
+                'readiness/validating': 'validating',
+                'readiness/passing': 'passing',
+                'readiness/failing': 'failing',
+                'readiness/blocked': 'blocked',
+                'readiness/validated': 'validated',
+                'readiness/released': 'released',
+              })) {
+                if (labels.includes(label)) status = s;
+              }
+              statusCounts[status]++;
+
+              // Parse repo name from title
+              const repoMatch = issue.title.match(/\[Release Readiness\]\s*(.+?)\s*—/);
+              const repoName = repoMatch ? repoMatch[1] : 'Unknown';
+
+              const icon = {
+                validated: '✅', passing: '🟢', failing: '🔴',
+                validating: '🔄', filed: '📋', blocked: '🚫', released: '🏁',
+              }[status] || '❓';
+
+              issueDetails.push(`| ${icon} ${repoName} | ${status} | #${issue.number} |`);
+            }
+
+            const TOTAL_REPOS = 26;
+            const notFiled = TOTAL_REPOS - readinessIssues.length;
+
+            let report = `## ${release} Release Status Report\n\n`;
+            report += `**Generated**: ${new Date().toISOString().split('T')[0]}\n\n`;
+            report += `| Status | Count |\n|---|---|\n`;
+            report += `| ✅ Validated | ${statusCounts.validated} |\n`;
+            report += `| 🟢 Passing | ${statusCounts.passing} |\n`;
+            report += `| 🔴 Failing | ${statusCounts.failing} |\n`;
+            report += `| 🚫 Blocked | ${statusCounts.blocked} |\n`;
+            report += `| 📋 Filed | ${statusCounts.filed + statusCounts.validating} |\n`;
+            report += `| ⬜ Not filed | ${notFiled} |\n`;
+            report += `| 🏁 Released | ${statusCounts.released} |\n\n`;
+
+            if (issueDetails.length > 0) {
+              report += `### Per-Repo Detail\n\n`;
+              report += `| Repo | Status | Issue |\n|---|---|---|\n`;
+              report += issueDetails.join('\n') + '\n';
+            }
+
+            // Find the tracking issue to comment on
+            const trackingIssues = issues.data.filter(i =>
+              i.title.startsWith('[Release Tracking]') && i.state === 'open'
+            );
+
+            if (trackingIssues.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: trackingIssues[0].number,
+                body: report,
+              });
+              console.log(`Posted report to tracking issue #${trackingIssues[0].number}`);
+            } else {
+              console.log('No open tracking issue found for this release');
+              core.setOutput('report', report);
+            }
+
+      - name: Close cycle
+        if: steps.config.outputs.action == 'close-cycle'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const release = '${{ steps.config.outputs.release }}';
+            const releaseLabel = `release/${release}`;
+
+            // Find all readiness issues for this release
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: `release-readiness,${releaseLabel}`,
+              per_page: 100,
+            });
+
+            // Ensure released label exists
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'readiness/released',
+              });
+            } catch {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'readiness/released',
+                color: '6F42C1',
+                description: 'Included in final release',
+              });
+            }
+
+            let closedCount = 0;
+            for (const issue of issues.data) {
+              // Add released label
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['readiness/released'],
+              });
+
+              // Close the issue
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+              closedCount++;
+            }
+
+            // Find and close the tracking issue with a summary
+            const trackingIssues = issues.data.filter(i =>
+              i.title.startsWith('[Release Tracking]')
+            );
+
+            for (const tracking of trackingIssues) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: tracking.number,
+                body: `## ${release} Release Cycle Closed\n\n` +
+                  `${closedCount} readiness issues closed and labeled \`readiness/released\`.\n` +
+                  `Release date: ${{ steps.config.outputs.target_date }}`,
+              });
+            }
+
+            console.log(`Closed ${closedCount} issues for ${release}`);

--- a/.github/workflows/release-readiness-lifecycle.yml
+++ b/.github/workflows/release-readiness-lifecycle.yml
@@ -70,7 +70,17 @@ jobs:
             core.setOutput('display_month', displayMonth);
             core.setOutput('target_date', `${targetYear}-${String(targetMonthNorm).padStart(2, '0')}-01`);
 
-            console.log(`Action: ${action}, Release: ${release}, Month: ${displayMonth}`);
+            // Code freeze = 23rd of month before release
+            const CODE_FREEZE_DAY = 23;
+            const freezeMonth = targetMonth - 1;
+            const freezeYear = BASE_YEAR + Math.floor((freezeMonth - 1) / 12);
+            const freezeMonthNorm = ((freezeMonth - 1) % 12) + 1;
+            const codeFreezeDate = `${freezeYear}-${String(freezeMonthNorm).padStart(2, '0')}-${CODE_FREEZE_DAY}`;
+            const codeFreezeDisplay = `${months[freezeMonthNorm]} ${CODE_FREEZE_DAY}, ${freezeYear}`;
+            core.setOutput('code_freeze_date', codeFreezeDate);
+            core.setOutput('code_freeze_display', codeFreezeDisplay);
+
+            console.log(`Action: ${action}, Release: ${release}, Month: ${displayMonth}, Code freeze: ${codeFreezeDisplay}`);
 
       - name: Open cycle
         if: steps.config.outputs.action == 'open-cycle'
@@ -135,6 +145,7 @@ jobs:
 
             const trackingBody = `# Release Tracking: ${release} — ${displayMonth}
 
+            **Code freeze**: ${{ steps.config.outputs.code_freeze_display }}
             **Release date**: ${displayMonth} 1st
             **Total repos**: ${ALL_REPOS.length} (${PRODUCTION_REPOS.length} production + ${INCUBATION_REPOS.length} incubation)
 

--- a/.github/workflows/release-readiness-validate.yml
+++ b/.github/workflows/release-readiness-validate.yml
@@ -1,0 +1,715 @@
+name: Release Readiness — Validate
+
+on:
+  issues:
+    types: [opened, edited]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to validate"
+        required: true
+        type: number
+
+env:
+  PROJECT_TITLE: "llm-d Release Readiness"
+  ORG: "llm-d"
+  TOTAL_CHECKS: 24
+
+jobs:
+  validate:
+    if: |
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'release-readiness')) ||
+      (github.event_name == 'issue_comment' && contains(github.event.issue.labels.*.name, 'release-readiness') && startsWith(github.event.comment.body, '/revalidate'))
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Determine issue number
+        id: issue
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "number=${{ github.event.inputs.issue_number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Get issue body
+        id: body
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.issue.outputs.number }},
+            });
+            core.setOutput('body', issue.data.body);
+            return issue.data.body;
+
+      - name: Parse issue fields
+        id: parse
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = ${{ steps.body.outputs.result }};
+
+            function parseField(label) {
+              const regex = new RegExp(`### ${label}\\s*\\n\\n([^\\n]+)`, 'i');
+              const match = body.match(regex);
+              return match ? match[1].trim() : '';
+            }
+
+            const repoRaw = parseField('Which repo is requesting release inclusion\\?');
+            const version = parseField('What version/tag are you releasing\\?');
+            const repo = repoRaw.replace(/\s*\(incubation\)$/, '');
+            const tier = repoRaw.includes('(incubation)') ? 'incubation' : 'production';
+
+            // Determine the GitHub org for this repo
+            const incubationRepos = [
+              'batch-gateway', 'coordinator', 'hermes', 'ig-wva',
+              'llm-d-async', 'llm-d-fast-model-actuation', 'llm-d-modelservice',
+              'llm-d-planner', 'llm-d-resiliency-operator', 'llm-d-rl',
+              'llm-d-skills', 'py-inference-scheduler', 'secure-inference',
+              'weight-propagation-interface',
+            ];
+            const orgName = incubationRepos.includes(repo) ? 'llm-d-incubation' : 'llm-d';
+
+            core.setOutput('repo', repo);
+            core.setOutput('version', version);
+            core.setOutput('tier', tier);
+            core.setOutput('org', orgName);
+            core.setOutput('full_repo', `${orgName}/${repo}`);
+
+      - name: Set validating label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumber = ${{ steps.issue.outputs.number }};
+            const labels = (await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+            })).data.map(l => l.name);
+
+            // Remove any existing readiness/* labels
+            for (const label of labels) {
+              if (label.startsWith('readiness/') && label !== 'readiness/validating') {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: label,
+                }).catch(() => {});
+              }
+            }
+
+            // Ensure readiness/validating label exists
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'readiness/validating',
+              });
+            } catch {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'readiness/validating',
+                color: 'FBCA04',
+                description: 'Automated checks running',
+              });
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              labels: ['readiness/validating'],
+            });
+
+      - name: Checkout target repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.parse.outputs.full_repo }}
+          token: ${{ secrets.ORG_GITHUB_TOKEN }}
+          path: target-repo
+
+      - name: Run validation checks
+        id: validate
+        uses: actions/github-script@v7
+        env:
+          TARGET_REPO: ${{ steps.parse.outputs.full_repo }}
+          TARGET_ORG: ${{ steps.parse.outputs.org }}
+          TARGET_REPO_NAME: ${{ steps.parse.outputs.repo }}
+          TARGET_VERSION: ${{ steps.parse.outputs.version }}
+          TARGET_TIER: ${{ steps.parse.outputs.tier }}
+          ORG_TOKEN: ${{ secrets.ORG_GITHUB_TOKEN }}
+        with:
+          github-token: ${{ secrets.ORG_GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const org = process.env.TARGET_ORG;
+            const repo = process.env.TARGET_REPO_NAME;
+            const fullRepo = process.env.TARGET_REPO;
+            const version = process.env.TARGET_VERSION;
+            const tier = process.env.TARGET_TIER;
+            const repoPath = 'target-repo';
+
+            const results = [];
+
+            function check(category, name, pass, detail) {
+              results.push({ category, name, pass, detail: detail || '' });
+            }
+
+            function fileExists(relPath) {
+              return fs.existsSync(path.join(repoPath, relPath));
+            }
+
+            // ═══════════════════════════════════════════════════════
+            // CI Health (5 checks)
+            // ═══════════════════════════════════════════════════════
+
+            // 1. Default branch CI passing
+            try {
+              const runs = await github.rest.actions.listWorkflowRunsForRepo({
+                owner: org,
+                repo: repo,
+                branch: 'main',
+                status: 'completed',
+                per_page: 5,
+              });
+              const recentRuns = runs.data.workflow_runs || [];
+              const hasPassingCI = recentRuns.some(r => r.conclusion === 'success');
+              check('CI Health', 'Default branch CI passing', hasPassingCI,
+                hasPassingCI ? 'Recent successful run found' : 'No recent successful CI runs on main');
+            } catch (e) {
+              check('CI Health', 'Default branch CI passing', false, `Error: ${e.message}`);
+            }
+
+            // 2. No failing required checks
+            try {
+              const runs = await github.rest.actions.listWorkflowRunsForRepo({
+                owner: org,
+                repo: repo,
+                branch: 'main',
+                status: 'completed',
+                per_page: 10,
+              });
+              const failedRuns = (runs.data.workflow_runs || [])
+                .filter(r => r.conclusion === 'failure')
+                .slice(0, 3);
+              const noFailures = failedRuns.length === 0;
+              check('CI Health', 'No failing required checks', noFailures,
+                noFailures ? 'No recent failures' : `${failedRuns.length} recent failed run(s): ${failedRuns.map(r => r.name).join(', ')}`);
+            } catch (e) {
+              check('CI Health', 'No failing required checks', false, `Error: ${e.message}`);
+            }
+
+            // 3. Branch protection enabled
+            try {
+              await github.rest.repos.getBranchProtection({
+                owner: org,
+                repo: repo,
+                branch: 'main',
+              });
+              check('CI Health', 'Branch protection enabled', true, 'Protection rules found on main');
+            } catch (e) {
+              const isNotFound = e.status === 404;
+              check('CI Health', 'Branch protection enabled', false,
+                isNotFound ? 'No branch protection on main' : `Error: ${e.message}`);
+            }
+
+            // 4. Signed commits / DCO
+            try {
+              const commits = await github.rest.repos.listCommits({
+                owner: org,
+                repo: repo,
+                per_page: 10,
+              });
+              const recentCommits = commits.data || [];
+              const signedCount = recentCommits.filter(c =>
+                c.commit.message.includes('Signed-off-by:') ||
+                (c.commit.verification && c.commit.verification.verified)
+              ).length;
+              const signedRatio = recentCommits.length > 0 ? signedCount / recentCommits.length : 0;
+              const SIGNED_THRESHOLD = 0.8;
+              check('CI Health', 'Signed commits / DCO', signedRatio >= SIGNED_THRESHOLD,
+                `${signedCount}/${recentCommits.length} recent commits signed (${Math.round(signedRatio * 100)}%)`);
+            } catch (e) {
+              check('CI Health', 'Signed commits / DCO', false, `Error: ${e.message}`);
+            }
+
+            // 5. No critical Dependabot alerts
+            try {
+              const alerts = await github.rest.dependabot.listAlertsForRepo({
+                owner: org,
+                repo: repo,
+                state: 'open',
+                severity: 'critical',
+                per_page: 5,
+              });
+              const criticalAlerts = alerts.data || [];
+              check('CI Health', 'No critical Dependabot alerts', criticalAlerts.length === 0,
+                criticalAlerts.length === 0 ? 'No open critical alerts' : `${criticalAlerts.length} critical alert(s) open`);
+            } catch (e) {
+              // Dependabot API may not be available for all repos
+              check('CI Health', 'No critical Dependabot alerts', true, 'Dependabot API unavailable (skipped)');
+            }
+
+            // ═══════════════════════════════════════════════════════
+            // Governance (5 checks)
+            // ═══════════════════════════════════════════════════════
+
+            // 6. OWNERS file
+            const hasOwners = fileExists('OWNERS') || fileExists('CODEOWNERS') || fileExists('.github/CODEOWNERS');
+            check('Governance', 'OWNERS file exists', hasOwners,
+              hasOwners ? 'Found OWNERS or CODEOWNERS' : 'Missing OWNERS / CODEOWNERS file');
+
+            // 7. LICENSE
+            const hasLicense = fileExists('LICENSE') || fileExists('LICENSE.md') || fileExists('LICENSE.txt');
+            check('Governance', 'LICENSE file exists', hasLicense,
+              hasLicense ? 'LICENSE found' : 'Missing LICENSE file');
+
+            // 8. CONTRIBUTING.md
+            const hasContributing = fileExists('CONTRIBUTING.md') || fileExists('.github/CONTRIBUTING.md');
+            check('Governance', 'CONTRIBUTING.md exists', hasContributing,
+              hasContributing ? 'CONTRIBUTING.md found' : 'Missing CONTRIBUTING.md');
+
+            // 9. SECURITY.md
+            const hasSecurity = fileExists('SECURITY.md') || fileExists('.github/SECURITY.md');
+            check('Governance', 'SECURITY.md exists', hasSecurity,
+              hasSecurity ? 'SECURITY.md found' : 'Missing SECURITY.md');
+
+            // 10. CODE_OF_CONDUCT.md
+            const hasCoc = fileExists('CODE_OF_CONDUCT.md') || fileExists('.github/CODE_OF_CONDUCT.md');
+            check('Governance', 'CODE_OF_CONDUCT.md exists', hasCoc,
+              hasCoc ? 'CODE_OF_CONDUCT.md found' : 'Missing CODE_OF_CONDUCT.md');
+
+            // ═══════════════════════════════════════════════════════
+            // Artifacts (4 checks)
+            // ═══════════════════════════════════════════════════════
+
+            // 11. Tag follows semver
+            const semverRegex = /^v?\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?$/;
+            const validSemver = semverRegex.test(version);
+            check('Artifacts', 'Tag follows semver', validSemver,
+              validSemver ? `${version} is valid semver` : `${version} does not follow vX.Y.Z format`);
+
+            // 12. Container image exists (if Dockerfile present)
+            const hasDockerfile = fileExists('Dockerfile') || fileExists('docker/Dockerfile');
+            if (hasDockerfile) {
+              try {
+                const packages = await github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg({
+                  package_type: 'container',
+                  package_name: repo,
+                  org: org,
+                  per_page: 5,
+                });
+                check('Artifacts', 'Container image exists', (packages.data || []).length > 0,
+                  'Container image found in GHCR');
+              } catch {
+                check('Artifacts', 'Container image exists', false,
+                  'No container image found in GHCR (Dockerfile present)');
+              }
+            } else {
+              check('Artifacts', 'Container image exists', true, 'No Dockerfile — container check skipped');
+            }
+
+            // 13. CHANGELOG or release notes
+            const hasChangelog = fileExists('CHANGELOG.md') || fileExists('CHANGES.md');
+            let hasReleaseNotes = false;
+            try {
+              const releases = await github.rest.repos.listReleases({
+                owner: org,
+                repo: repo,
+                per_page: 5,
+              });
+              hasReleaseNotes = (releases.data || []).some(r => r.body && r.body.length > 50);
+            } catch {}
+            check('Artifacts', 'CHANGELOG / release notes', hasChangelog || hasReleaseNotes,
+              hasChangelog ? 'CHANGELOG.md found' : hasReleaseNotes ? 'GitHub Release notes found' : 'No CHANGELOG.md or release notes');
+
+            // 14. No blocking draft releases
+            try {
+              const releases = await github.rest.repos.listReleases({
+                owner: org,
+                repo: repo,
+                per_page: 10,
+              });
+              const drafts = (releases.data || []).filter(r => r.draft);
+              check('Artifacts', 'No blocking draft releases', drafts.length === 0,
+                drafts.length === 0 ? 'No draft releases' : `${drafts.length} draft release(s) found`);
+            } catch (e) {
+              check('Artifacts', 'No blocking draft releases', true, 'Releases API unavailable (skipped)');
+            }
+
+            // ═══════════════════════════════════════════════════════
+            // Testing (4 checks)
+            // ═══════════════════════════════════════════════════════
+
+            // 15. Recent CI runs healthy
+            try {
+              const RECENT_DAYS = 7;
+              const since = new Date(Date.now() - RECENT_DAYS * 24 * 60 * 60 * 1000).toISOString();
+              const runs = await github.rest.actions.listWorkflowRunsForRepo({
+                owner: org,
+                repo: repo,
+                created: `>${since}`,
+                per_page: 20,
+              });
+              const total = runs.data.total_count || 0;
+              const successes = (runs.data.workflow_runs || []).filter(r => r.conclusion === 'success').length;
+              const CI_HEALTH_THRESHOLD = 0.5;
+              const healthy = total > 0 && (successes / total) >= CI_HEALTH_THRESHOLD;
+              check('Testing', 'Recent CI runs healthy', healthy,
+                total === 0 ? 'No CI runs in last 7 days' : `${successes}/${total} runs succeeded (${Math.round(successes/total*100)}%)`);
+            } catch (e) {
+              check('Testing', 'Recent CI runs healthy', false, `Error: ${e.message}`);
+            }
+
+            // 16. Nightly E2E passing
+            try {
+              const runs = await github.rest.actions.listWorkflowRunsForRepo({
+                owner: org,
+                repo: repo,
+                per_page: 50,
+              });
+              const nightlyRuns = (runs.data.workflow_runs || [])
+                .filter(r => r.name && (r.name.toLowerCase().includes('nightly') || r.name.toLowerCase().includes('e2e')));
+              if (nightlyRuns.length === 0) {
+                check('Testing', 'Nightly E2E passing', true, 'No nightly/E2E workflows found (skipped)');
+              } else {
+                const latestNightly = nightlyRuns[0];
+                const passing = latestNightly.conclusion === 'success';
+                check('Testing', 'Nightly E2E passing', passing,
+                  `Latest ${latestNightly.name}: ${latestNightly.conclusion}`);
+              }
+            } catch (e) {
+              check('Testing', 'Nightly E2E passing', true, 'Could not check nightly runs (skipped)');
+            }
+
+            // 17. No critical issues open
+            try {
+              const issues = await github.rest.issues.listForRepo({
+                owner: org,
+                repo: repo,
+                state: 'open',
+                labels: 'priority/critical,kind/bug',
+                per_page: 5,
+              });
+              // Also check for critical-only label
+              const criticalIssues = await github.rest.issues.listForRepo({
+                owner: org,
+                repo: repo,
+                state: 'open',
+                labels: 'priority/critical',
+                per_page: 5,
+              });
+              const total = criticalIssues.data.length;
+              check('Testing', 'No critical issues open', total === 0,
+                total === 0 ? 'No critical issues' : `${total} critical issue(s) open`);
+            } catch (e) {
+              check('Testing', 'No critical issues open', true, 'Could not check issues (skipped)');
+            }
+
+            // 18. Test coverage present
+            const hasTests = fileExists('tests') || fileExists('test') ||
+              fileExists('*_test.go') || fileExists('pkg') ||
+              fs.readdirSync(repoPath).some(f => f.endsWith('_test.go')) ||
+              fileExists('pytest.ini') || fileExists('setup.cfg') ||
+              fileExists('jest.config.js') || fileExists('jest.config.ts');
+            check('Testing', 'Test coverage present', hasTests,
+              hasTests ? 'Test files/directories found' : 'No test infrastructure detected');
+
+            // ═══════════════════════════════════════════════════════
+            // Docs (3 checks)
+            // ═══════════════════════════════════════════════════════
+
+            // 19. README.md non-trivial
+            const MIN_README_BYTES = 500;
+            if (fileExists('README.md')) {
+              const readmeSize = fs.statSync(path.join(repoPath, 'README.md')).size;
+              check('Docs', 'README.md non-trivial', readmeSize >= MIN_README_BYTES,
+                `README.md is ${readmeSize} bytes (min ${MIN_README_BYTES})`);
+            } else {
+              check('Docs', 'README.md non-trivial', false, 'README.md not found');
+            }
+
+            // 20. docs/ or api/ directory present
+            const hasDocs = fileExists('docs') || fileExists('api') || fileExists('doc');
+            check('Docs', 'docs/api directory present', hasDocs,
+              hasDocs ? 'Documentation directory found' : 'No docs/ or api/ directory');
+
+            // 21. Link health (deferred — always passes)
+            check('Docs', 'Link health', true, 'Deferred to nightly link checker');
+
+            // ═══════════════════════════════════════════════════════
+            // Hygiene (3 checks)
+            // ═══════════════════════════════════════════════════════
+
+            // 22. No open merge conflicts on default branch PRs
+            try {
+              const prs = await github.rest.pulls.list({
+                owner: org,
+                repo: repo,
+                state: 'open',
+                base: 'main',
+                per_page: 20,
+              });
+              const conflicting = (prs.data || []).filter(p => p.mergeable === false);
+              check('Hygiene', 'No merge conflicts', conflicting.length === 0,
+                conflicting.length === 0 ? 'No conflicting PRs' : `${conflicting.length} PR(s) have merge conflicts`);
+            } catch (e) {
+              check('Hygiene', 'No merge conflicts', true, 'Could not check PRs (skipped)');
+            }
+
+            // 23. Dependency pinning
+            let depsPinned = false;
+            let depsDetail = '';
+            if (fileExists('go.mod')) {
+              depsPinned = fileExists('go.sum');
+              depsDetail = depsPinned ? 'go.sum present' : 'go.mod without go.sum';
+            } else if (fileExists('requirements.txt') || fileExists('pyproject.toml')) {
+              depsPinned = fileExists('requirements.txt') || fileExists('poetry.lock') || fileExists('uv.lock');
+              depsDetail = depsPinned ? 'Lock file present' : 'No lock file found';
+            } else if (fileExists('package.json')) {
+              depsPinned = fileExists('package-lock.json') || fileExists('yarn.lock') || fileExists('pnpm-lock.yaml');
+              depsDetail = depsPinned ? 'Lock file present' : 'No lock file found';
+            } else {
+              depsPinned = true;
+              depsDetail = 'No recognized package manager';
+            }
+            check('Hygiene', 'Dependency pinning', depsPinned, depsDetail);
+
+            // 24. Cross-repo dep compatibility
+            // Check if go.mod references other llm-d repos and those are accessible
+            let crossDepsOk = true;
+            let crossDepsDetail = 'No cross-repo dependencies detected';
+            if (fileExists('go.mod')) {
+              const gomod = fs.readFileSync(path.join(repoPath, 'go.mod'), 'utf8');
+              const llmdDeps = gomod.match(/github\.com\/llm-d[^\s]*/g) || [];
+              if (llmdDeps.length > 0) {
+                crossDepsDetail = `Found ${llmdDeps.length} llm-d dependency(ies): ${llmdDeps.slice(0, 5).join(', ')}`;
+              }
+            }
+            check('Hygiene', 'Cross-repo dep compatibility', crossDepsOk, crossDepsDetail);
+
+            // ═══════════════════════════════════════════════════════
+            // Summary
+            // ═══════════════════════════════════════════════════════
+
+            const passing = results.filter(r => r.pass).length;
+            const failing = results.filter(r => !r.pass).length;
+            const allPassing = failing === 0;
+
+            // Build comment
+            const categories = [...new Set(results.map(r => r.category))];
+            let comment = `## Release Readiness Validation\n\n`;
+            comment += `**Repo**: \`${fullRepo}\` | **Version**: \`${version}\` | **Tier**: ${tier}\n\n`;
+            comment += `### Score: ${passing}/${results.length} checks passing ${allPassing ? '✅' : '❌'}\n\n`;
+
+            for (const cat of categories) {
+              const catResults = results.filter(r => r.category === cat);
+              const catPassing = catResults.filter(r => r.pass).length;
+              comment += `#### ${cat} (${catPassing}/${catResults.length})\n\n`;
+              comment += `| Check | Status | Detail |\n|---|---|---|\n`;
+              for (const r of catResults) {
+                const icon = r.pass ? '✅' : '❌';
+                comment += `| ${r.name} | ${icon} | ${r.detail} |\n`;
+              }
+              comment += `\n`;
+            }
+
+            comment += `\n---\n_Run \`/revalidate\` in a comment to re-run these checks._`;
+
+            core.setOutput('passing', passing);
+            core.setOutput('total', results.length);
+            core.setOutput('all_passing', allPassing);
+            core.setOutput('comment', comment);
+
+      - name: Post validation comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.issue.outputs.number }},
+              body: `${{ steps.validate.outputs.comment }}`.replace(/`/g, '`'),
+            });
+
+      - name: Set result label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumber = ${{ steps.issue.outputs.number }};
+            const allPassing = ${{ steps.validate.outputs.all_passing }};
+            const resultLabel = allPassing ? 'readiness/passing' : 'readiness/failing';
+            const removeLabel = allPassing ? 'readiness/failing' : 'readiness/passing';
+
+            // Remove validating label
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                name: 'readiness/validating',
+              });
+            } catch {}
+
+            // Remove opposite result label
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                name: removeLabel,
+              });
+            } catch {}
+
+            // Ensure result label exists
+            const labelConfig = allPassing
+              ? { name: 'readiness/passing', color: '0E8A16', description: 'All automated checks pass' }
+              : { name: 'readiness/failing', color: 'D93F0B', description: 'One or more checks fail' };
+
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: labelConfig.name,
+              });
+            } catch {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ...labelConfig,
+              });
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              labels: [resultLabel],
+            });
+
+      - name: Update project board fields
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const passing = parseInt('${{ steps.validate.outputs.passing }}', 10);
+            const allPassing = ${{ steps.validate.outputs.all_passing }};
+
+            // Find the project
+            const projectQuery = `
+              query($org: String!) {
+                organization(login: $org) {
+                  projectsV2(first: 20) {
+                    nodes {
+                      id
+                      title
+                      fields(first: 30) {
+                        nodes {
+                          ... on ProjectV2Field {
+                            id
+                            name
+                            dataType
+                          }
+                          ... on ProjectV2SingleSelectField {
+                            id
+                            name
+                            dataType
+                            options { id name }
+                          }
+                        }
+                      }
+                      items(first: 100) {
+                        nodes {
+                          id
+                          content {
+                            ... on Issue { id number }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const result = await github.graphql(projectQuery, { org: '${{ env.ORG }}' });
+            const project = result.organization.projectsV2.nodes
+              .find(p => p.title === '${{ env.PROJECT_TITLE }}');
+
+            if (!project) return;
+
+            const item = project.items.nodes.find(
+              i => i.content && i.content.number === ${{ steps.issue.outputs.number }}
+            );
+
+            if (!item) return;
+
+            const fields = project.fields.nodes;
+
+            function findField(name) {
+              return fields.find(f => f.name === name);
+            }
+
+            const updateMutation = `
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: ProjectV2FieldValue!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $projectId
+                  itemId: $itemId
+                  fieldId: $fieldId
+                  value: $value
+                }) {
+                  projectV2Item { id }
+                }
+              }
+            `;
+
+            // Update Validation Score
+            const scoreField = findField('Validation Score');
+            if (scoreField) {
+              await github.graphql(updateMutation, {
+                projectId: project.id,
+                itemId: item.id,
+                fieldId: scoreField.id,
+                value: { number: passing },
+              });
+            }
+
+            // Update Validation Status
+            const valStatusField = findField('Validation Status');
+            const valOption = valStatusField?.options?.find(o => o.name === (allPassing ? 'passing' : 'failing'));
+            if (valStatusField && valOption) {
+              await github.graphql(updateMutation, {
+                projectId: project.id,
+                itemId: item.id,
+                fieldId: valStatusField.id,
+                value: { singleSelectOptionId: valOption.id },
+              });
+            }
+
+            // Update Status based on validation result
+            const statusField = findField('Status');
+            const newStatus = allPassing ? 'Passing' : 'Blocked';
+            const statusOption = statusField?.options?.find(o => o.name === newStatus);
+            if (statusField && statusOption) {
+              await github.graphql(updateMutation, {
+                projectId: project.id,
+                itemId: item.id,
+                fieldId: statusField.id,
+                value: { singleSelectOptionId: statusOption.id },
+              });
+            }
+
+            console.log(`Updated board: Score=${passing}, Status=${newStatus}`);

--- a/RELEASE-READINESS.md
+++ b/RELEASE-READINESS.md
@@ -1,0 +1,146 @@
+# llm-d Release Readiness Process
+
+## Overview
+
+Every llm-d release ships on the **1st of the month**. Code freeze is the **23rd of the prior month** — your repo must have an approved release readiness issue by then to be included.
+
+The release readiness board tracks which of the 26 shipping repos (12 production + 14 incubation) are ready for each release.
+
+- **Board**: https://github.com/orgs/llm-d/projects/25
+- **Issue template**: Filed on [llm-d/llm-d](https://github.com/llm-d/llm-d/issues/new?template=release-readiness.yml)
+
+## Timeline (monthly)
+
+| Date | Event |
+|---|---|
+| 25th (month before) | Lifecycle workflow opens the release cycle — creates tracking issue, labels, board options |
+| 25th → 23rd | Repo maintainers file readiness issues, validation runs automatically |
+| **23rd** | **Code freeze** — all readiness issues must be validated by this date |
+| 1st (next month) | Release ships |
+| Post-release | Lifecycle workflow closes the cycle — marks all issues as released |
+
+## For Repo Maintainers
+
+### 1. File a Release Readiness Issue
+
+Go to **[llm-d/llm-d → Issues → New Issue → Release Readiness Request](https://github.com/llm-d/llm-d/issues/new?template=release-readiness.yml)**.
+
+Fill in:
+- **Which repo** — select your repo from the dropdown
+- **Version** — the exact semver tag you plan to release (e.g., `v0.8.0`)
+- **Prerequisites** — maintainer approval status, tests run, hardware affected
+- **Documentation** — whether guides are updated and tested
+- **Risk assessment** — breaking changes, cross-repo dependencies
+- **Attestation** — hardware verification, rollback plan, release notes
+
+### 2. What Happens Automatically
+
+Once you submit:
+
+1. **Labels applied**: `readiness/filed`, `release/vX.Y`, `tier/production` or `tier/incubation`
+2. **Board sync**: Your issue appears on the [Release Readiness board](https://github.com/orgs/llm-d/projects/25) with all fields populated
+3. **Validation runs**: 24 automated checks execute against your repo and post results as a comment
+
+### 3. Automated Checks (24 total)
+
+| Category | What's Checked |
+|---|---|
+| **CI Health** (5) | Default branch CI passing, no failing required checks, branch protection enabled, signed commits/DCO, no critical Dependabot alerts |
+| **Governance** (5) | OWNERS, LICENSE, CONTRIBUTING.md, SECURITY.md, CODE_OF_CONDUCT.md exist |
+| **Artifacts** (4) | Tag follows semver, container image exists (if Dockerfile present), CHANGELOG/release notes, no blocking draft releases |
+| **Testing** (4) | Recent CI runs healthy, nightly E2E passing, no critical open issues, test coverage present |
+| **Docs** (3) | README.md non-trivial, docs/ or api/ directory present, link health |
+| **Hygiene** (3) | No merge conflicts on default branch, dependency pinning verified, cross-repo dependency compatibility |
+
+### 4. Re-run Validation
+
+If you've fixed issues flagged by the checks, comment `/revalidate` on your readiness issue. The validation workflow will re-run all 24 checks.
+
+### 5. Label Progression
+
+Your issue moves through these statuses (reflected on the board):
+
+```
+Filed → Validating → Passing or Failing → Validated → Released
+                                    ↘ Blocked (manual, by release team)
+```
+
+| Label | Meaning |
+|---|---|
+| `readiness/filed` | Submitted, awaiting validation |
+| `readiness/validating` | Automated checks running |
+| `readiness/passing` | All automated checks pass |
+| `readiness/failing` | One or more checks fail — fix and `/revalidate` |
+| `readiness/blocked` | Blocked by release team (manual) |
+| `readiness/validated` | Approved for release inclusion |
+| `readiness/released` | Included in the final release |
+
+## For the Release Team
+
+### Board Views
+
+| View | What It Shows |
+|---|---|
+| **Repo Status** | Table of all repos for the current release, sorted by validation score |
+| **Release Board** | Kanban board grouped by status for the current release |
+| **Blocked** | Only items with Status = Blocked |
+| **Release History** | All releases (no filter) — historical audit trail |
+| **By Tier** | Board view for the current release, grouped by repo tier |
+
+All views except Release History and Blocked are filtered to the current release. To switch releases, update the filter (e.g., change `release:"v0.7 (May 2026)"` to `release:"v0.8 (Jun 2026)"`).
+
+### Generate a Status Report
+
+Run the lifecycle workflow manually with `status-report` action:
+
+```
+Actions → Release Readiness — Lifecycle → Run workflow → action: status-report
+```
+
+This posts a summary (validated/passing/failing/blocked/not-filed counts) as a comment on the tracking issue.
+
+### Close a Release Cycle
+
+After the release ships, run the lifecycle workflow with `close-cycle`:
+
+```
+Actions → Release Readiness — Lifecycle → Run workflow → action: close-cycle
+```
+
+This applies `readiness/released` to all issues, closes them, and posts a final summary.
+
+### Open a Release Cycle Manually
+
+The lifecycle workflow runs automatically on the 25th, but you can trigger it manually:
+
+```
+Actions → Release Readiness — Lifecycle → Run workflow → action: open-cycle
+```
+
+Optionally provide a `release_version` override (e.g., `v0.9`). If omitted, it auto-computes the next release.
+
+## Secrets Required
+
+| Secret | Scope | Purpose |
+|---|---|---|
+| `PROJECT_TOKEN` | PAT with `project`, `read:org` | Modify org-level project board fields |
+| `ORG_GITHUB_TOKEN` | PAT with `repo` across llm-d orgs | Cross-repo validation checks |
+
+Both are org-level secrets on the `llm-d` org.
+
+## FAQ
+
+**Q: My repo isn't in the dropdown. How do I add it?**
+A: Edit `.github/ISSUE_TEMPLATE/release-readiness.yml` in `llm-d/llm-d` and add your repo to the dropdown options. Also add it to the `PRODUCTION_REPOS` or `INCUBATION_REPOS` list in `release-readiness-lifecycle.yml`.
+
+**Q: I missed the code freeze. Can I still get included?**
+A: Talk to the release team. They can manually add `readiness/validated` if the risk is acceptable.
+
+**Q: The automated checks flagged something that doesn't apply to my repo.**
+A: Some checks (e.g., container image, nightly E2E) are skipped if not applicable. If a check is incorrectly failing, comment on your readiness issue and the release team will review.
+
+**Q: How do I see which repos haven't filed yet?**
+A: Check the tracking meta-issue (`[Release Tracking] vX.Y`) — it has a checklist of all 26 repos. Or run the `status-report` action for a current count.
+
+**Q: Do incubation repos have the same requirements as production?**
+A: Yes, the same 24 checks run. The `tier/incubation` label is informational — the release team may apply different criteria for blocking.


### PR DESCRIPTION
## Summary

- Adds release readiness issue template for all 26 shipping repos (12 production + 14 incubation)
- Board sync workflow: auto-adds issues to org-level "llm-d Release Readiness" project board, sets custom fields (Status, Release, Repo, Tier, Validation Score, etc.)
- Validation workflow: runs 24 automated checks across 6 categories (CI Health, Governance, Artifacts, Testing, Docs, Hygiene) and posts results as issue comment
- Lifecycle workflow: auto-opens release cycles (25th of month), generates status reports, and closes cycles post-release
- 11 new labels created: 7 `readiness/*` status labels, 2 `release/vX.Y` labels, 2 `tier/*` labels

### Files

| File | Purpose |
|---|---|
| `.github/ISSUE_TEMPLATE/release-readiness.yml` | Issue template for repo maintainers |
| `.github/workflows/release-readiness-board.yml` | Board sync (issue → project fields) |
| `.github/workflows/release-readiness-validate.yml` | 24-check validation engine |
| `.github/workflows/release-readiness-lifecycle.yml` | Monthly open/close/report cycle |

### Prerequisites

- [ ] Create org-level project board "llm-d Release Readiness" (requires `project` scope on PAT)
- [ ] Add `PROJECT_TOKEN` secret (PAT with `project` + `read:org` scope)
- [ ] `ORG_GITHUB_TOKEN` secret already exists for cross-repo access

### Labels created

`readiness/filed`, `readiness/validating`, `readiness/passing`, `readiness/failing`, `readiness/blocked`, `readiness/validated`, `readiness/released`, `release/v0.7`, `release/v0.8`, `tier/production`, `tier/incubation`

## Test plan

- [ ] Create project board and add custom fields
- [ ] Merge this PR
- [ ] File a test readiness issue for `llm-d-prism` @ `v0.7.0`
- [ ] Verify: issue appears on board with correct fields populated
- [ ] Verify: validation comment posted with 24-check results
- [ ] Verify: labels applied (`readiness/passing` or `readiness/failing`)
- [ ] Test `/revalidate` comment trigger
- [ ] Test lifecycle workflow `status-report` action