### PR TITLE
Docs: Clarify gRPC inference header metadata

### DIFF
--- a/docs/api-reference/epp-http-headers.md
+++ b/docs/api-reference/epp-http-headers.md
@@ -8,9 +8,29 @@ These headers allow the EPP to identify the request's goals, group them for fair
 
 | Header | Description |
 | --- | --- |
-| `x-gateway-inference-objective` | Specifies the name of the `InferenceObjective` resource associated with the request. The EPP uses this to look up the corresponding objective resource in the **same namespace as the InferencePool** to apply the defined priority and performance goals. |
-| `x-gateway-inference-fairness-id` | Provides a unique identifier for grouping requests for fairness-based flow control. Requests with the same ID share capacity according to the fairness policy. If omitted, the EPP defaults to `default-flow`. |
-| `x-gateway-model-name-rewrite` | Specifies the target model name to be used for the request. This is an alternative approach to model name rewriting; while the `InferenceModelRewrite` API provides rule-based rewriting on the server side, this header allows for an explicit, per-request override. When present, the EPP uses this value to override the model name in the request body and for recording model-specific metrics. |
+| `x-llm-d-gateway-inference-objective` | Specifies the name of the `InferenceObjective` resource associated with the request. The EPP uses this to look up the corresponding objective resource in the **same namespace as the InferencePool** to apply the defined priority and performance goals. |
+| `x-llm-d-gateway-inference-fairness-id` | Provides a unique identifier for grouping requests for fairness-based flow control. Requests with the same ID share capacity according to the fairness policy. If omitted, the EPP defaults to `default-flow`. |
+| `x-llm-d-gateway-model-name-rewrite` | Specifies the target model name to be used for the request. This is an alternative approach to model name rewriting; while the `InferenceModelRewrite` API provides rule-based rewriting on the server side, this header allows for an explicit, per-request override. When present, the EPP uses this value to override the model name in the request body and for recording model-specific metrics. |
+
+### Example gRPC Request
+
+When using the `vllmgrpc-parser`, send these values as gRPC request headers using the same key names shown above:
+
+
+For example, with `grpcurl`:
+
+```bash
+grpcurl \
+  -H 'x-llm-d-gateway-inference-fairness-id: tenant-a' \
+  -H 'x-llm-d-gateway-inference-objective: premium-traffic' \
+  -d '{
+    "model": "default-model",
+    "prompt": "Say hello"
+  }' \
+  ${HOST}:${PORT} vllm.GRPCInferenceService/Generate
+```
+
+In application code, attach the same keys as outgoing metadata on the gRPC call. These metadata entries are forwarded through the gateway and read by the EPP the same way as HTTP headers.
 
 ## Service Level Objectives (SLOs)
 
@@ -18,8 +38,8 @@ These headers are used by admission control and load balancing plugins to make d
 
 | Header | Description |
 | --- | --- |
-| `x-slo-ttft-ms` | Specifies the target Time To First Token (TTFT) in milliseconds. Used by plugins to determine if a request can be admitted while meeting the latency goal. |
-| `x-slo-tpot-ms` | Specifies the target Time Per Output Token (TPOT) in milliseconds. Used for admission control based on predicted or observed token generation latency. |
+| `x-llm-d-slo-ttft-ms` | Specifies the target Time To First Token (TTFT) in milliseconds. Used by plugins to determine if a request can be admitted while meeting the latency goal. |
+| `x-llm-d-slo-tpot-ms` | Specifies the target Time Per Output Token (TPOT) in milliseconds. Used for admission control based on predicted or observed token generation latency. |
 
 ---
 

