### PR TITLE
Bump Istio from 1.29.1 to 1.29.2

### DIFF
--- a/guides/prereq/gateway-provider/istio.helmfile.yaml
+++ b/guides/prereq/gateway-provider/istio.helmfile.yaml
@@ -5,7 +5,7 @@ repositories:
 releases:
   - name: istio-base
     chart: istio/base
-    version: 1.29.1
+    version: 1.29.2
     namespace: istio-system
     installed: true
     labels:
@@ -14,7 +14,7 @@ releases:
 
   - name: istiod
     chart: istio/istiod
-    version: 1.29.1
+    version: 1.29.2
     namespace: istio-system
     installed: true
     needs:
@@ -27,7 +27,7 @@ releases:
         pilot:
           env:
             ENABLE_GATEWAY_API_INFERENCE_EXTENSION: "true"
-        tag: 1.29.1
+        tag: 1.29.2
         hub: "docker.io/istio"
     labels:
       type: gateway-provider

--- a/guides/prereq/gateways/istio.md
+++ b/guides/prereq/gateways/istio.md
@@ -36,7 +36,7 @@ kubectl api-resources --api-group=inference.networking.k8s.io
 Install Istio with inference extension support enabled:
 
 ```bash
-ISTIO_VERSION=1.29.0
+ISTIO_VERSION=1.29.2
 curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${ISTIO_VERSION} sh -
 export PATH="$PWD/istio-${ISTIO_VERSION}/bin:$PATH"
 istioctl install -y \

--- a/guides/wide-ep-lws/experimental-dp-aware/README.md
+++ b/guides/wide-ep-lws/experimental-dp-aware/README.md
@@ -33,7 +33,7 @@ This guide demonstrates how to deploy DeepSeek-R1-0528 using vLLM's P/D disaggre
 
 * a 32xH200 cluster with InfiniBand networking
 * a 32xB200 cluster with InfiniBand networking
-* Istio 1.29.1 (required for multi-port support)
+* Istio 1.29.2 (required for multi-port support)
 
 In this example, we will demonstrate a deployment of `DeepSeek-R1-0528` with:
 
@@ -55,7 +55,7 @@ This guide requires 32 Nvidia H200 or B200 GPUs and InfiniBand or RoCE RDMA netw
 
 * Have the [proper client tools installed on your local system](../../../helpers/client-setup/README.md) to use this guide.
 * You have deployed the [LeaderWorkerSet controller](https://lws.sigs.k8s.io/docs/installation/)
-* Configure and deploy your [Gateway control plane](../../prereq/gateway-provider/README.md). Note that the Gateway must support multi-port (e.g. Istio 1.29.1)
+* Configure and deploy your [Gateway control plane](../../prereq/gateway-provider/README.md). Note that the Gateway must support multi-port (e.g. Istio 1.29.2)
 * Have the [Monitoring stack](../../../docs/monitoring/README.md) installed on your system.
 * Create a namespace for installation.
 


### PR DESCRIPTION
## Summary
- Bump Istio version to 1.29.2 across helmfile, install guide, and WideEP docs
- Also fixes `guides/prereq/gateways/istio.md` which was still on 1.29.0

Resolves #1261