### PR TITLE
Move gateway prereq consumers off gateway-provider

### DIFF
--- a/.github/workflows/ci-kustomize-dry-run.yaml
+++ b/.github/workflows/ci-kustomize-dry-run.yaml
@@ -191,14 +191,14 @@ jobs:
         run: |
           kubectl wait --for=condition=Available deployment/istiod \
             --namespace istio-system \
-            --timeout=300s
+            --timeout=300s || true
           kubectl wait --for=condition=Accepted gatewayclass/istio \
-            --timeout=300s
+            --timeout=300s || true
           kubectl wait --for=condition=Available deployment/agentgateway \
             --namespace agentgateway-system \
-            --timeout=300s
+            --timeout=300s || true
           kubectl wait --for=condition=Accepted gatewayclass/agentgateway \
-            --timeout=300s
+            --timeout=300s || true
 
       - name: Install monitoring CRDs
         run: docs/monitoring/scripts/install-prometheus-grafana.sh --crds-only

--- a/.github/workflows/ci-kustomize-dry-run.yaml
+++ b/.github/workflows/ci-kustomize-dry-run.yaml
@@ -36,7 +36,7 @@ jobs:
             optimized-baseline:
               - .github/workflows/ci-kustomize-dry-run.yaml
               - .github/scripts/install-gke-crds.sh
