### PR TITLE
ci: add xpu-sglang image build job

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -17,13 +17,16 @@ on:
       xpu:
         description: 'Whether XPU image was built'
         value: ${{ jobs.detect-changes.outputs.xpu }}
+      sglang-xpu:
+        description: 'Whether sglang-XPU image was built'
+        value: ${{ jobs.detect-changes.outputs.sglang-xpu }}
       hpu:
         description: 'Whether HPU image was built'
         value: ${{ jobs.detect-changes.outputs.hpu }}
   workflow_dispatch:
     inputs:
       platforms:
-        description: "Platforms to build (comma-separated: cuda,aws,gb200,xpu,cpu,hpu)"
+        description: "Platforms to build (comma-separated: cuda,aws,gb200,xpu,sglang-xpu,cpu,hpu)"
         required: false
         default: "cuda"
         type: string
@@ -42,6 +45,14 @@ on:
         type: string
       vllm_precompiled_wheel_commit:
         description: "vLLM commit SHA for precompiled wheel lookup (defaults to vllm_commit_sha)"
+        required: false
+        type: string
+      sglang_repo:
+        description: "sglang repository URL (overrides docker/common-versions; used by sglang-xpu only)"
+        required: false
+        type: string
+      sglang_ref:
+        description: "sglang ref (tag or branch) to check out — sglang's docker/xpu.Dockerfile self-clones via git clone --branch, so SHAs aren't valid here. Overrides docker/common-versions; used by sglang-xpu only."
         required: false
         type: string
 
@@ -66,6 +77,7 @@ jobs:
       gb200: ${{ steps.force.outputs.gb200 || steps.filter.outputs.gb200 || steps.dispatch.outputs.gb200 }}
       rocm: ${{ steps.force.outputs.rocm || steps.filter.outputs.rocm || steps.dispatch.outputs.rocm }}
       xpu: ${{ steps.force.outputs.xpu || steps.filter.outputs.xpu || steps.dispatch.outputs.xpu }}
+      sglang-xpu: ${{ steps.force.outputs.sglang-xpu || steps.filter.outputs.sglang-xpu || steps.dispatch.outputs.sglang-xpu }}
       cpu: ${{ steps.force.outputs.cpu || steps.filter.outputs.cpu || steps.dispatch.outputs.cpu }}
       hpu: ${{ steps.force.outputs.hpu || steps.filter.outputs.hpu || steps.dispatch.outputs.hpu }}
       rdma-tools: ${{ steps.filter.outputs.rdma-tools }}
@@ -79,6 +91,7 @@ jobs:
           echo "gb200=true" >> $GITHUB_OUTPUT
           echo "rocm=true" >> $GITHUB_OUTPUT
           echo "xpu=true" >> $GITHUB_OUTPUT
+          echo "sglang-xpu=true" >> $GITHUB_OUTPUT
           echo "cpu=true" >> $GITHUB_OUTPUT
           echo "hpu=true" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v6
@@ -125,6 +138,8 @@ jobs:
               - 'docker/Dockerfile.rocm'
             xpu:
               - 'docker/common-versions'
+            sglang-xpu:
+              - 'docker/common-versions'
             cpu:
               - 'docker/Dockerfile.cpu'
               - 'docker/common-versions'
@@ -139,14 +154,16 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         id: dispatch
         run: |
-          platforms="${{ inputs.platforms }}"
-          echo "cuda=$(echo $platforms | grep -q cuda && echo true || echo false)" >> $GITHUB_OUTPUT
-          echo "aws=$(echo $platforms | grep -q aws && echo true || echo false)" >> $GITHUB_OUTPUT
-          echo "gb200=$(echo $platforms | grep -q gb200 && echo true || echo false)" >> $GITHUB_OUTPUT
-          echo "rocm=$(echo $platforms | grep -q rocm && echo true || echo false)" >> $GITHUB_OUTPUT
-          echo "xpu=$(echo $platforms | grep -q xpu && echo true || echo false)" >> $GITHUB_OUTPUT
-          echo "cpu=$(echo $platforms | grep -q cpu && echo true || echo false)" >> $GITHUB_OUTPUT
-          echo "hpu=$(echo $platforms | grep -q hpu && echo true || echo false)" >> $GITHUB_OUTPUT
+          platforms=",${{ inputs.platforms }},"
+          has() { case "$platforms" in *,"$1",*) echo true ;; *) echo false ;; esac; }
+          echo "cuda=$(has cuda)" >> $GITHUB_OUTPUT
+          echo "aws=$(has aws)" >> $GITHUB_OUTPUT
+          echo "gb200=$(has gb200)" >> $GITHUB_OUTPUT
+          echo "rocm=$(has rocm)" >> $GITHUB_OUTPUT
+          echo "xpu=$(has xpu)" >> $GITHUB_OUTPUT
+          echo "sglang-xpu=$(has sglang-xpu)" >> $GITHUB_OUTPUT
+          echo "cpu=$(has cpu)" >> $GITHUB_OUTPUT
+          echo "hpu=$(has hpu)" >> $GITHUB_OUTPUT
 
   cuda-build-llm-d-debug:
     needs: [detect-changes]
