### PR TITLE
Add GKE CPU offloading LMCache nightly, rename workflows, and fix GPU requirements

### DIFF
--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-gke.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-gke.yaml
@@ -1,0 +1,52 @@
+name: Nightly - Tiered Prefix Cache CPU Offloading E2E (GKE)
+
+# Nightly regression test for the tiered-prefix-cache/cpu guide on GKE.
+# Deploys the CPU offloading connector and validates with e2e-validate.sh.
+
+on:
+  schedule:
+    - cron: '0 12 * * *'  # 12:00 UTC daily (staggered between other GKE nightlies)
+  workflow_dispatch:
+    inputs:
+      skip_cleanup:
+        description: 'Skip cleanup after tests (for debugging)'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-e2e-tiered-prefix-cache-gke
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    if: github.repository == 'llm-d/llm-d'
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke.yaml@main
+    with:
+      guide_name: tiered-prefix-cache
+      namespace: llm-d-nightly-pfc-cpu-gke
+      gateway_host: 'tiered-prefix-cache-cpu-epp'
+      custom_deploy_script: |
+        export GAIE_VERSION=v1.5.0
+        export GUIDE_NAME="tiered-prefix-cache-cpu"
+        export ACCELERATOR=gpu
+        export CONNECTOR=offloading-connector
+        kubectl apply -n ${NAMESPACE} -k guides/tiered-prefix-cache/cpu/modelserver/${ACCELERATOR}/vllm/${CONNECTOR}
+        helm install ${GUIDE_NAME} \
+          oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
+          -f guides/recipes/scheduler/base.values.yaml \
+          -f guides/tiered-prefix-cache/cpu/scheduler/${GUIDE_NAME}.values.yaml \
+          -n ${NAMESPACE} --version ${GAIE_VERSION}
+      gke_cluster_name: llm-d-e2e-us-east5
+      gke_cluster_zone: us-east5
+      required_gpus: 8
+      recommended_gpus: 8
+      accelerator_type: H100
+      pod_wait_timeout: '30m'
+      pod_readiness_delay: 180
+      allow_gpu_preemption: true
+      llm_d_ref: ${{ github.ref }}
+      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+    secrets: inherit

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-lmcache-gke.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-lmcache-gke.yaml
@@ -1,11 +1,11 @@
-name: Nightly - Tiered Prefix Cache E2E (GKE)
+name: Nightly - Tiered Prefix Cache CPU Offloading LMCache E2E (GKE)
 
-# Nightly regression test for the tiered-prefix-cache/cpu guide on GKE.
-# Deploys the CPU offloading connector and validates with e2e-validate.sh.
+# Nightly regression test for the tiered-prefix-cache/cpu guide with LMCache connector on GKE.
+# Deploys the LMCache connector and validates with e2e-validate.sh.
 
 on:
   schedule:
-    - cron: '0 12 * * *'  # 12:00 UTC daily (staggered between other GKE nightlies)
+    - cron: '30 15 * * *'  # 15:30 UTC daily (staggered between other GKE nightlies)
   workflow_dispatch:
     inputs:
       skip_cleanup:
@@ -27,12 +27,12 @@ jobs:
     with:
       guide_name: tiered-prefix-cache
       namespace: llm-d-nightly-pfc-cpu-gke
-      gateway_host: 'tiered-prefix-cache-epp'
+      gateway_host: 'tiered-prefix-cache-cpu-epp'
       custom_deploy_script: |
         export GAIE_VERSION=v1.5.0
         export GUIDE_NAME="tiered-prefix-cache-cpu"
         export ACCELERATOR=gpu
-        export CONNECTOR=offloading-connector
+        export CONNECTOR=lmcache-connector
         kubectl apply -n ${NAMESPACE} -k guides/tiered-prefix-cache/cpu/modelserver/${ACCELERATOR}/vllm/${CONNECTOR}
         helm install ${GUIDE_NAME} \
           oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
@@ -41,8 +41,8 @@ jobs:
           -n ${NAMESPACE} --version ${GAIE_VERSION}
       gke_cluster_name: llm-d-e2e-us-east5
       gke_cluster_zone: us-east5
-      required_gpus: 2
-      recommended_gpus: 4
+      required_gpus: 8
+      recommended_gpus: 8
       accelerator_type: H100
       pod_wait_timeout: '30m'
       pod_readiness_delay: 180

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-ocp.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-ocp.yaml
@@ -1,4 +1,4 @@
-name: Nightly - Tiered Prefix Cache E2E (OpenShift)
+name: Nightly - Tiered Prefix Cache CPU Offloading E2E (OpenShift)
 
 # Nightly regression test for the tiered-prefix-cache/cpu guide on OpenShift.
 # Uses kustomize for model server + helm for InferencePool + gateway recipe.

--- a/.github/workflows/slash-test-nightly.yaml
+++ b/.github/workflows/slash-test-nightly.yaml
@@ -22,7 +22,8 @@ name: /test-nightly Slash Command
 #   optimized-baseline-gke, optimized-baseline-ocp,
 #   pd-disaggregation-cks, pd-disaggregation-gke,
 #   pd-disaggregation-ocp, precise-prefix-cache-ocp,
-#   tiered-prefix-cache-ocp, wide-ep-lws-cks, 
+#   tiered-prefix-cache-cpu-offloading-gke, tiered-prefix-cache-cpu-offloading-lmcache-gke,
+#   tiered-prefix-cache-cpu-offloading-ocp, wide-ep-lws-cks, 
 #   wide-ep-lws-gke, wide-ep-lws-ocp,
 #   wva-cks, wva-ocp
 
