### PR TITLE
[CI] Add predicted-latency-based-scheduling nightly E2E (OCP/GKE/CKS)

### DIFF
--- a/.github/scripts/e2e/e2e-validate-predicted-latency.sh
+++ b/.github/scripts/e2e/e2e-validate-predicted-latency.sh
@@ -127,13 +127,16 @@ PAYLOAD=$(printf '{"model":"%s","prompt":"Tell me a short story.","max_tokens":3
 kubectl exec -n "$NAMESPACE" "$CURL_POD_NAME" -- sh -c "cat > /tmp/payload.json" <<<"$PAYLOAD"
 
 echo "Sending $ITERATIONS requests with concurrency $CONCURRENCY..."
+# Tolerate partial failures: a single curl that fails to connect would otherwise
+# propagate up through xargs/kubectl exec under `set -e` and abort the script
+# before we get to the ok/fail accounting and the metrics check below.
 status_log=$(kubectl exec -n "$NAMESPACE" "$CURL_POD_NAME" -- sh -c "
   seq 1 $ITERATIONS | xargs -I{} -P $CONCURRENCY \
     curl -sS --max-time 60 -o /dev/null -w '%{http_code}\n' \
       -X POST 'http://${SVC_HOST}/v1/completions' \
       -H 'content-type: application/json' \
       --data-binary @/tmp/payload.json
-")
+" || true)
 
 ok=$(echo "$status_log" | grep -c '^200$' || true)
 fail=$(echo "$status_log" | grep -cv '^200$' || true)

--- a/.github/scripts/e2e/e2e-validate-predicted-latency.sh
+++ b/.github/scripts/e2e/e2e-validate-predicted-latency.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# -----------------------------------------------------------------------------
+# e2e-validate-predicted-latency.sh
+# -----------------------------------------------------------------------------
+# Validates the predicted-latency-based-scheduling guide.
+#
+# The default e2e-validate.sh proves the gateway returns 200s, but cannot tell
+# whether the predicted-latency scheduler actually used predictions or silently
+# fell back to the composite KV/queue/prefix heuristic (see
+# docs/wip-docs-new/architecture/advanced/latency-predictor.md — "If the
+# prediction server is unreachable or fails to return a prediction, the latency
+# scorer falls back ...").
+#
+# This script:
+#   1. Sends ITERATIONS requests through the gateway (concurrent), seeding the
+#      predictor's training window.
+#   2. Scrapes the EPP /metrics endpoint and asserts the predicted-TTFT
+#      histogram has samples — proving the predictor served predictions.
+# -----------------------------------------------------------------------------
+
+show_help() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Options:
+  -n, --namespace NAMESPACE     Kubernetes namespace (default: llm-d)
+  -m, --model MODEL_ID          Model to query. If unset, auto-discovers.
+  -i, --iterations N            Total requests to send (default: 100)
+  -c, --concurrency N           Parallel requests (default: 8)
+  -e, --epp-host HOST           EPP service host (default: \$EPP_HOST or \$GATEWAY_HOST)
+  -p, --epp-metrics-port PORT   EPP metrics port (default: 9090)
+  -v, --verbose                 Verbose mode
+  -h, --help                    Show help
+EOF
+  exit 0
+}
+
+NAMESPACE="llm-d"
+CLI_MODEL_ID=""
+ITERATIONS=100
+CONCURRENCY=8
+EPP_METRICS_PORT="${EPP_METRICS_PORT:-9090}"
+EPP_HOST_OVERRIDE="${EPP_HOST:-}"
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -n|--namespace)        NAMESPACE="$2"; shift 2 ;;
+    -m|--model)            CLI_MODEL_ID="$2"; shift 2 ;;
+    -i|--iterations)       ITERATIONS="$2"; shift 2 ;;
+    -c|--concurrency)      CONCURRENCY="$2"; shift 2 ;;
+    -e|--epp-host)         EPP_HOST_OVERRIDE="$2"; shift 2 ;;
+    -p|--epp-metrics-port) EPP_METRICS_PORT="$2"; shift 2 ;;
+    -v|--verbose)          VERBOSE=true; shift ;;
+    -h|--help)             show_help ;;
+    *) echo "Unknown option: $1"; show_help ;;
+  esac
+done
+
+[[ "${VERBOSE}" == "true" ]] && set -x
+
+CURL_POD_NAME="curl-pl-${RANDOM}-$$"
+CURL_POD_TIMEOUT_SECONDS="${CURL_POD_TIMEOUT_SECONDS:-120}"
+
+setup_curl_pod() {
+  kubectl delete pod -n "$NAMESPACE" "$CURL_POD_NAME" --ignore-not-found >/dev/null 2>&1 || true
+  echo "Creating curl pod ${CURL_POD_NAME}..."
+  kubectl run "$CURL_POD_NAME" --namespace "$NAMESPACE" \
+    --image=curlimages/curl --restart=Never -- sleep 3600 >/dev/null
+  if ! kubectl wait --for=condition=Ready pod/"$CURL_POD_NAME" \
+       -n "$NAMESPACE" --timeout="${CURL_POD_TIMEOUT_SECONDS}s"; then
+    echo "Error: curl pod failed to become ready" >&2
+    kubectl describe pod -n "$NAMESPACE" "$CURL_POD_NAME" >&2 || true
+    exit 1
+  fi
+}
+
+cleanup_curl_pod() {
+  kubectl delete pod -n "$NAMESPACE" "$CURL_POD_NAME" --ignore-not-found >/dev/null 2>&1 || true
+}
+trap cleanup_curl_pod EXIT
+
+run_curl() {
+  CURL_OUTPUT=""; CURL_EXIT=0
+  CURL_OUTPUT=$(kubectl exec -n "$NAMESPACE" "$CURL_POD_NAME" -- "$@" 2>&1) || CURL_EXIT=$?
+}
+
+# ── Discover gateway address ────────────────────────────────────────────────
+HOST="${GATEWAY_HOST:-$(kubectl get gateway -n "$NAMESPACE" \
+        -o jsonpath='{.items[0].status.addresses[0].value}' 2>/dev/null || true)}"
+if [[ -z "$HOST" ]]; then
+  echo "Error: could not discover Gateway address in namespace '$NAMESPACE'." >&2
+  exit 1
+fi
+SVC_HOST="${HOST}:80"
+EPP_HOST="${EPP_HOST_OVERRIDE:-$HOST}"
+EPP_METRICS_URL="http://${EPP_HOST}:${EPP_METRICS_PORT}/metrics"
+
+setup_curl_pod
+
+# ── Discover model ──────────────────────────────────────────────────────────
+if [[ -n "$CLI_MODEL_ID" ]]; then
+  MODEL_ID="$CLI_MODEL_ID"
+elif [[ -n "${MODEL_ID-}" ]]; then
+  : # already set in env
+else
+  echo "Auto-discovering model from ${SVC_HOST}/v1/models..."
+  MODEL_ID=""
+  for _ in $(seq 1 10); do
+    run_curl curl -sS --max-time 15 "http://${SVC_HOST}/v1/models" || true
+    MODEL_ID=$(echo "${CURL_OUTPUT}" | grep -o '"id":"[^"]*"' | head -n 1 | cut -d '"' -f 4) || true
+    [[ -n "$MODEL_ID" ]] && break
+    sleep 10
+  done
+  if [[ -z "$MODEL_ID" ]]; then
+    echo "Error: could not auto-discover model after 10 attempts." >&2
+    exit 1
+  fi
+fi
+
+echo "Namespace=$NAMESPACE Gateway=${SVC_HOST} EPP=${EPP_METRICS_URL} Model=${MODEL_ID} Iterations=${ITERATIONS} Concurrency=${CONCURRENCY}"
+
+# ── Warmup loop: feed the predictor's training window ───────────────────────
+PAYLOAD=$(printf '{"model":"%s","prompt":"Tell me a short story.","max_tokens":32}' "$MODEL_ID")
+kubectl exec -n "$NAMESPACE" "$CURL_POD_NAME" -- sh -c "cat > /tmp/payload.json" <<<"$PAYLOAD"
+
+echo "Sending $ITERATIONS requests with concurrency $CONCURRENCY..."
+status_log=$(kubectl exec -n "$NAMESPACE" "$CURL_POD_NAME" -- sh -c "
+  seq 1 $ITERATIONS | xargs -I{} -P $CONCURRENCY \
+    curl -sS --max-time 60 -o /dev/null -w '%{http_code}\n' \
+      -X POST 'http://${SVC_HOST}/v1/completions' \
+      -H 'content-type: application/json' \
+      --data-binary @/tmp/payload.json
+")
+
+ok=$(echo "$status_log" | grep -c '^200$' || true)
+fail=$(echo "$status_log" | grep -cv '^200$' || true)
+echo "Warmup result: ok=$ok fail=$fail"
+if [[ "$ok" -eq 0 ]]; then
+  echo "Error: zero successful warmup requests — gateway/model server is not serving traffic." >&2
+  exit 1
+fi
+
+# ── Scrape EPP /metrics ─────────────────────────────────────────────────────
+echo "Scraping EPP metrics at ${EPP_METRICS_URL}..."
+run_curl curl -sS --max-time 15 "${EPP_METRICS_URL}"
+metrics="$CURL_OUTPUT"
+if [[ "$CURL_EXIT" -ne 0 || -z "$metrics" ]]; then
+  echo "Error: failed to scrape ${EPP_METRICS_URL} (exit $CURL_EXIT)" >&2
+  echo "$metrics" >&2
+  exit 1
+fi
+
+# Sum *_count samples across all label combinations for a histogram series.
+sum_histogram_count() {
+  echo "$metrics" \
+    | awk -v series="${1}_count" '
+        $1 ~ "^"series"(\\{|$)" { gsub(/[^0-9.eE+-]/, "", $NF); sum += $NF }
+        END { printf("%d\n", (sum=="" ? 0 : sum)) }
+      '
+}
+
+ACTUAL=$(sum_histogram_count inference_objective_request_ttft_seconds)
+PREDICTED=$(sum_histogram_count inference_objective_request_predicted_ttft_seconds)
+
+echo "actual_ttft_count=${ACTUAL} predicted_ttft_count=${PREDICTED}"
+
+if [[ "$ACTUAL" -eq 0 ]]; then
+  echo "Error: actual TTFT histogram is empty — request flow itself didn't reach the EPP." >&2
+  exit 1
+fi
+if [[ "$PREDICTED" -eq 0 ]]; then
+  echo "Error: predicted TTFT histogram is empty after ${ITERATIONS} requests." >&2
+  echo "       The scheduler likely fell back to the composite KV/queue/prefix heuristic." >&2
+  echo "       Inspect EPP logs for 'prediction server unreachable' or training-server errors." >&2
+  exit 1
+fi
+
+echo "✅ Predicted-latency scheduling is active: predictor returned predictions for ${PREDICTED} requests."

--- a/.github/scripts/e2e/e2e-validate-predicted-latency.sh
+++ b/.github/scripts/e2e/e2e-validate-predicted-latency.sh
@@ -87,11 +87,30 @@ run_curl() {
   CURL_OUTPUT=$(kubectl exec -n "$NAMESPACE" "$CURL_POD_NAME" -- "$@" 2>&1) || CURL_EXIT=$?
 }
 
-# ── Discover gateway address ────────────────────────────────────────────────
-HOST="${GATEWAY_HOST:-$(kubectl get gateway -n "$NAMESPACE" \
-        -o jsonpath='{.items[0].status.addresses[0].value}' 2>/dev/null || true)}"
+# ── Discover EPP service ────────────────────────────────────────────────────
+# The predicted-latency guide deploys the llm-d Router in standalone mode —
+# there is no Gateway resource. Both the request flow (port 80, Envoy sidecar)
+# and the metrics endpoint (port 9090) are served by the EPP service itself,
+# so we resolve directly to the EPP service's ClusterIP.
+#
+# Multi-replica caveat: when more than one EPP pod is running, /metrics is
+# forwarded to one pod at random per scrape, so the histogram counts reflect
+# only that pod's view. base.values.yaml currently sets replicas: 1 so this
+# is fine; future scale-out will need per-pod scraping (port-forward or
+# headless service).
+HOST="${GATEWAY_HOST:-}"
 if [[ -z "$HOST" ]]; then
-  echo "Error: could not discover Gateway address in namespace '$NAMESPACE'." >&2
+  EPP_SVC_NAME=$(kubectl get svc -n "$NAMESPACE" \
+      -o jsonpath='{.items[*].metadata.name}' 2>/dev/null \
+      | tr ' ' '\n' | grep -E -- '-epp$' | head -1 || true)
+  if [[ -n "$EPP_SVC_NAME" ]]; then
+    HOST=$(kubectl get svc "$EPP_SVC_NAME" -n "$NAMESPACE" \
+      -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)
+  fi
+fi
+if [[ -z "$HOST" ]]; then
+  echo "Error: could not discover EPP service in namespace '$NAMESPACE'." >&2
+  echo "       Set GATEWAY_HOST env var to the EPP service name or ClusterIP." >&2
   exit 1
 fi
 SVC_HOST="${HOST}:80"

--- a/.github/scripts/e2e/e2e-validate.sh
+++ b/.github/scripts/e2e/e2e-validate.sh
@@ -13,8 +13,9 @@ Options:
   -n, --namespace NAMESPACE   Kubernetes namespace (default: llm-d)
   -m, --model MODEL_ID        Model to query. If unset, discovers the first available model.
   -v, --verbose               Echo kubectl/curl commands before running
-  --predicted-latency         After the smoke loop, run e2e-validate-predicted-latency.sh
-                              to assert the predictor returned predictions.
+  --extra-validate NAME       After the smoke loop, hand off to e2e-validate-NAME.sh
+                              for guide-specific validation (e.g. NAME=predicted-latency
+                              runs e2e-validate-predicted-latency.sh).
   -h, --help                  Show this help and exit
 EOF
   exit 0
@@ -24,7 +25,7 @@ EOF
 NAMESPACE="llm-d"
 CLI_MODEL_ID=""
 VERBOSE=false
-RUN_PREDICTED_LATENCY_CHECK=false
+EXTRA_VALIDATE=""
 
 # ── Flag parsing ────────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
@@ -32,7 +33,7 @@ while [[ $# -gt 0 ]]; do
     -n|--namespace)      NAMESPACE="$2"; shift 2 ;;
     -m|--model)          CLI_MODEL_ID="$2"; shift 2 ;;
     -v|--verbose)        VERBOSE=true; shift ;;
