### PR TITLE
fix: add missing versions to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -30,6 +30,8 @@ body:
       label: Version
       description: What version of our software are you running?
       options:
+        - v0.6.0
+        - v0.5.1
         - v0.5.0
         - v0.4.0
         - v0.3.1


### PR DESCRIPTION
Add v0.5.1 and v0.6.0 to the bug report issue template version dropdown. The dropdown previously only listed up to v0.5.0, preventing reporters from selecting their actual version.

Fixes #1310