### PR TITLE
docs: reduce naming redundancy and improve clarity by spelling out acronyms

### DIFF
--- a/docs/architecture/advanced/README.md
+++ b/docs/architecture/advanced/README.md
@@ -1,0 +1,35 @@
+# Advanced
+
+Advanced patterns and features for production LLM inference deployments. These extend the core llm-d architecture to handle complex workloads and specialized infrastructure.
+
+## Overview
+
+llm-d's core design supports optional advanced patterns for production-scale deployments:
+
+- **[Disaggregated Serving](disaggregation/README.md)** - Split inference into specialized prefill and decode workers for improved efficiency and predictable latency.
+
+- **[KV Cache Management](kv-management/README.md)** - Comprehensive ecosystem for managing and reusing KV cache across the inference pool, including prefix-cache aware routing, real-time cache indexing, and tiered offloading.
+
+- **[Latency Predictor](latency-predictor.md)** - Machine learning-based routing that predicts request latency for SLO-aware scheduling and intelligent endpoint selection.
+
+- **[Autoscaling](autoscaling/README.md)** - Proactive, SLO-aware autoscaling through HPA/KEDA metrics or the Workload Variant Autoscaler for globally optimized cost efficiency.
+
+- **[Batch Inference](batch/README.md)** - OpenAI-compatible Batch API and async processing for high-volume offline workloads.
+
+## When to Use Advanced Features
+
+Start with the [core architecture](../README.md) and add advanced features as your deployment requirements grow:
+
+- **Disaggregated Serving**: When serving large models with long prompts, or when deploying Mixture-of-Experts models with Data Parallelism/Expert Parallelism.
+
+- **KV Cache Management**: When prefix cache hit rates impact latency, or when cache capacity limits throughput.
+
+- **Latency Predictor**: When workload variance makes queue-depth a poor proxy for load, or when strict SLOs require admission control.
+
+- **Autoscaling**: When traffic patterns vary significantly, or when optimizing cost across heterogeneous hardware.
+
+- **Batch Inference**: When processing large offline datasets alongside interactive traffic, or when implementing async processing pipelines.
+
+## Composability
+
+These features compose independently. You can adopt prefix-cache aware routing without disaggregation, or use the Latency Predictor with standard aggregated serving. Choose the patterns that address your specific bottlenecks.

--- a/docs/architecture/advanced/disaggregation/README.md
+++ b/docs/architecture/advanced/disaggregation/README.md
@@ -3,9 +3,9 @@
 ## Functionality
 
 Disaggregated serving separates the **prefill** and **decode** stages of LLM inference onto different model server instances, enabling:
-* **Specialization of P and D** - LLM inference is composed of two distinct phases of inference - prefill (FLOPs-bound) and decode (memory bandwidth-bound). Disaggregation enables specialization, e.g. using a larger TP for the memory-bound decoding phase while a smaller TP for the computation-bound prefill phase.
+* **Specialization of Prefill and Decode** - LLM inference is composed of two distinct phases of inference - prefill (FLOPs-bound) and decode (memory bandwidth-bound). Disaggregation enables specialization, e.g. using a larger Tensor Parallelism (TP) for the memory-bound decoding phase while a smaller TP for the computation-bound prefill phase.
 * **Avoidance of Request Interference** - For long context requests, prefills can slow down processing of existing requests in the decode phase. Separating the prefill phase of these long requests into dedicated prefill instances allows the ongoing decoding requests to be efficiently processed without being blocked by these long prefills, improving quality-of-service.
-* **Compatibility with DP/EP** - For DP/EP deployments of Mixture of Experts models, disaggregated serving is essential to avoid pipeline bubbles and leveraging the specialized "MaskedGEMM" format for decode.
+* **Compatibility with Data Parallelism/Expert Parallelism (DP/EP)** - For DP/EP deployments of Mixture of Experts models, disaggregated serving is essential to avoid pipeline bubbles and leveraging the specialized "MaskedGEMM" format for decode.
 
 An implementation of disaggregated serving requires two key components:
 * **Request Flow Orchestration** - select and route the requests to the correct prefill and decode pods