-    --predicted-latency) RUN_PREDICTED_LATENCY_CHECK=true; shift ;;
+    --extra-validate)    EXTRA_VALIDATE="$2"; shift 2 ;;
     -h|--help)           show_help ;;
     *) echo "Unknown option: $1"; show_help ;;
   esac
@@ -207,16 +208,21 @@ done
 
 echo "✅ All 10 iterations succeeded."
 
-# ── Optional: predicted-latency-specific validation ─────────────────────────
-# When --predicted-latency is set, hand off to the dedicated validator. We
+# ── Optional: hand off to a guide-specific validator ────────────────────────
+# When --extra-validate NAME is set, exec into ${SCRIPT_DIR}/e2e-validate-NAME.sh
+# so guides can layer their own checks on top of the standard smoke loop. We
 # release the smoke-test curl pod first (the dispatched script creates its
 # own) and clear the EXIT trap before exec'ing.
-if [[ "$RUN_PREDICTED_LATENCY_CHECK" == "true" ]]; then
+if [[ -n "$EXTRA_VALIDATE" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  EXTRA_SCRIPT="${SCRIPT_DIR}/e2e-validate-${EXTRA_VALIDATE}.sh"
+  if [[ ! -x "$EXTRA_SCRIPT" ]]; then
+    echo "Error: --extra-validate '${EXTRA_VALIDATE}' but ${EXTRA_SCRIPT} is not executable" >&2
+    exit 1
+  fi
   echo
-  echo "=== Running predicted-latency validation ==="
+  echo "=== Running extra validation: ${EXTRA_VALIDATE} ==="
   cleanup_curl_pod
   trap - EXIT
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  exec "${SCRIPT_DIR}/e2e-validate-predicted-latency.sh" \
-    -n "$NAMESPACE" -m "$MODEL_ID"
+  exec "$EXTRA_SCRIPT" -n "$NAMESPACE" -m "$MODEL_ID"
 fi

--- a/.github/scripts/e2e/e2e-validate.sh
+++ b/.github/scripts/e2e/e2e-validate.sh
@@ -13,6 +13,8 @@ Options:
   -n, --namespace NAMESPACE   Kubernetes namespace (default: llm-d)
   -m, --model MODEL_ID        Model to query. If unset, discovers the first available model.
   -v, --verbose               Echo kubectl/curl commands before running
+  --predicted-latency         After the smoke loop, run e2e-validate-predicted-latency.sh
+                              to assert the predictor returned predictions.
   -h, --help                  Show this help and exit
 EOF
   exit 0
@@ -22,14 +24,16 @@ EOF
 NAMESPACE="llm-d"
 CLI_MODEL_ID=""
 VERBOSE=false
+RUN_PREDICTED_LATENCY_CHECK=false
 
 # ── Flag parsing ────────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
   case $1 in
-    -n|--namespace) NAMESPACE="$2"; shift 2 ;;
-    -m|--model)     CLI_MODEL_ID="$2"; shift 2 ;;
-    -v|--verbose)   VERBOSE=true; shift ;;
-    -h|--help)      show_help ;;
+    -n|--namespace)      NAMESPACE="$2"; shift 2 ;;
+    -m|--model)          CLI_MODEL_ID="$2"; shift 2 ;;
+    -v|--verbose)        VERBOSE=true; shift ;;
+    --predicted-latency) RUN_PREDICTED_LATENCY_CHECK=true; shift ;;
+    -h|--help)           show_help ;;
     *) echo "Unknown option: $1"; show_help ;;
   esac
 done
