### PR TITLE
fix: correct typos in documentation

### DIFF
--- a/docs/wip-docs-new/architecture/advanced/disaggregation/operations-vllm.md
+++ b/docs/wip-docs-new/architecture/advanced/disaggregation/operations-vllm.md
@@ -173,11 +173,11 @@ sequenceDiagram
 
 
 > [!WARNING]
-> Robustness against Decode instance failure is currently a weakness of the design, since the `VLLM_NIXL_ABORT_REQUEST_TIMEOUT` defaults to a long timeout (`480s` to avoid early-free when D instancess are backed up). We recommend that production users consider reducing this timeout, especially if they can ensure Decode instances do not have significant request queuing. We are currently implementing a "lease-extension" system, which will dramatically reduce the timeout with no tradeoff.
+> Robustness against Decode instance failure is currently a weakness of the design, since the `VLLM_NIXL_ABORT_REQUEST_TIMEOUT` defaults to a long timeout (`480s` to avoid early-free when D instances are backed up). We recommend that production users consider reducing this timeout, especially if they can ensure Decode instances do not have significant request queuing. We are currently implementing a "lease-extension" system, which will dramatically reduce the timeout with no tradeoff.
 
 ## Rollouts
 
-In disaggregated serving, rolling out a new version of the model server (e.g. a new version of vLLM or a new configuration) requires care, since prefill-decode instance pairs communicate with eachother to execute the KV transfer operation. As a motivating example, vLLM has multiple attention kernel implementations, each of which can have slightly different KV cache layouts - since NIXL pulls the KVs directly from the GPU KV cache memory of the remote instance, we need to ensure these are matching.
+In disaggregated serving, rolling out a new version of the model server (e.g. a new version of vLLM or a new configuration) requires care, since prefill-decode instance pairs communicate with each other to execute the KV transfer operation. As a motivating example, vLLM has multiple attention kernel implementations, each of which can have slightly different KV cache layouts - since NIXL pulls the KVs directly from the GPU KV cache memory of the remote instance, we need to ensure these are matching.
 
 By default, vLLM checks for [compatibility between instances](https://github.com/vllm-project/vllm/pull/29503) during the NIXL handshake, failing the request if scheduled to incompatible pods. There is an escape hatch to disable compatibility checking:
 

--- a/docs/wip-docs-new/architecture/core/inferencepool.md
+++ b/docs/wip-docs-new/architecture/core/inferencepool.md
@@ -17,7 +17,7 @@ The following diagram visualizes how the `InferencePool` resource is involved in
 
 ### 1. Endpoint Discovery (EPP Perspective)
 
-The EPP uses the `InferencePool` to disocver which pods it can pick from.
+The EPP uses the `InferencePool` to discover which pods it can pick from.
 
 *   **Selector-based Discovery:** The `InferencePool` defines a `selector` (label matching). The EPP watches for Pods that match these labels within the same namespace.
 *   **Dynamic Membership:** As model server Pods are scaled up or down, or as their readiness state changes, the EPP automatically updates its internal list of healthy candidates.

--- a/docs/wip-docs-new/architecture/core/router/epp/datalayer.md
+++ b/docs/wip-docs-new/architecture/core/router/epp/datalayer.md
@@ -49,7 +49,7 @@ flowchart LR
 The Data Layer is built around three primary source types, each paired with a corresponding extractor interface:
 
 ### 1. Polling Data Sources
-Used for periodic retrieval of data from model servers, primarly metrics.
+Used for periodic retrieval of data from model servers, primarily metrics.
 *   **Source Interface**: `PollingDataSource` (e.g., `metrics-data-source`)
 *   **Extractor Interface**: `Extractor` (e.g., `core-metrics-extractor`)
 *   **Workflow**: The runtime starts a `Collector` for every new endpoint. The collector polls the source at a configured interval and passes the result to associated extractors. Metrics pulling is the primary motivation for this type of data source.

--- a/guides/README.md
+++ b/guides/README.md
@@ -17,7 +17,7 @@ We currently offer the following:
 ### Serving Large Models
 
 * [Prefill/Decode Disaggregation](./pd-disaggregation/README.md) - Split inference into specialized prefill and decode instances, improving throughput and quality of service stability for medium and large models like `openai/gpt-oss-120b`.
-* [Wide Expert-Parallelism](./wide-ep-lws/README.md) - Deploy large Mixture-of-Experts (MoE) models like `deepseek-ai/DeepSeek-R1` over mulple nodes via DP/EP configuration, increasing available KV cache space and throughput.
+* [Wide Expert-Parallelism](./wide-ep-lws/README.md) - Deploy large Mixture-of-Experts (MoE) models like `deepseek-ai/DeepSeek-R1` over multiple nodes via DP/EP configuration, increasing available KV cache space and throughput.
 
 ### Operational Excellence
 

--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -117,9 +117,9 @@ helm install ${GUIDE_NAME} \
 Apply the Kustomize overlays for your specific backend (defaulting to NVIDIA GPU / vLLM):
 
 > [!NOTE]
-> The Kuberentes ecosystem has not yet standardized on how to expose
+> The Kubernetes ecosystem has not yet standardized on how to expose
 > NICs to pods. We provide some pre-configured setups for certain
-> Kuberentes providers. You may need to adapt the guides for the
+> Kubernetes providers. You may need to adapt the guides for the
 > specifics of your infrastructure provider. The provider specific
 > overlays deal with the specifics of each cloud's setup.
 

--- a/guides/wide-ep-lws/experimental-dp-aware/README.md
+++ b/guides/wide-ep-lws/experimental-dp-aware/README.md
@@ -25,7 +25,7 @@ We can, therefore, compose the WideEP deployment with the existing scorers (for 
 
 ### Why This is Experimental
 
-We are currently working on hardenening the process management, health checking, and probes in vLLM to handle better this style of deployment. Once this is complete, we will upgrade this guide to the default.
+We are currently working on hardening the process management, health checking, and probes in vLLM to handle better this style of deployment. Once this is complete, we will upgrade this guide to the default.
 
 ## Overview
 

--- a/helpers/benchmark.md
+++ b/helpers/benchmark.md
@@ -580,7 +580,7 @@ The name indicates `inference-perf` was used as harness, the workload was `share
 
 ### Workload file
 
-The harness workload configuration file, as was used, is copied into the the experiment results directory; in this case, `shared_prefix_synthetic.yaml`.
+The harness workload configuration file, as was used, is copied into the experiment results directory; in this case, `shared_prefix_synthetic.yaml`.
 
 <details>
 <summary><b><i>Click</i></b> to view the workload details (<code>shared_prefix_synthetic.yaml</code>)</summary>


### PR DESCRIPTION
Fixes #1240

## Summary
- fixed 9 typos across 7 documentation files

## Test plan
- [x] Verified typos exist before fixing
- [x] No functional changes, documentation only