### PR TITLE
Fix: PD disaggregation CKS nightly values

### DIFF
--- a/.github/workflows/nightly-e2e-pd-disaggregation-cks.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-cks.yaml
@@ -44,7 +44,6 @@ jobs:
         helm install ${GUIDE_NAME} \
           oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
           -f guides/recipes/scheduler/base.values.yaml \
-          -f guides/recipes/scheduler/pd.values.yaml \
           -f guides/${GUIDE_NAME}/scheduler/${GUIDE_NAME}.values.yaml \
           -n ${NAMESPACE} --version ${GAIE_VERSION}
       required_gpus: 8


### PR DESCRIPTION

When the PD disaggregation CKS nightly job runs, the scheduler deployment attempts to load a missing Helm values input. This causes deployment to fail before validation starts, blocking that nightly run. The expected behavior is that the job deploys using only existing base and PD-specific scheduler configuration.

Root cause: 
The CKS nightly path still referenced an obsolete shared PD scheduler values input after the PD-specific scheduler configuration had already been moved into the guide-specific configuration.

