### PR TITLE
Fix/predicted latency duplicate metrics port

### DIFF
--- a/.github/scripts/e2e/e2e-validate-predicted-latency.sh
+++ b/.github/scripts/e2e/e2e-validate-predicted-latency.sh
@@ -143,7 +143,11 @@ echo "Namespace=$NAMESPACE Gateway=${SVC_HOST} EPP=${EPP_METRICS_URL} Model=${MO
 
 # ── Warmup loop: feed the predictor's training window ───────────────────────
 PAYLOAD=$(printf '{"model":"%s","prompt":"Tell me a short story.","max_tokens":32}' "$MODEL_ID")
-kubectl exec -n "$NAMESPACE" "$CURL_POD_NAME" -- sh -c "cat > /tmp/payload.json" <<<"$PAYLOAD"
+# Pipe via tee so the payload actually lands in the file. `kubectl exec` +
+# `sh -c "cat > file"` silently produces a 0-byte file (cat's stdin never gets
+# the data through sh -c, even with -i), which would make every warmup curl
+# send an empty body and report ok=0 fail=N.
+printf '%s' "$PAYLOAD" | kubectl exec -i -n "$NAMESPACE" "$CURL_POD_NAME" -- tee /tmp/payload.json >/dev/null
 
 echo "Sending $ITERATIONS requests with concurrency $CONCURRENCY..."
 # Tolerate partial failures: a single curl that fails to connect would otherwise

--- a/.github/workflows/nightly-e2e-predicted-latency-cks.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-cks.yaml
@@ -37,10 +37,13 @@ jobs:
       gateway_host: 'predicted-latency-based-scheduling-epp'
       custom_deploy_script: |
         kubectl apply -k guides/optimized-baseline/modelserver/gpu/vllm -n ${NAMESPACE}
+        # CI-only: disable EPP /metrics auth so the validate script's curl pod
+        # can scrape predicted/actual TTFT histograms without a bearer token.
         helm install predicted-latency-based-scheduling \
           oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
           -f guides/recipes/scheduler/base.values.yaml \
           -f guides/predicted-latency-based-scheduling/scheduler/predicted-latency.values.yaml \
+          --set inferenceExtension.monitoring.prometheus.auth.enabled=false \
           -n ${NAMESPACE} --version v1.5.0
       e2e_validate_args: '--extra-validate predicted-latency'
       accelerator_type: H100

--- a/.github/workflows/nightly-e2e-predicted-latency-gke.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-gke.yaml
@@ -37,10 +37,15 @@ jobs:
       gateway_host: 'predicted-latency-based-scheduling-epp'
       custom_deploy_script: |
         kubectl apply -k guides/optimized-baseline/modelserver/gpu/gke-patch/vllm -n ${NAMESPACE}
+        # CI-only: disable EPP /metrics auth so the validate script's curl pod
+        # can scrape predicted/actual TTFT histograms without a bearer token.
+        # This adds --metrics-endpoint-auth=false to the EPP container; the
+        # production guide default (auth on) is unchanged.
         helm install predicted-latency-based-scheduling \
           oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
           -f guides/recipes/scheduler/base.values.yaml \
           -f guides/predicted-latency-based-scheduling/scheduler/predicted-latency.values.yaml \
+          --set inferenceExtension.monitoring.prometheus.auth.enabled=false \
           -n ${NAMESPACE} --version v1.5.0
       e2e_validate_args: '--extra-validate predicted-latency'
       gke_cluster_name: llm-d-e2e-us-east5

--- a/.github/workflows/nightly-e2e-predicted-latency-ocp.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-ocp.yaml
@@ -41,10 +41,13 @@ jobs:
         yq '.spec.template.spec.containers[0].volumeMounts += {"mountPath": "/.triton", "name": "triton-cache"}' -i guides/optimized-baseline/modelserver/gpu/vllm/patch-vllm.yaml
         yq '.spec.replicas=2' -i guides/optimized-baseline/modelserver/gpu/vllm/patch-vllm.yaml
         kubectl apply -k guides/optimized-baseline/modelserver/gpu/vllm -n ${NAMESPACE}
+        # CI-only: disable EPP /metrics auth so the validate script's curl pod
+        # can scrape predicted/actual TTFT histograms without a bearer token.
         helm install predicted-latency-based-scheduling \
           oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
           -f guides/recipes/scheduler/base.values.yaml \
           -f guides/predicted-latency-based-scheduling/scheduler/predicted-latency.values.yaml \
+          --set inferenceExtension.monitoring.prometheus.auth.enabled=false \
           -n ${NAMESPACE} --version v1.5.0
       e2e_validate_args: '--extra-validate predicted-latency'
       accelerator_type: H100


### PR DESCRIPTION
## Summary

Fixes two failures hit by `nightly-e2e-predicted-latency-{gke,cks,ocp}` after the duplicate-port fix in #1383 unblocked the deploy step. Both failures are in the `e2e-validate-predicted-latency.sh` validate stage that runs after the smoke loop.

### 1. Empty warmup payload (`8937f00`)

The script wrote the request body via:

```bash
kubectl exec -n "$NS" "$POD" -- sh -c "cat > /tmp/payload.json" <<<"$PAYLOAD"
```

`kubectl exec ... -- sh -c "cat > file"` silently produces a **0-byte file** — `cat`'s stdin never receives the herestring through `sh -c`, even when `-i` is passed. The 100 warmup curls then sent empty bodies, vLLM rejected all of them, and the script aborted at:

```
Sending 100 requests with concurrency 8...
Error: zero successful warmup requests — gateway/model server is not serving traffic.
Warmup result: ok=0 fail=100
```

Reproduced on a live cluster:

| pattern | result |
|---|---|
| `kubectl exec -i -- sh -c 'cat > file'` | 0 bytes ❌ |
| `kubectl exec -i -- tee /tmp/file` | 76 bytes ✓ |

Pipe through `tee` instead — when the inner command is the direct stdin consumer (rather than a redirect inside `sh -c`), `kubectl exec -i` delivers stdin reliably.

### 2. EPP `/metrics` rejected by auth (`e70b2dc`)

After the warmup fix, the next failure is the metrics scrape. The chart defaults `--metrics-endpoint-auth=true`, which 401s requests without a service-account bearer token. `e2e-validate-predicted-latency.sh` runs in a generic `curlimages/curl` pod with no token, so `/metrics` returns the 401 body, `sum_histogram_count` finds no histogram lines, and the script aborts with:

```
predicted_ttft_count=0
Error: predicted TTFT histogram is empty after 100 requests.
```

Pass `--set inferenceExtension.monitoring.prometheus.auth.enabled=false` to the chart's `helm install` in all three nightlies (GKE/CKS/OCP). This adds `--metrics-endpoint-auth=false` to the EPP container args (chart helper at [`charts/inference-extension/templates/_deployment.yaml:143-144`](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/v1.5.0/config/charts/inference-extension/templates/_deployment.yaml#L143-L144)). **CI-only** — the production guide default (auth on) is unchanged.

### Verified locally end-to-end

Ran the patched script against a live cluster (with auth-off applied):

```
Warmup result: ok=100 fail=0
actual_ttft_count=116 predicted_ttft_count=116
✅ Predicted-latency scheduling is active: predictor returned predictions for 116 requests.
```

