### PR TITLE
[Build] Use Proper Wheel Variant

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -74,6 +74,7 @@ ARG VLLM_COMMIT_SHA
 ARG VLLM_PRECOMPILED_WHEEL_COMMIT
 ARG VLLM_PREBUILT
 ARG VLLM_USE_PRECOMPILED
+ARG VLLM_PRECOMPILED_WHEEL_VARIANT=cu${CUDA_MAJOR}${CUDA_MINOR}
 
 # ============================================================================
 # BUILD STAGE - Install build dependencies and create wheels

--- a/docker/scripts/cuda/runtime/install-vllm.sh
+++ b/docker/scripts/cuda/runtime/install-vllm.sh
@@ -18,7 +18,9 @@ set -Eeu
 . /opt/vllm/bin/activate
 
 # default VLLM_PRECOMPILED_WHEEL_COMMIT to VLLM_COMMIT_SHA if not set
+# default VLLM_PRECOMPILED_WHEEL_VARIANT to cu${CUDA_MAJOR}${CUDA_MINOR} if not set
 VLLM_PRECOMPILED_WHEEL_COMMIT="${VLLM_PRECOMPILED_WHEEL_COMMIT:-${VLLM_COMMIT_SHA}}"
+VLLM_PRECOMPILED_WHEEL_VARIANT="${VLLM_PRECOMPILED_WHEEL_VARIANT:-cu${CUDA_MAJOR}${CUDA_MINOR}}"
 
 # build list of packages to install
 # flashinfer-cubin/jit-cache are pre-built wheels (building from source times out)
@@ -76,7 +78,7 @@ fi
 
 # detect if prebuilt wheel exists (using VLLM_PRECOMPILED_WHEEL_COMMIT for lookup)
 # note: vllm wheel index structure isn't pip-compatible, so we scrape the HTML directly
-echo "DEBUG: Looking for wheel at: https://wheels.vllm.ai/${VLLM_PRECOMPILED_WHEEL_COMMIT}/vllm/"
+echo "DEBUG: Looking for wheel at: https://wheels.vllm.ai/${VLLM_PRECOMPILED_WHEEL_COMMIT}/${VLLM_PRECOMPILED_WHEEL_VARIANT}/vllm/"
 echo "DEBUG: Architecture: $(uname -m), Python: $(python3 --version)"
 
 # determine platform tag from architecture
@@ -90,7 +92,7 @@ case "${MACHINE}" in
 esac
 
 # scrape wheel filename from HTML index
-WHEEL_INDEX_HTML=$(curl -sf "https://wheels.vllm.ai/${VLLM_PRECOMPILED_WHEEL_COMMIT}/vllm/" || echo "")
+WHEEL_INDEX_HTML=$(curl -sf "https://wheels.vllm.ai/${VLLM_PRECOMPILED_WHEEL_COMMIT}/${VLLM_PRECOMPILED_WHEEL_VARIANT}/vllm/" || echo "")
 if [ -z "${WHEEL_INDEX_HTML}" ]; then
   echo "DEBUG: Failed to fetch wheel index or index does not exist"
   WHEEL_FILENAME=""
@@ -101,7 +103,7 @@ fi
 if [ -n "${WHEEL_FILENAME}" ]; then
   # construct full URL (wheels are in parent directory)
   # URL-encode the + sign in the wheel filename
-  WHEEL_URL="https://wheels.vllm.ai/${VLLM_PRECOMPILED_WHEEL_COMMIT}/${WHEEL_FILENAME}"
+  WHEEL_URL="https://wheels.vllm.ai/${VLLM_PRECOMPILED_WHEEL_COMMIT}/${VLLM_PRECOMPILED_WHEEL_VARIANT}/${WHEEL_FILENAME}"
   WHEEL_URL=$(echo "${WHEEL_URL}" | sed -E 's/\+/%2B/g')
   echo "DEBUG: Found wheel: ${WHEEL_FILENAME}"
   echo "DEBUG: Wheel URL: ${WHEEL_URL}"
@@ -112,7 +114,7 @@ fi
 
 if [ "${VLLM_PREBUILT}" = "1" ]; then
   if [ -z "${WHEEL_URL}" ]; then
-    echo "VLLM_PREBUILT set but no platform compatible wheel exists for: https://wheels.vllm.ai/${VLLM_PRECOMPILED_WHEEL_COMMIT}/vllm/"
+    echo "VLLM_PREBUILT set but no platform compatible wheel exists for: https://wheels.vllm.ai/${VLLM_PRECOMPILED_WHEEL_COMMIT}/${VLLM_PRECOMPILED_WHEEL_VARIANT}/vllm/"
     exit 1
   fi
   INSTALL_PACKAGES+=("${WHEEL_URL}")

--- a/docker/scripts/cuda/runtime/install-vllm.sh
+++ b/docker/scripts/cuda/runtime/install-vllm.sh
@@ -103,7 +103,9 @@ fi
 if [ -n "${WHEEL_FILENAME}" ]; then
   # construct full URL (wheels are in parent directory)
   # URL-encode the + sign in the wheel filename
-  WHEEL_URL="https://wheels.vllm.ai/${VLLM_PRECOMPILED_WHEEL_COMMIT}/${VLLM_PRECOMPILED_WHEEL_VARIANT}/${WHEEL_FILENAME}"
+  # The wheel url itself does not use the VLLM_PRECOMPILED_WHEEL_VARIANT
+  # suffix, this is part of the wheel filename url
+  WHEEL_URL="https://wheels.vllm.ai/${VLLM_PRECOMPILED_WHEEL_COMMIT}/${WHEEL_FILENAME}"
   WHEEL_URL=$(echo "${WHEEL_URL}" | sed -E 's/\+/%2B/g')
   echo "DEBUG: Found wheel: ${WHEEL_FILENAME}"
   echo "DEBUG: Wheel URL: ${WHEEL_URL}"

--- a/docker/scripts/cuda/runtime/install-vllm.sh
+++ b/docker/scripts/cuda/runtime/install-vllm.sh
@@ -84,10 +84,10 @@ echo "DEBUG: Architecture: $(uname -m), Python: $(python3 --version)"
 # determine platform tag from architecture
 MACHINE=$(uname -m)
 case "${MACHINE}" in
-  x86_64) PLATFORM_TAG="manylinux_2_31_x86_64" ;;
-  amd64) PLATFORM_TAG="manylinux_2_31_x86_64" ;;
-  aarch64) PLATFORM_TAG="manylinux_2_31_aarch64" ;;
-  arm64) PLATFORM_TAG="manylinux_2_31_aarch64" ;;
+  x86_64) PLATFORM_TAG="manylinux_2_35_x86_64" ;;
+  amd64) PLATFORM_TAG="manylinux_2_35_x86_64" ;;
+  aarch64) PLATFORM_TAG="manylinux_2_35_aarch64" ;;
+  arm64) PLATFORM_TAG="manylinux_2_35_aarch64" ;;
   *) echo "unsupported architecture: ${MACHINE}"; exit 1 ;;
 esac
 


### PR DESCRIPTION
SUMMARY:
- in 0.7.0-rc2 vllm startup fails, looking for cu12 runtime
- the images are cu13 now
- we are installing the prebuild vllm binary, which defaults to cu129 for 0.19.1
- this pr updates the precompiled wheel variant to match