### PR TITLE
Fixes for missing tags which break docusaurus website builds

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
         name: lint HTML details/summary tag balance (MDX compatibility)
         language: script
         entry: scripts/lint-details-summary.py
-        files: \.md$
+        files: \.(md|mdx)$
         types: [file]
 
   # yaml linting

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,15 @@ repos:
       - id: markdownlint
         args: [--fix]
 
+  - repo: local
+    hooks:
+      - id: lint-details-summary
+        name: lint HTML details/summary tag balance (MDX compatibility)
+        language: script
+        entry: scripts/lint-details-summary.py
+        files: \.md$
+        types: [file]
+
   # yaml linting
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.37.1

--- a/guides/optimized-baseline/README.md
+++ b/guides/optimized-baseline/README.md
@@ -51,11 +51,13 @@ This guide includes configurations for the following accelerators:
   ```
 
 - Set the following environment variables:
+
   ```bash
     export GAIE_VERSION=v1.5.0
     export GUIDE_NAME="optimized-baseline"
     export NAMESPACE=llm-d-optimized-baseline
   ```
+
 - Install the Gateway API Inference Extension CRDs:
 
   ```bash
@@ -63,6 +65,7 @@ This guide includes configurations for the following accelerators:
   ```
 
 - Create a target namespace for the installation
+
   ```bash
       kubectl create namespace ${NAMESPACE}
   ```
@@ -84,7 +87,7 @@ helm install ${GUIDE_NAME} \
 ```
 
 <details>
-<summary><h4>Gateway Mode</h4></summary>
+<summary><b>Gateway Mode</b></summary>
 
 To use a Kubernetes Gateway managed proxy rather than the standalone version, follow these steps instead of applying the previous Helm chart:
 
@@ -114,7 +117,7 @@ kubectl apply -n ${NAMESPACE} -k guides/${GUIDE_NAME}/modelserver/gpu/vllm/
 ```
 
 <details>
-<summary><h4>If you run into NCCL errors on GKE</h4></summary>
+<summary><b>If you run into NCCL errors on GKE</b></summary>
 
 Try applying the patch:
 
@@ -127,7 +130,7 @@ See [gke-patch/README.md](./modelserver/gpu/gke-patch/README.md) for more detail
 </details>
 
 <details>
-<summary><h4>Other Accelerators</h4></summary>
+<summary><b>Other Accelerators</b></summary>
 
 ```bash
 # AMD GPU
@@ -167,7 +170,7 @@ kubectl apply -n ${NAMESPACE} -k guides/recipes/modelserver/components/monitorin
 
 ### 1. Get the IP of the Proxy
 
