### PR TITLE
fix: remove invalid workflows permission, use WORKFLOW_TOKEN PAT

### DIFF
--- a/.github/workflows/slash-test-nightly.yaml
+++ b/.github/workflows/slash-test-nightly.yaml
@@ -34,7 +34,6 @@ permissions:
   contents: write
   pull-requests: write
   actions: write
-  workflows: write
 
 # Use comment ID in concurrency group so different /test-nightly
 # commands on the same PR can run in parallel.
@@ -216,17 +215,17 @@ jobs:
           MATCH_NAMES: ${{ steps.parse.outputs.match_names }}
           HEAD_REF: ${{ steps.pr.outputs.head_ref }}
           IS_FORK: ${{ steps.pr.outputs.is_fork }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
         run: |
           if [ "$IS_FORK" = "true" ]; then
-            if [ -z "$GITHUB_TOKEN" ]; then
-              echo "::error::Fork PR /test-nightly runs require the repository secret WORKFLOW_TOKEN to be configured with contents:write and workflows permissions."
+            if [ -z "$WORKFLOW_TOKEN" ]; then
+              echo "::error::Fork PR /test-nightly runs require the org secret WORKFLOW_TOKEN (a fine-grained PAT with contents:write and workflows permissions)."
               exit 1
             fi
             # Include comment ID to avoid races when multiple /test-nightly
             # commands on the same PR run concurrently.
             BRANCH="test-nightly/pr-${PR_NUMBER}-${{ github.event.comment.id }}"
-            git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+            git remote set-url origin "https://x-access-token:${WORKFLOW_TOKEN}@github.com/${{ github.repository }}.git"
             git checkout -b "$BRANCH"
             # Add an empty commit so the branch tip has a fresh timestamp
             # (used by cleanup to determine branch age)


### PR DESCRIPTION
## Summary

- Removes `workflows: write` from the permissions block — it's not a valid `GITHUB_TOKEN` permission and caused `Invalid workflow file` on line 37, preventing the workflow from triggering at all
- Switches the fork PR temp-branch push from `GITHUB_TOKEN` to the org secret `WORKFLOW_TOKEN` (a fine-grained PAT with `contents:write` + `workflows` scope)

## Root Cause

PR #1335 added `workflows: write` to fix fork PR pushes, but `workflows` is not a valid permission for `GITHUB_TOKEN`. GitHub rejected the entire workflow file, breaking `/test-nightly` for **all** PRs (not just forks).

The correct fix is a separate PAT with workflows scope, stored as `WORKFLOW_TOKEN`.

## Test plan

- [ ] Comment `/test-nightly simulated-accelerators` on a fork PR to verify the full flow
- [ ] Comment `/test-nightly simulated-accelerators` on a non-fork PR to verify no regression