### PR TITLE
fix: use WORKFLOW_TOKEN for fork PR /test-nightly push

### DIFF
--- a/.github/workflows/slash-test-nightly.yaml
+++ b/.github/workflows/slash-test-nightly.yaml
@@ -34,6 +34,7 @@ permissions:
   contents: write
   pull-requests: write
   actions: write
+  workflows: write
 
 # Use comment ID in concurrency group so different /test-nightly
 # commands on the same PR can run in parallel.
@@ -215,7 +216,7 @@ jobs:
           MATCH_NAMES: ${{ steps.parse.outputs.match_names }}
           HEAD_REF: ${{ steps.pr.outputs.head_ref }}
           IS_FORK: ${{ steps.pr.outputs.is_fork }}
-          GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "$IS_FORK" = "true" ]; then
             # Include comment ID to avoid races when multiple /test-nightly

--- a/.github/workflows/slash-test-nightly.yaml
+++ b/.github/workflows/slash-test-nightly.yaml
@@ -219,6 +219,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "$IS_FORK" = "true" ]; then
+            if [ -z "$GITHUB_TOKEN" ]; then
+              echo "::error::Fork PR /test-nightly runs require the repository secret WORKFLOW_TOKEN to be configured with contents:write and workflows permissions."
+              exit 1
+            fi
             # Include comment ID to avoid races when multiple /test-nightly
             # commands on the same PR run concurrently.
             BRANCH="test-nightly/pr-${PR_NUMBER}-${{ github.event.comment.id }}"

--- a/.github/workflows/slash-test-nightly.yaml
+++ b/.github/workflows/slash-test-nightly.yaml
@@ -215,7 +215,7 @@ jobs:
           MATCH_NAMES: ${{ steps.parse.outputs.match_names }}
           HEAD_REF: ${{ steps.pr.outputs.head_ref }}
           IS_FORK: ${{ steps.pr.outputs.is_fork }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
         run: |
           if [ "$IS_FORK" = "true" ]; then
             # Include comment ID to avoid races when multiple /test-nightly


### PR DESCRIPTION
## Summary

- Restores `workflows: write` permission that was removed in #1260 (Apr 24)
- This broke `/test-nightly` for **fork PRs** — pushing a temp branch containing `.github/workflows/` files requires the `workflows` permission
- The permission was originally added in #1245 (Apr 23) for exactly this reason

## Root Cause

PR #1260 removed `workflows: write` from the permissions block on Apr 24. After that, any fork PR using `/test-nightly` fails with:

```
refusing to allow a GitHub App to create or update workflow
`.github/workflows/nightly-e2e-*.yaml` without `workflows` permission
```

Non-fork PRs still work because they don't need to push a temp branch.

## Timeline

| Date | Event |
|------|-------|
| Apr 23 | #1245 added `workflows: write` |
| Apr 24 | #1260 **removed** it |
| Apr 28 20:45 UTC | First fork PR failure (PR #1282) |
| May 1 | Reported by Rob via Marcio |

No new secrets needed — just restoring the YAML permission line.