--- a/docs/architecture/advanced/latency-predictor.md
+++ b/docs/architecture/advanced/latency-predictor.md
@@ -97,7 +97,7 @@ Each prediction sidecar sustains roughly 300 QPS of prediction work on a `c4-sta
 The `predicted-latency-producer` plugin has two training modes, exposed via a `streamingMode` parameter:
 
 - **`streamingMode: false`** (default) — Trains on end-to-end request latency. TTFT is recorded at response completion (effectively e2e latency); TPOT is not trained. **Use this mode if** your workload mixes streaming and non-streaming responses, or if you only need latency-aware routing without per-request SLO enforcement.
-- **`streamingMode: true`** — Trains separate TTFT and TPOT models. TTFT is recorded on the first streamed chunk; TPOT is sampled across subsequent tokens. **Use this mode if** your workload is fully streaming and you need meaningful `x-slo-ttft-ms` / `x-slo-tpot-ms` enforcement — a mixed workload in this mode will produce incorrect measurements for the non-streamed responses.
+- **`streamingMode: true`** — Trains separate TTFT and TPOT models. TTFT is recorded on the first streamed chunk; TPOT is sampled across subsequent tokens. **Use this mode if** your workload is fully streaming and you need meaningful `x-llm-d-slo-ttft-ms` / `x-llm-d-slo-tpot-ms` enforcement — a mixed workload in this mode will produce incorrect measurements for the non-streamed responses.
 
 ## Scheduling Strategy
 

--- a/docs/architecture/core/router/epp/flow-control.md
+++ b/docs/architecture/core/router/epp/flow-control.md
@@ -27,7 +27,7 @@ The Flow Control layer intercepts requests at the EPP and holds them in centrali
 To understand how policy plugins act, it helps to visualize the queuing topology as a grid defined by two dimensions: **Priority** and **Flow (Fairness ID)**.
 
 1.  **Flow Identification**: Every request is assigned a `FlowKey` — a tuple of `(FairnessID, Priority)`.
-    *   `FairnessID` is extracted from the `x-gateway-inference-fairness-id` header (e.g., tenant ID).
+    *   `FairnessID` is extracted from the `x-llm-d-gateway-inference-fairness-id` header (e.g., tenant ID).
     *   `Priority` is derived from the `InferenceObjective`.
 2.  **Separate Queues**: Each unique `FlowKey` maps to its own in-memory queue.
 
@@ -48,8 +48,8 @@ Here is an example of how to target a specific `InferenceObjective` and ensure f
 ```bash
 curl -X POST http://${IP}:${PORT}/v1/completions \
   -H 'Content-Type: application/json' \
-  -H 'x-gateway-inference-fairness-id: tenant-a' \
-  -H 'x-gateway-inference-objective: premium-traffic' \
+  -H 'x-llm-d-gateway-inference-fairness-id: tenant-a' \
+  -H 'x-llm-d-gateway-inference-objective: premium-traffic' \
   -d '{
     "model": "default-model",
     "prompt": "Say hello"
