### PR TITLE
[Guides] Fix duplicate metrics service port in predicted-latency values

### DIFF
--- a/guides/predicted-latency-based-scheduling/scheduler/predicted-latency-slo.values.yaml
+++ b/guides/predicted-latency-based-scheduling/scheduler/predicted-latency-slo.values.yaml
@@ -15,10 +15,6 @@ inferenceExtension:
       port: 80
       protocol: TCP
       targetPort: 8081
-    - name: metrics
-      port: 9090
-      protocol: TCP
-      targetPort: 9090
   pluginsConfigFile: "predicted-latency-slo-plugins.yaml"
   pluginsCustomConfig:
     predicted-latency-slo-plugins.yaml: |

--- a/guides/predicted-latency-based-scheduling/scheduler/predicted-latency.values.yaml
+++ b/guides/predicted-latency-based-scheduling/scheduler/predicted-latency.values.yaml
@@ -12,10 +12,6 @@ inferenceExtension:
       port: 80
       protocol: TCP
       targetPort: 8081
-    - name: metrics
-      port: 9090
-      protocol: TCP
-      targetPort: 9090
 
 inferencePool:
   modelServers:


### PR DESCRIPTION
The standalone chart's Service template already exposes 9090 as http-metrics. Adding a second `metrics: 9090` entry under extraServicePorts produced a duplicate port and made `helm install` fail with:

  Service "predicted-latency-based-scheduling-epp" is invalid:
  spec.ports[3]: Duplicate value: ...Port:9090...

This is what the GKE nightly hit (Run #2 of nightly-e2e-predicted-latency-gke). Drop the duplicate from both routing-only and SLO values files.