### PR TITLE
Fix HPU image name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ ifeq ($(BUILD_DEBUG), true)
 	IMAGE_BASE := $(IMAGE_BASE)-debug
 endif
 
-IMG := $(IMAGE_BASE):$(VERSION)-$(ARCH)
+IMG := $(IMAGE_BASE):$(VERSION)
 
 CONTAINER_TOOL := $(shell (command -v docker >/dev/null 2>&1 && echo docker) || (command -v podman >/dev/null 2>&1 && echo podman) || echo "")
 BUILDER := $(shell command -v buildah >/dev/null 2>&1 && echo buildah || echo $(CONTAINER_TOOL))


### PR DESCRIPTION
**Description:**
Remove `-$(ARCH)` suffix from the Makefile `IMG` variable so HPU images are tagged as `v0.7.0-rc.1` instead of `v0.7.0-rc.1-amd64`
@llm-d/release-crew 