### PR TITLE
[docs] Add user impact assessment to contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,8 @@ All features involving public APIs, behavior between core components, or new cor
    * **Proposal**: Can include User Stories ("As a User I want to X"), should have enough detail that reviewers can understand exactly what you're proposing, but should not include things like API designs or implementation. What is the desired outcome and how do we measure success?
    * **Design Details**: Should contain enough information that the specifics of your change are understandable. This may include API specs (though not always required) or even code snippets. If there's any ambiguity about HOW your proposal will be implemented, this is the place to discuss them.
    * **Alternatives**: Provide alternative implementations/proposals and a short summary of why they were rejected
+   * **Release Notes**" Call out any impact on user facing aspects, such as documentation, release notes,
+   deprecation and replacement of existing functionality, etc.
 3. Get review from impacted component maintainers
 4. Get approval from project maintainers
 


### PR DESCRIPTION
User facing changes introduced in PRs or proposals, shoud be clearly called out and reviewed as part of contribution