@@ -43,11 +43,11 @@ sequenceDiagram
     DSidecar->>Proxy: Response
 ```
 
-Next we will discuss the design of the EPP and Routing Sidecar for disaggregated serving.
+Next we will discuss the design of the Endpoint Picker (EPP) and Routing Sidecar for disaggregated serving.
 
-### EPP
+### Endpoint Picker (EPP)
 
-The llm-d EPP supports disaggregation via the `disagg-profile-handler`.
+The llm-d Endpoint Picker (EPP) supports disaggregation via the `disagg-profile-handler`.
 
 > [!NOTE]
 > Rather than hardcoding a single scheduling algorithm, the EPP delegates execution to one or more `Profile Handlers`, each of which represents a complete scheduling strategy. They can be thought of as "the dispatcher", which maps each incoming inference request to the right scheduling strategy before the scorers and pickers do their work of selecting the actual endpoint. By default, llm-d uses the `single-profile-handler` for simple aggregated serving.

--- a/docs/architecture/advanced/disaggregation/operations-vllm.md
+++ b/docs/architecture/advanced/disaggregation/operations-vllm.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Serving Operations (vLLM)
+---
+
 # Disaggregated Serving: Operations (vLLM)
 
 While disaggregated serving can offer superior performance, it introduces additional operational complexity, including:

--- a/docs/architecture/core/router/epp/configuration.md
+++ b/docs/architecture/core/router/epp/configuration.md
@@ -1,4 +1,8 @@
-# Configuration
+---
+sidebar_label: Configuration
+---
+
+# Endpoint Picker (EPP) Configuration
 
 The `EndpointPickerConfig` is the central configuration for the Endpoint Picker (EPP), defining the graph of plugins and parameters that drive request handling, flow control, and scheduling decisions.
 

--- a/docs/architecture/core/router/epp/datalayer.md
+++ b/docs/architecture/core/router/epp/datalayer.md
@@ -1,6 +1,10 @@
-# Data Layer
+---
+sidebar_label: Data Layer
+---
 
-The Data Layer is a pluggable and extensible component within the EPP responsible for gathering, processing, and storing real-time state for model server endpoints. It provides the foundational data—such as queue depths, KV cache utilization, and LoRA adapter states—that [request scheduling](scheduling.md) and [flow control](flow-control.md) plugins use to make informed decisions.
+# Endpoint Picker (EPP): Data Layer
+
+The EPP Data Layer is a pluggable and extensible component responsible for gathering, processing, and storing real-time state for model server endpoints. It provides the foundational data—such as queue depths, KV cache utilization, and LoRA adapter states—that [request scheduling](scheduling.md) and [flow control](flow-control.md) plugins use to make informed decisions.
 
 ## Architecture Overview
 

--- a/docs/architecture/core/router/epp/flow-control.md
+++ b/docs/architecture/core/router/epp/flow-control.md
@@ -1,6 +1,10 @@
-# Flow Control
+---
+sidebar_label: Flow Control
+---
 
-The Flow Control layer within the EPP is a critical mechanism for pool defense and multi-tenancy. It protects the pool of model servers from overload by shifting intelligent queuing to the gateway, enforcing strict priority and tenant-aware fairness.
+# Endpoint Picker (EPP): Flow Control
+
+The Flow Control layer within the Endpoint Picker (EPP) is a critical mechanism for pool defense and multi-tenancy. It protects the pool of model servers from overload by shifting intelligent queuing to the gateway, enforcing strict priority and tenant-aware fairness.
 
 > [!IMPORTANT]
 > EPP Flow Control is currently behind the `flowControl` feature gate. You must explicitly enable it in your [EndpointPickerConfig](configuration.md) to use these capabilities.

--- a/docs/architecture/core/router/epp/request-handling.md
+++ b/docs/architecture/core/router/epp/request-handling.md
@@ -1,8 +1,12 @@
-# Request Handler
+---
+sidebar_label: Request Handling
+---
+
+# Endpoint Picker (EPP): Request Handling
 
 ## Functionality
 
-The Request Handler manages the lifecycle of an inference request before and after the request scheduling phase within the EPP. It handles parsing the request payload, preparing and managing state for the [Request Scheduler](scheduling.md), interacting with [Flow Control](flow-control.md) and processing the response from the model server.
+The Request Handler manages the lifecycle of an inference request before and after the request scheduling phase within the Endpoint Picker (EPP). It handles parsing the request payload, preparing and managing state for the [Request Scheduler](scheduling.md), interacting with [Flow Control](flow-control.md) and processing the response from the model server.
 
 ## Design
 

--- a/docs/architecture/core/router/epp/scheduling.md
+++ b/docs/architecture/core/router/epp/scheduling.md
@@ -1,6 +1,10 @@
-# Request Scheduler
+---
+sidebar_label: Request Scheduler
+---
 
-The Request Scheduler is a highly modular and extensible component within the EPP designed to select the optimal model server (endpoint) for an inference request. It leverages a plugin-based architecture, allowing for sophisticated endpoint picking strategies based on real-time metrics, prefix cache tracking, and model-specific requirements like LoRA adapters.
+# Endpoint Picker (EPP): Request Scheduler
+
+The EPP Request Scheduler is a highly modular and extensible component within the Endpoint Picker (EPP) designed to select the optimal model server (endpoint) for an inference request. It leverages a plugin-based architecture, allowing for sophisticated endpoint picking strategies based on real-time metrics, prefix cache tracking, and model-specific requirements like LoRA adapters.
 
 ## Architecture Overview
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -14,7 +14,7 @@ llm-d is a [CNCF sandbox project](https://www.cncf.io/) that supports multiple i
 
 ### Kubernetes-Native
 
-llm-d integrates with standard Kubernetes primitives — Gateway API, Custom Resources, Labels, and HPA. If you already run workloads on Kubernetes, llm-d fits naturally into your infrastructure.
+llm-d integrates with standard Kubernetes primitives — Gateway API, Custom Resources, Labels, and Horizontal Pod Autoscaler (HPA). If you already run workloads on Kubernetes, llm-d fits naturally into your infrastructure.
 
 ### Composable and Incremental Adoption
 
@@ -57,11 +57,11 @@ By composing these layers, llm-d allows an inference pool to scale its effective
 
 ### Prefill/Decode Disaggregation
 
-Split inference into dedicated **prefill workers** (prompt processing) and **decode workers** (token generation) to reduce time-to-first-token (TTFT) and achieve more predictable time-per-output-token (TPOT). KV-cache is transferred between phases via [NIXL](https://github.com/ai-dynamo/nixl) over high-speed interconnects (InfiniBand, RoCE RDMA).
+Split inference into dedicated **prefill workers** (prompt processing) and **decode workers** (token generation) to reduce time-to-first-token (TTFT) and achieve more predictable time-per-output-token (TPOT). KV-cache is transferred between phases via [NIXL](https://github.com/ai-dynamo/nixl) over high-speed interconnects (InfiniBand, RoCE) using Remote Direct Memory Access (RDMA).
 
 ### Predicted Latency-Based Routing
 
-An **llm-d Router** capability implemented primarily as an EPP plugin that routes each request to the replica predicted to serve it fastest, using an XGBoost model trained online on live traffic to predict ITL and TTFT. Optionally enforce per-request SLOs via `x-slo-ttft-ms` / `x-slo-tpot-ms` headers — requests that no replica can meet within budget are shed at admission rather than routed to a guaranteed miss. Useful when workload variance makes queue-depth a poor proxy for true load, or when clients need to express interactive vs. batch latency budgets.
+An **llm-d Router** capability implemented primarily as an EPP plugin that routes each request to the replica predicted to serve it fastest, using an XGBoost model trained online on live traffic to predict Inter-Token Latency (ITL) and Time to First Token (TTFT). Optionally enforce per-request Service Level Objectives (SLOs) via `x-slo-ttft-ms` / `x-slo-tpot-ms` headers — requests that no replica can meet within budget are shed at admission rather than routed to a guaranteed miss. Useful when workload variance makes queue-depth a poor proxy for true load, or when clients need to express interactive vs. batch latency budgets.
 
 ### Batch Inference
 

--- a/docs/resources/rdma/README.md
+++ b/docs/resources/rdma/README.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: High-Speed Networking
+---
+
 # Remote Direct Memory Access (RDMA) and Networking Configuration
 
 ## Why Networking Matters

--- a/guides/prereq/gateways/agentgateway.md
+++ b/guides/prereq/gateways/agentgateway.md
@@ -12,8 +12,8 @@ your model servers via the llm-d EPP.
 
 1. The environment variables `${GUIDE_NAME}`, `${MODEL_NAME}` and `${NAMESPACE}` should be set as part of deploying one of the well-lit path guides.
 2. A Kubernetes cluster running one of the three most recent [Kubernetes releases](https://kubernetes.io/releases/)
-3. [Helm](https://helm.sh/docs/intro/install/)
-4. [jq](https://jqlang.org/download/)
+3. [Helm](https://helm.sh/docs/intro/install/) - Package manager for Kubernetes, used to install Agent Gateway and its CRDs
+4. [jq](https://jqlang.org/download/) - Command-line JSON processor, used to parse and format API responses for verification
 
 ## Step 1: Install Gateway API and Gateway API Inference Extension CRDs
 

--- a/guides/prereq/gateways/gke.md
+++ b/guides/prereq/gateways/gke.md
@@ -11,7 +11,9 @@ This guide shows how to deploy llm-d with
 
 1. The environment variables `${GUIDE_NAME}`, `${MODEL_NAME}` and `${NAMESPACE}` should be set as part of deploying one of the well-lit path guides.
 
-2. The following steps from the [GKE Inference Gateway deployment documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/deploy-gke-inference-gateway) should be run:
+2. [jq](https://jqlang.org/download/) - Command-line JSON processor, used to parse and format API responses for verification
+
+3. The following steps from the [GKE Inference Gateway deployment documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/deploy-gke-inference-gateway) should be run:
   * [Verify your prerequisites](https://cloud.google.com/kubernetes-engine/docs/how-to/deploy-gke-inference-gateway#before-you-begin)
   * [Configure a proxy-only subnet](https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-gateways#configure_a_proxy-only_subnet)
   * [Enable Gateway API in your cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-gateways#enable-gateway)

--- a/guides/prereq/gateways/istio.md
+++ b/guides/prereq/gateways/istio.md
@@ -9,8 +9,8 @@ This guide shows how to deploy llm-d with [Istio](https://istio.io/) as your inf
 
 1. The environment variables `${GUIDE_NAME}`, `${MODEL_NAME}` and `${NAMESPACE}` should be set as part of deploying one of the well-lit path guides.
 2. A Kubernetes cluster running one of the three most recent [Kubernetes releases](https://kubernetes.io/releases/)
-3. [Helm](https://helm.sh/docs/intro/install/)
-4. [jq](https://jqlang.org/download/)
+3. [Helm](https://helm.sh/docs/intro/install/) - Package manager for Kubernetes, used to install Istio and its components
+4. [jq](https://jqlang.org/download/) - Command-line JSON processor, used to parse and format API responses for verification
 
 ## Step 1: Install Gateway API and Gateway API Inference Extension CRDs
 


### PR DESCRIPTION
## Summary

This PR improves documentation clarity for new users by reducing naming redundancy and spelling out acronyms on first use throughout the getting-started documentation.

## Changes

### Reduce Naming Redundancy

**Removed redundant "EPP" prefix from EPP subsection titles:**
- The parent section "Endpoint Picker (EPP)" establishes context
- Subsections simplified: "EPP Request Scheduler" → "Request Scheduler", "EPP Flow Control" → "Flow Control", etc.
- Makes navigation cleaner without losing meaning

**Removed redundancy in disaggregation docs:**
- "Disaggregated Serving: Operations (vLLM)" → "Serving Operations (vLLM)" (parent section already says "Disaggregation")
- "Specialization of P and D" → "Specialization of Prefill and Decode"

### Improve Clarity by Spelling Out Acronyms

**Getting-started documentation:**
- HPA → Horizontal Pod Autoscaler (HPA)
- ITL → Inter-Token Latency (ITL)
- TTFT → Time to First Token (TTFT)
- SLO → Service Level Objectives (SLOs)
- RDMA → Remote Direct Memory Access
- TP → Tensor Parallelism (TP)
- DP/EP → Data Parallelism/Expert Parallelism (DP/EP)

**Feature matrix:**
- GKE → Google Kubernetes Engine (GKE)
- CKS → CoreWeave Kubernetes Service (CKS)
- AKS → Azure Kubernetes Service (AKS)
- P/D Disaggregation → Prefill/Decode Disaggregation
- Wide EP → Wide Expert Parallelism

**RDMA documentation:**
- Added sidebar label "High-Speed Networking" (no acronym)
- Page title spells out: "Remote Direct Memory Access (RDMA) and Networking Configuration"

**Gateway deployment guides:**
- Added explanations for prerequisites (Helm, jq) so users understand why each tool is needed

### Additional Improvements

- **Added Advanced overview page** - Makes "Advanced" section clickable with guidance on when to use each feature
- **Added links to Gateway Providers** - Istio, Agent Gateway, GKE Gateway, kgateway all link to their documentation
- **Fixed Gateway Provider naming** - "AgentGateway" → "Agent Gateway" (correct two-word form per official branding)

## Impact

- New users can navigate docs without needing to know specialized acronyms upfront
- Reduced cognitive load by removing redundant prefixes in navigation
- Clearer understanding of platform and infrastructure provider names

Related to #1103

🤖 Generated with [Claude Code](https://claude.com/claude-code)