-**Standalone Mode**
+#### Standalone Mode
 
 ```bash
 export IP=$(kubectl get service ${GUIDE_NAME}-epp -n ${NAMESPACE} -o jsonpath='{.spec.clusterIP}')

--- a/guides/pd-disaggregation/README.tpu.md
+++ b/guides/pd-disaggregation/README.tpu.md
@@ -1,6 +1,6 @@
 # Prefill/Decode Disaggregation on Google TPU v7
 
-This guide demonstrates how to deploy `Qwen/Qwen3.5-397B-A17B-FP8` using prefill-decode (P/D) disaggregation on Google TPU v7 clusters. 
+This guide demonstrates how to deploy `Qwen/Qwen3.5-397B-A17B-FP8` using prefill-decode (P/D) disaggregation on Google TPU v7 clusters.
 
 For a comprehensive overview of P/D disaggregation architecture, best practices, and benchmarking, please refer to the **[Unified P/D Disaggregation Guide](./README.md)**.
 
@@ -10,7 +10,7 @@ Before starting, ensure your cluster and environment are properly configured:
 
 1. **TPU Topology:** Your GKE cluster must have TPU v7 nodes provisioned with a `2x2x1` topology (4 chips per node) to accommodate the model requirements.
    > [!NOTE]
-   > **TPUv7 Cores and Parallelism:** TPUv7 has 2 cores per chip. You need to consider this when setting parallelism. For example, in `guides/pd-disaggregation/modelserver/tpu/vllm/patch-decode.yaml`, with 4 chips per pod, the tensor parallel size (`--tensor-parallel-size`) is set to `8`. 
+   > **TPUv7 Cores and Parallelism:** TPUv7 has 2 cores per chip. You need to consider this when setting parallelism. For example, in `guides/pd-disaggregation/modelserver/tpu/vllm/patch-decode.yaml`, with 4 chips per pod, the tensor parallel size (`--tensor-parallel-size`) is set to `8`.
 2. Complete the **[Prerequisites](./README.md#prerequisites)** section in the main guide to clone the repository and install the Gateway API Inference Extension CRDs.
 3. Set your environment variables, overriding the model name for Qwen 3.5:
 
@@ -39,7 +39,7 @@ kubectl apply -n ${NAMESPACE} -k guides/${GUIDE_NAME}/modelserver/tpu/vllm/
 
 ## Verification
 
-Follow the **[Verification steps in the main guide](./README.md#verification)** to retrieve the proxy IP address. 
+Follow the **[Verification steps in the main guide](./README.md#verification)** to retrieve the proxy IP address.
 
 When sending your test request, ensure you use the correct TPU model name:
 
@@ -73,6 +73,7 @@ curl -LJO "https://raw.githubusercontent.com/llm-d/llm-d/main/guides/pd-disaggre
 envsubst < tpu_v7_qwen3_5.yaml > config.yaml
 ./run_only.sh -c config.yaml -o ./results
 ```
+
 ## Cleanup
 
 To clean up your cluster, return to the **[Cleanup](./README.md#cleanup)** section of the unified guide.

--- a/guides/pd-disaggregation/README.tpu.md
+++ b/guides/pd-disaggregation/README.tpu.md
@@ -298,3 +298,5 @@ scenario:
 version: '0.1'
 
 ```
+
+</details>

--- a/scripts/lint-details-summary.py
+++ b/scripts/lint-details-summary.py
@@ -30,7 +30,14 @@ _DETAILS_OPEN = re.compile(r"<details(\s[^>]*)?>", re.IGNORECASE)
 _DETAILS_CLOSE = re.compile(r"</details>", re.IGNORECASE)
 _SUMMARY_OPEN = re.compile(r"<summary(\s[^>]*)?>", re.IGNORECASE)
 _SUMMARY_CLOSE = re.compile(r"</summary>", re.IGNORECASE)
-_CODE_FENCE = re.compile(r"^(\s*)(`{3,}|~{3,})")
+# Allow optional blockquote prefix (e.g. "> ```bash") before the fence characters.
+_CODE_FENCE = re.compile(r"^(\s*(?:>\s*)*)(`{3,}|~{3,})")
+# Splitter that tokenises a line into alternating non-tag / tag segments so
+# tags can be processed in document order with correct multiplicity.
+_ANY_TAG = re.compile(
+    r"(<details(?:\s[^>]*)?>|</details>|<summary(?:\s[^>]*)?>|</summary>)",
+    re.IGNORECASE,
+)
 
 
 def check_file(path: Path) -> list[str]:
@@ -58,61 +65,56 @@ def check_file(path: Path) -> list[str]:
                 in_code_block = True
                 fence_pattern = fence_chars  # store full string, e.g. "```"
             elif (
-                # closing fence: same character, at least as many chars, nothing else on line
+                # closing fence: same character, at least as many chars, nothing else on line.
+                # Use fence_match.end() instead of line.strip() so that blockquoted
+                # fences like "> ```" are recognised as closers correctly.
                 fence_chars[0] == fence_pattern[0]
                 and len(fence_chars) >= len(fence_pattern)
-                and line.strip() == fence_chars.strip()
+                and fence_match.end() == len(line.rstrip())
             ):
                 in_code_block = False
                 fence_pattern = None
         if in_code_block:
             continue
 
