### PR TITLE
Add UCCL transport to images

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -35,6 +35,9 @@ ARG GDRCOPY_VERSION="v2.5.2"
 ARG UCX_REPO="https://github.com/openucx/ucx.git"
 ARG UCX_VERSION="v1.20.0"
 
+ARG UCCL_REPO="https://github.com/uccl-project/uccl.git"
+ARG UCCL_VERSION="v0.0.1.post6"
+
 ARG NVSHMEM_USE_GIT="true"
 ARG NVSHMEM_REPO="https://github.com/NVIDIA/nvshmem.git"
 ARG NVSHMEM_VERSION="v3.5.19-1"
@@ -160,6 +163,7 @@ RUN export UV_INSTALL_DIR=/usr/local/bin && \
 # Set up build environment paths
 ENV NVSHMEM_DIR="/opt/nvshmem-${NVSHMEM_VERSION}" \
     UCX_PREFIX="/opt/ucx" \
+    UCCL_PREFIX="/opt/uccl" \
     NIXL_PREFIX="/opt/nixl" \
     EFA_PREFIX="/opt/amazon/efa"
 
@@ -167,11 +171,13 @@ ENV PATH="${NVSHMEM_DIR}/bin:${VIRTUAL_ENV}/bin:${PATH}" \
     LIBRARY_PATH="\
 ${EFA_PREFIX}/lib:${EFA_PREFIX}/lib64:\
 ${UCX_PREFIX}/lib:${UCX_PREFIX}/lib64:\
+${UCCL_PREFIX}/lib:\
 ${NVSHMEM_DIR}/lib:${NVSHMEM_DIR}/lib64:\
 ${CUDA_HOME}/lib64:\
 /usr/local/lib:/usr/local/lib64:\
 ${LIBRARY_PATH}" \
     CPATH="${NVSHMEM_DIR}/include:\
+${UCCL_PREFIX}/include:\
 ${CUDA_HOME}/include:\
 /usr/local/include:\
 /usr/include:\
@@ -206,6 +212,14 @@ RUN --mount=type=cache,target=/var/cache/git \
     --mount=type=secret,id=aws_secret_access_key \
     /tmp/build-ucx.sh && \
     rm -f /tmp/build-ucx.sh
+
+# Build UCCL
+ARG UCCL_REPO
+ARG UCCL_VERSION
+COPY docker/scripts/common/build-uccl.sh /tmp/build-uccl.sh
+RUN --mount=type=cache,target=/var/cache/git \
+    /tmp/build-uccl.sh && \
+    rm -f /tmp/build-uccl.sh
 
 # Build NVSHMEM
 ARG NVSHMEM_USE_GIT
@@ -319,6 +333,7 @@ ENV LANG="C.UTF-8" \
     VIRTUAL_ENV="/opt/vllm" \
     NVSHMEM_DIR="/opt/nvshmem-${NVSHMEM_VERSION}" \
     UCX_PREFIX="/opt/ucx" \
+    UCCL_PREFIX="/opt/uccl" \
     EFA_PREFIX="/opt/amazon/efa" \
     CUDA_HOME="/usr/local/cuda"
 
@@ -328,6 +343,7 @@ ENV LD_LIBRARY_PATH="\
 ${CUDA_HOME}/lib64:\
 ${EFA_PREFIX}/lib:${EFA_PREFIX}/lib64:\
 ${UCX_PREFIX}/lib:${UCX_PREFIX}/lib64:\
+${UCCL_PREFIX}/lib:\
 ${NVSHMEM_DIR}/lib:${NVSHMEM_DIR}/lib64:\
 /usr/local/lib:/usr/local/lib64:\
 /usr/lib/x86_64-linux-gnu:/usr/lib/aarch64-linux-gnu:\
@@ -391,6 +407,9 @@ COPY --from=builder /tmp/gdrcopy_libs /tmp/
 
 # Copy UCX libraries from builder
 COPY --from=builder /opt/ucx /opt/ucx
+
+# Copy UCCL libraries from builder
+COPY --from=builder /opt/uccl /opt/uccl
 
 RUN if [ -d /tmp/gdrcopy_libs ]; then \
         if [ "${TARGETOS:-rhel}" = "ubuntu" ]; then \

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -4,6 +4,8 @@ ARG RIXL_BRANCH="f33a5599"
 ARG RIXL_REPO="https://github.com/ROCm/RIXL.git"
 ARG UCX_BRANCH="da3fac2a"
 ARG UCX_REPO="https://github.com/ROCm/ucx.git"
