### PR TITLE
[bugfix] Fix DeepGEMM JIT in llm-d builds

### DIFF
--- a/docker/packages/cuda/runtime-packages.json
+++ b/docker/packages/cuda/runtime-packages.json
@@ -12,7 +12,8 @@
     "libatomic": "libatomic1",
     "libaio": null,
     "libxcb":"libxcb1",
-    "libxcb-devel":"libxcb1-dev"
+    "libxcb-devel":"libxcb1-dev",
+    "cuda-cuobjdump-${CUDA_MAJOR}-${CUDA_MINOR}": "cuda-cuobjdump-${CUDA_MAJOR}-${CUDA_MINOR}"
   },
   "ubuntu_only": [
     "hwloc",


### PR DESCRIPTION
SUMMARY:
* deepgemm need cuobjdump in the runtime layer of the image
* this is not installed
* nvcc works, but then loading the cubin fails for this reason