-        # Determine which tags appear on this line (order matters for same-line pairs).
-        has_details_open = bool(_DETAILS_OPEN.search(line))
-        has_details_close = bool(_DETAILS_CLOSE.search(line))
-        has_summary_open = bool(_SUMMARY_OPEN.search(line))
-        has_summary_close = bool(_SUMMARY_CLOSE.search(line))
-
-        if has_details_open:
-            details_stack.append(lineno)
-            summary_expected = True
-
-        if has_details_close:
-            if details_stack:
-                details_stack.pop()
+        # Split the line into alternating [text, tag, text, tag, …, text] segments
+        # so that tags are processed strictly left-to-right with correct multiplicity.
+        # Odd-indexed segments are matched tags; even-indexed are the text between them.
+        segments = _ANY_TAG.split(line)
+        for idx, segment in enumerate(segments):
+            if idx % 2 == 0:
+                # Plain text segment — any non-blank content cancels the
+                # expectation that the very next thing is a <summary>.
+                if summary_expected and segment.strip():
+                    summary_expected = False
             else:
-                errors.append(
-                    f"{path}:{lineno}: dangling </details> with no matching <details>"
-                )
-            # Fix 1: clear expectation once the block is closed so a <summary>
-            # immediately after </details> is not silently accepted.
-            summary_expected = False
-
-        if has_summary_open:
-            if not summary_expected:
-                errors.append(
-                    f"{path}:{lineno}: <summary> is not immediately inside a <details> block"
-                )
-            summary_expected = False
-            summary_stack.append(lineno)
-
-        # Fix 3: validate </summary> closers.
-        if has_summary_close:
-            if summary_stack:
-                summary_stack.pop()
-            else:
-                errors.append(
-                    f"{path}:{lineno}: dangling </summary> with no matching <summary>"
-                )
-
-        # Fix 2: any non-blank content that is not one of the four tracked tags
-        # cancels the expectation that the next element will be <summary>.
-        if summary_expected and line.strip() and not (
-            has_details_open or has_details_close
-            or has_summary_open or has_summary_close
-        ):
-            summary_expected = False
+                # Tag segment — classify and update state.
+                tag_lower = segment.lower()
+                if _DETAILS_OPEN.match(tag_lower):
+                    details_stack.append(lineno)
+                    summary_expected = True
+                elif _DETAILS_CLOSE.match(tag_lower):
+                    if details_stack:
+                        details_stack.pop()
+                    else:
+                        errors.append(
+                            f"{path}:{lineno}: dangling </details> with no matching <details>"
+                        )
+                    summary_expected = False
+                elif _SUMMARY_OPEN.match(tag_lower):
+                    if not summary_expected:
+                        errors.append(
+                            f"{path}:{lineno}: <summary> is not immediately inside a <details> block"
+                        )
+                    summary_expected = False
+                    summary_stack.append(lineno)
+                elif _SUMMARY_CLOSE.match(tag_lower):
+                    if summary_stack:
+                        summary_stack.pop()
+                    else:
+                        errors.append(
+                            f"{path}:{lineno}: dangling </summary> with no matching <summary>"
+                        )
 
     for lineno in details_stack:
         errors.append(f"{path}:{lineno}: unclosed <details> with no matching </details>")

--- a/scripts/lint-details-summary.py
+++ b/scripts/lint-details-summary.py
@@ -18,7 +18,7 @@ Rules checked:
   4. Every <summary> opener must have a matching </summary> closer.
   5. Every </summary> closer must have a matching <summary> opener.
 