@@ -202,3 +206,17 @@ for i in {1..10}; do
 done
 
 echo "✅ All 10 iterations succeeded."
+
+# ── Optional: predicted-latency-specific validation ─────────────────────────
+# When --predicted-latency is set, hand off to the dedicated validator. We
+# release the smoke-test curl pod first (the dispatched script creates its
+# own) and clear the EXIT trap before exec'ing.
+if [[ "$RUN_PREDICTED_LATENCY_CHECK" == "true" ]]; then
+  echo
+  echo "=== Running predicted-latency validation ==="
+  cleanup_curl_pod
+  trap - EXIT
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  exec "${SCRIPT_DIR}/e2e-validate-predicted-latency.sh" \
+    -n "$NAMESPACE" -m "$MODEL_ID"
+fi

--- a/.github/workflows/nightly-e2e-predicted-latency-cks.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-cks.yaml
@@ -41,8 +41,8 @@ jobs:
           oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
           -f guides/recipes/scheduler/base.values.yaml \
           -f guides/predicted-latency-based-scheduling/scheduler/predicted-latency.values.yaml \
-          -n ${NAMESPACE} --version v1.4.0
-      e2e_validate_args: '--predicted-latency'
+          -n ${NAMESPACE} --version v1.5.0
+      e2e_validate_args: '--extra-validate predicted-latency'
       accelerator_type: H100
       required_gpus: 2
       recommended_gpus: 4