@@ -362,7 +362,7 @@ The Flow Control layer behavior is customizable via several extension points imp
 #### Ordering Policies
 *   **[`fcfs-ordering-policy`](https://github.com/llm-d/llm-d-inference-scheduler/tree/main/pkg/epp/framework/plugins/flowcontrol/ordering/fcfs/README.md)**: First-Come, First-Served based on arrival time. (Default)
 *   **[`edf-ordering-policy`](https://github.com/llm-d/llm-d-inference-scheduler/tree/main/pkg/epp/framework/plugins/flowcontrol/ordering/edf/README.md)**: Earliest Deadline First, prioritizing requests with the closest expiration time.
-*   **[`slo-deadline-ordering-policy`](https://github.com/llm-d/llm-d-inference-scheduler/tree/main/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline/README.md)**: Orders requests by an SLO-based deadline computed from arrival time. Uses the `x-slo-ttft-ms` header. Requests without this header are placed behind all SLO requests, risking starvation.
+*   **[`slo-deadline-ordering-policy`](https://github.com/llm-d/llm-d-inference-scheduler/tree/main/pkg/epp/framework/plugins/flowcontrol/ordering/slodeadline/README.md)**: Orders requests by an SLO-based deadline computed from arrival time. Uses the `x-llm-d-slo-ttft-ms` header. Requests without this header are placed behind all SLO requests, risking starvation.
 
 #### Saturation Detectors
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -61,7 +61,7 @@ Split inference into dedicated **prefill workers** (prompt processing) and **dec
 
 ### Predicted Latency-Based Routing
 
-An **llm-d Router** capability implemented primarily as an EPP plugin that routes each request to the replica predicted to serve it fastest, using an XGBoost model trained online on live traffic to predict ITL and TTFT. Optionally enforce per-request SLOs via `x-slo-ttft-ms` / `x-slo-tpot-ms` headers — requests that no replica can meet within budget are shed at admission rather than routed to a guaranteed miss. Useful when workload variance makes queue-depth a poor proxy for true load, or when clients need to express interactive vs. batch latency budgets.
+An **llm-d Router** capability implemented primarily as an EPP plugin that routes each request to the replica predicted to serve it fastest, using an XGBoost model trained online on live traffic to predict ITL and TTFT. Optionally enforce per-request SLOs via `x-llm-d-slo-ttft-ms` / `x-llm-d-slo-tpot-ms` headers — requests that no replica can meet within budget are shed at admission rather than routed to a guaranteed miss. Useful when workload variance makes queue-depth a poor proxy for true load, or when clients need to express interactive vs. batch latency budgets.
 
 ### Batch Inference
 

--- a/guides/flow-control/README.md
+++ b/guides/flow-control/README.md
@@ -237,8 +237,8 @@ Clients must send the appropriate headers to be placed in the correct queues.
 ```bash
 curl -X POST http://${IP}/v1/completions \
   -H 'Content-Type: application/json' \
-  -H 'x-gateway-inference-fairness-id: tenant-a' \
-  -H 'x-gateway-inference-objective: premium-traffic' \
+  -H 'x-llm-d-gateway-inference-fairness-id: tenant-a' \
+  -H 'x-llm-d-gateway-inference-objective: premium-traffic' \
   -d "{
     \"model\": \"${MODEL_NAME}\",
     \"prompt\": \"Say hello\"
@@ -248,7 +248,7 @@ curl -X POST http://${IP}/v1/completions \
 > [!WARNING]
 > **Trust Boundary**: In a production system, allowing end-users to self-assert their tenant ID or traffic priority (`premium-traffic`) is an abuse vector.
 >
-> **Production Pattern**: Your ingress API Gateway (or an Envoy `ext_authz` filter) should be configured to automatically strip any incoming `x-gateway-*` headers from external traffic. It should then validate the user's API Key or JWT, extract their tier/tenant from the token claims, and securely inject the authoritative `x-gateway-inference-fairness-id` and `x-gateway-inference-objective` headers before passing the request to the EPP.
+> **Production Pattern**: Your ingress API Gateway (or an Envoy `ext_authz` filter) should be configured to automatically strip any incoming `x-llm-d-gateway-*` headers from external traffic. It should then validate the user's API Key or JWT, extract their tier/tenant from the token claims, and securely inject the authoritative `x-llm-d-gateway-inference-fairness-id` and `x-llm-d-gateway-inference-objective` headers before passing the request to the EPP.
 
 ### Use Case 2: Backpressure Management
 
@@ -278,8 +278,8 @@ To verify backpressure management, you must overwhelm the pool's capacity. Becau
 
     ```bash
     hey -c 150 -n 150 -m POST -T "application/json" \
-      -H "x-gateway-inference-fairness-id: tenant-b" \
-      -H "x-gateway-inference-objective: best-effort-traffic" \
+      -H "x-llm-d-gateway-inference-fairness-id: tenant-b" \
+      -H "x-llm-d-gateway-inference-objective: best-effort-traffic" \
       -D payload.json http://${IP}/v1/completions
     ```
 

--- a/guides/predicted-latency-based-scheduling/README.md
+++ b/guides/predicted-latency-based-scheduling/README.md
@@ -59,7 +59,7 @@ Two ready-to-use values files ship with this guide:
 | File | When to use |
 |---|---|
 | [`scheduler/predicted-latency.values.yaml`](./scheduler/predicted-latency.values.yaml) | Default — predictor trains on end-to-end latency. Routing-only, no SLO header support. |
-| [`scheduler/predicted-latency-slo.values.yaml`](./scheduler/predicted-latency-slo.values.yaml) | SLO-aware — Assumes `x-slo-ttft-ms` / `x-slo-tpot-ms` are set on requests. Every request must be sent with `"stream": true`. |
+| [`scheduler/predicted-latency-slo.values.yaml`](./scheduler/predicted-latency-slo.values.yaml) | SLO-aware — Assumes `x-llm-d-slo-ttft-ms` / `x-llm-d-slo-tpot-ms` are set on requests. Every request must be sent with `"stream": true`. |
 
 Both target model server pods labeled `llm-d.ai/guide=optimized-baseline` since in the next step we will simply reuse the model server manifests from the [optimized-baseline guide](../optimized-baseline).
 
@@ -123,8 +123,8 @@ Once enabled, latency-based scheduling works on every request — no header chan
 
 To opt an individual request into SLO-aware routing, add one or both headers:
 
-- `x-slo-ttft-ms` — Time-to-first-token SLO in milliseconds.
-- `x-slo-tpot-ms` — Time-per-output-token SLO in milliseconds.
+- `x-llm-d-slo-ttft-ms` — Time-to-first-token SLO in milliseconds.
+- `x-llm-d-slo-tpot-ms` — Time-per-output-token SLO in milliseconds.
 
 ### 1. Get the IP of the Proxy
 
@@ -160,8 +160,8 @@ kubectl run curl-debug --rm -it \
 ```bash
 curl -X POST http://${IP}/v1/completions \
     -H 'Content-Type: application/json' \
-    -H 'x-slo-ttft-ms: 200' \
-    -H 'x-slo-tpot-ms: 50' \
+    -H 'x-llm-d-slo-ttft-ms: 200' \
+    -H 'x-llm-d-slo-tpot-ms: 50' \
     -d '{
         "model": "'${MODEL_NAME}'",
         "prompt": "Explain the difference between prefill and decode.",

--- a/guides/predicted-latency-based-scheduling/scheduler/predicted-latency-slo.values.yaml
+++ b/guides/predicted-latency-based-scheduling/scheduler/predicted-latency-slo.values.yaml
@@ -1,7 +1,7 @@
 ## Predicted Latency-Based Scheduling — SLO-aware setup (streamingMode: true).
 ##
 ## Overrides the chart's default plugin pipeline so predicted-latency-producer
-## trains on streaming TPOT samples. Required for x-slo-ttft-ms / x-slo-tpot-ms
+## trains on streaming TPOT samples. Required for x-llm-d-slo-ttft-ms / x-llm-d-slo-tpot-ms
 ## request headers to be honored. Every request must be sent with
 ## "stream": true in the body.
 ##

--- a/guides/predicted-latency-based-scheduling/scheduler/predicted-latency.values.yaml
+++ b/guides/predicted-latency-based-scheduling/scheduler/predicted-latency.values.yaml
@@ -1,7 +1,7 @@
 ## Predicted Latency-Based Scheduling — default (routing-only) setup.
 ##
 ## The predictor trains on end-to-end latency. Suitable for non-SLO traffic.
-## For SLO header support (x-slo-ttft-ms / x-slo-tpot-ms), use
+## For SLO header support (x-llm-d-slo-ttft-ms / x-llm-d-slo-tpot-ms), use
 ## predicted-latency-slo.values.yaml instead.
 
 inferenceExtension:


### PR DESCRIPTION
## Summary
Document how to send EPP inference classification headers on gRPC requests when using the `vllmgrpc-parser`.

## Problem
Issue #1506 notes that the HTTP header reference explains the `x-gateway-inference-objective` and `x-gateway-inference-fairness-id` headers, but does not show how to supply the same values on gRPC requests

## Changes

  - Add a gRPC Requests section to docs/api-reference/epp-http-headers.md
  - Document x-llm-d-gateway-* headers and show an example of using it to send it in gRPC requests. 

  ## Validation

  - Reviewed the rendered markdown structure locally
  - Docs-only change; no tests were run

Closes #1506