### PR TITLE
fix: persist-credentials false so WORKFLOW_TOKEN works for fork pushes

### DIFF
--- a/.github/workflows/slash-test-nightly.yaml
+++ b/.github/workflows/slash-test-nightly.yaml
@@ -34,7 +34,6 @@ permissions:
   contents: write
   pull-requests: write
   actions: write
-  workflows: write
 
 # Use comment ID in concurrency group so different /test-nightly
 # commands on the same PR can run in parallel.
@@ -216,17 +215,17 @@ jobs:
           MATCH_NAMES: ${{ steps.parse.outputs.match_names }}
           HEAD_REF: ${{ steps.pr.outputs.head_ref }}
           IS_FORK: ${{ steps.pr.outputs.is_fork }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
         run: |
           if [ "$IS_FORK" = "true" ]; then
-            if [ -z "$GITHUB_TOKEN" ]; then
-              echo "::error::Fork PR /test-nightly runs require the repository secret WORKFLOW_TOKEN to be configured with contents:write and workflows permissions."
+            if [ -z "$WORKFLOW_TOKEN" ]; then
+              echo "::error::Fork PR /test-nightly runs require the org secret WORKFLOW_TOKEN (a fine-grained PAT with contents:write and workflows permissions)."
               exit 1
             fi
             # Include comment ID to avoid races when multiple /test-nightly
             # commands on the same PR run concurrently.
             BRANCH="test-nightly/pr-${PR_NUMBER}-${{ github.event.comment.id }}"
-            git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+            git remote set-url origin "https://x-access-token:${WORKFLOW_TOKEN}@github.com/${{ github.repository }}.git"
             git checkout -b "$BRANCH"
             # Add an empty commit so the branch tip has a fresh timestamp
             # (used by cleanup to determine branch age)

--- a/.github/workflows/slash-test-nightly.yaml
+++ b/.github/workflows/slash-test-nightly.yaml
@@ -220,7 +220,7 @@ jobs:
         run: |
           if [ "$IS_FORK" = "true" ]; then
             if [ -z "$WORKFLOW_TOKEN" ]; then
-              echo "::error::Fork PR /test-nightly runs require the org secret WORKFLOW_TOKEN (a fine-grained PAT with contents:write and workflows permissions)."
+              echo "::error::Fork PR /test-nightly runs require WORKFLOW_TOKEN to be configured with permission to push branches and trigger workflows (for example, a fine-grained PAT with Contents: write and Actions: write, or a classic PAT with repo and workflow scope)."
               exit 1
             fi
             # Include comment ID to avoid races when multiple /test-nightly

--- a/.github/workflows/slash-test-nightly.yaml
+++ b/.github/workflows/slash-test-nightly.yaml
@@ -206,6 +206,7 @@ jobs:
         with:
           ref: refs/pull/${{ steps.pr.outputs.pr_number }}/head
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Push temp branch (fork PRs only)
         if: steps.parse.outputs.result == 'ok' && steps.perm.outputs.result == 'ok'


### PR DESCRIPTION
## Summary

- Adds `persist-credentials: false` to the `actions/checkout` step in the `/test-nightly` workflow
- Without this, `actions/checkout` sets an `http.extraheader` with `GITHUB_TOKEN` auth that **overrides** the `git remote set-url` using `WORKFLOW_TOKEN`, causing the push to use `GITHUB_TOKEN` (which lacks `workflows` permission)

## Root Cause

`actions/checkout` defaults to `persist-credentials: true`, which configures a git credential helper using `GITHUB_TOKEN`. This takes precedence over `git remote set-url`, so the `WORKFLOW_TOKEN` PAT (with `repo` + `workflow` scopes) was never actually used for the push.

## Test plan

- [ ] Comment `/test-nightly simulated-accelerators` on a fork PR after merge