--- a/.github/workflows/nightly-e2e-predicted-latency-cks.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-cks.yaml
@@ -1,0 +1,54 @@
+name: Nightly - Predicted Latency E2E (CKS)
+
+# Nightly regression test for the predicted-latency-based-scheduling guide on
+# CoreWeave (CKS). Deploys the optimized-baseline model server (the
+# predicted-latency guide reuses these pods via the
+# `llm-d.ai/guide=optimized-baseline` selector) plus the predicted-latency
+# scheduler chart. Passes --predicted-latency via e2e_validate_args so
+# e2e-validate.sh dispatches to e2e-validate-predicted-latency.sh after the
+# smoke loop, sending 100 requests and asserting the EPP's predicted-TTFT
+# histogram populated — proving the predictor returned predictions instead of
+# silently falling back to the composite KV/queue/prefix heuristic.
+
+on:
+  schedule:
+    - cron: '0 7 * * *'  # 07:00 UTC daily (staggered)
+  workflow_dispatch:
+    inputs:
+      skip_cleanup:
+        description: 'Skip cleanup after tests (for debugging)'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-e2e-predicted-latency-cks
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    if: github.repository == 'llm-d/llm-d'
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-cks.yaml@main
+    with:
+      guide_name: predicted-latency-based-scheduling
+      namespace: llm-d-nightly-predicted-latency-cks
+      gateway_host: 'predicted-latency-based-scheduling-epp'
+      custom_deploy_script: |
+        kubectl apply -k guides/optimized-baseline/modelserver/gpu/vllm -n ${NAMESPACE}
+        helm install predicted-latency-based-scheduling \
+          oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
+          -f guides/recipes/scheduler/base.values.yaml \
+          -f guides/predicted-latency-based-scheduling/scheduler/predicted-latency.values.yaml \
+          -n ${NAMESPACE} --version v1.4.0
+      e2e_validate_args: '--predicted-latency'
+      accelerator_type: H100
+      required_gpus: 2
+      recommended_gpus: 4
+      pod_wait_timeout: '30m'
+      pod_readiness_delay: 180
+      image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
+      allow_gpu_preemption: true
+      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+    secrets: inherit

