### PR TITLE
Fix: nightly CI pipeline fails due to broken Helm values path

### DIFF
--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-ocp.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-ocp.yaml
@@ -93,7 +93,7 @@ jobs:
         echo "Deploying InferencePool..."
         helm install llm-d-infpool \
           -n "$NAMESPACE" \
-          -f guides/tiered-prefix-cache/cpu/manifests/scheduler/tiered-prefix-cache.values.yaml \
+          -f guides/tiered-prefix-cache/cpu/scheduler/tiered-prefix-cache-cpu.values.yaml \
           --set "provider.name=${GATEWAY_TYPE}" \
           oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool \
           --version v1.5.0


### PR DESCRIPTION
The entire nightly CI pipeline fails at the deploy stage.
  Error: open guides/tiered-prefix-cache/cpu/manifests/scheduler/tiered-prefix-cache.values.yaml: no such file or directory

The workflow should load the scheduler values from guides/tiered-prefix-cache/cpu/scheduler/tiered-prefix-cache-cpu.values.yaml, which is the actual  file on disk.

Root cause: 
PR #1345 restructured the guide directory from manifests/vllm/ to modelserver/gpu/vllm/ and moved the scheduler values file from  manifests/inferencepool/values.yaml to scheduler/tiered-prefix-cache-cpu.values.yaml. During this refactor, the workflow path was updated incorrectly — it references a  non-existent manifests/scheduler/ directory and a wrong filename (tiered-prefix-cache.values.yaml instead of tiered-prefix-cache-cpu.values.yaml).