@@ -1366,6 +1383,110 @@ jobs:
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: "trivy-results.sarif"
+
+      - name: Display vulnerability summary
+        run: |
+          echo "=== Vulnerability Scan Summary ==="
+          if [ -f trivy-results.sarif ]; then
+            echo "Scan completed. Check the Security tab for detailed results."
+          else
+            echo "No vulnerabilities found or scan failed."
+          fi
+
+  xpu-sglang-build-llm-d:
+    needs: [detect-changes]
+    if: ${{ needs.detect-changes.outputs.sglang-xpu == 'true' }}
+    strategy:
+      fail-fast: false
+    runs-on: xpu
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || '' }}
+
+      - name: Load sglang version from file
+        id: common-versions
+        run: |
+          # Read sglang repo + pinned ref from docker/common-versions.
+          source docker/common-versions
+          echo "repo=${SGLANG_REPO}" >> $GITHUB_OUTPUT
+          echo "ref=${SGLANG_XPU_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.GHCR_USER }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Set image tag
+        id: set-tag
+        run: |
+          TAG="sha-$(git rev-parse --short HEAD)"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          PR_TAG="${{ github.event.pull_request.number }}"
+          if [ -n "${PR_TAG}" ]; then
+            echo "pr_tag=pr-${PR_TAG}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Calculate Cache Bust Timestamp
+        id: cache_buster_timestamp
+        run: |
+          echo "cache_buster_timestamp=$(date)" >> $GITHUB_OUTPUT
+
+      - name: Checkout sglang source
+        uses: actions/checkout@v6
+        with:
+          repository: sgl-project/sglang
+          ref: ${{ inputs.sglang_ref || steps.common-versions.outputs.ref }}
+          path: .cache/sglang-src
+
+      - name: Build and push the image
+        id: build-and-push
+        uses: docker/build-push-action@v7
+        with:
+          context: ./.cache/sglang-src
+          file: ./.cache/sglang-src/docker/xpu.Dockerfile
+          platforms: linux/amd64
+          push: true
+          provenance: true
+          build-args: |
+            CACHE_BUSTER=${{ steps.cache_buster_timestamp.outputs.cache_buster_timestamp }}
+            SG_LANG_REPO=${{ inputs.sglang_repo || steps.common-versions.outputs.repo }}
+            SG_LANG_BRANCH=${{ inputs.sglang_ref || steps.common-versions.outputs.ref }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ github.repository }}-xpu-sglang:${{ steps.set-tag.outputs.tag }}
+            ${{ steps.set-tag.outputs.pr_tag != '' && format('{0}/{1}-xpu-sglang:{2}', env.REGISTRY, github.repository, steps.set-tag.outputs.pr_tag) || '' }}
+            ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event_name != 'pull_request_target' && format('{0}/{1}-xpu-sglang:latest', env.REGISTRY, github.repository) || '' }}
+          github-token: ${{ secrets.GHCR_TOKEN }}
+        env:
+          DOCKER_BUILDKIT: "1"
+          BUILDKIT_PROGRESS: "plain"
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ github.repository }}-xpu-sglang:${{ steps.set-tag.outputs.tag }}
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH,MEDIUM"
+          scanners: vuln # skip secrets/config/license analyzers
+          timeout: 30m
+          skip-dirs: /root/.cache/uv
+        env:
+          TRIVY_USERNAME: ${{ secrets.GHCR_USER }}
+          TRIVY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: "trivy-results.sarif"
+          # Distinct category so results don't collide with xpu-build-llm-d's upload.
+          category: trivy-xpu-sglang
 
       - name: Display vulnerability summary
         run: |

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1436,7 +1436,7 @@ jobs:
       - name: Calculate Cache Bust Timestamp
         id: cache_buster_timestamp
         run: |
-          echo "cache_buster_timestamp=$(date)" >> $GITHUB_OUTPUT
+          echo "cache_buster_timestamp=$(date +%s)" >> $GITHUB_OUTPUT
 
       - name: Checkout sglang source
         uses: actions/checkout@v6

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -857,6 +857,95 @@ jobs:
             echo "No vulnerabilities found or scan failed."
           fi
 