--- a/.github/workflows/nightly-e2e-predicted-latency-gke.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-gke.yaml
@@ -36,7 +36,7 @@ jobs:
       namespace: llm-d-nightly-predicted-latency-gke
       gateway_host: 'predicted-latency-based-scheduling-epp'
       custom_deploy_script: |
-        kubectl apply -k guides/optimized-baseline/modelserver/gpu/vllm -n ${NAMESPACE}
+        kubectl apply -k guides/optimized-baseline/modelserver/gpu/gke-patch/vllm -n ${NAMESPACE}
         helm install predicted-latency-based-scheduling \
           oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
           -f guides/recipes/scheduler/base.values.yaml \

--- a/.github/workflows/nightly-e2e-predicted-latency-gke.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-gke.yaml
@@ -1,0 +1,57 @@
+name: Nightly - Predicted Latency E2E (GKE)
+
+# Nightly regression test for the predicted-latency-based-scheduling guide on
+# GKE. Deploys the optimized-baseline model server (the predicted-latency
+# guide reuses these pods via the `llm-d.ai/guide=optimized-baseline`
+# selector) plus the predicted-latency scheduler chart. Passes
+# --predicted-latency via e2e_validate_args so e2e-validate.sh dispatches to
+# e2e-validate-predicted-latency.sh after the smoke loop, sending 100 requests
+# and asserting the EPP's predicted-TTFT histogram populated — proving the
+# predictor returned predictions instead of silently falling back to the
+# composite KV/queue/prefix heuristic.
+
+on:
+  schedule:
+    - cron: '0 13 * * *'  # 13:00 UTC daily (staggered)
+  workflow_dispatch:
+    inputs:
+      skip_cleanup:
+        description: 'Skip cleanup after tests (for debugging)'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-e2e-predicted-latency-gke
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    if: github.repository == 'llm-d/llm-d'
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke.yaml@main
+    with:
+      guide_name: predicted-latency-based-scheduling
+      namespace: llm-d-nightly-predicted-latency-gke
+      gateway_host: 'predicted-latency-based-scheduling-epp'
+      custom_deploy_script: |
+        kubectl apply -k guides/optimized-baseline/modelserver/gpu/vllm -n ${NAMESPACE}
+        helm install predicted-latency-based-scheduling \
+          oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
+          -f guides/recipes/scheduler/base.values.yaml \
+          -f guides/predicted-latency-based-scheduling/scheduler/predicted-latency.values.yaml \
+          -n ${NAMESPACE} --version v1.4.0
+      e2e_validate_args: '--predicted-latency'
+      gke_cluster_name: llm-d-e2e-us-east5
+      gke_cluster_zone: us-east5
+      required_gpus: 2
+      recommended_gpus: 4
+      accelerator_type: H100
+      pod_wait_timeout: '30m'
+      pod_readiness_delay: 180
+      image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
+      allow_gpu_preemption: true
+      llm_d_ref: ${{ github.ref }}
+      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+    secrets: inherit

