### PR TITLE
Fix broken documentation links for GitHub + Docusaurus compatibility

### DIFF
--- a/docs/accelerators/README.md
+++ b/docs/accelerators/README.md
@@ -8,13 +8,13 @@ Maintainers for each accelerator type are listed below. See our well-lit path gu
 
 | Vendor | Models | Maintainers | Supported Well-lit Paths |
 | --- | --- | --- | --- |
-| AMD | ROCm | Kenny Roche (<Kenny.Roche@amd.com>), Vincent Cave (<Vincent.Cave@amd.com>) | [optimized baseline](../well-lit-paths/optimized-baseline.md), [Prefill/Decode Disaggregation](../well-lit-paths/pd-disaggregation.md) |
-| CPU | x86_64 | Hongming Zheng (@ZhengHongming888, <hongming.zheng@intel.com>) | [optimized baseline](../well-lit-paths/optimized-baseline.md) |
-| Google | [TPU](../infra-providers/gke/README.md#llm-d-on-google-kubernetes-engine-gke) | Edwin Hernandez (@Edwinhr716), Cong Liu (@liu-cong, <congliu.thu@gmail.com>) | [optimized baseline](../well-lit-paths/optimized-baseline.md), [Prefill/Decode Disaggregation](../well-lit-paths/pd-disaggregation.md) |
-| Intel | XPU | Yuan Wu (@yuanwu2017, <yuan.wu@intel.com>) | [optimized baseline](../well-lit-paths/optimized-baseline.md), [Prefill/Decode Disaggregation](../well-lit-paths/pd-disaggregation.md) |
-| Intel | HPU | Sakari Poussa (@poussa, <sakari.poussa@intel.com>) | [optimized baseline](../well-lit-paths/optimized-baseline.md) |
+| AMD | ROCm | Kenny Roche (<Kenny.Roche@amd.com>), Vincent Cave (<Vincent.Cave@amd.com>) | [optimized baseline](../well-lit-paths/optimized-baseline), [Prefill/Decode Disaggregation](../well-lit-paths/pd-disaggregation) |
+| CPU | x86_64 | Hongming Zheng (@ZhengHongming888, <hongming.zheng@intel.com>) | [optimized baseline](../well-lit-paths/optimized-baseline) |
+| Google | [TPU](/docs/infra-providers/gke/#llm-d-on-google-kubernetes-engine-gke) | Edwin Hernandez (@Edwinhr716), Cong Liu (@liu-cong, <congliu.thu@gmail.com>) | [optimized baseline](../well-lit-paths/optimized-baseline), [Prefill/Decode Disaggregation](../well-lit-paths/pd-disaggregation) |
+| Intel | XPU | Yuan Wu (@yuanwu2017, <yuan.wu@intel.com>) | [optimized baseline](../well-lit-paths/optimized-baseline), [Prefill/Decode Disaggregation](../well-lit-paths/pd-disaggregation) |
+| Intel | HPU | Sakari Poussa (@poussa, <sakari.poussa@intel.com>) | [optimized baseline](../well-lit-paths/optimized-baseline) |
 | NVIDIA | GPU | Will Eaton (<weaton@redhat.com>), Greg (<grpereir@redhat.com>) | All |
-| Rebellions | NPU | Jinmoo Seok (@rebel-jinmoo, <jinmoo_seok@rebellions.ai>), Minwook Ahn (@rebel-minwook, <minwook.ahn@rebellions.ai>) | [optimized baseline](../well-lit-paths/optimized-baseline.md) |
+| Rebellions | NPU | Jinmoo Seok (@rebel-jinmoo, <jinmoo_seok@rebellions.ai>), Minwook Ahn (@rebel-minwook, <minwook.ahn@rebellions.ai>) | [optimized baseline](../well-lit-paths/optimized-baseline) |
 
 ## Requirements
 
@@ -53,7 +53,7 @@ For the full CUDA/driver compatibility matrix, see the [CUDA Toolkit Release Not
 
 ## Google TPU
 
-Google Cloud TPUs (v6e, v7) are supported when running on GKE. See the [GKE infrastructure provider docs](../infra-providers/gke/README.md) for cluster setup.
+Google Cloud TPUs (v6e, v7) are supported when running on GKE. See the [GKE infrastructure provider docs](/docs/infra-providers/gke/) for cluster setup.
 
 ## AMD ROCm
 

--- a/docs/api-reference/README.md
+++ b/docs/api-reference/README.md
@@ -6,9 +6,9 @@ The following Kubernetes APIs are defined in the `inference.networking.k8s.io` (
 
 | Resource | Version | Description |
 | --- | --- | --- |
-| [InferencePool](inferencepool.md) | `v1` | Defines a pool of inference endpoints (model servers) to configure the **Endpoint Picker (EPP)** and Gateways for inference-optimized routing. |
-| [InferenceObjective](inferenceobjective.md) | `v1alpha2` | Defines performance goals (priority, latency) for specific model workloads within a pool. |
-| [InferenceModelRewrite](inferencemodelrewrite.md) | `v1alpha2` | Specifies rules for rewriting model names in request bodies, enabling traffic splitting and canary rollouts. |
+| [InferencePool](inferencepool) | `v1` | Defines a pool of inference endpoints (model servers) to configure the **Endpoint Picker (EPP)** and Gateways for inference-optimized routing. |
+| [InferenceObjective](inferenceobjective) | `v1alpha2` | Defines performance goals (priority, latency) for specific model workloads within a pool. |
+| [InferenceModelRewrite](inferencemodelrewrite) | `v1alpha2` | Specifies rules for rewriting model names in request bodies, enabling traffic splitting and canary rollouts. |
 
 ## Component Configuration
 
@@ -16,12 +16,12 @@ These schemas define the internal configuration for project components and are t
 
 | Schema | Version | Description |
 | --- | --- | --- |
-| [EndpointPickerConfig](endpointpickerconfig.md) | `v1alpha1` | Defines the internal configuration for the **Endpoint Picker (EPP)**, including plugins and request scheduling profiles. |
+| [EndpointPickerConfig](endpointpickerconfig) | `v1alpha1` | Defines the internal configuration for the **Endpoint Picker (EPP)**, including plugins and request scheduling profiles. |
 
 ## Recognized HTTP Headers
 
-*   [EPP HTTP Headers Reference](epp-http-headers.md): The EPP inspects specific HTTP headers to manage flow control and observability for inference requests.
+*   [EPP HTTP Headers Reference](epp-http-headers: The EPP inspects specific HTTP headers to manage flow control and observability for inference requests.
 
 ## See Also
 
-*   [Glossary](glossary.md): Definitions of key terms and concepts used across this project.
+*   [Glossary](glossary: Definitions of key terms and concepts used across this project.

--- a/docs/api-reference/endpointpickerconfig.md
+++ b/docs/api-reference/endpointpickerconfig.md
@@ -10,13 +10,13 @@
 
 | Field | Description |
 | --- | --- |
-| `featureGates` | `[]string` <br> A set of flags to enable experimental features (e.g., `flowControl`). |
-| `plugins` | [][PluginSpec](#pluginspec) <br> **Required** <br> List of plugins to be instantiated (e.g., scorers, adapters, reporters). |
-| `schedulingProfiles` | [][SchedulingProfile](#schedulingprofile) <br> **Required** <br> Named profiles that group plugins into routing slots. |
-| `saturationDetector` | [SaturationDetectorConfig](#saturationdetectorconfig) <br> Configuration for the saturation detector plugin. Defaults to `utilization-detector`. |
-| `dataLayer` | [DataLayerConfig](#datalayerconfig) <br> Configures the DataLayer for metadata extraction and processing. |
-| `flowControl` | [FlowControlConfig](#flowcontrolconfig) <br> Configures global and per-priority admission control. Only respected if the `flowControl` feature gate is enabled. |
-| `parser` | [ParserConfig](#parserconfig) <br> Specifies the parsing logic for protocol messages (e.g., `openai-parser`). |
+| `featureGates` | `[]string` <br /> A set of flags to enable experimental features (e.g., `flowControl`). |
+| `plugins` | [][PluginSpec](#pluginspec) <br /> **Required** <br /> List of plugins to be instantiated (e.g., scorers, adapters, reporters). |
+| `schedulingProfiles` | [][SchedulingProfile](#schedulingprofile) <br /> **Required** <br /> Named profiles that group plugins into routing slots. |
+| `saturationDetector` | [SaturationDetectorConfig](#saturationdetectorconfig) <br /> Configuration for the saturation detector plugin. Defaults to `utilization-detector`. |
+| `dataLayer` | [DataLayerConfig](#datalayerconfig) <br /> Configures the DataLayer for metadata extraction and processing. |
+| `flowControl` | [FlowControlConfig](#flowcontrolconfig) <br /> Configures global and per-priority admission control. Only respected if the `flowControl` feature gate is enabled. |
+| `parser` | [ParserConfig](#parserconfig) <br /> Specifies the parsing logic for protocol messages (e.g., `openai-parser`). |
 
 ## PluginSpec
 
@@ -24,9 +24,9 @@ Defines a plugin instance and its parameters.
 
 | Field | Description |
 | --- | --- |
-| `name` | `string` <br> Unique name for this plugin instance. If omitted, `type` is used. |
-| `type` | `string` <br> **Required** <br> The plugin type to instantiate (e.g., `least-request`, `openai-parser`). |
-| `parameters` | `json.RawMessage` <br> Arbitrary parameters passed to the plugin's factory function. |
+| `name` | `string` <br /> Unique name for this plugin instance. If omitted, `type` is used. |
+| `type` | `string` <br /> **Required** <br /> The plugin type to instantiate (e.g., `least-request`, `openai-parser`). |
+| `parameters` | `json.RawMessage` <br /> Arbitrary parameters passed to the plugin's factory function. |
 
 ## SchedulingProfile
 
@@ -34,15 +34,15 @@ Groups plugins to define specific routing behavior.
 
 | Field | Description |
 | --- | --- |
-| `name` | `string` <br> **Required** <br> Name of the profile. |
-| `plugins` | [][SchedulingPlugin](#schedulingplugin) <br> **Required** <br> List of plugins associated with this profile. |
+| `name` | `string` <br /> **Required** <br /> Name of the profile. |
+| `plugins` | [][SchedulingPlugin](#schedulingplugin) <br /> **Required** <br /> List of plugins associated with this profile. |
 
 ## SchedulingPlugin
 
 | Field | Description |
 | --- | --- |
-| `pluginRef` | `string` <br> **Required** <br> Reference to a named plugin in the top-level `plugins` list. |
-| `weight` | `float64` <br> Weight used if the plugin is a Scorer. |
+| `pluginRef` | `string` <br /> **Required** <br /> Reference to a named plugin in the top-level `plugins` list. |
+| `weight` | `float64` <br /> Weight used if the plugin is a Scorer. |
 
 ## FlowControlConfig
 
@@ -50,44 +50,44 @@ Configures admission control and queuing.
 
 | Field | Description |
 | --- | --- |
-| `maxBytes` | `resource.Quantity` <br> Global maximum aggregate byte size of all active requests. |
-| `maxRequests` | `resource.Quantity` <br> Global maximum number of concurrent requests. |
-| `defaultRequestTTL` | `duration` <br> Fallback timeout for queued requests. |
-| `defaultPriorityBand` | [PriorityBandConfig](#prioritybandconfig) <br> Template for priority levels not explicitly configured. |
-| `priorityBands` | [][PriorityBandConfig](#prioritybandconfig) <br> Explicit policies for specific priority levels. |
-| `usageLimitPolicyPluginRef` | `string` <br> Reference to a `UsageLimitPolicy` plugin for adaptive capacity management. |
+| `maxBytes` | `resource.Quantity` <br /> Global maximum aggregate byte size of all active requests. |
+| `maxRequests` | `resource.Quantity` <br /> Global maximum number of concurrent requests. |
+| `defaultRequestTTL` | `duration` <br /> Fallback timeout for queued requests. |
+| `defaultPriorityBand` | [PriorityBandConfig](#prioritybandconfig) <br /> Template for priority levels not explicitly configured. |
+| `priorityBands` | [][PriorityBandConfig](#prioritybandconfig) <br /> Explicit policies for specific priority levels. |
+| `usageLimitPolicyPluginRef` | `string` <br /> Reference to a `UsageLimitPolicy` plugin for adaptive capacity management. |
 
 ## PriorityBandConfig
 
 | Field | Description |
 | --- | --- |
-| `priority` | `int` <br> Integer priority level. Higher is more critical. |
-| `maxBytes` | `resource.Quantity` <br> Max bytes allowed for this priority band. |
-| `maxRequests` | `resource.Quantity` <br> Max concurrent requests allowed for this band. |
-| `fairnessPolicyRef` | `string` <br> Policy governing flow selection (default: `global-strict-fairness-policy`). |
-| `orderingPolicyRef` | `string` <br> Policy governing request selection within a flow (default: `fcfs-ordering-policy`). |
+| `priority` | `int` <br /> Integer priority level. Higher is more critical. |
+| `maxBytes` | `resource.Quantity` <br /> Max bytes allowed for this priority band. |
+| `maxRequests` | `resource.Quantity` <br /> Max concurrent requests allowed for this band. |
+| `fairnessPolicyRef` | `string` <br /> Policy governing flow selection (default: `global-strict-fairness-policy`). |
+| `orderingPolicyRef` | `string` <br /> Policy governing request selection within a flow (default: `fcfs-ordering-policy`). |
 
 ## DataLayerConfig
 
 | Field | Description |
 | --- | --- |
-| `sources` | [][DataLayerSource](#datalayersource) <br> **Required** <br> List of metadata sources. |
+| `sources` | [][DataLayerSource](#datalayersource) <br /> **Required** <br /> List of metadata sources. |
 
 ## DataLayerSource
 
 | Field | Description |
 | --- | --- |
-| `pluginRef` | `string` <br> **Required** <br> Reference to a plugin providing the data source. |
-| `extractors` | [][DataLayerExtractor](#datalayerextractor) <br> **Required** <br> Plugins that extract specific attributes from the source. |
+| `pluginRef` | `string` <br /> **Required** <br /> Reference to a plugin providing the data source. |
+| `extractors` | [][DataLayerExtractor](#datalayerextractor) <br /> **Required** <br /> Plugins that extract specific attributes from the source. |
 
 ## SaturationDetectorConfig
 
 | Field | Description |
 | --- | --- |
-| `pluginRef` | `string` <br> Reference to a plugin instance for saturation detection. |
+| `pluginRef` | `string` <br /> Reference to a plugin instance for saturation detection. |
 
 ## ParserConfig
 
 | Field | Description |
 | --- | --- |
-| `pluginRef` | `string` <br> **Required** <br> Reference to a parser plugin (default: `openai-parser`). |
+| `pluginRef` | `string` <br /> **Required** <br /> Reference to a parser plugin (default: `openai-parser`). |

--- a/docs/api-reference/glossary.md
+++ b/docs/api-reference/glossary.md
@@ -18,9 +18,9 @@ Quick-reference definitions for terms used throughout the llm-d documentation. F
 
 **Expert Parallelism (EP)** — Distributing the expert layers of MoE models across multiple GPUs, enabling large models like DeepSeek-R1 to be served across nodes. See [Model Servers](../architecture/core/model-servers.md).
 
-**ext-proc (External Processing)** — An Envoy filter protocol that offloads per-request routing decisions to an external gRPC service — in llm-d, the EPP. This is the communication channel between the Proxy and the routing logic. See [EPP](../architecture/core/router/epp/README.md).
+**ext-proc (External Processing)** — An Envoy filter protocol that offloads per-request routing decisions to an external gRPC service — in llm-d, the EPP. This is the communication channel between the Proxy and the routing logic. See [EPP](../architecture/core/router/epp/).
 
-**Flow Control** — The EPP subsystem that manages admission, queuing, and dispatch of requests using a Priority, Fairness, and Ordering hierarchy to prevent backend overload. See [EPP](../architecture/core/router/epp/README.md).
+**Flow Control** — The EPP subsystem that manages admission, queuing, and dispatch of requests using a Priority, Fairness, and Ordering hierarchy to prevent backend overload. See [EPP](../architecture/core/router/epp/).
 
 **Gateway API** — The Kubernetes-native API for configuring L7 traffic routing, succeeding Ingress. llm-d uses Gateway API resources (`HTTPRoute`, `Gateway`) to route external traffic to InferencePools. See [Proxy](../architecture/core/router/proxy.md).
 
@@ -42,7 +42,7 @@ Quick-reference definitions for terms used throughout the llm-d documentation. F
 
 **llm-d Batch Gateway** — An OpenAI-compatible API server (`/v1/batches`, `/v1/files`) for submitting, tracking, and managing batch inference jobs. It coordinates with the llm-d Async Processor for throttled request dispatch. See [Batch Inference](../architecture/advanced/batch/README.md).
 
-**llm-d Endpoint Picker (EPP)** — The central routing component of llm-d. Receives ext-proc callbacks from the Proxy, evaluates candidate Model Servers through a Plugin Pipeline of filters, scorers, and pickers, and returns the address of the optimal backend. See [EPP](../architecture/core/router/epp/README.md).
+**llm-d Endpoint Picker (EPP)** — The central routing component of llm-d. Receives ext-proc callbacks from the Proxy, evaluates candidate Model Servers through a Plugin Pipeline of filters, scorers, and pickers, and returns the address of the optimal backend. See [EPP](../architecture/core/router/epp/).
 
 **llm-d Router** — The intelligent entry point for inference requests. It provides LLM-aware load balancing (e.g., prefix-cache and load-aware routing) and request queuing, and manages disaggregated serving. It is composed of two functional parts: a data-plane **Proxy** (e.g., Envoy) and the **Endpoint Picker (EPP)**. See [Architecture Overview](../architecture/README.md).
 
@@ -54,7 +54,7 @@ Quick-reference definitions for terms used throughout the llm-d documentation. F
 
 **NIXL** — NVIDIA Inference Xfer Library for high-speed GPU-to-GPU KV-cache transfer over InfiniBand, RoCE, EFA, and TCP. Used between Prefill and Decode workers in Disaggregated Serving.
 
-**Plugin Pipeline** — The modular Filter, Score, Pick architecture inside the EPP that evaluates and selects Model Server endpoints for each request. Filters narrow candidates, scorers rank them, and pickers make the final selection. See [EPP](../architecture/core/router/epp/README.md).
+**Plugin Pipeline** — The modular Filter, Score, Pick architecture inside the EPP that evaluates and selects Model Server endpoints for each request. Filters narrow candidates, scorers rank them, and pickers make the final selection. See [EPP](../architecture/core/router/epp/).
 
 **Prefix Caching** — A technique where the EPP routes requests to Model Servers that already hold matching KV Cache entries for the prompt prefix, eliminating redundant Prefill computation and reducing TTFT. See [Architecture Overview](../architecture/README.md).
 
@@ -68,7 +68,7 @@ Quick-reference definitions for terms used throughout the llm-d documentation. F
 
 **Tensor Parallelism (TP)** — Sharding model layers across multiple GPUs within a node to serve models that exceed single-GPU memory. See [Model Servers](../architecture/core/model-servers.md).
 
-**KV Cache Management** — A comprehensive ecosystem for managing and reusing the KV cache across the inference pool. It includes **Prefix-Cache Aware Routing**, **KV-Cache Indexing**, and **KV Offloading** to scale effective cache capacity beyond hardware limits. See [KV Cache Management](../architecture/advanced/kv-management/README.md).
+**KV Cache Management** — A comprehensive ecosystem for managing and reusing the KV cache across the inference pool. It includes **Prefix-Cache Aware Routing**, **KV-Cache Indexing**, and **KV Offloading** to scale effective cache capacity beyond hardware limits. See [KV Cache Management](../architecture/advanced/kv-management/).
 
 **TPOT (Time Per Output Token)** — The average latency to generate each subsequent token during Decode. A key metric for streaming response quality. See [Architecture Overview](../architecture/README.md).
 

--- a/docs/api-reference/inferencemodelrewrite.md
+++ b/docs/api-reference/inferencemodelrewrite.md
@@ -14,15 +14,15 @@
 | `apiVersion` | `inference.networking.x-k8s.io/v1alpha2` |
 | `kind` | `InferenceModelRewrite` |
 | `metadata` | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta) |
-| `spec` | [InferenceModelRewriteSpec](#inferencemodelrewritespec) <br> Spec defines the desired state of the rewrite rules. |
-| `status` | [InferenceModelRewriteStatus](#inferencemodelrewritestatus) <br> Status defines the observed state of the resource. |
+| `spec` | [InferenceModelRewriteSpec](#inferencemodelrewritespec) <br /> Spec defines the desired state of the rewrite rules. |
+| `status` | [InferenceModelRewriteStatus](#inferencemodelrewritestatus) <br /> Status defines the observed state of the resource. |
 
 ## InferenceModelRewriteSpec
 
 | Field | Description |
 | --- | --- |
-| `poolRef` | [PoolObjectReference](#poolobjectreference) <br> **Required** <br> Reference to the target `InferencePool`. |
-| `rules` | [][InferenceModelRewriteRule](#inferencemodelrewriterule) <br> **Required** <br> Ordered set of rules. The first rule to match a request is used. |
+| `poolRef` | [PoolObjectReference](#poolobjectreference) <br /> **Required** <br /> Reference to the target `InferencePool`. |
+| `rules` | [][InferenceModelRewriteRule](#inferencemodelrewriterule) <br /> **Required** <br /> Ordered set of rules. The first rule to match a request is used. |
 
 ## InferenceModelRewriteRule
 
@@ -30,8 +30,8 @@
 
 | Field | Description |
 | --- | --- |
-| `matches` | [][Match](#match) <br> **Optional** <br> Criteria for matching a request. Logical OR if multiple criteria are specified. If empty, matches all requests. |
-| `targets` | [][TargetModel](#targetmodel) <br> **Optional** <br> How to distribute traffic across weighted model targets. Min items: 1. |
+| `matches` | [][Match](#match) <br /> **Optional** <br /> Criteria for matching a request. Logical OR if multiple criteria are specified. If empty, matches all requests. |
+| `targets` | [][TargetModel](#targetmodel) <br /> **Optional** <br /> How to distribute traffic across weighted model targets. Min items: 1. |
 
 ## Match
 
@@ -39,14 +39,14 @@
 
 | Field | Description |
 | --- | --- |
-| `model` | [ModelMatch](#modelmatch) <br> **Required** <br> Criteria for matching the `model` field in the JSON request body. |
+| `model` | [ModelMatch](#modelmatch) <br /> **Required** <br /> Criteria for matching the `model` field in the JSON request body. |
 
 ## ModelMatch
 
 | Field | Description |
 | --- | --- |
-| `type` | `string` <br> Kind of string matching to use. Supported value: `Exact`. Defaults to `Exact`. |
-| `value` | `string` <br> **Required** <br> The model name string to match against. |
+| `type` | `string` <br /> Kind of string matching to use. Supported value: `Exact`. Defaults to `Exact`. |
+| `value` | `string` <br /> **Required** <br /> The model name string to match against. |
 
 ## TargetModel
 
@@ -54,14 +54,14 @@
 
 | Field | Description |
 | --- | --- |
-| `weight` | `int32` <br> **Optional** <br> Proportion of requests forwarded to the model. Computed as `weight/(sum of all weights)`. Min: 1, Max: 1000000. If set for one, must be set for all. |
-| `modelRewrite` | `string` <br> **Required** <br> The static model name to rewrite the request to. |
+| `weight` | `int32` <br /> **Optional** <br /> Proportion of requests forwarded to the model. Computed as `weight/(sum of all weights)`. Min: 1, Max: 1000000. If set for one, must be set for all. |
+| `modelRewrite` | `string` <br /> **Required** <br /> The static model name to rewrite the request to. |
 
 ## InferenceModelRewriteStatus
 
 | Field | Description |
 | --- | --- |
-| `conditions` | [][metav1.Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) <br> Conditions track the state. Known type: `Accepted`. |
+| `conditions` | [][metav1.Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) <br /> Conditions track the state. Known type: `Accepted`. |
 
 ## PoolObjectReference
 
@@ -69,9 +69,9 @@
 
 | Field | Description |
 | --- | --- |
-| `group` | `string` <br> Group of the referent. Defaults to `inference.networking.k8s.io`. |
-| `kind` | `string` <br> Kind of the referent. Defaults to `InferencePool`. |
-| `name` | `string` <br> **Required** <br> Name of the referent. |
+| `group` | `string` <br /> Group of the referent. Defaults to `inference.networking.k8s.io`. |
+| `kind` | `string` <br /> Kind of the referent. Defaults to `InferencePool`. |
+| `name` | `string` <br /> **Required** <br /> Name of the referent. |
 
 ---
 

--- a/docs/api-reference/inferenceobjective.md
+++ b/docs/api-reference/inferenceobjective.md
@@ -14,8 +14,8 @@
 | `apiVersion` | `inference.networking.x-k8s.io/v1alpha2` |
 | `kind` | `InferenceObjective` |
 | `metadata` | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta) |
-| `spec` | [InferenceObjectiveSpec](#inferenceobjectivespec) <br> Spec represents the desired state of the model use case. |
-| `status` | [InferenceObjectiveStatus](#inferenceobjectivestatus) <br> Status defines the observed state of the InferenceObjective. |
+| `spec` | [InferenceObjectiveSpec](#inferenceobjectivespec) <br /> Spec represents the desired state of the model use case. |
+| `status` | [InferenceObjectiveStatus](#inferenceobjectivestatus) <br /> Status defines the observed state of the InferenceObjective. |
 
 ## InferenceObjectiveSpec
 
@@ -23,8 +23,8 @@
 
 | Field | Description |
 | --- | --- |
-| `priority` | `int` <br> **Optional** <br> Defines how important it is to serve the request compared to others in the same pool. Higher values have higher priority. Unset value is treated as `0`. Requests of higher priority are served first when resources are scarce. |
-| `poolRef` | [PoolObjectReference](#poolobjectreference) <br> **Required** <br> Reference to the inference pool. The pool must exist in the same namespace. |
+| `priority` | `int` <br /> **Optional** <br /> Defines how important it is to serve the request compared to others in the same pool. Higher values have higher priority. Unset value is treated as `0`. Requests of higher priority are served first when resources are scarce. |
+| `poolRef` | [PoolObjectReference](#poolobjectreference) <br /> **Required** <br /> Reference to the inference pool. The pool must exist in the same namespace. |
 
 ## InferenceObjectiveStatus
 
@@ -32,7 +32,7 @@
 
 | Field | Description |
 | --- | --- |
-| `conditions` | [][metav1.Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) <br> Conditions track the state of the InferenceObjective. Known type: `Accepted`. |
+| `conditions` | [][metav1.Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) <br /> Conditions track the state of the InferenceObjective. Known type: `Accepted`. |
 
 ## PoolObjectReference
 
@@ -40,9 +40,9 @@
 
 | Field | Description |
 | --- | --- |
-| `group` | `string` <br> Group of the referent. Defaults to `inference.networking.k8s.io`. |
-| `kind` | `string` <br> Kind of the referent. Defaults to `InferencePool`. |
-| `name` | `string` <br> **Required** <br> Name of the referent. |
+| `group` | `string` <br /> Group of the referent. Defaults to `inference.networking.k8s.io`. |
+| `kind` | `string` <br /> Kind of the referent. Defaults to `InferencePool`. |
+| `name` | `string` <br /> **Required** <br /> Name of the referent. |
 
 ---
 

--- a/docs/api-reference/inferencepool.md
+++ b/docs/api-reference/inferencepool.md
@@ -14,8 +14,8 @@
 | `apiVersion` | `inference.networking.k8s.io/v1` |
 | `kind` | `InferencePool` |
 | `metadata` | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta) |
-| `spec` | [InferencePoolSpec](#inferencepoolspec) <br> **Required** <br> Spec defines the desired state of the InferencePool. |
-| `status` | [InferencePoolStatus](#inferencepoolstatus) <br> Status defines the observed state of the InferencePool. |
+| `spec` | [InferencePoolSpec](#inferencepoolspec) <br /> **Required** <br /> Spec defines the desired state of the InferencePool. |
+| `status` | [InferencePoolStatus](#inferencepoolstatus) <br /> Status defines the observed state of the InferencePool. |
 
 ## InferencePoolSpec
 
@@ -23,10 +23,10 @@
 
 | Field | Description |
 | --- | --- |
-| `selector` | [LabelSelector](#labelselector) <br> **Required** <br> Selector determines which Pods are members of this inference pool. It matches Pods by their labels only within the same namespace; cross-namespace selection is not supported. <br> The structure is intentionally simple to be compatible with Kubernetes Service selectors. |
-| `targetPorts` | [][Port](#port) <br> **Required** <br> TargetPorts defines a list of ports that are exposed by this InferencePool. Every port will be treated as a distinctive endpoint by EPP, addressable as a `podIP:portNumber` combination. <br> Max items: 8. Port numbers must be unique. |
-| `appProtocol` | [AppProtocol](#appprotocol) <br> AppProtocol describes the application protocol for all the target ports. If unspecified, the protocol defaults to `http` (HTTP/1.1). |
-| `endpointPickerRef` | [EndpointPickerRef](#endpointpickerref) <br> **Required** <br> EndpointPickerRef is a reference to the Endpoint Picker extension and its associated configuration. |
+| `selector` | [LabelSelector](#labelselector) <br /> **Required** <br /> Selector determines which Pods are members of this inference pool. It matches Pods by their labels only within the same namespace; cross-namespace selection is not supported. <br /> The structure is intentionally simple to be compatible with Kubernetes Service selectors. |
+| `targetPorts` | [][Port](#port) <br /> **Required** <br /> TargetPorts defines a list of ports that are exposed by this InferencePool. Every port will be treated as a distinctive endpoint by EPP, addressable as a `podIP:portNumber` combination. <br /> Max items: 8. Port numbers must be unique. |
+| `appProtocol` | [AppProtocol](#appprotocol) <br /> AppProtocol describes the application protocol for all the target ports. If unspecified, the protocol defaults to `http` (HTTP/1.1). |
+| `endpointPickerRef` | [EndpointPickerRef](#endpointpickerref) <br /> **Required** <br /> EndpointPickerRef is a reference to the Endpoint Picker extension and its associated configuration. |
 
 ## InferencePoolStatus
 
@@ -34,7 +34,7 @@
 
 | Field | Description |
 | --- | --- |
-| `parents` | [][ParentStatus](#parentstatus) <br> Parents is a list of parent resources, typically Gateways, that are associated with the InferencePool, and the status of the InferencePool with respect to each parent. <br> Max items: 32. |
+| `parents` | [][ParentStatus](#parentstatus) <br /> Parents is a list of parent resources, typically Gateways, that are associated with the InferencePool, and the status of the InferencePool with respect to each parent. <br /> Max items: 32. |
 
 ## Port
 
@@ -42,7 +42,7 @@
 
 | Field | Description |
 | --- | --- |
-| `number` | `int32` <br> **Required** <br> Number defines the port number to access the selected model server Pods. Must be in range 1 to 65535. |
+| `number` | `int32` <br /> **Required** <br /> Number defines the port number to access the selected model server Pods. Must be in range 1 to 65535. |
 
 ## AppProtocol
 
@@ -58,11 +58,11 @@ Supported values:
 
 | Field | Description |
 | --- | --- |
-| `group` | `string` <br> Group of the referent API object. Defaults to "" (Core API group). |
-| `kind` | `string` <br> Kind of the referent. Defaults to `Service`. Implementations MUST NOT support `ExternalName` Services. |
-| `name` | `string` <br> **Required** <br> Name of the referent API object. |
-| `port` | [Port](#port) <br> Port of the Endpoint Picker extension service. Required when `kind` is `Service`. |
-| `failureMode` | `string` <br> Configures how the parent handles cases when the Endpoint Picker extension is non-responsive. <br> Defaults to `FailClose`. <br> Supported values: `FailOpen`, `FailClose`. |
+| `group` | `string` <br /> Group of the referent API object. Defaults to "" (Core API group). |
+| `kind` | `string` <br /> Kind of the referent. Defaults to `Service`. Implementations MUST NOT support `ExternalName` Services. |
+| `name` | `string` <br /> **Required** <br /> Name of the referent API object. |
+| `port` | [Port](#port) <br /> Port of the Endpoint Picker extension service. Required when `kind` is `Service`. |
+| `failureMode` | `string` <br /> Configures how the parent handles cases when the Endpoint Picker extension is non-responsive. <br /> Defaults to `FailClose`. <br /> Supported values: `FailOpen`, `FailClose`. |
 
 ## ParentStatus
 
@@ -70,9 +70,9 @@ Supported values:
 
 | Field | Description |
 | --- | --- |
-| `conditions` | [][metav1.Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) <br> Conditions provide information about the observed state. Supported types: `Accepted`, `ResolvedRefs`. |
-| `parentRef` | [ParentReference](#parentreference) <br> **Required** <br> Identifies the parent resource this status is associated with. |
-| `controllerName` | `string` <br> Name of the controller that wrote this status (e.g., `example.net/gateway-controller`). |
+| `conditions` | [][metav1.Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) <br /> Conditions provide information about the observed state. Supported types: `Accepted`, `ResolvedRefs`. |
+| `parentRef` | [ParentReference](#parentreference) <br /> **Required** <br /> Identifies the parent resource this status is associated with. |
+| `controllerName` | `string` <br /> Name of the controller that wrote this status (e.g., `example.net/gateway-controller`). |
 
 ## ParentReference
 
@@ -80,10 +80,10 @@ Supported values:
 
 | Field | Description |
 | --- | --- |
-| `group` | `string` <br> Group of the referent. Defaults to `gateway.networking.k8s.io`. |
-| `kind` | `string` <br> Kind of the referent. Defaults to `Gateway`. |
-| `name` | `string` <br> **Required** <br> Name of the referent. |
-| `namespace` | `string` <br> Namespace of the referenced object. Defaults to the local namespace. |
+| `group` | `string` <br /> Group of the referent. Defaults to `gateway.networking.k8s.io`. |
+| `kind` | `string` <br /> Kind of the referent. Defaults to `Gateway`. |
+| `name` | `string` <br /> **Required** <br /> Name of the referent. |
+| `namespace` | `string` <br /> Namespace of the referenced object. Defaults to the local namespace. |
 
 ## LabelSelector
 
@@ -91,7 +91,7 @@ Supported values:
 
 | Field | Description |
 | --- | --- |
-| `matchLabels` | `map[string]string` <br> **Required** <br> A set of {key,value} pairs. An object must match every label in this map (AND operation). <br> Max properties: 64. |
+| `matchLabels` | `map[string]string` <br /> **Required** <br /> A set of \{key,value\} pairs. An object must match every label in this map (AND operation). <br /> Max properties: 64. |
 
 ---
 

--- a/docs/architecture/core/router/README.md
+++ b/docs/architecture/core/router/README.md
@@ -13,9 +13,9 @@ See the [**Proxy deep dive**](proxy.md) to learn about deployment modes (Standal
 
 ### llm-d Endpoint Picker (EPP) 
 
-A specialized service that the proxy consults for every request. The [EPP](epp/README.md) contains the routing "intelligence," using real-time signals from model servers to make optimal placement decisions.
+A specialized service that the proxy consults for every request. The [EPP](./epp) contains the routing "intelligence," using real-time signals from model servers to make optimal placement decisions.
 
-See the [**llm-d EPP deep dive**](epp/README.md) to learn about the the routing engine's architecture, plugin pipeline (Filters, Scorers, Pickers), and flow control mechanisms.
+See the [**llm-d EPP deep dive**](./epp) to learn about the the routing engine's architecture, plugin pipeline (Filters, Scorers, Pickers), and flow control mechanisms.
 
 ## How it Works
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -108,4 +108,4 @@ Each path includes:
 - Sample workloads and benchmarks against baseline setups
 - Monitoring and observability configuration
 
-See the [Well-Lit Paths Guides](../well-lit-paths/README.md) for more details on how to deploy.
+See the [Well-Lit Paths Guides](/docs/guides/) for more details on how to deploy.

--- a/docs/getting-started/artifacts.md
+++ b/docs/getting-started/artifacts.md
@@ -19,9 +19,9 @@ llm-d uses the APIs defined in the Gateway API Inference Extension (GAIE) projec
 
 | CRD |  Purpose |
 |-----|----------|
-| [InferencePool](../api-reference/inferencepool.md) | Defines a pool of inference endpoints (model servers) and configures the EPP and proxy for LLM-aware routing. |
-| [InferenceObjective](../api-reference/inferenceobjective.md) | Defines performance goals (priority, latency) for specific model workloads within a pool. |
-| [InferenceModelRewrite](../api-reference/inferencemodelrewrite.md) | Specifies rules for rewriting model names in request bodies, enabling traffic splitting and canary rollouts. |
+| [InferencePool](../api-reference/inferencepool) | Defines a pool of inference endpoints (model servers) and configures the EPP and proxy for LLM-aware routing. |
+| [InferenceObjective](../api-reference/inferenceobjective) | Defines performance goals (priority, latency) for specific model workloads within a pool. |
+| [InferenceModelRewrite](../api-reference/inferencemodelrewrite) | Specifies rules for rewriting model names in request bodies, enabling traffic splitting and canary rollouts. |
 
 Manifests are published at [kubernetes-sigs/gateway-api-inference-extension/config/crd](https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/config/crd) and can be installed like:
 

--- a/docs/getting-started/feature-matrix.md
+++ b/docs/getting-started/feature-matrix.md
@@ -122,7 +122,7 @@ This page describes the current coverage as validated in the v0.7.0 release and 
 
 ### Supported Hardware
 
-For accelerator maintainer contacts and contribution requirements, see [Accelerator Support](../accelerators/README.md). The information below is also maintained in that document and will be consolidated into this feature matrix in a future docs revision.
+For accelerator maintainer contacts and contribution requirements, see [Accelerator Support](../accelerators/). The information below is also maintained in that document and will be consolidated into this feature matrix in a future docs revision.
 
 | Accelerator | Supported Devices | Notes |
 |-------------|-------------------|-------|

--- a/docs/well-lit-paths/README.md
+++ b/docs/well-lit-paths/README.md
@@ -25,5 +25,5 @@ Well-lit paths are curated, end-to-end guides for common LLM inference patterns 
 ### Experimental
 
 - **[Asynchronous Processing](asynchronous-processing.md)**: Intelligently processing latency-tolerant requests sourced from message queues via a lightweight agent to leverage "slack" capacity without the complexity of a full batch gateway.
-- **[Batch Gateway](experimental/batch-gateway.md)**: Managing large-scale batch inference coexisting with interactive workloads via an OpenAI-compatible Batch API.
+- **[Batch Gateway](./experimental/batch-gateway)**: Managing large-scale batch inference coexisting with interactive workloads via an OpenAI-compatible Batch API.
 

--- a/docs/well-lit-paths/asynchronous-processing.md
+++ b/docs/well-lit-paths/asynchronous-processing.md
@@ -4,7 +4,7 @@ The Asynchronous Processing path enables queue-based inference for latency-insen
 
 ## Deploy
 
-See the [asynchronous processing guide](../../guides/asynchronous-processing) for deployment instructions using Helm and supported queue implementations (Redis or GCP Pub/Sub).
+See the [asynchronous processing guide](https://github.com/llm-d/llm-d/tree/main/guides/asynchronous-processing) for deployment instructions using Helm and supported queue implementations (Redis or GCP Pub/Sub).
 
 ## Architecture
 

--- a/docs/well-lit-paths/experimental/batch-gateway.md
+++ b/docs/well-lit-paths/experimental/batch-gateway.md
@@ -18,7 +18,7 @@ Process large-scale batch inference jobs via an OpenAI-compatible API, enabling 
 
 ## Related
 
-- [Batch Gateway Deployment Guide](../../../guides/batch-gateway) — full deployment instructions, configuration options, and troubleshooting.
+- [Batch Gateway Deployment Guide](https://github.com/llm-d/llm-d/tree/main/guides/batch-gateway) — full deployment instructions, configuration options, and troubleshooting.
 - [Batch Gateway Architecture](../../architecture/advanced/batch/batch-gateway.md) — components, data flow, and processing pipeline.
 - [Batch Gateway Repository](https://github.com/llm-d-incubation/batch-gateway) — source code, Helm chart, platform-specific deployment guides, and demo scripts.
-- [Asynchronous Processing](../../../guides/asynchronous-processing) — complementary queue-based async inference for individual requests.
+- [Asynchronous Processing](https://github.com/llm-d/llm-d/tree/main/guides/asynchronous-processing) — complementary queue-based async inference for individual requests.

--- a/docs/well-lit-paths/optimized-baseline.md
+++ b/docs/well-lit-paths/optimized-baseline.md
@@ -14,7 +14,7 @@ The llm-d Router injects awareness of the LLM-workload into the load-balancing l
 
 ## Deploy
 
-See the [optimized baseline guide](../../guides/optimized-baseline) for manifests and step-by-step deployment.
+See the [optimized baseline guide](https://github.com/llm-d/llm-d/tree/main/guides/optimized-baseline) for manifests and step-by-step deployment.
 
 ## Architecture
 

--- a/docs/well-lit-paths/pd-disaggregation.md
+++ b/docs/well-lit-paths/pd-disaggregation.md
@@ -16,7 +16,7 @@ llm-d's EPP natively supports the concept of disaggregation, enabling compositio
 
 ## Deploy
 
-See the [P/D Disaggregation guide](../../guides/pd-disaggregation) for manifests and step-by-step deployment.
+See the [P/D Disaggregation guide](https://github.com/llm-d/llm-d/tree/main/guides/pd-disaggregation) for manifests and step-by-step deployment.
 
 ## Architecture
 

--- a/docs/well-lit-paths/precise-prefix-cache-aware.md
+++ b/docs/well-lit-paths/precise-prefix-cache-aware.md
@@ -12,7 +12,7 @@ As KV-cache orchestration grows more sophisticated and agentic workloads stretch
 
 ## Deploy
 
-See the [precise prefix cache-aware guide](../../guides/precise-prefix-cache-aware) for manifests and step-by-step deployment.
+See the [precise prefix cache-aware guide](https://github.com/llm-d/llm-d/tree/main/guides/precise-prefix-cache-aware) for manifests and step-by-step deployment.
 
 ## Architecture
 

--- a/docs/well-lit-paths/predicted-latency.md
+++ b/docs/well-lit-paths/predicted-latency.md
@@ -12,7 +12,7 @@ This path is for operators who want to adopt predicted latency-based scheduling 
 
 ## Deploy
 
-See the [Predicted Latency guide](../../guides/predicted-latency-based-scheduling) for manifests and step-by-step deployment.
+See the [Predicted Latency guide](https://github.com/llm-d/llm-d/tree/main/guides/predicted-latency-based-scheduling) for manifests and step-by-step deployment.
 
 ## Architecture
 

--- a/docs/well-lit-paths/tiered-prefix-cache.md
+++ b/docs/well-lit-paths/tiered-prefix-cache.md
@@ -53,7 +53,7 @@ This increases the **KV-working set size**, growing the **receptive-field** (the
 
 ## Deploy
 
-See the [KV Cache Management guide](../../guides/tiered-prefix-cache) for manifests and step-by-step deployment.
+See the [KV Cache Management guide](https://github.com/llm-d/llm-d/tree/main/guides/tiered-prefix-cache) for manifests and step-by-step deployment.
 
 ## Architecture
 

--- a/docs/well-lit-paths/wide-expert-parallelism.md
+++ b/docs/well-lit-paths/wide-expert-parallelism.md
@@ -27,7 +27,7 @@ The following steps occurs:
 
 ## Deploy
 
-See the [Wide Expert Parallelism guide](../../guides/wide-ep-lws) for manifests and step-by-step deployment.
+See the [Wide Expert Parallelism guide](https://github.com/llm-d/llm-d/tree/main/guides/wide-ep-lws) for manifests and step-by-step deployment.
 
 ## Architecture
 

--- a/docs/well-lit-paths/workload-autoscaling.md
+++ b/docs/well-lit-paths/workload-autoscaling.md
@@ -8,7 +8,7 @@ The llm-d stack provides two primary paths for workload autoscaling, both levera
 
 ## Deploy
 
-See the [workload autoscaling guide](../../guides/workload-autoscaling) for manifests and step-by-step deployment instructions for both paths.
+See the [workload autoscaling guide](https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling) for manifests and step-by-step deployment instructions for both paths.
 
 ## Strategies
 


### PR DESCRIPTION
Documentation is published to both GitHub and llm-d.ai (Docusaurus). Links with .md extensions work on GitHub but break on Docusaurus, which uses clean URLs (/docs/file/ instead of /docs/file.md/).

The solution is to use relative paths without .md extensions. This format works on both platforms:

GitHub resolves [text](filename) → filename.md
Docusaurus resolves [text](filename) → /docs/filename/


Removed .md extensions from ~170 internal links
Fixed malformed table links (missing closing parens)

I used this branch as the source for the website sync and was able to resolve the broken links on the site. 

For guides i'm pointing them back to github from the website on the first pass and can then later resolve that on the site. 