-Tags inside fenced code blocks (``` ... ```) are ignored.
+Tags inside fenced code blocks (``` ... ```) and inline code spans (`...`) are ignored.
 """
 
 import re
@@ -38,6 +38,58 @@ _ANY_TAG = re.compile(
     r"(<details(?:\s[^>]*)?>|</details>|<summary(?:\s[^>]*)?>|</summary>)",
     re.IGNORECASE,
 )
+
+
+def strip_inline_code(line: str) -> str:
+    """
+    Remove inline code spans from a line, replacing them with spaces.
+
+    Handles both single backtick spans (`code`) and multi-backtick spans (``code``).
+    Returns the line with code spans replaced by equivalent-length whitespace
+    to preserve character positions for error reporting.
+    """
+    result = []
+    i = 0
+    while i < len(line):
+        # Check for backtick sequence
+        if line[i] == '`':
+            # Count consecutive backticks
+            backtick_count = 0
+            start = i
+            while i < len(line) and line[i] == '`':
+                backtick_count += 1
+                i += 1
+
+            # Look for closing backtick sequence of same length
+            found_close = False
+            while i < len(line):
+                if line[i] == '`':
+                    # Count closing backticks
+                    close_start = i
+                    close_count = 0
+                    while i < len(line) and line[i] == '`':
+                        close_count += 1
+                        i += 1
+
+                    if close_count == backtick_count:
+                        # Found matching close - replace entire span with spaces
+                        result.append(' ' * (i - start))
+                        found_close = True
+                        break
+                    else:
+                        # Not a match, continue searching
+                        continue
+                else:
+                    i += 1
+
+            if not found_close:
+                # No closing backtick found - treat opening backticks as literal
+                result.append(line[start:i])
+        else:
+            result.append(line[i])
+            i += 1
+
+    return ''.join(result)
 
 
 def check_file(path: Path) -> list[str]:
@@ -77,10 +129,13 @@ def check_file(path: Path) -> list[str]:
         if in_code_block:
             continue
 
+        # Strip inline code spans (backticks) before processing tags
+        line_without_code = strip_inline_code(line)
+
         # Split the line into alternating [text, tag, text, tag, …, text] segments
         # so that tags are processed strictly left-to-right with correct multiplicity.
         # Odd-indexed segments are matched tags; even-indexed are the text between them.
-        segments = _ANY_TAG.split(line)
+        segments = _ANY_TAG.split(line_without_code)
         for idx, segment in enumerate(segments):
             if idx % 2 == 0:
                 # Plain text segment — any non-blank content cancels the

--- a/scripts/lint-details-summary.py
+++ b/scripts/lint-details-summary.py
@@ -85,7 +85,9 @@ def check_file(path: Path) -> list[str]:
             if idx % 2 == 0:
                 # Plain text segment — any non-blank content cancels the
                 # expectation that the very next thing is a <summary>.
-                if summary_expected and segment.strip():
+                # Strip blockquote prefixes (e.g., "> ") to get actual content.
+                content = re.sub(r'^(\s*>\s*)+', '', segment).strip()
+                if summary_expected and content:
                     summary_expected = False
             else:
                 # Tag segment — classify and update state.

--- a/scripts/lint-details-summary.py
+++ b/scripts/lint-details-summary.py
@@ -48,9 +48,9 @@ def check_file(path: Path) -> list[str]:
     in_code_block = False
     fence_pattern: str | None = None  # full fence string, e.g. "```" or "~~~~"
 
-    # Stack of line numbers for unclosed <details> / <summary> openers.
-    details_stack: list[int] = []
-    summary_stack: list[int] = []
+    # Unified stack to track open tags and enforce proper nesting.
+    # Each entry is a tuple of (tag_type, lineno) where tag_type is 'details' or 'summary'.
+    tag_stack: list[tuple[str, int]] = []
 
     # True after a <details> opener until <summary> or non-blank content is seen.
     # Used to enforce that <summary> is the first element inside <details>.
@@ -93,11 +93,17 @@ def check_file(path: Path) -> list[str]:
                 # Tag segment — classify and update state.
                 tag_lower = segment.lower()
                 if _DETAILS_OPEN.match(tag_lower):
-                    details_stack.append(lineno)
+                    tag_stack.append(('details', lineno))
                     summary_expected = True
                 elif _DETAILS_CLOSE.match(tag_lower):
-                    if details_stack:
-                        details_stack.pop()
+                    if tag_stack and tag_stack[-1][0] == 'details':
+                        tag_stack.pop()
+                    elif tag_stack:
+                        # Wrong tag type on top of stack - crossed nesting
+                        wrong_tag, wrong_lineno = tag_stack[-1]
+                        errors.append(
+                            f"{path}:{lineno}: </details> closes before <{wrong_tag}> from line {wrong_lineno}"
+                        )
                     else:
                         errors.append(
                             f"{path}:{lineno}: dangling </details> with no matching <details>"
@@ -109,19 +115,23 @@ def check_file(path: Path) -> list[str]:
                             f"{path}:{lineno}: <summary> is not immediately inside a <details> block"
                         )
                     summary_expected = False
-                    summary_stack.append(lineno)
+                    tag_stack.append(('summary', lineno))
                 elif _SUMMARY_CLOSE.match(tag_lower):
-                    if summary_stack:
-                        summary_stack.pop()
+                    if tag_stack and tag_stack[-1][0] == 'summary':
+                        tag_stack.pop()
+                    elif tag_stack:
+                        # Wrong tag type on top of stack - crossed nesting
+                        wrong_tag, wrong_lineno = tag_stack[-1]
+                        errors.append(
+                            f"{path}:{lineno}: </summary> closes before <{wrong_tag}> from line {wrong_lineno}"
+                        )
                     else:
                         errors.append(
                             f"{path}:{lineno}: dangling </summary> with no matching <summary>"
                         )
 
-    for lineno in details_stack:
-        errors.append(f"{path}:{lineno}: unclosed <details> with no matching </details>")
-    for lineno in summary_stack:
-        errors.append(f"{path}:{lineno}: unclosed <summary> with no matching </summary>")
+    for tag_type, lineno in tag_stack:
+        errors.append(f"{path}:{lineno}: unclosed <{tag_type}> with no matching </{tag_type}>")
 
     return errors
 

--- a/scripts/lint-details-summary.py
+++ b/scripts/lint-details-summary.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# dependencies = []
+# ///
+"""
+Lint Markdown files for unmatched <details>/<summary> HTML tags.
+
+MDX (used by Docusaurus in llm-d.io website) treats inline HTML as JSX and enforces strict tag
+pairing, even though GitHub-Flavored Markdown silently ignores unmatched tags.
+This script catches those mismatches before they break the website build.
+
+Rules checked:
+  1. Every <details> opener must have a matching </details> closer.
+  2. Every </details> closer must have a matching <details> opener.
+  3. Every <summary> must be immediately preceded (within 2 non-blank lines)
+     by a <details> opener.
+
+Tags inside fenced code blocks (``` ... ```) are ignored.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+_DETAILS_OPEN = re.compile(r"<details(\s[^>]*)?>", re.IGNORECASE)
+_DETAILS_CLOSE = re.compile(r"</details>", re.IGNORECASE)
+_SUMMARY_OPEN = re.compile(r"<summary(\s[^>]*)?>", re.IGNORECASE)
+_CODE_FENCE = re.compile(r"^(\s*)(`{3,}|~{3,})")
+
+
+def check_file(path: Path) -> list[str]:
+    """Return a list of error strings for *path*, empty if the file is clean."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    errors: list[str] = []
+
+    in_code_block = False
+    fence_pattern: str | None = None
+    fence_indent: str = ""
+
+    # Stack of line numbers for unmatched <details> openers.
+    open_stack: list[int] = []
+    # Line number of the most recent <details> opener (used for <summary> check).
+    last_details_lineno: int | None = None
+
+    for lineno, line in enumerate(lines, start=1):
+        # Track fenced code blocks so we skip tags inside them.
+        fence_match = _CODE_FENCE.match(line)
+        if fence_match:
+            indent, fence_chars = fence_match.group(1), fence_match.group(2)
+            if not in_code_block:
+                in_code_block = True
+                fence_pattern = fence_chars[0]
+                fence_indent = indent
+            elif (
+                fence_chars[0] == fence_pattern
+                and len(fence_chars) >= len(fence_pattern)
+                and line.strip() == fence_chars.strip()
+            ):
+                in_code_block = False
+                fence_pattern = None
+        if in_code_block:
+            continue
+
+        if _DETAILS_OPEN.search(line):
+            open_stack.append(lineno)
+            last_details_lineno = lineno
+
+        if _DETAILS_CLOSE.search(line):
+            if open_stack:
+                open_stack.pop()
+            else:
+                errors.append(f"{path}:{lineno}: dangling </details> with no matching <details>")
+
+        if _SUMMARY_OPEN.search(line):
+            # A <summary> must be within 2 non-blank lines of a <details> opener.
+            if last_details_lineno is None or (lineno - last_details_lineno) > 2:
+                errors.append(
+                    f"{path}:{lineno}: <summary> is not immediately inside a <details> block"
+                )
+
+    for lineno in open_stack:
+        errors.append(f"{path}:{lineno}: unclosed <details> with no matching </details>")
+
+    return errors
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: lint-details-summary.py <file.md> [file2.md ...]", file=sys.stderr)
+        return 1
+
+    all_errors: list[str] = []
+    for arg in sys.argv[1:]:
+        all_errors.extend(check_file(Path(arg)))
+
+    for err in all_errors:
+        print(err, file=sys.stderr)
+
+    return 1 if all_errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lint-details-summary.py
+++ b/scripts/lint-details-summary.py
@@ -5,15 +5,18 @@
 """
 Lint Markdown files for unmatched <details>/<summary> HTML tags.
 