--- a/.github/workflows/nightly-e2e-predicted-latency-gke.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-gke.yaml
@@ -41,8 +41,8 @@ jobs:
           oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
           -f guides/recipes/scheduler/base.values.yaml \
           -f guides/predicted-latency-based-scheduling/scheduler/predicted-latency.values.yaml \
-          -n ${NAMESPACE} --version v1.4.0
-      e2e_validate_args: '--predicted-latency'
+          -n ${NAMESPACE} --version v1.5.0
+      e2e_validate_args: '--extra-validate predicted-latency'
       gke_cluster_name: llm-d-e2e-us-east5
       gke_cluster_zone: us-east5
       required_gpus: 2

--- a/.github/workflows/nightly-e2e-predicted-latency-ocp.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-ocp.yaml
@@ -1,0 +1,58 @@
+name: Nightly - Predicted Latency E2E (OpenShift)
+
+# Nightly regression test for the predicted-latency-based-scheduling guide on
+# OpenShift. Deploys the optimized-baseline model server (the predicted-latency
+# guide reuses these pods via the `llm-d.ai/guide=optimized-baseline` selector)
+# plus the predicted-latency scheduler chart. Passes --predicted-latency via
+# e2e_validate_args so e2e-validate.sh dispatches to
+# e2e-validate-predicted-latency.sh after the smoke loop, sending 100 requests
+# and asserting the EPP's predicted-TTFT histogram populated — proving the
+# predictor returned predictions instead of silently falling back to the
+# composite KV/queue/prefix heuristic.
+
+on:
+  schedule:
+    - cron: '0 3 * * *'  # 03:00 UTC daily (staggered)
+  workflow_dispatch:
+    inputs:
+      skip_cleanup:
+        description: 'Skip cleanup after tests (for debugging)'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-e2e-predicted-latency
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    if: github.repository == 'llm-d/llm-d'
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift.yaml@main
+    with:
+      guide_name: predicted-latency-based-scheduling
+      namespace: llm-d-nightly-predicted-latency-ocp
+      gateway_host: 'predicted-latency-based-scheduling-epp'
+      custom_deploy_script: |
+        yq '.spec.template.spec.priorityClassName="nightly-gpu-critical"' -i guides/optimized-baseline/modelserver/gpu/vllm/patch-vllm.yaml
+        yq '.spec.template.spec.volumes += {"name": "triton-cache", "emptyDir": {}}' -i guides/optimized-baseline/modelserver/gpu/vllm/patch-vllm.yaml
+        yq '.spec.template.spec.containers[0].volumeMounts += {"mountPath": "/.triton", "name": "triton-cache"}' -i guides/optimized-baseline/modelserver/gpu/vllm/patch-vllm.yaml
+        yq '.spec.replicas=2' -i guides/optimized-baseline/modelserver/gpu/vllm/patch-vllm.yaml
+        kubectl apply -k guides/optimized-baseline/modelserver/gpu/vllm -n ${NAMESPACE}
+        helm install predicted-latency-based-scheduling \
+          oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
+          -f guides/recipes/scheduler/base.values.yaml \
+          -f guides/predicted-latency-based-scheduling/scheduler/predicted-latency.values.yaml \
+          -n ${NAMESPACE} --version v1.4.0
+      e2e_validate_args: '--predicted-latency'
+      accelerator_type: H100
+      required_gpus: 2
+      recommended_gpus: 4
+      pod_wait_timeout: '30m'
+      pod_readiness_delay: 180
+      image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
+      allow_gpu_preemption: true
+      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+    secrets: inherit

