### PR TITLE
Fix MDX syntax error in optimized-baseline guide

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -27,7 +27,7 @@ llm-d uses a layered, composable architecture. See the [Architecture Overview](.
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)">
-    <img alt="llm-d Arch" src="../assets/images/llm-d-arch.svg" width=95%>
+    <img alt="llm-d Arch" src="../assets/images/llm-d-arch.svg" width="95%" />
   </picture>
 </p>
 

--- a/guides/optimized-baseline/README.md
+++ b/guides/optimized-baseline/README.md
@@ -113,6 +113,7 @@ Apply the Kustomize overlays for your specific backend (defaulting to NVIDIA GPU
 kubectl apply -n ${NAMESPACE} -k guides/${GUIDE_NAME}/modelserver/gpu/vllm/
 ```
 
+<details>
 <summary><h4>If you run into NCCL errors on GKE</h4></summary>
 
 Try applying the patch:


### PR DESCRIPTION
Fixes MDX compilation error blocking website deployment (llm-d.github.io#261).

**Problem:**
Line 116 had `<summary>` without an opening `<details>` tag, causing:
```
Unexpected closing slash `/` in tag, expected an open tag first
```

**Fix:**
Added missing `<details>` tag before `<summary>`.

**Impact:**
- Unblocks llm-d.github.io#261 (preview docs sync script update)
- Unblocks llm-d.github.io#262 (promote preview to /docs/)

**Testing:**
Will be validated by website CI once merged.