### PR TITLE
Bump agentgateway from v1.0.0 to v1.1.0

### DIFF
--- a/guides/pd-disaggregation/README.tpu.md
+++ b/guides/pd-disaggregation/README.tpu.md
@@ -15,7 +15,7 @@ Before starting, ensure your cluster and environment are properly configured:
 3. Set your environment variables, overriding the model name for Qwen 3.5:
 
 ```bash
-export GAIE_VERSION=v1.4.0
+export GAIE_VERSION=v1.5.0
 export GUIDE_NAME="pd-disaggregation"
 export NAMESPACE="llm-d-pd-disaggregation"
 export MODEL_NAME="Qwen/Qwen3.5-397B-A17B-FP8"

--- a/guides/prereq/gateway-provider/README.md
+++ b/guides/prereq/gateway-provider/README.md
@@ -78,7 +78,7 @@ llm-d provides helmfiles that install and configure `istio`, `kgateway`, and `ag
 
 The two self-installed inference modes are:
 
-* `agentgateway`: installs the `agentgateway` v1.0.0 control plane and data plane. This is the preferred self-installed inference path.
+* `agentgateway`: installs the `agentgateway` v1.1.0 control plane and data plane. This is the preferred self-installed inference path.
 * `kgateway`: installs the deprecated llm-d `kgateway` path using the `ghcr.io/kgateway-dev/charts/agentgateway*` charts at `v2.2.3`, with `inferenceExtension.enabled=true`. This path is retained only to support migrations.
 
 Both self-installed inference modes use the `agentgateway` GatewayClass in llm-d guide manifests.

--- a/guides/prereq/gateway-provider/agentgateway.helmfile.yaml
+++ b/guides/prereq/gateway-provider/agentgateway.helmfile.yaml
@@ -2,7 +2,7 @@ releases:
   - name: agentgateway-crds
     chart: oci://cr.agentgateway.dev/charts/agentgateway-crds
     namespace: agentgateway-system
-    version: v1.0.0
+    version: v1.1.0
     installed: true
     labels:
       type: gateway-provider
@@ -10,7 +10,7 @@ releases:
 
   - name: agentgateway
     chart: oci://cr.agentgateway.dev/charts/agentgateway
-    version: v1.0.0
+    version: v1.1.0
     namespace: agentgateway-system
     installed: true
     values:

--- a/guides/prereq/gateways/agentgateway.md
+++ b/guides/prereq/gateways/agentgateway.md
@@ -40,7 +40,7 @@ Install the agentgateway CRDs and control plane with inference extension support
 enabled:
 
 ```bash
-AGENTGATEWAY_VERSION=v1.0.0
+AGENTGATEWAY_VERSION=v1.1.0
 
 helm upgrade --install agentgateway-crds \
   oci://cr.agentgateway.dev/charts/agentgateway-crds \


### PR DESCRIPTION
Update the agentgateway CRDs chart, control plane chart, install guide, and README prose to v1.1.0.

v1.1.0 adds OIDC browser auth, network authorization policy, Azure managed identity fixes, and Vertex AI/Bedrock proxy improvements. 

The only breaking changes, the removed MCP auth fields on AgentgatewayBackend are not used by llm-d, which uses agentgateway purely as an HTTP inference gateway with inferenceExtension.enabled=true.

Also update GAIE_VERSION from v1.4.0 to v1.5.0 in the TPU P/D guide (the only remaining stale reference; all other guides are already at v1.5.0).

Closes #1420
Closes #1204
Closes #1203
Closes #1202