### PR TITLE
add tiered prefix cache nightly for gke

### DIFF
--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke.yaml
@@ -1,0 +1,52 @@
+name: Nightly - Tiered Prefix Cache E2E (GKE)
+
+# Nightly regression test for the tiered-prefix-cache/cpu guide on GKE.
+# Deploys the CPU offloading connector and validates with e2e-validate.sh.
+
+on:
+  schedule:
+    - cron: '0 12 * * *'  # 12:00 UTC daily (staggered between other GKE nightlies)
+  workflow_dispatch:
+    inputs:
+      skip_cleanup:
+        description: 'Skip cleanup after tests (for debugging)'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-e2e-tiered-prefix-cache-gke
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    if: github.repository == 'llm-d/llm-d'
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke.yaml@main
+    with:
+      guide_name: tiered-prefix-cache
+      namespace: llm-d-nightly-pfc-cpu-gke
+      gateway_host: 'tiered-prefix-cache-epp'
+      custom_deploy_script: |
+        export GAIE_VERSION=v1.5.0
+        export GUIDE_NAME="tiered-prefix-cache-cpu"
+        export ACCELERATOR=gpu
+        export CONNECTOR=offloading-connector
+        kubectl apply -n ${NAMESPACE} -k guides/tiered-prefix-cache/cpu/modelserver/${ACCELERATOR}/vllm/${CONNECTOR}
+        helm install ${GUIDE_NAME} \
+          oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
+          -f guides/recipes/scheduler/base.values.yaml \
+          -f guides/tiered-prefix-cache/cpu/scheduler/${GUIDE_NAME}.values.yaml \
+          -n ${NAMESPACE} --version ${GAIE_VERSION}
+      gke_cluster_name: llm-d-e2e-us-east5
+      gke_cluster_zone: us-east5
+      required_gpus: 2
+      recommended_gpus: 4
+      accelerator_type: H100
+      pod_wait_timeout: '30m'
+      pod_readiness_delay: 180
+      allow_gpu_preemption: true
+      llm_d_ref: ${{ github.ref }}
+      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+    secrets: inherit

--- a/.github/workflows/slash-test-nightly.yaml
+++ b/.github/workflows/slash-test-nightly.yaml
@@ -63,7 +63,8 @@ jobs:
               'optimized-baseline-ocp', 'pd-disaggregation-cks',
               'pd-disaggregation-gke', 'pd-disaggregation-ocp',
               'precise-prefix-cache-ocp',
-              'tiered-prefix-cache-ocp', 'wide-ep-lws-cks',
+              'tiered-prefix-cache-gke', 'tiered-prefix-cache-ocp',
+              'wide-ep-lws-cks',
               'wide-ep-lws-gke', 'wide-ep-lws-ocp',
               'wva-cks', 'wva-ocp',
             ];

--- a/guides/tiered-prefix-cache/cpu/modelserver/gpu/vllm/base/kustomization.yaml
+++ b/guides/tiered-prefix-cache/cpu/modelserver/gpu/vllm/base/kustomization.yaml
@@ -5,6 +5,12 @@ resources:
 
 namePrefix: gpu-vllm-
 
+images:
+  - name: REPLACE_MODEL_SERVER_IMAGE
+    newName: vllm/vllm-openai
+    newTag: v0.19.1
+
+
 labels:
   - pairs:
       llm-d.ai/model: Qwen3-32B

--- a/guides/tiered-prefix-cache/cpu/modelserver/gpu/vllm/base/patch-vllm.yaml
+++ b/guides/tiered-prefix-cache/cpu/modelserver/gpu/vllm/base/patch-vllm.yaml
@@ -8,7 +8,6 @@ spec:
     spec:
       containers:
         - name: modelserver
-          image: vllm/vllm-openai:v0.19.1
           command: ["vllm", "serve"]
           resources:
             limits:


### PR DESCRIPTION
This PR:
1. Creates the missing nightly-e2e-tiered-prefix-cache-gke.yaml workflow for GKE E2E regression testing.
2. Aligns the tiered-prefix-cache/cpu model server kustomization to use the standard REPLACE_MODEL_SERVER_IMAGE mapping, enabling nightly E2E test image overrides.