### PR TITLE
Fix InferencePool diagram reference

### DIFF
--- a/docs/architecture/core/inferencepool.md
+++ b/docs/architecture/core/inferencepool.md
@@ -13,7 +13,7 @@ The `InferencePool` performs two primary roles in the inference infrastructure:
 
 The following diagram visualizes how the `InferencePool` resource is involved in the control path of both the EPP and Gateway Controller:
 
-![InferencePool](../../assets/gateway-design.svg)
+![InferencePool](../../assets/inferencepool.svg)
 
 ### 1. Endpoint Discovery (EPP Perspective)
 


### PR DESCRIPTION
The InferencePool documentation referenced `gateway-design.svg` but should reference `inferencepool.svg` to match the actual diagram for this component.

Both SVG files exist in `docs/assets/`, but the markdown had the wrong filename.