### PR TITLE
Add CNCF Sandbox project references to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Achieve SOTA Inference Performance On Any Accelerator
 
 llm-d is a high-performance distributed inference serving stack optimized for production deployments on Kubernetes. We help you achieve the fastest "time to state-of-the-art (SOTA) performance" for key OSS large language models across most hardware accelerators and infrastructure providers with well-tested guides and real-world benchmarks.
 
+llm-d is a [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io/) sandbox project, founded by Red Hat, Google Cloud, IBM Research, CoreWeave, and NVIDIA.
+
 ## What does llm-d offer to production inference?
 
 Model servers like [vLLM](https://docs.vllm.ai) and [SGLang](https://github.com/sgl-project/sglang) handle efficiently running large language models on accelerators. llm-d provides state of the art orchestration above model servers to serve high-scale real world traffic efficiently and reliably:
@@ -37,6 +39,7 @@ We recommend new users start with a deployment of [optimized baseline](./guides/
 
 ### Latest News 🔥
 
+- [2026-03] llm-d [joins the CNCF as a Sandbox project](https://www.cncf.io/blog/2026/03/24/welcome-llm-d-to-the-cncf-evolving-kubernetes-into-sota-ai-infrastructure/)! Founded by Red Hat, Google Cloud, IBM Research, CoreWeave, and NVIDIA, with support from AMD, Cisco, Hugging Face, Intel, Lambda, Mistral AI, UC Berkeley, and University of Chicago. We're excited to collaborate openly on building flexible, future-proof AI infrastructure.
 - [2026-02] The [v0.5](https://llm-d.ai/blog/llm-d-v0.5-sustaining-performance-at-scale) introduces reproducible benchmark workflows, hierarchical KV offloading, cache-aware LoRA routing, active-active HA, UCCL-based transport resilience, and scale-to-zero autoscaling; validated ~3.1k tok/s per B200 decode GPU (wide-EP) and up to 50k output tok/s on a 16×16 B200 prefill/decode topology with order-of-magnitude TTFT reduction vs round-robin baseline.
 - [2025-12] The [v0.4](https://llm-d.ai/blog/llm-d-v0.4-achieve-sota-inference-across-accelerators) release demonstrates 40% reduction in per output token latency for DeepSeek V3.1 on H200 GPUs, Intel XPU and Google TPU disaggregation support for lower time to first token, a new well-lit path for prefix cache offload to vLLM-native CPU memory tiering, and a preview of the workload variant autoscaler improving model-as-a-service efficiency.
 
@@ -94,6 +97,8 @@ Our [guides](./guides/README.md) are living docs and kept current. For details a
 Check out our [roadmap for upcoming releases](https://github.com/llm-d/llm-d/issues?q=is%3Aissue%20state%3Aopen%20%22%5BRoadmap%5D%22).
 
 ## Contribute
+
+We adhere to the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
 - See [our project overview](PROJECT.md) for more details on our development process and governance.
 - Review [our contributing guidelines](CONTRIBUTING.md) for detailed information on how to contribute to the project.


### PR DESCRIPTION
## Summary
Highlights llm-d's status as a CNCF Sandbox project in the README, making the affiliation more visible to users and contributors.

## Changes
- Added CNCF affiliation statement after project description 
- Added March 2026 CNCF announcement as top item in Latest News
- Added CNCF Code of Conduct reference in Contribute section

## Related Links
- CNCF announcement: https://www.cncf.io/blog/2026/03/24/welcome-llm-d-to-the-cncf-evolving-kubernetes-into-sota-ai-infrastructure/
- Similar patterns used in KServe and Envoy AI Gateway READMEs

🤖 Generated with [Claude Code](https://claude.com/claude-code)