### PR TITLE
chore(xpu): bump VLLM_XPU_COMMIT_SHA to v0.19.1

### DIFF
--- a/docker/common-versions
+++ b/docker/common-versions
@@ -21,8 +21,8 @@ VLLM_PRECOMPILED_WHEEL_COMMIT=b1388b1fbf5aaef47937fabe98931211684666a6 # maps to
 
 
 
-# Used by XPU, commit from vllm, point to v0.17.0
-VLLM_XPU_COMMIT_SHA=9dd656f0ea06ba452e1f26666c111ea4909cd488
+# Used by XPU, commit from vllm, maps to v0.19.1 tag
+VLLM_XPU_COMMIT_SHA=b1388b1fbf5aaef47937fabe98931211684666a6
 
 # ============================================================================
 # CUDA Version Configuration


### PR DESCRIPTION
## Summary

Pin `VLLM_XPU_COMMIT_SHA` in `docker/common-versions` to `b1388b1f…`. This brings XPU in line with the v0.19.1 stack already used for CUDA's `VLLM_PRECOMPILED_WHEEL_COMMIT`.

## Follow-up tasks
once v0.7.0 release is out, update xpu related guides/workflows to use v0.7.0 llm-d-xpu image:
- https://github.com/llm-d/llm-d/blob/4ece9cdd3a83f65b4bf42d3cafcc76c7408e76ef/guides/optimized-baseline/modelserver/xpu/vllm/kustomization.yaml#L12
- https://github.com/llm-d/llm-d/blob/4ece9cdd3a83f65b4bf42d3cafcc76c7408e76ef/guides/pd-disaggregation/modelserver/xpu/vllm/kustomization.yaml#L15
- https://github.com/llm-d/llm-d/blob/4ece9cdd3a83f65b4bf42d3cafcc76c7408e76ef/guides/precise-prefix-cache-aware/modelserver/xpu/vllm/kustomization.yaml#L13

### Validation

**1. Local image build against `Dockerfile.xpu@v0.19.1`** — succeeded in ~35 min on 8× Arc Pro B60, yielded a 32.1 GB image with `vllm 0.19.1` / `torch 2.10.0+xpu`.

**2. Runtime smoke test** via the `precise-prefix-cache-aware` XPU overlay (kind cluster, DRA-allocated XPUs, 2× Qwen/Qwen3-0.6B decode pods):
- Both pods reach `1/1 Ready` in **2m30s** (well inside the 5-8 min warmup budget)
- `/v1/models` returns the Qwen entry
- `/v1/chat/completions` produces a valid response
- `/v1/completions` on a 200-word prompt succeeds twice (second request hits precise-prefix-cache warm path)
- Scheduler's ZMQ subscriber binds `tcp://*:5556`, vLLM pods publish KV events

**3. CI build dispatch** against `xiaojun-zhang/llm-d` via a throwaway testing branch (that relaxes `ghcr.io` login + Trivy for forks) — [run #25405198901](https://github.com/xiaojun-zhang/llm-d/actions/runs/25405198901) — green in 7m36s. The throwaway branch has been deleted; this PR contains **only** the one-line `docker/common-versions` change.


## Test plan

- [x] Local docker build with `Dockerfile.xpu@v0.19.1` succeeds
- [x] k8s runtime smoke (decode pods Ready, chat + completions respond)
- [x] CI `build-image.yml` → `xpu-build-llm-d` succeeds on self-hosted XPU runner
- [ ] Nightly XPU e2e (post-merge; requires GHCR push which only works on `llm-d/llm-d`)
