### PR TITLE
Add documentation release branch step to release template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -73,6 +73,19 @@ This document defines the process for releasing llm-d.
     git push ${REMOTE} release-${MAJOR}.${MINOR}
     ```
 
+### Create documentation release branch
+
+1. Create a release branch in the llm-d.github.io repository:
+
+   ```shell
+   gh workflow run create-release-branch.yml \
+     --repo llm-d/llm-d.github.io \
+     --field version=${MAJOR}.${MINOR}.${PATCH} \
+     --field source_branch=release-${MAJOR}.${MINOR}
+   ```
+
+1. This creates a `release-${MAJOR}.${MINOR}.${PATCH}` branch that syncs docs nightly from the llm-d release branch.
+
 ### Tag commit and trigger image build
 
 1. Tag the head of your release branch with the sem-ver release version.


### PR DESCRIPTION
This PR adds a documentation release branch creation step to the release process template.

## Changes

- Adds a new section "Create documentation release branch" after pushing the release branch
- Provides command to trigger the `create-release-branch.yml` workflow in llm-d.github.io
- Documents that this creates a release branch that syncs docs nightly from the llm-d release branch

## Context

Starting with release 0.7, documentation will be synced to release-specific branches in the llm-d.github.io repository. This ensures stable release documentation is kept up-to-date with patches while remaining separate from the latest/main documentation.