--- a/.github/workflows/nightly-e2e-predicted-latency-ocp.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-ocp.yaml
@@ -45,8 +45,8 @@ jobs:
           oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
           -f guides/recipes/scheduler/base.values.yaml \
           -f guides/predicted-latency-based-scheduling/scheduler/predicted-latency.values.yaml \
-          -n ${NAMESPACE} --version v1.4.0
-      e2e_validate_args: '--predicted-latency'
+          -n ${NAMESPACE} --version v1.5.0
+      e2e_validate_args: '--extra-validate predicted-latency'
       accelerator_type: H100
       required_gpus: 2
       recommended_gpus: 4

--- a/docs/wip-docs-new/getting-started/feature-matrix.md
+++ b/docs/wip-docs-new/getting-started/feature-matrix.md
@@ -72,9 +72,11 @@ This page describes the current coverage as validated in the v0.7.0 release and 
 
 | Accelerator | vLLM | SGLang |
 |-------------|------|--------|
-| NVIDIA CUDA | ✅ | — |
+| NVIDIA CUDA | ✅ | ✅ |
 
-**Nightly CI**: None
+**Nightly CI**: OpenShift (CUDA), GKE (CUDA), CoreWeave (CUDA)
+
+> Accelerator-agnostic: only validated on NVIDIA CUDA, but the scheduler logic does not depend on accelerator type and should work on any backend supported by vLLM or SGLang.
 
 ### Asynchronous Processing
 