+ARG UCCL_VERSION="v0.0.1.post6"
+ARG UCCL_REPO="https://github.com/uccl-project/uccl.git"
 ARG ETCD_BRANCH="7c6e714"
 ARG ETCD_REPO="https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3.git"
 
@@ -27,6 +29,7 @@ ENV PATH=${ROCM_PATH}/llvm/bin:${ROCM_PATH}/bin:/usr/local/sbin:/usr/local/bin:/
 ENV LD_LIBRARY_PATH=${ROCM_PATH}/lib:/usr/local/lib:
 
 ENV UCX_PATH=/usr/local/ucx
+ENV UCCL_PREFIX=/usr/local/uccl
 ENV RIXL_PATH=/usr/local/rixl
 ENV RIXL_BENCH_PATH=/usr/local/rixl_bench
 
@@ -50,6 +53,8 @@ FROM base AS build_rixl
 
 ARG UCX_BRANCH
 ARG UCX_REPO
+ARG UCCL_VERSION
+ARG UCCL_REPO
 ARG RIXL_BRANCH
 ARG RIXL_REPO
 ARG ETCD_BRANCH
@@ -104,6 +109,13 @@ RUN --mount=type=cache,target=/root/.cache/ccache \
 ENV PATH=/usr/local/ucx/bin:$PATH
 ENV LD_LIBRARY_PATH=${UCX_PATH}/lib:${LD_LIBRARY_PATH}
 
+# Build UCCL
+COPY docker/scripts/common/build-uccl.sh /tmp/build-uccl.sh
+RUN TARGETOS=ubuntu UCCL_DEVICE=rocm /tmp/build-uccl.sh && \
+    rm -f /tmp/build-uccl.sh
+    
+ENV LD_LIBRARY_PATH=${UCCL_PREFIX}/lib:${LD_LIBRARY_PATH}
+
 RUN --mount=type=cache,target=/root/.cache/ccache \
     git clone ${RIXL_REPO} /opt/rixl && \
     cd /opt/rixl && \
@@ -147,6 +159,8 @@ RUN mkdir -p /export/wheels && \
 ###
 
 FROM base AS final
+
+COPY --from=build_rixl ${UCCL_PREFIX} ${UCCL_PREFIX}
 
 RUN --mount=type=bind,from=build_rixl,src=/export/wheels,target=/export/wheels \
     --mount=type=bind,from=build_rixl,src=/export/packages,target=/export/packages \

--- a/docker/scripts/common/build-uccl.sh
+++ b/docker/scripts/common/build-uccl.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -Eeux
+
+# builds and installs UCCL from source
+#
+# Required environment variables:
+# - UCCL_REPO: git repo to build UCCL from
+# - UCCL_VERSION: git ref to build UCCL from
+# - UCCL_PREFIX: installation prefix for UCCL libraries and headers
+#
+# Optional environment variables:
+# - UCCL_TRANSPORT: transport backend to use (default: rdma)
+#   Options: rdma, tcp, tcpx
+# - ENABLE_EFA: set to "true" to build with EFA transport instead (default: false)
+# - UCCL_DEVICE: device target (default: cuda). Options: cuda, rocm
+
+UCCL_TRANSPORT="${UCCL_TRANSPORT:-rdma}"
+ENABLE_EFA="${ENABLE_EFA:-false}"
+UCCL_DEVICE="${UCCL_DEVICE:-cuda}"
+
+cd /tmp
+
+git clone "${UCCL_REPO}" uccl && cd uccl
+git checkout -q "${UCCL_VERSION}"
+
+mkdir -p "${UCCL_PREFIX}/lib" "${UCCL_PREFIX}/include"
+
+# Install pre-requisites
+if [ "${TARGETOS:-rhel}" = "ubuntu" ]; then
+    apt-get install -y --no-install-recommends libelf-dev
+else
+    dnf install -y elfutils-libelf-devel
+fi
+
+if [ -n "${VIRTUAL_ENV:-}" ]; then
+    uv pip install nanobind
+else
+    uv pip install --system nanobind
+fi
+
+cd p2p
+
+# Select Makefile based on device
+if [ "${UCCL_DEVICE}" = "rocm" ]; then
+    MAKEFILE="Makefile.rocm"
+else
+    MAKEFILE="Makefile"
+fi
+
+# Transport selection and build
+# ENABLE_EFA takes precedence over UCCL_TRANSPORT
+if [ "${ENABLE_EFA}" = "true" ]; then
+    USE_EFA=1 make -f "${MAKEFILE}" -j
+else
+    case "${UCCL_TRANSPORT}" in
+      tcp)
+        USE_TCP=1 make -f "${MAKEFILE}" -j
+        ;;
+      tcpx)
+        USE_TCPX=1 make -f "${MAKEFILE}" -j
+        ;;
+      *)
+        make -f "${MAKEFILE}" -j
+        ;;
+    esac
+fi
+
+PREFIX="${UCCL_PREFIX}" make -f "${MAKEFILE}" install
+
+cd /tmp
+rm -rf uccl

