### PR TITLE
one build approval per set of chagnes in a PR

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -152,7 +152,6 @@ jobs:
     needs: [detect-changes]
     if: ${{ needs.detect-changes.outputs.cuda == 'true' }}
     continue-on-error: true
-    environment: build-approval
     strategy:
       fail-fast: false
       matrix:
@@ -312,7 +311,6 @@ jobs:
     needs: [detect-changes]
     if: ${{ needs.detect-changes.outputs.cuda == 'true' }}
     continue-on-error: true
-    environment: build-approval
     strategy:
       fail-fast: false
       # multi-OS build matrix: creates 4 images (2 platforms × 2 OS variants)
@@ -557,7 +555,6 @@ jobs:
     if: ${{ needs.cuda-success-check.outputs.any_succeeded == 'true' }}
     runs-on: ubuntu-latest
     continue-on-error: true
-    environment: build-approval
     strategy:
       fail-fast: false
       matrix:
@@ -702,7 +699,6 @@ jobs:
     needs: [detect-changes]
     if: ${{ needs.detect-changes.outputs.aws == 'true' }}
     continue-on-error: true
-    environment: build-approval
     strategy:
       fail-fast: false
       # AWS/EFA build matrix: RHEL-only, amd64-only (for now)
@@ -917,7 +913,6 @@ jobs:
     if: ${{ needs.aws-success-check.outputs.any_succeeded == 'true' }}
     runs-on: ubuntu-latest
     continue-on-error: true
-    environment: build-approval
     steps:
       - name: Check if build succeeded
         id: should-run
@@ -1187,7 +1182,6 @@ jobs:
   rdma-tools-build-llm-d:
     needs: [detect-changes]
     if: ${{ needs.detect-changes.outputs.rdma-tools == 'true' }}
-    environment: build-approval
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -1282,7 +1276,6 @@ jobs:
   xpu-build-llm-d:
     needs: [detect-changes]
     if: ${{ needs.detect-changes.outputs.xpu == 'true' }}
-    environment: build-approval
     strategy:
       fail-fast: false
     runs-on: xpu
@@ -1386,7 +1379,6 @@ jobs:
   rocm-build-llm-d:
     needs: [detect-changes]
     if: ${{ needs.detect-changes.outputs.rocm == 'true' }}
-    environment: build-approval
     runs-on: vllm-runner
     steps:
       - name: Checkout code
@@ -1465,7 +1457,6 @@ jobs:
   hpu-build-llm-d:
     needs: [detect-changes]
     if: ${{ needs.detect-changes.outputs.hpu == 'true' }}
-    environment: build-approval
     strategy:
       fail-fast: false
     runs-on: vllm-runner
@@ -1543,7 +1534,6 @@ jobs:
   cpu-build-llm-d:
     needs: [detect-changes]
     if: ${{ needs.detect-changes.outputs.cpu == 'true' }}
-    environment: build-approval
     runs-on: vllm-runner
     steps:
       - name: Checkout code

--- a/.github/workflows/ci-pr-test.yaml
+++ b/.github/workflows/ci-pr-test.yaml
@@ -41,12 +41,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Gate: determine whether this workflow run should proceed.
+  # Quick check: do any image-related files have changes?
+  # Runs immediately without approval — only reads the GitHub API diff,
+  # does not execute PR code. Used to skip the approval gate when no
+  # images need building.
+  needs-build-check:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    outputs:
+      any_image_changes: ${{ steps.check.outputs.any_image_changes }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            images:
+              - 'docker/**'
+              - 'patches/**'
+              - 'scripts/**'
+      - name: Summarize
+        id: check
+        run: |
+          echo "any_image_changes=${{ steps.filter.outputs.images }}" >> $GITHUB_OUTPUT
+
+  # Gate: require approval only when image-related files changed.
   # For pull_request_target (fork PRs): requires approval from a maintainer via
   # the "build-approval" GitHub Environment with required reviewers.
-  # For push/workflow_dispatch: proceeds automatically.
+  # Skipped entirely when no image files changed — builds will be skipped anyway.
+  # For push/workflow_dispatch: proceeds automatically via auto-gate.
   pr-gate:
-    if: github.event_name == 'pull_request_target'
+    needs: [needs-build-check]
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      needs.needs-build-check.outputs.any_image_changes == 'true'
     runs-on: ubuntu-latest
     environment: build-approval
     steps:
@@ -123,7 +151,7 @@ jobs:
   # Call the build-image workflow to build any changed images
   # Resolves build-image.yml from main (pull_request_target), checks out PR code via ref.
   build-images:
-    needs: [pr-gate, auto-gate]
+    needs: [needs-build-check, pr-gate, auto-gate]
     if: ${{ !cancelled() && !failure() }}
     uses: ./.github/workflows/build-image.yml
     with:


### PR DESCRIPTION
cc @llm-d/release-crew 

This PR makes it such that you only need to approve once for a full build instead of 3 times