### PR TITLE
Fix nightly PD OCP workflow for kustomize deployment

### DIFF
--- a/.github/workflows/nightly-e2e-pd-disaggregation-ocp.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-ocp.yaml
@@ -1,8 +1,5 @@
 name: Nightly - PD Disaggregation E2E (OpenShift)
 
-# Nightly regression test for the pd-disaggregation guide on OpenShift.
-# Deploys the guide and validates with e2e-validate.sh.
-
 on:
   schedule:
     - cron: '30 0 * * *'
@@ -44,52 +41,7 @@ jobs:
       pod_wait_timeout: '30m'
       pod_readiness_delay: 180
 
-      pre_deploy_script: |
-        echo "Applying pd-disaggregation slim transforms..."
-
-        cd guides/pd-disaggregation/modelserver/gpu/vllm/base
-
-        yq e '.spec.replicas = 1' -i patch-decode.yaml
-        yq e '.spec.replicas = 1' -i patch-prefill.yaml
-
-        yq e '
-          (.spec.template.spec.containers[] | select(.name == "modelserver") | .args[0]) = "Qwen/Qwen3-0.6B"
-        ' -i patch-decode.yaml
-
-        yq e '
-          (.spec.template.spec.containers[] | select(.name == "modelserver") | .args[0]) = "Qwen/Qwen3-0.6B"
-        ' -i patch-prefill.yaml
-
-        yq e '
-          (.spec.template.spec.containers[] | select(.name == "modelserver") | .resources.limits["nvidia.com/gpu"]) = "1"
-        ' -i patch-decode.yaml
-
-        yq e '
-          (.spec.template.spec.containers[] | select(.name == "modelserver") | .resources.requests["nvidia.com/gpu"]) = "1"
-        ' -i patch-decode.yaml
-
-        yq e '
-          del(
-            .spec.template.spec.containers[] |
-            select(.name == "modelserver") |
-            .resources.limits.memory
-          )
-        ' -i patch-decode.yaml
-
-        yq e '
-          del(
-            .spec.template.spec.containers[] |
-            select(.name == "modelserver") |
-            .resources.requests.memory
-          )
-        ' -i patch-decode.yaml
-
-        echo "Slim transform applied"
-
-        cd "$GITHUB_WORKSPACE"
-
       allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
 
     secrets: inherit
-    

--- a/.github/workflows/nightly-e2e-pd-disaggregation-ocp.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-ocp.yaml
@@ -1,23 +1,13 @@
 name: Nightly - PD Disaggregation E2E (OpenShift)
 
 # Nightly regression test for the pd-disaggregation guide on OpenShift.
-# Deploys via helmfile and validates with e2e-validate.sh.
-# Uses a slim model transformation to reduce GPU requirements.
+# Deploys the guide and validates with e2e-validate.sh.
 
 on:
   schedule:
-    - cron: '30 0 * * *'  # 00:30 UTC daily (staggered from optimized-baseline)
+    - cron: '30 0 * * *'
   workflow_dispatch:
     inputs:
-      helmfile_env:
-        description: 'Helmfile environment'
-        required: false
-        default: 'ocp'
-        type: choice
-        options:
-          - ocp
-          - istio
-          - kgateway
       skip_cleanup:
         description: 'Skip cleanup after tests (for debugging)'
         required: false
@@ -27,53 +17,79 @@ permissions:
   contents: read
 
 concurrency:
-  group: nightly-e2e-pd-disaggregation
+  group: nightly-e2e-pd-disaggregation-ocp
   cancel-in-progress: true
 
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift.yaml@main
+
     with:
       guide_name: pd-disaggregation
       namespace: llm-d-nightly-pd
-      helmfile_env: ${{ github.event.inputs.helmfile_env || 'ocp' }}
-      gateway_type: ${{ github.event.inputs.helmfile_env || 'istio' }}
+
+      custom_deploy_script: |
+        kubectl apply -k guides/pd-disaggregation/modelserver/gpu/vllm/coreweave -n ${NAMESPACE}
+
+        helm install pd-disaggregation \
+          oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
+          -f guides/recipes/scheduler/base.values.yaml \
+          -f guides/pd-disaggregation/scheduler/pd-disaggregation.values.yaml \
+          -n ${NAMESPACE} --version v1.5.0
+
       accelerator_type: H100
       required_gpus: 2
       recommended_gpus: 4
       pod_wait_timeout: '30m'
       pod_readiness_delay: 180
-      # Slim transform: reduce model to Qwen3-0.6B, 1 GPU per pod, reduce memory
+
       pre_deploy_script: |
         echo "Applying pd-disaggregation slim transforms..."
