### PR TITLE
Update local build

### DIFF
--- a/helpers/local-llm-d-cuda-builder/build-local-llm-d-cuda.sh
+++ b/helpers/local-llm-d-cuda-builder/build-local-llm-d-cuda.sh
@@ -24,6 +24,7 @@ ENABLE_EFA="${ENABLE_EFA:-false}"
 TARGETOS="${TARGETOS:-rhel}"
 DOCKER="${DOCKER:-docker}"                 # or podman
 BUILDER="${BUILDER:-}"                     # buildx builder name (e.g. remote-amd64)
+USE_SCCACHE="${USE_SCCACHE:-false}"        # CI uses true; local builds typically lack sccache
 
 # ── parse flags ──────────────────────────────────────────────────────
 usage() {
@@ -42,6 +43,7 @@ Options:
   --debug             Build with debug symbols     (default: false)
   --efa               Enable AWS EFA support       (default: false)
   --os OS             Target OS: rhel or ubuntu    (default: ${TARGETOS})
+  --sccache           Enable sccache               (default: false)
   --docker CMD        Container tool               (default: ${DOCKER})
   --builder NAME      Buildx builder name          (default: default builder)
                       e.g. remote-amd64
@@ -50,7 +52,7 @@ Options:
 
 Environment variables:
   IMAGE_NAME, IMAGE_TAG, TARGET, TARGETPLATFORM, BUILD_DEBUG,
-  ENABLE_EFA, TARGETOS, DOCKER, BUILDER
+  ENABLE_EFA, TARGETOS, DOCKER, BUILDER, USE_SCCACHE
 EOF
     exit 0
 }
@@ -65,6 +67,7 @@ while [[ $# -gt 0 ]]; do
         --debug)      BUILD_DEBUG=true; shift ;;
         --efa)        ENABLE_EFA=true;  shift ;;
         --os)         TARGETOS="$2";   shift 2 ;;
+        --sccache)    USE_SCCACHE=true; shift ;;
         --docker)     DOCKER="$2";     shift 2 ;;
         --builder)    BUILDER="$2";    shift 2 ;;
         --dry-run)    DRY_RUN=true;    shift ;;