@@ -63,7 +64,8 @@ jobs:
               'optimized-baseline-ocp', 'pd-disaggregation-cks',
               'pd-disaggregation-gke', 'pd-disaggregation-ocp',
               'precise-prefix-cache-ocp',
-              'tiered-prefix-cache-gke', 'tiered-prefix-cache-ocp',
+              'tiered-prefix-cache-cpu-offloading-gke', 'tiered-prefix-cache-cpu-offloading-lmcache-gke',
+              'tiered-prefix-cache-cpu-offloading-ocp',
               'wide-ep-lws-cks',
               'wide-ep-lws-gke', 'wide-ep-lws-ocp',
               'wva-cks', 'wva-ocp',

--- a/guides/tiered-prefix-cache/README.md
+++ b/guides/tiered-prefix-cache/README.md
@@ -1,6 +1,11 @@
 # KV Cache Offloading
 
-[![Nightly - Tiered Prefix Cache E2E (OpenShift)](https://github.com/llm-d/llm-d/actions/workflows/nightly-e2e-tiered-prefix-cache-ocp.yaml/badge.svg)](https://github.com/llm-d/llm-d/actions/workflows/nightly-e2e-tiered-prefix-cache-ocp.yaml)
+### CPU Offloading (vLLM Native)
+[![Nightly - Tiered Prefix Cache E2E (GKE)](https://github.com/llm-d/llm-d/actions/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-gke.yaml/badge.svg)](https://github.com/llm-d/llm-d/actions/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-gke.yaml)
+[![Nightly - Tiered Prefix Cache E2E (OpenShift)](https://github.com/llm-d/llm-d/actions/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-ocp.yaml/badge.svg)](https://github.com/llm-d/llm-d/actions/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-ocp.yaml)
+
+### CPU Offloading (LMCache)
+[![Nightly - Tiered Prefix Cache LMCache E2E (GKE)](https://github.com/llm-d/llm-d/actions/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-lmcache-gke.yaml/badge.svg)](https://github.com/llm-d/llm-d/actions/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-lmcache-gke.yaml)
 
 ## Overview
 

--- a/guides/tiered-prefix-cache/cpu/README.md
+++ b/guides/tiered-prefix-cache/cpu/README.md
@@ -1,6 +1,10 @@
 # Offloading Prefix Cache to CPU Memory
+### CPU Offloading (vLLM Native)
+[![Nightly - Tiered Prefix Cache E2E (GKE)](https://github.com/llm-d/llm-d/actions/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-gke.yaml/badge.svg)](https://github.com/llm-d/llm-d/actions/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-gke.yaml)
+[![Nightly - Tiered Prefix Cache E2E (OpenShift)](https://github.com/llm-d/llm-d/actions/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-ocp.yaml/badge.svg)](https://github.com/llm-d/llm-d/actions/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-ocp.yaml)
 
-[![Nightly - tiered cache CPU E2E (OCP)](https://github.com/llm-d/llm-d/actions/workflows/nightly-e2e-tiered-prefix-cache-ocp.yaml/badge.svg)](https://github.com/llm-d/llm-d/actions/workflows/nightly-e2e-tiered-prefix-cache-ocp.yaml)
+### CPU Offloading (LMCache)
+[![Nightly - Tiered Prefix Cache LMCache E2E (GKE)](https://github.com/llm-d/llm-d/actions/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-lmcache-gke.yaml/badge.svg)](https://github.com/llm-d/llm-d/actions/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-lmcache-gke.yaml)
 
 ## Overview
 


### PR DESCRIPTION
This PR expands nightly End-to-End (E2E) regression testing for the `tiered-prefix-cache` CPU offloading guide to cover both available CPU offloading connectors (vLLM Native and LMCache) on GKE and OpenShift (OCP).

### Key Changes

1. **Created & Configured GKE LMCache Nightly Workflow:**
   - Added `nightly-e2e-tiered-prefix-cache-cpu-offloading-lmcache-gke.yaml` to test the LMCache CPU offloading connector on GKE (staggered daily at 15:30 UTC with 8 H100 GPUs).

2. **Renamed Native CPU Offloading Workflows for Naming Consistency:**
   - Renamed both GKE and OpenShift (OCP) native workflow files to explicitly include `cpu-offloading` in their filenames, internal names, and concurrency groups:
     - `nightly-e2e-tiered-prefix-cache-gke.yaml` -> `nightly-e2e-tiered-prefix-cache-cpu-offloading-gke.yaml`
     - `nightly-e2e-tiered-prefix-cache-ocp.yaml` -> `nightly-e2e-tiered-prefix-cache-cpu-offloading-ocp.yaml`

3. **Restored Pristine Concurrency Groups:**
   - Retained original concurrency groups to coordinate scheduling and slot occupancy on nightly runners:
     - GKE Native: `nightly-e2e-tiered-prefix-cache-gke`
     - OCP Native: `nightly-e2e-tiered-prefix-cache`

4. **Updated Guide Status Badges:**
   - Updated status badges for vLLM Native (both GKE and OCP) and LMCache (GKE) in `guides/tiered-prefix-cache/README.md` and `guides/tiered-prefix-cache/cpu/README.md` to match the new filenames.

5. **Registered New Nightlies in Slash Test Runner:**
   - Registered all new and renamed workflows in `slash-test-nightly.yaml` to enable on-demand `/test-nightly` triggering.

6. **Fixed GKE GPU Requirements:**
   - Set GKE native and LMCache CPU offloading workflows to request 8 H100 GPUs to ensure Qwen3-32B is tested as-is.

Signed-off-by: Cong Liu <conliu@google.com>