+  release-xpu-sglang-llm-d:
+    strategy:
+      fail-fast: false
+    runs-on: vllm-runner
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.TAG }}
+          fetch-depth: 0
+
+      - name: Load sglang version from file
+        id: common-versions
+        run: |
+          # Read sglang repo + pinned ref from docker/common-versions.
+          source docker/common-versions
+          echo "repo=${SGLANG_REPO}" >> $GITHUB_OUTPUT
+          echo "ref=${SGLANG_XPU_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          buildkitd-flags: --oci-worker-gc
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.GHCR_USER }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Checkout sglang source
+        uses: actions/checkout@v6
+        with:
+          repository: sgl-project/sglang
+          ref: ${{ steps.common-versions.outputs.ref }}
+          path: .cache/sglang-src
+
+      - name: Build and push the image
+        id: build-and-push
+        uses: docker/build-push-action@v7
+        with:
+          context: ./.cache/sglang-src
+          file: ./.cache/sglang-src/docker/xpu.Dockerfile
+          platforms: linux/amd64
+          push: true
+          provenance: true
+          build-args: |
+            CACHE_BUSTER=${{ github.ref_name }}-${{ github.run_id }}
+            SG_LANG_REPO=${{ steps.common-versions.outputs.repo }}
+            SG_LANG_BRANCH=${{ steps.common-versions.outputs.ref }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ github.repository }}-xpu-sglang:${{ env.TAG }}
+            ${{ env.IS_STABLE == 'true' && format('{0}/{1}-xpu-sglang:latest', env.REGISTRY, github.repository) || '' }}
+          github-token: ${{ secrets.GHCR_TOKEN }}
+        env:
+          DOCKER_BUILDKIT: "1"
+          BUILDKIT_PROGRESS: "plain"
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ github.repository }}-xpu-sglang:${{ env.TAG }}
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH,MEDIUM"
+          scanners: vuln
+          timeout: 30m
+          skip-dirs: /root/.cache/uv
+        env:
+          TRIVY_USERNAME: ${{ secrets.GHCR_USER }}
+          TRIVY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: "trivy-results.sarif"
+          # Distinct category so results don't collide with release-xpu-llm-d's upload.
+          category: trivy-xpu-sglang
+
+      - name: Display vulnerability summary
+        run: |
+          echo "=== Vulnerability Scan Summary ==="
+          if [ -f trivy-results.sarif ]; then
+            echo "Scan completed. Check the Security tab for detailed results."
+          else
+            echo "No vulnerabilities found or scan failed."
+          fi
+
   release-hpu-llm-d:
     strategy:
       fail-fast: false
@@ -928,6 +1017,7 @@ jobs:
       - release-cpu-llm-d
       - release-rocm-llm-d
       - release-xpu-llm-d
+      - release-xpu-sglang-llm-d
       - release-hpu-llm-d
     if: always()
     runs-on: ubuntu-latest
@@ -952,6 +1042,7 @@ jobs:
             "${{ env.REGISTRY }}/llm-d/llm-d-cpu:${TAG}"
             "${{ env.REGISTRY }}/llm-d/llm-d-rocm:${TAG}"
             "${{ env.REGISTRY }}/llm-d/llm-d-xpu:${TAG}"
+            "${{ env.REGISTRY }}/llm-d/llm-d-xpu-sglang:${TAG}"
             "${{ env.REGISTRY }}/llm-d/llm-d-hpu:${TAG}"
           )
 

--- a/.github/workflows/verify-release-images.yaml
+++ b/.github/workflows/verify-release-images.yaml
@@ -40,6 +40,7 @@ jobs:
             "${{ env.REGISTRY }}/llm-d/llm-d-cpu:${TAG}"
             "${{ env.REGISTRY }}/llm-d/llm-d-rocm:${TAG}"
             "${{ env.REGISTRY }}/llm-d/llm-d-xpu:${TAG}"
+            "${{ env.REGISTRY }}/llm-d/llm-d-xpu-sglang:${TAG}"
             "${{ env.REGISTRY }}/llm-d/llm-d-hpu:${TAG}"
           )
 

--- a/docker/common-versions
+++ b/docker/common-versions
@@ -26,6 +26,13 @@ VLLM_PRECOMPILED_WHEEL_COMMIT=b1388b1fbf5aaef47937fabe98931211684666a6 # maps to
 VLLM_XPU_COMMIT_SHA=b1388b1fbf5aaef47937fabe98931211684666a6
 
 # ============================================================================
+# sglang Version Configuration
+# ============================================================================
+# Used by XPU sglang image build (docker/xpu.Dockerfile from sglang upstream).
+SGLANG_REPO=https://github.com/sgl-project/sglang.git
+SGLANG_XPU_VERSION=v0.5.11
+
+# ============================================================================
 # CUDA Version Configuration
 # ============================================================================
 # Used by CUDA builds (Dockerfile.cuda, Dockerfile.rdma-tools)


### PR DESCRIPTION
## Summary

Adds a new `xpu-sglang-build-llm-d` job to `.github/workflows/build-image.yaml` to build sglang's XPU
Dockerfile for llm-d. The docker image will be pushed as "llm-d-xpu-sglang". 

Later when SGLang upstream has a docker image for XPU, we will switch to use upstream image instead of building within llm-d.

## Dependent PR
There is a follow-up PR #1508 for Optimized Baseline guide that depends on this PR.


## Test plan

- [x] `workflow_dispatch` against a fork + self-hosted runner, image lands in the expected registry path: https://github.com/users/xiaojun-zhang/packages/container/package/llm-d-xpu-sglang
- [x] Trivy step runs and uploads SARIF without colliding with the vLLM-XPU job's upload
- [ ] Nightly / path-filter trigger on merge — covered by `paths-filter` on `docker/common-versions`
