### PR TITLE
docs: document feature gate removal process

### DIFF
--- a/docs/architecture/core/router/epp/configuration.md
+++ b/docs/architecture/core/router/epp/configuration.md
@@ -161,7 +161,7 @@ featureGates:
 
 To ensure backward compatibility, a feature gate should usually be removed over two releases:
 
-1.  **First Release:** Graduate the feature functionally but keep the feature gate in the configuration. This ensures that existing configurations remain valid and provides a mechanism for rollback if needed. During this phase, inform users (e.g., via release notes) that the feature gate is deprecated and will be removed in the next release.
+1.  **First Release:** Mark the feature as stable and enable it by default, but keep the feature gate in the configuration as a deprecated, still-functional gate so existing configurations remain valid and operators retain a temporary rollback mechanism by disabling the feature if needed. During this phase, inform users (e.g., via release notes) that the feature gate is deprecated and will be removed in the next release.
 2.  **Second Release:** Completely remove the feature gate from the configuration and code.
 
 ### Request Handling

--- a/docs/architecture/core/router/epp/configuration.md
+++ b/docs/architecture/core/router/epp/configuration.md
@@ -157,6 +157,13 @@ featureGates:
 
 - `flowControl`: Enables the Admission and Flow Control layer. This must be enabled to use the `flowControl` configuration section.
 
+#### Removing a Feature Gate
+
+To ensure backward compatibility, a feature gate should usually be removed over two releases:
+
+1.  **First Release:** Graduate the feature functionally but keep the feature gate in the configuration. This ensures that existing configurations remain valid and provides a mechanism for rollback if needed. During this phase, inform users (e.g., via release notes) that the feature gate is deprecated and will be removed in the next release.
+2.  **Second Release:** Completely remove the feature gate from the configuration and code.
+
 ### Request Handling
 
 This section covers components that process requests and responses before they reach the scheduling phase, or after a backend has been selected.


### PR DESCRIPTION
Update the EPP configuration guide to include a two-release process for removing feature gates, ensuring backward compatibility and safe transitions.