-MDX (used by Docusaurus in llm-d.io website) treats inline HTML as JSX and enforces strict tag
-pairing, even though GitHub-Flavored Markdown silently ignores unmatched tags.
-This script catches those mismatches before they break the website build.
+MDX (used by Docusaurus for the llm-d.ai website) treats inline HTML as JSX
+and enforces strict tag pairing, even though GitHub-Flavored Markdown silently
+ignores unmatched tags. This script catches those mismatches before they break
+the website build.
 
 Rules checked:
   1. Every <details> opener must have a matching </details> closer.
   2. Every </details> closer must have a matching <details> opener.
-  3. Every <summary> must be immediately preceded (within 2 non-blank lines)
-     by a <details> opener.
+  3. Every <summary> must be the first non-blank content inside its <details>
+     block — any non-tag content between <details> and <summary> is an error.
+  4. Every <summary> opener must have a matching </summary> closer.
+  5. Every </summary> closer must have a matching <summary> opener.
 
 Tags inside fenced code blocks (``` ... ```) are ignored.
 """
@@ -26,6 +29,7 @@ from pathlib import Path
 _DETAILS_OPEN = re.compile(r"<details(\s[^>]*)?>", re.IGNORECASE)
 _DETAILS_CLOSE = re.compile(r"</details>", re.IGNORECASE)
 _SUMMARY_OPEN = re.compile(r"<summary(\s[^>]*)?>", re.IGNORECASE)
+_SUMMARY_CLOSE = re.compile(r"</summary>", re.IGNORECASE)
 _CODE_FENCE = re.compile(r"^(\s*)(`{3,}|~{3,})")
 
 
@@ -35,13 +39,15 @@ def check_file(path: Path) -> list[str]:
     errors: list[str] = []
 
     in_code_block = False
-    fence_pattern: str | None = None
-    fence_indent: str = ""
+    fence_pattern: str | None = None  # full fence string, e.g. "```" or "~~~~"
 
-    # Stack of line numbers for unmatched <details> openers.
-    open_stack: list[int] = []
-    # Line number of the most recent <details> opener (used for <summary> check).
-    last_details_lineno: int | None = None
+    # Stack of line numbers for unclosed <details> / <summary> openers.
+    details_stack: list[int] = []
+    summary_stack: list[int] = []
+
+    # True after a <details> opener until <summary> or non-blank content is seen.
+    # Used to enforce that <summary> is the first element inside <details>.
+    summary_expected = False
 
     for lineno, line in enumerate(lines, start=1):
         # Track fenced code blocks so we skip tags inside them.
@@ -50,10 +56,10 @@ def check_file(path: Path) -> list[str]:
             indent, fence_chars = fence_match.group(1), fence_match.group(2)
             if not in_code_block:
                 in_code_block = True
-                fence_pattern = fence_chars[0]
-                fence_indent = indent
+                fence_pattern = fence_chars  # store full string, e.g. "```"
             elif (
-                fence_chars[0] == fence_pattern
+                # closing fence: same character, at least as many chars, nothing else on line
+                fence_chars[0] == fence_pattern[0]
                 and len(fence_chars) >= len(fence_pattern)
                 and line.strip() == fence_chars.strip()
             ):
@@ -62,25 +68,56 @@ def check_file(path: Path) -> list[str]:
         if in_code_block:
             continue
 
-        if _DETAILS_OPEN.search(line):
-            open_stack.append(lineno)
-            last_details_lineno = lineno
+        # Determine which tags appear on this line (order matters for same-line pairs).
+        has_details_open = bool(_DETAILS_OPEN.search(line))
+        has_details_close = bool(_DETAILS_CLOSE.search(line))
+        has_summary_open = bool(_SUMMARY_OPEN.search(line))
+        has_summary_close = bool(_SUMMARY_CLOSE.search(line))
 
-        if _DETAILS_CLOSE.search(line):
-            if open_stack:
-                open_stack.pop()
+        if has_details_open:
+            details_stack.append(lineno)
+            summary_expected = True
+
+        if has_details_close:
+            if details_stack:
+                details_stack.pop()
             else:
-                errors.append(f"{path}:{lineno}: dangling </details> with no matching <details>")
+                errors.append(
+                    f"{path}:{lineno}: dangling </details> with no matching <details>"
+                )
+            # Fix 1: clear expectation once the block is closed so a <summary>
+            # immediately after </details> is not silently accepted.
+            summary_expected = False
 
-        if _SUMMARY_OPEN.search(line):
-            # A <summary> must be within 2 non-blank lines of a <details> opener.
-            if last_details_lineno is None or (lineno - last_details_lineno) > 2:
+        if has_summary_open:
+            if not summary_expected:
                 errors.append(
                     f"{path}:{lineno}: <summary> is not immediately inside a <details> block"
                 )
+            summary_expected = False
+            summary_stack.append(lineno)
 
-    for lineno in open_stack:
+        # Fix 3: validate </summary> closers.
+        if has_summary_close:
+            if summary_stack:
+                summary_stack.pop()
+            else:
+                errors.append(
+                    f"{path}:{lineno}: dangling </summary> with no matching <summary>"
+                )
+
+        # Fix 2: any non-blank content that is not one of the four tracked tags
+        # cancels the expectation that the next element will be <summary>.
+        if summary_expected and line.strip() and not (
+            has_details_open or has_details_close
+            or has_summary_open or has_summary_close
+        ):
+            summary_expected = False
+
+    for lineno in details_stack:
         errors.append(f"{path}:{lineno}: unclosed <details> with no matching </details>")
+    for lineno in summary_stack:
+        errors.append(f"{path}:{lineno}: unclosed <summary> with no matching </summary>")
 
     return errors
 


### PR DESCRIPTION
Some of the new docs were missing `<details>` tags which looks fine on github but breaks the build on docusaurus, fixed those issues and added a pre-commit test to check for these in the future. 