--- a/docs/wip-docs-new/guides/rdma/README.md
+++ b/docs/wip-docs-new/guides/rdma/README.md
@@ -40,12 +40,14 @@ UCCL currently supports:
 - Native RDMA (IB/RoCE)
 - GPUDirect TCP-X (Google Cloud)
 - TCP
+- EFA (AWS)
 
+Currently, UCCL needs to be built for a specific transport option with the `USE_TCPX`/`USE_TCP`/`USE_EFA` flag (refer to [build instructions](https://github.com/uccl-project/uccl/tree/main/p2p)). In the future, this will be enhanced to provide runtime selection.
 UCCL automatically discovers NICs based on PCIe proximity during memory registration, removing the need for manual NIC-to-GPU mapping in most cases.
 
 ### libfabric
 
-On AWS, NIXL uses [libfabric](https://ofiwg.github.io/libfabric/) as the transport backend. EFA (Elastic Fabric Adapter) requires OpenFabrics Interfaces — neither UCX nor UCCL support EFA natively. The libfabric plugin provides multi-rail RDMA with topology-aware GPU-to-EFA mapping via hwloc.
+On AWS, NIXL uses [libfabric](https://ofiwg.github.io/libfabric/) as the transport backend. EFA (Elastic Fabric Adapter) requires OpenFabrics Interfaces — UCX does not support EFA natively. The libfabric plugin provides multi-rail RDMA with topology-aware GPU-to-EFA mapping via hwloc.
 
 ### Choosing a Transport Backend
 
@@ -54,14 +56,14 @@ On AWS, NIXL uses [libfabric](https://ofiwg.github.io/libfabric/) as the transpo
 | On-premise InfiniBand / RoCE | UCX | Mature, battle-tested on HPC fabrics with dedicated, uncongested paths |
 | Cloud with RoCE (GKE, Azure, etc.) | UCCL | Software packet spraying avoids single-path congestion on shared fabric |
 | GKE with GPUDirect TCP-X | UCCL | Native support for Google's GPU-initiated TCP transport |
-| AWS with EFA | libfabric | EFA requires OFI/libfabric; UCX and UCCL don't support EFA |
-| TCP-only (XPU, HPU, CPU) | UCX | Simplest configuration for non-RDMA environments |
+| AWS with EFA | libfabric/UCCL | EFA requires OFI/libfabric; UCX doesn't support EFA |
+| TCP-only (XPU, HPU, CPU) | UCX/UCCL | Simplest configuration for non-RDMA environments |
 
 The core tradeoff:
 
 - **UCX** offloads transport to hardware — works best when the network fabric has dedicated, uncongested paths, typical in on-premise HPC clusters with InfiniBand.
 - **UCCL** manages transport in software on the CPU — it splits traffic across up to 256 network paths with adaptive congestion control. This matters in cloud environments where network paths are shared and individual paths may be congested.
-- **libfabric** is the only option for AWS EFA. It is not interchangeable with UCX or UCCL on EFA hardware.
+- **libfabric** is the default option for AWS EFA. UCCL also supports EFA but requires compilation with the `USE_EFA` flag. UCX does not support EFA.
 
 NIXL selects the backend based on what is available and the memory types involved. You control which backends are loaded at agent creation time.
 
@@ -84,6 +86,20 @@ For XPU and HPU devices where KV transfer happens via CPU memory, add:
 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"cpu"}'
 ```
 
+#### Backend Selection
+
+NIXL uses UCX backend by default. NIXL's transport backend can be configured using the `kv_connector_extra_config`:
+
+To configure NIXL with UCCL backend:
+
+```bash
+vllm serve <model> \
+  --kv-transfer-config '{"kv_connector":"NixlConnector",
+  "kv_role":"kv_both",
+  "kv_connector_extra_config":
+  {"backends":["UCCL"]}}'
+```
+
 ### NIXL Side Channel
 
 NIXL uses a side channel for metadata exchange between pods. Configure with:
@@ -99,8 +115,10 @@ UCX transport is configured via environment variables:
 
 | Variable | Description | Example |
 |---|---|---|
-| `UCX_TLS` | Transport layers to use | `sm,cuda_ipc,cuda_copy,tcp` |
+| `UCX_TLS` | Transport layers to use | `sm,cuda_ipc,cuda_copy,rc,tcp` |
 | `UCX_SOCKADDR_TLS_PRIORITY` | Priority for socket-based transports | `tcp` |
+| `UCX_PROTO_INFO` | Check transport selection | `y` |
+| `UCX_NET_DEVICES` | Network devices to use for transport | e.g. `mlx5_0:1, mlx5_1:1` |
 
 For RDMA-capable clusters, UCX will automatically use RDMA verbs when available. For TCP-only clusters (XPU, HPU), set `UCX_TLS=tcp`.
 
@@ -169,9 +187,10 @@ For wide-EP (DeepEP), map GPUs to specific HCAs for optimal topology:
 #### AWS (EFA)
 
 - EFA support is built into the llm-d CUDA image when `ENABLE_EFA=true`
-- NIXL uses the `libfabric` backend (not UCX or UCCL) — see [Choosing a Transport Backend](#choosing-a-transport-backend)
+- NIXL uses the `libfabric` backend (not UCX) — see [Choosing a Transport Backend](#choosing-a-transport-backend)
 - Requires libfabric v1.21.0+ (or latest AWS EFA installer)
 - The libfabric plugin auto-discovers GPU-to-EFA topology via hwloc for optimal multi-rail placement
+- UCCL backend also supports EFA, however, it requires compiling with the `USE_EFA` option — see [UCCL](#uccl)
 
 ## Verifying Network Performance
 
@@ -183,7 +202,7 @@ Confirm GPUs within each pod are optimally connected:
 
 ```bash
 # NVIDIA
-nvidia-smi topo -m          # Look for NVLink, not SYS or PHB
+nvidia-smi topo -m          # Look for NV/PIX, not SYS or PHB
 nvidia-smi nvlink --status  # Verify NVLink is active
 
 # AMD
@@ -199,14 +218,32 @@ Verify RDMA connectivity and bandwidth between pods:
 ```bash
 # Check RDMA devices are available
 ibv_devinfo
-
-# Run NIXL benchmark between prefill and decode pods
-nixlbench --transport rdma --size 1G
 ```
 
-If throughput is significantly below the expected line rate for your fabric, check NIC affinity, MTU settings, and whether traffic is falling back to TCP.
+Run NIXL benchmark between prefill and decode pods. nixlbench requires an etcd server for peer coordination when using network backends.
+
+Start a standalone etcd (e.g., in one of the pods or as a separate pod):
+
+```bash
+etcd --listen-client-urls http://0.0.0.0:2379 \
+     --advertise-client-urls http://$(hostname -i):2379 \
+     --listen-peer-urls http://0.0.0.0:2380 \
+     --initial-advertise-peer-urls http://$(hostname -i):2380 \
+     --initial-cluster "default=http://$(hostname -i):2380" &
+```
+
+From the prefill/decode pods, run:
+
+```
+nixlbench --etcd_endpoints http://<ETCD_SERVER_IP>:2379 --backend <UCX/UCCL/LIBFABRIC> --op_type=READ --check-consistency --start_batch_size=100 --max_batch_size=100 --max-block-size=85899340
+```
+
+The above test runs nixl benchmarks with the specified backend for message sizes of 1GB - 8GB, and reports the throughput, latency, etc.
+
+If throughput is significantly below the expected line rate for your fabric, check NIC affinity, MTU settings, and whether traffic is falling back to TCP (by setting `UCX_PROTO_INFO=y` for UCX backend).
 
 If vLLM is already running, GPU memory may be insufficient for in-pod benchmarks. Add a pre-start script that runs tests before vLLM launches and blocks until a condition is met (e.g., removal of a sentinel file).
+In the future, this diagnostic will be automated as runtime scripts.
 
 ## Further Reading
 


### PR DESCRIPTION
UCCL transport is additionally built after UCX for cuda/rocm.
NIXL auto-detects the UCCL library, and builds the UCCL plugin for NIXL automatically.

> Replaces #1136 