--- a/docs/wip-docs-new/getting-started/feature-matrix.md
+++ b/docs/wip-docs-new/getting-started/feature-matrix.md
@@ -180,5 +180,5 @@ Each well-lit path guide is assigned a maturity level reflecting its testing and
 | Simulated Accelerators | Medium | OpenShift |
 | Workload Autoscaling (WVA) | Experimental | OpenShift, CoreWeave |
 | Workload Autoscaling (HPA + IGW) | Experimental | — |
-| Predicted Latency-Based Scheduling | Experimental | — |
+| Predicted Latency-Based Scheduling | Medium | OpenShift, GKE, CoreWeave |
 | Asynchronous Processing | Experimental | — |

--- a/guides/predicted-latency-based-scheduling/scheduler/predicted-latency-slo.values.yaml
+++ b/guides/predicted-latency-based-scheduling/scheduler/predicted-latency-slo.values.yaml
@@ -15,6 +15,10 @@ inferenceExtension:
       port: 80
       protocol: TCP
       targetPort: 8081
+    - name: metrics
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
   pluginsConfigFile: "predicted-latency-slo-plugins.yaml"
   pluginsCustomConfig:
     predicted-latency-slo-plugins.yaml: |

--- a/guides/predicted-latency-based-scheduling/scheduler/predicted-latency.values.yaml
+++ b/guides/predicted-latency-based-scheduling/scheduler/predicted-latency.values.yaml
@@ -12,6 +12,10 @@ inferenceExtension:
       port: 80
       protocol: TCP
       targetPort: 8081
+    - name: metrics
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
 
 inferencePool:
   modelServers:


### PR DESCRIPTION
Adds nightly regression tests for the predicted-latency guide on all three nightly providers (OpenShift, GKE, CoreWeave). Each deploys the optimized-baseline model server pods (the predicted-latency guide reuses these via the llm-d.ai/guide=optimized-baseline selector) plus the predicted-latency scheduler chart.

Beyond the standard e2e-validate.sh smoke test, the new e2e-validate-predicted-latency.sh sends 100 requests and scrapes the EPP /metrics endpoint, asserting
inference_objective_request_predicted_ttft_seconds_count > 0. This catches the silent fallback failure mode where the scorer reverts to the composite KV/queue/prefix heuristic — a 200 OK from the gateway alone doesn't prove the predictor is active.

Wired in via a new --predicted-latency flag on e2e-validate.sh, passed through the reusable workflow's existing e2e_validate_args input so the caller workflows stay minimal.

Feature matrix updated: SGLang marked supported for predicted-latency (scheduler is accelerator/server-agnostic, only validated on CUDA), and the nightly CI line set to OpenShift/GKE/CoreWeave.