@@ -119,6 +122,7 @@ cmd=(
     --build-arg "BUILD_BASE_IMAGE_SUFFIX=${BUILD_BASE_IMAGE_SUFFIX}"
     --build-arg "FINAL_BASE_IMAGE_SUFFIX=${FINAL_BASE_IMAGE_SUFFIX}"
     --build-arg "BUILD_DEBUG=${BUILD_DEBUG}"
+    --build-arg "USE_SCCACHE=${USE_SCCACHE}"
     --build-arg "ENABLE_EFA=${ENABLE_EFA}"
     --build-arg "VLLM_REPO=${VLLM_REPO}"
     --build-arg "VLLM_COMMIT_SHA=${VLLM_COMMIT_SHA}"

--- a/helpers/local-llm-d-cuda-builder/build-local-llm-d-cuda.sh
+++ b/helpers/local-llm-d-cuda-builder/build-local-llm-d-cuda.sh
@@ -3,9 +3,9 @@
 # Build the llm-d CUDA image locally.
 #
 # Usage:
-#   ./docker/scripts/cuda/builder/build-local-llm-d-cuda.sh                # defaults
-#   ./docker/scripts/cuda/builder/build-local-llm-d-cuda.sh --tag my-test   # custom tag
-#   ./docker/scripts/cuda/builder/build-local-llm-d-cuda.sh --help
+#   ./helpers/local-llm-d-cuda-builder/build-local-llm-d-cuda.sh                # defaults
+#   ./helpers/local-llm-d-cuda-builder/build-local-llm-d-cuda.sh --tag my-test   # custom tag
+#   ./helpers/local-llm-d-cuda-builder/build-local-llm-d-cuda.sh --help
 #
 # All options can also be set via environment variables (see below).
 #
@@ -89,14 +89,14 @@ case "${TARGETOS}" in
         ;;
 esac
 
-# ── load vLLM version pinning ───────────────────────────────────────
-VLLM_VERSION_FILE="${REPO_ROOT}/docker/vllm-version"
-if [[ ! -f "${VLLM_VERSION_FILE}" ]]; then
-    echo "Error: ${VLLM_VERSION_FILE} not found." >&2
+# ── load version pinning from common-versions ───────────────────────
+COMMON_VERSIONS_FILE="${REPO_ROOT}/docker/common-versions"
+if [[ ! -f "${COMMON_VERSIONS_FILE}" ]]; then
+    echo "Error: ${COMMON_VERSIONS_FILE} not found." >&2
     exit 1
 fi
 # shellcheck source=/dev/null
-source "${VLLM_VERSION_FILE}"
+source "${COMMON_VERSIONS_FILE}"
 
 # ── check container tool ────────────────────────────────────────────
 if ! command -v "${DOCKER}" &>/dev/null; then
@@ -125,6 +125,11 @@ cmd=(
     --build-arg "VLLM_PRECOMPILED_WHEEL_COMMIT=${VLLM_PRECOMPILED_WHEEL_COMMIT:-${VLLM_COMMIT_SHA}}"
     --build-arg "VLLM_PREBUILT=${VLLM_PREBUILT:-0}"
     --build-arg "VLLM_USE_PRECOMPILED=${VLLM_USE_PRECOMPILED:-1}"
+    --build-arg "CUDA_MAJOR=${CUDA_MAJOR}"
+    --build-arg "CUDA_MINOR=${CUDA_MINOR}"
+    --build-arg "CUDA_PATCH=${CUDA_PATCH}"
+    --build-arg "LLM_D_OFFLOADING_CONNECTOR_VERSION=${LLM_D_OFFLOADING_CONNECTOR_VERSION:-}"
+    --build-arg "INSTALL_OFFLOADING_CONNECTOR=${INSTALL_OFFLOADING_CONNECTOR:-true}"
 )
 
 if [[ -n "${TARGET}" ]]; then
@@ -136,6 +141,7 @@ cmd+=(-t "${FULL_IMAGE}" "${REPO_ROOT}")
 # ── run ──────────────────────────────────────────────────────────────
 echo "==> Building ${FULL_IMAGE}"
 echo "    Platform=${TARGETPLATFORM}  OS=${TARGETOS}  DEBUG=${BUILD_DEBUG}  EFA=${ENABLE_EFA}  Builder=${BUILDER:-default}"
+echo "    CUDA=${CUDA_MAJOR}.${CUDA_MINOR}.${CUDA_PATCH}"
 echo "    vLLM repo=${VLLM_REPO}"
 echo "    vLLM commit=${VLLM_COMMIT_SHA}"
 echo ""


### PR DESCRIPTION
**Description:**
`./helpers/local-llm-d-cuda-builder/build-local-llm-d-cuda.sh` has been updated with proper version files

**Test:**

We built on OCP cluster pod (Docker-in-Docker). Spin up a privileged pod with Docker (DinD), clone the repo, and run the build:

```
 # test-build-pod.yaml
 apiVersion: v1
 kind: Pod
 metadata:
   name: llm-d-cuda-builder
 spec:
   containers:
   - name: dind
     image: docker:dind
     command: ["dockerd-entrypoint.sh"]
     securityContext:
       privileged: true
     resources:
       requests:
         memory: "16Gi"
         cpu: "8"
       limits:
         memory: "32Gi"
         cpu: "16"
     volumeMounts:
     - name: docker-storage
       mountPath: /var/lib/docker
   - name: builder
     image: docker:latest
     command: ["sleep", "infinity"]
     env:
     - name: DOCKER_HOST
       value: "tcp://localhost:2375"
     resources:
       requests:
         memory: "2Gi"
         cpu: "1"
   volumes:
   - name: docker-storage
     emptyDir: {}
   restartPolicy: Never
```

 Then:
```
 oc apply -f test-build-pod.yaml
 oc exec -it llm-d-cuda-builder -c builder -- sh

 # Inside the pod:
 apk add --no-cache git bash
 git clone https://github.com/llm-d/llm-d.git && cd llm-d
 git checkout update-local-build

 # Run with docker (default)
 ./helpers/local-llm-d-cuda-builder/build-local-llm-d-cuda.sh --tag test-fix
```
As a result:

```
...bla bla bla....
#81 exporting to image
#81 exporting layers
#81 exporting layers 499.3s done
#81 exporting manifest sha256:c5fb076c7fc0fa8d91a0fc4a68b1e4002ccc6e75fedb3cdcd4cb38a0ebc04e1b done
#81 exporting config sha256:22ff5353aa2d4a8b9e25773d9d4e9e20669c140fc40a7214474dd5757fdb9ab6 done
#81 exporting attestation manifest sha256:da7f8cf833f369719404c0489fd92b8b2f6a0406cd8e32db144e155e6a3ae17d done
#81 exporting manifest list sha256:d4fa81d00231d18063f50e91eaca69cfcefbb062fd9a5555833794d2e742d1f2 done
#81 naming to docker.io/library/llm-d-cuda:test-fix done
#81 unpacking to docker.io/library/llm-d-cuda:test-fix
#81 unpacking to docker.io/library/llm-d-cuda:test-fix 65.1s done
#81 DONE 564.4s
```

**Note:**
As we already described in https://github.com/llm-d/llm-d/pull/865, when building on MacOS and emulating with QEMU, a segmentation fault can happen:
```
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
```

This is happening because the Dockerfile is designed for native x86_64 Linux machines, and QEMU emulation is too unreliable for a build this complex (even if uv didn't crash, later steps with CUDA compilation would likely fail or take hours).