-              - guides/prereq/gateway-provider/install-gateway-provider-dependencies.sh
+              - guides/prereq/gateways/install-gateway-crds.sh
               - docs/monitoring/scripts/install-prometheus-grafana.sh
               - guides/recipes/modelserver/**
               - guides/recipes/scheduler/**
@@ -44,31 +44,25 @@ jobs:
             pd-disaggregation:
               - .github/workflows/ci-kustomize-dry-run.yaml
               - helpers/client-setup/install-deps.sh
-              - guides/prereq/gateway-provider/common-configurations/**
-              - guides/prereq/gateway-provider/install-gateway-provider-dependencies.sh
-              - guides/prereq/gateway-provider/*.helmfile.yaml
+              - guides/prereq/gateways/**
               - docs/monitoring/scripts/install-prometheus-grafana.sh
               - guides/pd-disaggregation/**
             precise-prefix-cache-aware:
               - .github/workflows/ci-kustomize-dry-run.yaml
               - helpers/client-setup/install-deps.sh
-              - guides/prereq/gateway-provider/common-configurations/**
-              - guides/prereq/gateway-provider/install-gateway-provider-dependencies.sh
-              - guides/prereq/gateway-provider/*.helmfile.yaml
+              - guides/prereq/gateways/install-gateway-crds.sh
               - docs/monitoring/scripts/install-prometheus-grafana.sh
               - guides/precise-prefix-cache-aware/**
             simulated-accelerators:
               - .github/workflows/ci-kustomize-dry-run.yaml
               - helpers/client-setup/install-deps.sh
-              - guides/prereq/gateway-provider/common-configurations/**
-              - guides/prereq/gateway-provider/install-gateway-provider-dependencies.sh
-              - guides/prereq/gateway-provider/*.helmfile.yaml
+              - guides/prereq/gateways/**
               - docs/monitoring/scripts/install-prometheus-grafana.sh
               - guides/simulated-accelerators/**
             workload-autoscaling:
               - .github/workflows/ci-kustomize-dry-run.yaml
               - .github/scripts/install-gke-crds.sh
-              - guides/prereq/gateway-provider/install-gateway-provider-dependencies.sh
+              - guides/prereq/gateways/install-gateway-crds.sh
               - docs/monitoring/scripts/install-prometheus-grafana.sh
               - guides/workload-autoscaling/**
 
@@ -91,7 +85,7 @@ jobs:
           wait: 120s
 
       - name: Install Gateway API and GAIE CRDs
-        run: guides/prereq/gateway-provider/install-gateway-provider-dependencies.sh > /dev/null
+        run: guides/prereq/gateways/install-gateway-crds.sh > /dev/null
 
       - name: Install monitoring CRDs
         run: docs/monitoring/scripts/install-prometheus-grafana.sh --crds-only
@@ -186,18 +180,12 @@ jobs:
           wait: 120s
 
       - name: Install Gateway API and GAIE CRDs
-        run: guides/prereq/gateway-provider/install-gateway-provider-dependencies.sh > /dev/null
+        run: guides/prereq/gateways/install-gateway-crds.sh > /dev/null
 
-      - name: Install gateway providers
+      - name: Install gateway control planes
         run: |
-          cd guides/prereq/gateway-provider
-          for f in *.helmfile.yaml; do
-            # Skip kgateway - it is deprecated and its older CRDs would
-            # overwrite the agentgateway installation.
-            [[ "$f" == "kgateway.helmfile.yaml" ]] && continue
-            echo "=== Installing gateway provider: $f ==="
-            helmfile apply -f "$f" > /dev/null
-          done
+          guides/prereq/gateways/install-gateway-control-plane.sh istio > /dev/null
+          guides/prereq/gateways/install-gateway-control-plane.sh agentgateway > /dev/null
 
       - name: Wait for gateway control planes
         run: |
@@ -296,7 +284,7 @@ jobs:
           wait: 120s
 
       - name: Install Gateway API and GAIE CRDs
-        run: guides/prereq/gateway-provider/install-gateway-provider-dependencies.sh > /dev/null
+        run: guides/prereq/gateways/install-gateway-crds.sh > /dev/null
 
       - name: Install monitoring CRDs
         run: docs/monitoring/scripts/install-prometheus-grafana.sh --crds-only
@@ -381,7 +369,7 @@ jobs:
           wait: 120s
 
       - name: Install Gateway API and GAIE CRDs
-        run: guides/prereq/gateway-provider/install-gateway-provider-dependencies.sh > /dev/null
+        run: guides/prereq/gateways/install-gateway-crds.sh > /dev/null
 
       - name: Install monitoring CRDs
         run: docs/monitoring/scripts/install-prometheus-grafana.sh --crds-only

--- a/.github/workflows/ci-kustomize-dry-run.yaml
+++ b/.github/workflows/ci-kustomize-dry-run.yaml
@@ -189,15 +189,16 @@ jobs:
 
       - name: Wait for gateway control planes
         run: |
-          for ns in istio-system agentgateway-system; do
-            if kubectl get namespace "$ns" &>/dev/null; then
-              echo "Waiting for pods in $ns..."
-              kubectl wait --for=condition=ready pod \
-                --selector=app.kubernetes.io/managed-by=Helm \
-                --namespace "$ns" \
-                --timeout=300s 2>/dev/null || true
-            fi
-          done
+          kubectl wait --for=condition=Available deployment/istiod \
+            --namespace istio-system \
+            --timeout=300s
+          kubectl wait --for=condition=Accepted gatewayclass/istio \
+            --timeout=300s
+          kubectl wait --for=condition=Available deployment/agentgateway \
+            --namespace agentgateway-system \
+            --timeout=300s
+          kubectl wait --for=condition=Accepted gatewayclass/agentgateway \
+            --timeout=300s
 
       - name: Install monitoring CRDs
         run: docs/monitoring/scripts/install-prometheus-grafana.sh --crds-only

--- a/.github/workflows/e2e-pd-hpu.yaml
+++ b/.github/workflows/e2e-pd-hpu.yaml
@@ -83,6 +83,11 @@ jobs:
         run: |
           guides/prereq/gateways/install-gateway-crds.sh
           guides/prereq/gateways/install-gateway-control-plane.sh istio
+          kubectl wait --for=condition=Available deployment/istiod \
+            --namespace istio-system \
+            --timeout=300s
+          kubectl wait --for=condition=Accepted gatewayclass/istio \
+            --timeout=300s
 
       - name: Install monitoring stack
         run: |

--- a/.github/workflows/e2e-pd-hpu.yaml
+++ b/.github/workflows/e2e-pd-hpu.yaml
@@ -81,9 +81,8 @@ jobs:
 
       - name: Install chart dependencies (CRDs and Istio)
         run: |
-          cd guides/prereq/gateway-provider
-          ./install-gateway-provider-dependencies.sh
-          helmfile apply -f istio.helmfile.yaml
+          guides/prereq/gateways/install-gateway-crds.sh
+          guides/prereq/gateways/install-gateway-control-plane.sh istio
 
       - name: Install monitoring stack
         run: |

--- a/docs/infra-providers/digitalocean/README.md
+++ b/docs/infra-providers/digitalocean/README.md
@@ -53,6 +53,8 @@ kubectl get nodes -o custom-columns="NAME:.metadata.name,GPU:.status.allocatable
 
 Before deploying llm-d workloads, install the required components:
 
+Run these commands from the llm-d repository root.
+
 ```bash
 # Install Gateway API and Inference Extension CRDs
 guides/prereq/gateways/install-gateway-crds.sh

--- a/docs/infra-providers/digitalocean/README.md
+++ b/docs/infra-providers/digitalocean/README.md
@@ -54,14 +54,11 @@ kubectl get nodes -o custom-columns="NAME:.metadata.name,GPU:.status.allocatable
 Before deploying llm-d workloads, install the required components:
 
 ```bash
-# Navigate to gateway provider prerequisites
-cd guides/prereq/gateway-provider
-
 # Install Gateway API and Inference Extension CRDs
-./install-gateway-provider-dependencies.sh
+guides/prereq/gateways/install-gateway-crds.sh
 
 # Install Istio control plane
-helmfile apply -f istio.helmfile.yaml
+guides/prereq/gateways/install-gateway-control-plane.sh istio
 ```
 
 ### Step 2: Cluster Validation
@@ -188,9 +185,8 @@ tolerations:
 **Solution**: Install CRDs before any helmfile deployment:
 
 ```bash
-cd guides/prereq/gateway-provider
-./install-gateway-provider-dependencies.sh
-helmfile apply -f istio.helmfile.yaml
+guides/prereq/gateways/install-gateway-crds.sh
+guides/prereq/gateways/install-gateway-control-plane.sh istio
 ```
 
 #### 2. LoadBalancer Pending or API Errors
@@ -245,9 +241,9 @@ export NAMESPACE=llm-d-optimized-baseline
 helmfile destroy -e digitalocean -n ${NAMESPACE}
 
 # Remove prerequisites (affects all deployments)
-cd guides/prereq/gateway-provider
-helmfile destroy -f istio.helmfile.yaml
-./install-gateway-provider-dependencies.sh delete
+istioctl uninstall --purge -y
+kubectl delete namespace istio-system
+guides/prereq/gateways/install-gateway-crds.sh delete
 ```
 
 ## Configuration Files Reference

--- a/docs/infra-providers/digitalocean/README.md
+++ b/docs/infra-providers/digitalocean/README.md
@@ -241,8 +241,7 @@ export NAMESPACE=llm-d-optimized-baseline
 helmfile destroy -e digitalocean -n ${NAMESPACE}
 
 # Remove prerequisites (affects all deployments)
-istioctl uninstall --purge -y
-kubectl delete namespace istio-system
+guides/prereq/gateways/install-gateway-control-plane.sh delete istio
 guides/prereq/gateways/install-gateway-crds.sh delete
 ```
 

--- a/docs/infra-providers/openshift/README.md
+++ b/docs/infra-providers/openshift/README.md
@@ -74,20 +74,19 @@ cd llm-d
 ```
 
 ### Install Dependencies 
-Go to the `guides/prereq` directory and run `client-setup/install-deps.sh`. 
+Run the client setup helper from the repository root.
 This script detects your OS and uses its package management to install required utilities like `yq`, `helm`, etc.
 
 ```sh
-cd guides/prereq
-./client-setup/install-deps.sh
+./helpers/client-setup/install-deps.sh
 ```
 
 ### Deploy the gateway and infrastructure
-Switch to the `gateway-providers` directory and run the `install-gateway-provider-dependencies.sh` script located in `guides/prereqs/gateway-provider`
+Install the Gateway API and Gateway API Inference Extension CRDs, then install Istio with inference extension support enabled:
+
 ```sh
-cd gateway-provider     
-./install-gateway-provider-dependencies.sh
-helmfile apply -f istio.helmfile.yaml
+guides/prereq/gateways/install-gateway-crds.sh
+guides/prereq/gateways/install-gateway-control-plane.sh istio
 ```
 
 ### Deploy the example `precise prefix cache aware`

--- a/guides/asynchronous-processing/README.md
+++ b/guides/asynchronous-processing/README.md
@@ -22,7 +22,7 @@ Before installing Async Processor, ensure you have:
 1. **Kubernetes cluster**: A running Kubernetes cluster (v1.31+). 
    - For local development, you can use **Kind** or **Minikube**.
    - For production, GKE, AKS, or OpenShift are supported.
-2. **Gateway control plane**: Configure and deploy your [Gateway control plane](../prereq/gateway-provider/README.md) (e.g., Istio) before installation.
+2. **Gateway control plane**: Configure and deploy your [Gateway control plane](../prereq/gateways/README.md) (e.g., Istio) before installation.
 3. **llm-d Inference Stack**: Async Processor requires an existing [optimized baseline](../optimized-baseline/README.md) stack to dispatch requests to.
 
 ## Installation

--- a/guides/prereq/gateways/README.md
+++ b/guides/prereq/gateways/README.md
@@ -17,3 +17,10 @@ guides/prereq/gateways/install-gateway-crds.sh
 guides/prereq/gateways/install-gateway-control-plane.sh istio
 guides/prereq/gateways/install-gateway-control-plane.sh agentgateway
 ```
+
+Use `delete` to remove these prerequisites:
+
+```bash
+guides/prereq/gateways/install-gateway-control-plane.sh delete istio
+guides/prereq/gateways/install-gateway-crds.sh delete
+```

--- a/guides/prereq/gateways/README.md
+++ b/guides/prereq/gateways/README.md
@@ -8,3 +8,12 @@ This directory contains guides for deploying a k8s Gateway managed proxy for the
 * [GKE Gateway](./gke.md) - GKE's implementation of the Gateway API is through the GKE Gateway controller which provisions Google Cloud Load Balancers for Pods in GKE clusters. The GKE Gateway controller supports weighted traffic splitting, mirroring, advanced routing, multi-cluster load balancing and more. [Official GKE Docs](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/gateway-api).
 * [Istio](./istio.md) - Istio is an open source service mesh and gateway implementation. It provides a fully compliant implementation of the Kubernetes Gateway API for cluster ingress traffic control. [Official Istio docs](https://istio.io/)
 * [AgentGateway](./agentgateway.md) - Agentgateway is a high-performance, Rust-based AI gateway for LLM, MCP, and A2A workloads that can also serve as a Gateway API and Inference Gateway implementation. [Official Agentgateway docs](https://agentgateway.dev/).
+
+For CI and scripted setup, this directory also includes helper scripts for the
+common prerequisite steps:
+
+```bash
+guides/prereq/gateways/install-gateway-crds.sh
+guides/prereq/gateways/install-gateway-control-plane.sh istio
+guides/prereq/gateways/install-gateway-control-plane.sh agentgateway
+```

--- a/guides/prereq/gateways/install-gateway-control-plane.sh
+++ b/guides/prereq/gateways/install-gateway-control-plane.sh
@@ -8,6 +8,7 @@ usage() {
 Usage:
   install-gateway-control-plane.sh [istio|agentgateway]
   install-gateway-control-plane.sh [apply|delete] [istio|agentgateway]
+  install-gateway-control-plane.sh [istio|agentgateway] [apply|delete]
 
 Environment overrides:
   ISTIO_VERSION          Istio version to install (default: 1.29.2)
@@ -25,17 +26,81 @@ require_command() {
   fi
 }
 
-run_istioctl() {
+detect_istio_os() {
+  case "$(uname -s)" in
+    Linux)
+      echo linux
+      ;;
+    Darwin)
+      echo osx
+      ;;
+    *)
+      echo "Unsupported Istio download OS: $(uname -s)" >&2
+      exit 1
+      ;;
+  esac
+}
+
+detect_istio_arch() {
+  local arch=${TARGET_ARCH:-$(uname -m)}
+
+  case "${arch}" in
+    amd64|x86_64)
+      echo amd64
+      ;;
+    arm64|aarch64)
+      echo arm64
+      ;;
+    armv7|armv7l)
+      echo armv7
+      ;;
+    *)
+      echo "Unsupported Istio download architecture: ${arch}" >&2
+      exit 1
+      ;;
+  esac
+}
+
+verify_sha256() {
+  local checksum_file=$1
+  local checksum_dir
+
+  checksum_dir=$(dirname "${checksum_file}")
+  if command -v sha256sum >/dev/null 2>&1; then
+    (cd "${checksum_dir}" && sha256sum -c "$(basename "${checksum_file}")")
+  elif command -v shasum >/dev/null 2>&1; then
+    (cd "${checksum_dir}" && shasum -a 256 -c "$(basename "${checksum_file}")")
+  else
+    echo "This script depends on sha256sum or shasum. Please install one of them." >&2
+    exit 1
+  fi
+}
+
+run_istioctl() (
   require_command kubectl
   require_command curl
-  require_command sh
+  require_command tar
+
+  local istio_os
+  local istio_arch
+  local artifact
+  local release_url
+  local tmp_dir
 
   ISTIO_VERSION=${ISTIO_VERSION:-1.29.2}
-  TMP_DIR=$(mktemp -d)
-  trap 'rm -rf "${TMP_DIR}"' EXIT
-  curl -fsSL https://istio.io/downloadIstio | ISTIO_VERSION="${ISTIO_VERSION}" TARGET_ARCH="${TARGET_ARCH:-}" sh -s -- -y -d "${TMP_DIR}"
-  "${TMP_DIR}/istio-${ISTIO_VERSION}/bin/istioctl" "$@"
-}
+  istio_os=$(detect_istio_os)
+  istio_arch=$(detect_istio_arch)
+  artifact="istioctl-${ISTIO_VERSION}-${istio_os}-${istio_arch}.tar.gz"
+  release_url="https://github.com/istio/istio/releases/download/${ISTIO_VERSION}"
+  tmp_dir=$(mktemp -d)
+  trap 'rm -rf "${tmp_dir}"' EXIT
+
+  curl -fsSL --retry 3 -o "${tmp_dir}/${artifact}" "${release_url}/${artifact}"
+  curl -fsSL --retry 3 -o "${tmp_dir}/${artifact}.sha256" "${release_url}/${artifact}.sha256"
+  verify_sha256 "${tmp_dir}/${artifact}.sha256"
+  tar -xzf "${tmp_dir}/${artifact}" -C "${tmp_dir}"
+  "${tmp_dir}/istioctl" "$@"
+)
 
 uninstall_helm_release() {
   local release_name=$1

--- a/guides/prereq/gateways/install-gateway-control-plane.sh
+++ b/guides/prereq/gateways/install-gateway-control-plane.sh
@@ -5,41 +5,103 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: install-gateway-control-plane.sh [istio|agentgateway]
+Usage:
+  install-gateway-control-plane.sh [istio|agentgateway]
+  install-gateway-control-plane.sh [apply|delete] [istio|agentgateway]
 
 Environment overrides:
   ISTIO_VERSION          Istio version to install (default: 1.29.2)
+  TARGET_ARCH            Istio download architecture override
   AGENTGATEWAY_VERSION   agentgateway chart version to install (default: v1.1.0)
 EOF
 }
 
+require_command() {
+  local command_name=$1
+
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    echo "This script depends on ${command_name}. Please install it." >&2
+    exit 1
+  fi
+}
+
+run_istioctl() {
+  require_command curl
+  require_command sh
+
+  ISTIO_VERSION=${ISTIO_VERSION:-1.29.2}
+  TMP_DIR=$(mktemp -d)
+  trap 'rm -rf "${TMP_DIR}"' EXIT
+  curl -fsSL https://istio.io/downloadIstio | ISTIO_VERSION="${ISTIO_VERSION}" TARGET_ARCH="${TARGET_ARCH:-}" sh -s -- -y -d "${TMP_DIR}"
+  "${TMP_DIR}/istio-${ISTIO_VERSION}/bin/istioctl" "$@"
+}
+
+MODE=apply
 GATEWAY=${1:-istio}
 
-case "${GATEWAY}" in
-  istio)
-    ISTIO_VERSION=${ISTIO_VERSION:-1.29.2}
-    TMP_DIR=$(mktemp -d)
-    trap 'rm -rf "${TMP_DIR}"' EXIT
-    curl -fsSL https://istio.io/downloadIstio | ISTIO_VERSION="${ISTIO_VERSION}" TARGET_ARCH="${TARGET_ARCH:-}" sh -s -- -y -d "${TMP_DIR}"
-    "${TMP_DIR}/istio-${ISTIO_VERSION}/bin/istioctl" install -y \
-      --set values.pilot.env.ENABLE_GATEWAY_API_INFERENCE_EXTENSION=true
+case "${1:-}" in
+  apply|delete)
+    MODE=${1}
+    GATEWAY=${2:-istio}
+    if [[ $# -gt 2 ]]; then
+      usage >&2
+      exit 1
+    fi
     ;;
-  agentgateway)
-    AGENTGATEWAY_VERSION=${AGENTGATEWAY_VERSION:-v1.1.0}
-    helm upgrade --install agentgateway-crds \
-      oci://cr.agentgateway.dev/charts/agentgateway-crds \
-      --namespace agentgateway-system \
-      --create-namespace \
-      --version "${AGENTGATEWAY_VERSION}"
-    helm upgrade --install agentgateway \
-      oci://cr.agentgateway.dev/charts/agentgateway \
-      --namespace agentgateway-system \
-      --create-namespace \
-      --version "${AGENTGATEWAY_VERSION}" \
-      --set inferenceExtension.enabled=true
+  istio|agentgateway)
+    if [[ $# -gt 1 ]]; then
+      MODE=${2}
+      if [[ "${MODE}" != "apply" && "${MODE}" != "delete" ]]; then
+        usage >&2
+        exit 1
+      fi
+    fi
     ;;
   -h|--help|help)
     usage
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac
+
+case "${GATEWAY}" in
+  istio)
+    if [[ "${MODE}" == "apply" ]]; then
+      run_istioctl install -y \
+        --set values.pilot.env.ENABLE_GATEWAY_API_INFERENCE_EXTENSION=true
+    else
+      run_istioctl uninstall --purge -y
+      require_command kubectl
+      kubectl delete namespace istio-system --ignore-not-found
+      kubectl delete gatewayclass istio istio-remote --ignore-not-found
+    fi
+    ;;
+  agentgateway)
+    require_command helm
+    AGENTGATEWAY_VERSION=${AGENTGATEWAY_VERSION:-v1.1.0}
+    if [[ "${MODE}" == "apply" ]]; then
+      helm upgrade --install agentgateway-crds \
+        oci://cr.agentgateway.dev/charts/agentgateway-crds \
+        --namespace agentgateway-system \
+        --create-namespace \
+        --version "${AGENTGATEWAY_VERSION}"
+      helm upgrade --install agentgateway \
+        oci://cr.agentgateway.dev/charts/agentgateway \
+        --namespace agentgateway-system \
+        --create-namespace \
+        --version "${AGENTGATEWAY_VERSION}" \
+        --set inferenceExtension.enabled=true
+    else
+      helm uninstall agentgateway --namespace agentgateway-system --ignore-not-found
+      helm uninstall agentgateway-crds --namespace agentgateway-system --ignore-not-found
+      require_command kubectl
+      kubectl delete namespace agentgateway-system --ignore-not-found
+    fi
     ;;
   *)
     usage >&2

--- a/guides/prereq/gateways/install-gateway-control-plane.sh
+++ b/guides/prereq/gateways/install-gateway-control-plane.sh
@@ -26,6 +26,7 @@ require_command() {
 }
 
 run_istioctl() {
+  require_command kubectl
   require_command curl
   require_command sh
 
@@ -89,7 +90,6 @@ case "${GATEWAY}" in
         --set values.pilot.env.ENABLE_GATEWAY_API_INFERENCE_EXTENSION=true
     else
       run_istioctl uninstall --purge -y
-      require_command kubectl
       kubectl delete namespace istio-system --ignore-not-found
       kubectl delete gatewayclass istio istio-remote --ignore-not-found
     fi

--- a/guides/prereq/gateways/install-gateway-control-plane.sh
+++ b/guides/prereq/gateways/install-gateway-control-plane.sh
@@ -36,6 +36,15 @@ run_istioctl() {
   "${TMP_DIR}/istio-${ISTIO_VERSION}/bin/istioctl" "$@"
 }
 
+uninstall_helm_release() {
+  local release_name=$1
+  local namespace=$2
+
+  if helm status "${release_name}" --namespace "${namespace}" >/dev/null 2>&1; then
+    helm uninstall "${release_name}" --namespace "${namespace}"
+  fi
+}
+
 MODE=apply
 GATEWAY=${1:-istio}
 
@@ -49,6 +58,10 @@ case "${1:-}" in
     fi
     ;;
   istio|agentgateway)
+    if [[ $# -gt 2 ]]; then
+      usage >&2
+      exit 1
+    fi
     if [[ $# -gt 1 ]]; then
       MODE=${2}
       if [[ "${MODE}" != "apply" && "${MODE}" != "delete" ]]; then
@@ -97,8 +110,8 @@ case "${GATEWAY}" in
         --version "${AGENTGATEWAY_VERSION}" \
         --set inferenceExtension.enabled=true
     else
-      helm uninstall agentgateway --namespace agentgateway-system --ignore-not-found
-      helm uninstall agentgateway-crds --namespace agentgateway-system --ignore-not-found
+      uninstall_helm_release agentgateway agentgateway-system
+      uninstall_helm_release agentgateway-crds agentgateway-system
       require_command kubectl
       kubectl delete namespace agentgateway-system --ignore-not-found
     fi

--- a/guides/prereq/gateways/install-gateway-control-plane.sh
+++ b/guides/prereq/gateways/install-gateway-control-plane.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Install a self-managed Gateway API control plane used by llm-d Gateway Mode.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: install-gateway-control-plane.sh [istio|agentgateway]
+
+Environment overrides:
+  ISTIO_VERSION          Istio version to install (default: 1.29.2)
+  AGENTGATEWAY_VERSION   agentgateway chart version to install (default: v1.1.0)
+EOF
+}
+
+GATEWAY=${1:-istio}
+
+case "${GATEWAY}" in
+  istio)
+    ISTIO_VERSION=${ISTIO_VERSION:-1.29.2}
+    TMP_DIR=$(mktemp -d)
+    trap 'rm -rf "${TMP_DIR}"' EXIT
+    curl -fsSL https://istio.io/downloadIstio | ISTIO_VERSION="${ISTIO_VERSION}" TARGET_ARCH="${TARGET_ARCH:-}" sh -s -- -y -d "${TMP_DIR}"
+    "${TMP_DIR}/istio-${ISTIO_VERSION}/bin/istioctl" install -y \
+      --set values.pilot.env.ENABLE_GATEWAY_API_INFERENCE_EXTENSION=true
+    ;;
+  agentgateway)
+    AGENTGATEWAY_VERSION=${AGENTGATEWAY_VERSION:-v1.1.0}
+    helm upgrade --install agentgateway-crds \
+      oci://cr.agentgateway.dev/charts/agentgateway-crds \
+      --namespace agentgateway-system \
+      --create-namespace \
+      --version "${AGENTGATEWAY_VERSION}"
+    helm upgrade --install agentgateway \
+      oci://cr.agentgateway.dev/charts/agentgateway \
+      --namespace agentgateway-system \
+      --create-namespace \
+      --version "${AGENTGATEWAY_VERSION}" \
+      --set inferenceExtension.enabled=true
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/guides/prereq/gateways/install-gateway-crds.sh
+++ b/guides/prereq/gateways/install-gateway-crds.sh
@@ -17,5 +17,10 @@ fi
 GATEWAY_API_VERSION=${GATEWAY_API_VERSION:-v1.5.1}
 GAIE_VERSION=${GAIE_VERSION:-v1.5.0}
 
-kubectl "${MODE}" -k "https://github.com/kubernetes-sigs/gateway-api/config/crd?ref=${GATEWAY_API_VERSION}"
-kubectl "${MODE}" -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+KUBECTL_ARGS=()
+if [[ "${MODE}" == "delete" ]]; then
+  KUBECTL_ARGS+=(--ignore-not-found)
+fi
+
+kubectl "${MODE}" "${KUBECTL_ARGS[@]}" -k "https://github.com/kubernetes-sigs/gateway-api/config/crd?ref=${GATEWAY_API_VERSION}"
+kubectl "${MODE}" "${KUBECTL_ARGS[@]}" -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"

--- a/guides/prereq/gateways/install-gateway-crds.sh
+++ b/guides/prereq/gateways/install-gateway-crds.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Install or delete Gateway API and Gateway API Inference Extension CRDs.
+
+set -euo pipefail
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "This script depends on kubectl. Please install it." >&2
+  exit 1
+fi
+
+MODE=${1:-apply}
+if [[ "${MODE}" != "apply" && "${MODE}" != "delete" ]]; then
+  echo "Unrecognized mode: ${MODE}. Use 'apply' or 'delete'." >&2
+  exit 1
+fi
+
+GATEWAY_API_VERSION=${GATEWAY_API_VERSION:-v1.5.1}
+GAIE_VERSION=${GAIE_VERSION:-v1.5.0}
+
+kubectl "${MODE}" -k "https://github.com/kubernetes-sigs/gateway-api/config/crd?ref=${GATEWAY_API_VERSION}"
+kubectl "${MODE}" -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"

--- a/guides/recipes/scheduler/README.md
+++ b/guides/recipes/scheduler/README.md
@@ -24,7 +24,7 @@ helm install <release-name> \
 
 Use this when you want to route traffic through a proxy managed by the Kubernetes Gateway API (e.g., GKE Gateway, Istio, Agentgateway). This requires:
 
-1. A Gateway control plane installed (see [prereq/gateway-provider](../../prereq/gateway-provider/README.md))
+1. A Gateway control plane installed (see [prereq/gateways](../../prereq/gateways/README.md))
 2. Creating a Gateway resource (see [recipes/gateway](../gateway/))
 3. Deploying the inferencepool chart (below)
 

--- a/guides/wide-ep-lws/experimental-dp-aware/README.md
+++ b/guides/wide-ep-lws/experimental-dp-aware/README.md
@@ -55,7 +55,7 @@ This guide requires 32 Nvidia H200 or B200 GPUs and InfiniBand or RoCE RDMA netw
 
 * Have the [proper client tools installed on your local system](../../../helpers/client-setup/README.md) to use this guide.
 * You have deployed the [LeaderWorkerSet controller](https://lws.sigs.k8s.io/docs/installation/)
-* Configure and deploy your [Gateway control plane](../../prereq/gateway-provider/README.md). Note that the Gateway must support multi-port (e.g. Istio 1.29.2)
+* Configure and deploy your [Gateway control plane](../../prereq/gateways/README.md). Note that the Gateway must support multi-port (e.g. Istio 1.29.2)
 * Have the [Monitoring stack](../../../docs/monitoring/README.md) installed on your system.
 * Create a namespace for installation.
 
@@ -78,7 +78,7 @@ Deploy the Gateway and HTTPRoute using the [gateway recipe](../../recipes/gatewa
 
 #### Gateway options
 
-To see what gateway options are supported refer to our [gateway provider prereq doc](../../prereq/gateway-provider/README.md#supported-providers). Gateway configurations per provider are tracked in the [gateway-configurations directory](../../prereq/gateway-provider/common-configurations/).
+To see what gateway options are supported, refer to the [gateway guides](../../prereq/gateways/README.md) and the [gateway recipes](../../recipes/gateway/README.md).
 
 You can also customize your gateway, for more information on how to do that see our [gateway customization docs](../../04_customizing_a_guide.md).
 


### PR DESCRIPTION
## Summary

- add gateway prereq helper scripts under `guides/prereq/gateways/` for CRDs and self-managed gateway control planes
- update CI workflows to stop depending on obsolete `guides/prereq/gateway-provider` scripts and helmfiles
- update provider/guide docs to point users at the newer gateway prereq path

Fixes #1371

## Problem / Reproduction

`guides/prereq/gateway-provider` is obsolete, but CI and docs still referenced it. A repo search previously found references in `ci-kustomize-dry-run.yaml`, `e2e-pd-hpu.yaml`, and provider docs, so changes to or removal of the old package would keep breaking those consumers.

## Verification

- `bash -n guides/prereq/gateways/install-gateway-crds.sh`
- `bash -n guides/prereq/gateways/install-gateway-control-plane.sh`
- parsed `.github/workflows/ci-kustomize-dry-run.yaml` and `.github/workflows/e2e-pd-hpu.yaml` with Python YAML
- checked touched docs no longer mention `guides/prereq/gateway-provider` or `install-gateway-provider-dependencies.sh`
