### PR TITLE
nightlies should comment status on PR

### DIFF
--- a/.github/workflows/nightly-e2e-optimized-baseline-cks.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-cks.yaml
@@ -12,6 +12,14 @@ on:
         description: 'Skip cleanup after tests (for debugging)'
         required: false
         default: 'false'
+      pr_number:
+        description: 'PR number for comment-back (set by /test-nightly)'
+        required: false
+        default: ''
+      pr_repo:
+        description: 'Repo for PR comment-back'
+        required: false
+        default: 'llm-d/llm-d'
 
 permissions:
   contents: read
@@ -43,4 +51,6 @@ jobs:
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
       allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_repo: ${{ github.event.inputs.pr_repo }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-optimized-baseline-gke.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-gke.yaml
@@ -12,6 +12,14 @@ on:
         description: 'Skip cleanup after tests (for debugging)'
         required: false
         default: 'false'
+      pr_number:
+        description: 'PR number for comment-back (set by /test-nightly)'
+        required: false
+        default: ''
+      pr_repo:
+        description: 'Repo for PR comment-back'
+        required: false
+        default: 'llm-d/llm-d'
 
 permissions:
   contents: read
@@ -47,4 +55,6 @@ jobs:
       allow_gpu_preemption: true
       llm_d_ref: ${{ github.ref }}
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_repo: ${{ github.event.inputs.pr_repo }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-optimized-baseline-ocp.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-ocp.yaml
@@ -20,6 +20,14 @@ on:
         description: 'Skip cleanup after tests (for debugging)'
         required: false
         default: 'false'
+      pr_number:
+        description: 'PR number for comment-back (set by /test-nightly)'
+        required: false
+        default: ''
+      pr_repo:
+        description: 'Repo for PR comment-back'
+        required: false
+        default: 'llm-d/llm-d'
 
 permissions:
   contents: read
@@ -53,4 +61,6 @@ jobs:
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
       allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_repo: ${{ github.event.inputs.pr_repo }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-pd-disaggregation-cks.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-cks.yaml
@@ -12,6 +12,14 @@ on:
         description: 'Skip cleanup after tests (for debugging)'
         required: false
         default: 'false'
+      pr_number:
+        description: 'PR number for comment-back (set by /test-nightly)'
+        required: false
+        default: ''
+      pr_repo:
+        description: 'Repo for PR comment-back'
+        required: false
+        default: 'llm-d/llm-d'
 
 permissions:
   contents: read
@@ -49,4 +57,6 @@ jobs:
         cd "$GITHUB_WORKSPACE"
       allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_repo: ${{ github.event.inputs.pr_repo }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-pd-disaggregation-gke.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-gke.yaml
@@ -13,6 +13,14 @@ on:
         description: 'Skip cleanup after tests (for debugging)'
         required: false
         default: 'false'
+      pr_number:
+        description: 'PR number for comment-back (set by /test-nightly)'
+        required: false
+        default: ''
+      pr_repo:
+        description: 'Repo for PR comment-back'
+        required: false
+        default: 'llm-d/llm-d'
 
 permissions:
   contents: read
@@ -75,4 +83,6 @@ jobs:
       allow_gpu_preemption: true
       llm_d_ref: ${{ github.ref }}
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_repo: ${{ github.event.inputs.pr_repo }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-pd-disaggregation-ocp.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-ocp.yaml
@@ -22,6 +22,14 @@ on:
         description: 'Skip cleanup after tests (for debugging)'
         required: false
         default: 'false'
+      pr_number:
+        description: 'PR number for comment-back (set by /test-nightly)'
+        required: false
+        default: ''
+      pr_repo:
+        description: 'Repo for PR comment-back'
+        required: false
+        default: 'llm-d/llm-d'
 
 permissions:
   contents: read
@@ -76,4 +84,6 @@ jobs:
       allow_gpu_preemption: true
       install_gateway_provider: false
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_repo: ${{ github.event.inputs.pr_repo }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-precise-prefix-cache-cks.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-cks.yaml
@@ -14,6 +14,14 @@ on:
         description: 'Skip cleanup after tests (for debugging)'
         required: false
         default: 'false'
+      pr_number:
+        description: 'PR number for comment-back (set by /test-nightly)'
+        required: false
+        default: ''
+      pr_repo:
+        description: 'Repo for PR comment-back'
+        required: false
+        default: 'llm-d/llm-d'
 
 permissions:
   contents: read
@@ -46,4 +54,6 @@ jobs:
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
       allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_repo: ${{ github.event.inputs.pr_repo }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-precise-prefix-cache-gke.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-gke.yaml
@@ -14,6 +14,14 @@ on:
         description: 'Skip cleanup after tests (for debugging)'
         required: false
         default: 'false'
+      pr_number:
+        description: 'PR number for comment-back (set by /test-nightly)'
+        required: false
+        default: ''
+      pr_repo:
+        description: 'Repo for PR comment-back'
+        required: false
+        default: 'llm-d/llm-d'
 
 permissions:
   contents: read
@@ -49,4 +57,6 @@ jobs:
       allow_gpu_preemption: true
       llm_d_ref: ${{ github.ref }}
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_repo: ${{ github.event.inputs.pr_repo }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-precise-prefix-cache-ocp.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-ocp.yaml
@@ -17,6 +17,14 @@ on:
         description: 'Skip cleanup after tests (for debugging)'
         required: false
         default: 'false'
+      pr_number:
+        description: 'PR number for comment-back (set by /test-nightly)'
+        required: false
+        default: ''
+      pr_repo:
+        description: 'Repo for PR comment-back'
+        required: false
+        default: 'llm-d/llm-d'
 
 permissions:
   contents: read
@@ -50,4 +58,6 @@ jobs:
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
       allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_repo: ${{ github.event.inputs.pr_repo }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-predicted-latency-cks.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-cks.yaml
@@ -19,6 +19,14 @@ on:
         description: 'Skip cleanup after tests (for debugging)'
         required: false
         default: 'false'
+      pr_number:
+        description: 'PR number for comment-back (set by /test-nightly)'
+        required: false
+        default: ''
+      pr_repo:
+        description: 'Repo for PR comment-back'
+        required: false
+        default: 'llm-d/llm-d'
 
 permissions:
   contents: read
@@ -54,4 +62,6 @@ jobs:
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
       allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_repo: ${{ github.event.inputs.pr_repo }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-predicted-latency-gke.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-gke.yaml
@@ -19,6 +19,14 @@ on:
         description: 'Skip cleanup after tests (for debugging)'
         required: false
         default: 'false'
+      pr_number:
+        description: 'PR number for comment-back (set by /test-nightly)'
+        required: false
+        default: ''
+      pr_repo:
+        description: 'Repo for PR comment-back'
+        required: false
+        default: 'llm-d/llm-d'
 
 permissions:
   contents: read
@@ -59,4 +67,6 @@ jobs:
       allow_gpu_preemption: true
       llm_d_ref: ${{ github.ref }}
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_repo: ${{ github.event.inputs.pr_repo }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-gke.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-gke.yaml
@@ -12,6 +12,14 @@ on:
         description: 'Skip cleanup after tests (for debugging)'
         required: false
         default: 'false'
+      pr_number:
+        description: 'PR number for comment-back (set by /test-nightly)'
+        required: false
+        default: ''
+      pr_repo:
+        description: 'Repo for PR comment-back'
+        required: false
+        default: 'llm-d/llm-d'
 
 permissions:
   contents: read
@@ -49,4 +57,6 @@ jobs:
       allow_gpu_preemption: true
       llm_d_ref: ${{ github.ref }}
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_repo: ${{ github.event.inputs.pr_repo }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-lmcache-gke.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-lmcache-gke.yaml
@@ -12,6 +12,14 @@ on:
         description: 'Skip cleanup after tests (for debugging)'
         required: false
         default: 'false'
+      pr_number:
+        description: 'PR number for comment-back (set by /test-nightly)'
+        required: false
+        default: ''
+      pr_repo:
+        description: 'Repo for PR comment-back'
+        required: false
+        default: 'llm-d/llm-d'
 
 permissions:
   contents: read
@@ -49,4 +57,6 @@ jobs:
       allow_gpu_preemption: true
       llm_d_ref: ${{ github.ref }}
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_repo: ${{ github.event.inputs.pr_repo }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-ocp.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-ocp.yaml
@@ -21,6 +21,14 @@ on:
         description: 'Skip cleanup after tests (for debugging)'
         required: false
         default: 'false'
+      pr_number:
+        description: 'PR number for comment-back (set by /test-nightly)'
+        required: false
+        default: ''
+      pr_repo:
+        description: 'Repo for PR comment-back'
+        required: false
+        default: 'llm-d/llm-d'
 
 permissions:
   contents: read
@@ -69,4 +77,6 @@ jobs:
       allow_gpu_preemption: true
       install_gateway_provider: false
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_repo: ${{ github.event.inputs.pr_repo }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-wide-ep-lws-cks.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-cks.yaml
@@ -22,6 +22,14 @@ on:
         description: 'Skip cleanup after tests (for debugging)'
         required: false
         default: 'false'
+      pr_number:
+        description: 'PR number for comment-back (set by /test-nightly)'
+        required: false
+        default: ''
+      pr_repo:
+        description: 'Repo for PR comment-back'
+        required: false
+        default: 'llm-d/llm-d'
 
 permissions:
   contents: read
@@ -283,4 +291,6 @@ jobs:
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
       allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_repo: ${{ github.event.inputs.pr_repo }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-wide-ep-lws-gke.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-gke.yaml
@@ -15,6 +15,14 @@ on:
         description: 'Skip cleanup after tests (for debugging)'
         required: false
         default: 'false'
+      pr_number:
+        description: 'PR number for comment-back (set by /test-nightly)'
+        required: false
+        default: ''
+      pr_repo:
+        description: 'Repo for PR comment-back'
+        required: false
+        default: 'llm-d/llm-d'
 
 permissions:
   contents: read
@@ -77,4 +85,6 @@ jobs:
       e2e_validate_args: '-v'
       allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_repo: ${{ github.event.inputs.pr_repo }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-wide-ep-lws-ocp.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-ocp.yaml
@@ -22,6 +22,14 @@ on:
         description: 'Skip cleanup after tests (for debugging)'
         required: false
         default: 'false'
+      pr_number:
+        description: 'PR number for comment-back (set by /test-nightly)'
+        required: false
+        default: ''
+      pr_repo:
+        description: 'Repo for PR comment-back'
+        required: false
+        default: 'llm-d/llm-d'
 
 permissions:
   contents: read
@@ -285,4 +293,6 @@ jobs:
       allow_gpu_preemption: true
       install_gateway_provider: false
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_repo: ${{ github.event.inputs.pr_repo }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-wva-cks.yaml
+++ b/.github/workflows/nightly-e2e-wva-cks.yaml
@@ -48,6 +48,14 @@ on:
         description: 'Skip cleanup after tests (for debugging)'
         required: false
         default: 'false'
+      pr_number:
+        description: 'PR number for comment-back (set by /test-nightly)'
+        required: false
+        default: ''
+      pr_repo:
+        description: 'Repo for PR comment-back'
+        required: false
+        default: 'llm-d/llm-d'
 
 permissions:
   contents: read
@@ -149,4 +157,6 @@ jobs:
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
       allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_repo: ${{ github.event.inputs.pr_repo }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-wva-ocp.yaml
+++ b/.github/workflows/nightly-e2e-wva-ocp.yaml
@@ -48,6 +48,14 @@ on:
         description: 'Skip cleanup after tests (for debugging)'
         required: false
         default: 'false'
+      pr_number:
+        description: 'PR number for comment-back (set by /test-nightly)'
+        required: false
+        default: ''
+      pr_repo:
+        description: 'Repo for PR comment-back'
+        required: false
+        default: 'llm-d/llm-d'
 
 permissions:
   contents: read
@@ -156,4 +164,6 @@ jobs:
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
       allow_gpu_preemption: true
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_repo: ${{ github.event.inputs.pr_repo }}
     secrets: inherit

--- a/.github/workflows/slash-test-nightly.yaml
+++ b/.github/workflows/slash-test-nightly.yaml
@@ -279,6 +279,10 @@ jobs:
                 owner, repo,
                 workflow_id: m.workflowFile,
                 ref,
+                inputs: {
+                  pr_number: context.issue.number.toString(),
+                  pr_repo: `${context.repo.owner}/${context.repo.repo}`,
+                },
               });
               m.runUrl = null;
             }


### PR DESCRIPTION
Consumes: https://github.com/llm-d/llm-d-infra/pull/157

cc @llm-d/release-crew - this is what will make all our triggered nightlies comment back on the PR