### PR TITLE
Fix broken link in openshift-aws documentation

### DIFF
--- a/docs/infra-providers/openshift-aws/README.md
+++ b/docs/infra-providers/openshift-aws/README.md
@@ -43,4 +43,4 @@ Refer to the NVIDIA documentation for detailed instructions on installing and co
 
 Once the operators are installed and configured, you can proceed with deploying llm-d using the llm-d quick start.
 
-Try out the [well-lit path guides](../../../guides/README.md) for more information.
+Try out the [well-lit path guides](../../well-lit-paths/README.md) for more information.


### PR DESCRIPTION
Change relative path from ../../../guides/README.md to ../../well-lit-paths/README.md. This works for both GitHub viewing and Docusaurus transformation.