-        cd guides/pd-disaggregation
-        yq e '.modelArtifacts.uri = "hf://Qwen/Qwen3-0.6B"' -i ms-pd/values.yaml
-        yq e '.routing.modelName = "Qwen/Qwen3-0.6B"' -i ms-pd/values.yaml
-        yq e 'del(.decode.containers[0].args[] | select(. == "--max-model-len" or . == "32000"))' -i ms-pd/values.yaml
-        yq e 'del(.prefill.containers[0].args[] | select(. == "--max-model-len" or . == "32000"))' -i ms-pd/values.yaml
-        yq e 'del(.decode.containers[0].resources.limits.memory)' -i ms-pd/values.yaml
-        yq e 'del(.decode.containers[0].resources.requests.memory)' -i ms-pd/values.yaml
-        yq e 'del(.decode.containers[0].resources.limits.cpu)' -i ms-pd/values.yaml
-        yq e 'del(.decode.containers[0].resources.requests.cpu)' -i ms-pd/values.yaml
-        yq e 'del(.decode.containers[0].resources.limits."rdma/ib")' -i ms-pd/values.yaml
-        yq e 'del(.decode.containers[0].resources.requests."rdma/ib")' -i ms-pd/values.yaml
-        yq e 'del(.prefill.containers[0].resources.limits.memory)' -i ms-pd/values.yaml
-        yq e 'del(.prefill.containers[0].resources.requests.memory)' -i ms-pd/values.yaml
-        yq e 'del(.prefill.containers[0].resources.limits.cpu)' -i ms-pd/values.yaml
-        yq e 'del(.prefill.containers[0].resources.requests.cpu)' -i ms-pd/values.yaml
-        yq e 'del(.prefill.containers[0].resources.limits."rdma/ib")' -i ms-pd/values.yaml
-        yq e 'del(.prefill.containers[0].resources.requests."rdma/ib")' -i ms-pd/values.yaml
-        yq e '.decode.containers[0].resources.limits["nvidia.com/gpu"] = "1"' -i ms-pd/values.yaml
-        yq e '.decode.containers[0].resources.requests["nvidia.com/gpu"] = "1"' -i ms-pd/values.yaml
-        yq e '.decode.parallelism.tensor = 1' -i ms-pd/values.yaml
-        yq e '.prefill.replicas = 1' -i ms-pd/values.yaml
-        yq e '.decode.volumes[1].emptyDir.sizeLimit = "2Gi"' -i ms-pd/values.yaml
-        yq e '.prefill.volumes[1].emptyDir.sizeLimit = "2Gi"' -i ms-pd/values.yaml
-        echo "Slim transform applied — model: Qwen3-0.6B, 1 GPU decode, 1 prefill replica"
+
+        cd guides/pd-disaggregation/modelserver/gpu/vllm/base
+
+        yq e '.spec.replicas = 1' -i patch-decode.yaml
+        yq e '.spec.replicas = 1' -i patch-prefill.yaml
+
+        yq e '
+          (.spec.template.spec.containers[] | select(.name == "modelserver") | .args[0]) = "Qwen/Qwen3-0.6B"
+        ' -i patch-decode.yaml
+
+        yq e '
+          (.spec.template.spec.containers[] | select(.name == "modelserver") | .args[0]) = "Qwen/Qwen3-0.6B"
+        ' -i patch-prefill.yaml
+
+        yq e '
+          (.spec.template.spec.containers[] | select(.name == "modelserver") | .resources.limits["nvidia.com/gpu"]) = "1"
+        ' -i patch-decode.yaml
+
+        yq e '
+          (.spec.template.spec.containers[] | select(.name == "modelserver") | .resources.requests["nvidia.com/gpu"]) = "1"
+        ' -i patch-decode.yaml
+
+        yq e '
+          del(
+            .spec.template.spec.containers[] |
+            select(.name == "modelserver") |
+            .resources.limits.memory
+          )
+        ' -i patch-decode.yaml
+
+        yq e '
+          del(
+            .spec.template.spec.containers[] |
+            select(.name == "modelserver") |
+            .resources.requests.memory
+          )
+        ' -i patch-decode.yaml
+
+        echo "Slim transform applied"
+
         cd "$GITHUB_WORKSPACE"
-      image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
+
       allow_gpu_preemption: true
-      install_gateway_provider: false
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+
     secrets: inherit
+    


### PR DESCRIPTION
This updates the OCP nightly PD workflow after the guide moved to kustomize.

The old workflow was still using the helmfile/ms-pd flow, which no longer matches the current guide setup.

Changes:
- switched to the newer reusable OpenShift workflow
- deploy PD manifests with kubectl apply -k
- install the scheduler from custom_deploy_script
- update the slim test transforms to modify:
  - patch-decode.yaml
  - patch-prefill.yaml

Checked locally by:
- validating the workflow YAML
- rendering the kustomize manifests successfully
- verifying the yq patch updates

Fixes #1433