### PR TITLE
Supporting Mooncake in llm-d 

### DIFF
--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -129,6 +129,33 @@ export INFRA_PROVIDER=base # base | coreweave | gke
 kubectl apply -n ${NAMESPACE} -k guides/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}
 ```
 
+<details>
+<summary><b>For NVIDIA GPU with Mooncake MultiConnector</b></summary>
+
+This variant uses vLLM's `MultiConnector` combining `MooncakeConnector` (direct P2P KV transfer between prefill and decode) with `MooncakeStoreConnector` (shared CPU memory pool for cross-instance prefix cache sharing). It deploys `Qwen/Qwen3-32B` with 2 prefill replicas (TP=1) and 2 decode replicas (TP=1).
+
+> [!NOTE]
+> `MooncakeStoreConnector` requires vLLM main (merged via [PR #40900](https://github.com/vllm-project/vllm/pull/40900)) and is not available in any released version as of v0.20.x. Both prefill and decode pods clone vLLM from source at startup, which adds several minutes to initial pod readiness.
+
+This variant deploys:
+- Prefill and decode deployments (clone vLLM source at startup, run as root)
+- A `mooncake-master` coordination service (required by `MooncakeStoreConnector`)
+- A `mooncake-config` ConfigMap with connection settings
+
+**On OpenShift**, grant `anyuid` SCC to the model server service account first:
+
+```bash
+oc adm policy add-scc-to-user anyuid -z pd-disaggregation-nvidia-gpu-vllm-sa -n ${NAMESPACE}
+```
+
+Deploy:
+
+```bash
+kubectl apply -n ${NAMESPACE} -k guides/${GUIDE_NAME}/modelserver/gpu/vllm/mooncake/base/
+```
+
+</details>
+
 ### 3. Enable Monitoring (optional)
 
 > [!NOTE]
@@ -217,6 +244,13 @@ To remove the deployed components:
 ```bash
 helm uninstall ${GUIDE_NAME} -n ${NAMESPACE}
 kubectl delete -n ${NAMESPACE} -k guides/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}
+```
+
+For the Mooncake MultiConnector variant:
+
+```bash
+helm uninstall ${GUIDE_NAME} -n ${NAMESPACE}
+kubectl delete -n ${NAMESPACE} -k guides/${GUIDE_NAME}/modelserver/gpu/vllm/mooncake/base/
 ```
 
 ## Benchmarking Report

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/mooncake/base/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/mooncake/base/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - mooncake-master.yaml
+  - mooncake-config.yaml
+
+labels:
+  - pairs:
+      llm-d.ai/subguide: pd-disaggregation-mooncake
+    includeSelectors: false
+    includeTemplates: false
+    fields:
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: metadata/labels
+        create: true
+
+patches:
+  - path: patch-decode.yaml
+  - path: patch-prefill.yaml

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/mooncake/base/mooncake-config.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/mooncake/base/mooncake-config.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mooncake-config
+data:
+  mooncake_config.json: |
+    {
+      "metadata_server": "P2PHANDSHAKE",
+      "master_server_address": "mooncake-master:50051",
+      "global_segment_size": "20GB",
+      "local_buffer_size": "2GB",
+      "protocol": "tcp",
+      "device_name": ""
+    }

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/mooncake/base/mooncake-master.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/mooncake/base/mooncake-master.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mooncake-master
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mooncake-master
+  template:
+    metadata:
+      labels:
+        app: mooncake-master
+    spec:
+      containers:
+        - name: mooncake-master
+          image: python:3.12-slim
+          command: ["/bin/sh", "-c"]
+          args:
+            - "apt-get update -qq && apt-get install -y --no-install-recommends libibverbs1 libnuma1 librdmacm1 ibverbs-providers && pip install mooncake-transfer-engine && mooncake_master --port 50051"
+          ports:
+            - containerPort: 50051
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mooncake-master
+spec:
+  selector:
+    app: mooncake-master
+  ports:
+    - port: 50051
+      targetPort: 50051

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/mooncake/base/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/mooncake/base/patch-decode.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: modelserver
+          securityContext:
+            runAsUser: 0
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              export PATH="/root/.local/bin:$PATH"
+              if ! command -v git > /dev/null 2>&1; then
+                apt-get update -qq && apt-get install -y -qq git
+              fi
+              rm -rf /workspace/vllm
+              cd /workspace
+              git clone https://github.com/vllm-project/vllm.git
+              cd vllm
+              git checkout ebeb09d822
+              uv venv .venv --python 3.12
+              source .venv/bin/activate
+              VLLM_USE_PRECOMPILED=1 \
+              VLLM_PRECOMPILED_WHEEL_COMMIT=bc150f50299199599673614f80d12a196f377655 \
+              uv pip install -e . --torch-backend=auto
+              uv pip install mooncake-transfer-engine
+              uv pip install nvidia-cuda-runtime-cu12
+              CUDA12_LIB=$(python -c "import nvidia.cuda_runtime; print(list(nvidia.cuda_runtime.__path__)[0] + '/lib')")
+              export LD_LIBRARY_PATH="${CUDA12_LIB}:${LD_LIBRARY_PATH:-}"
+              exec vllm serve \
+                Qwen/Qwen3-8B \
+                --disable-access-log-for-endpoints=/health,/metrics,/v1/models \
+                --tensor-parallel-size=1 \
+                --block-size=128 \
+                --port=8200 \
+                --kv-transfer-config '{"kv_connector":"MultiConnector","kv_role":"kv_consumer","kv_connector_extra_config":{"connectors":[{"kv_connector":"MooncakeConnector","kv_role":"kv_consumer"},{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_consumer"}]}}'
+          env:
+            - name: MOONCAKE_CONFIG_PATH
+              value: /etc/mooncake/mooncake_config.json
+            - name: VLLM_MOONCAKE_BOOTSTRAP_PORT
+              value: "50052"
+            - name: PYTHONHASHSEED
+              value: "0"
+          volumeMounts:
+            - name: mooncake-config
+              mountPath: /etc/mooncake
+            - name: workspace
+              mountPath: /workspace
+      volumes:
+        - name: mooncake-config
+          configMap:
+            name: mooncake-config
+        - name: workspace
+          emptyDir: {}

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/mooncake/base/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/mooncake/base/patch-prefill.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prefill
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: modelserver
+          securityContext:
+            runAsUser: 0
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              export PATH="/root/.local/bin:$PATH"
+              if ! command -v git > /dev/null 2>&1; then
+                apt-get update -qq && apt-get install -y -qq git
+              fi
+              rm -rf /workspace/vllm
+              cd /workspace
+              git clone https://github.com/vllm-project/vllm.git
+              cd vllm
+              git checkout ebeb09d822
+              uv venv .venv --python 3.12
+              source .venv/bin/activate
+              VLLM_USE_PRECOMPILED=1 \
+              VLLM_PRECOMPILED_WHEEL_COMMIT=bc150f50299199599673614f80d12a196f377655 \
+              uv pip install -e . --torch-backend=auto
+              uv pip install mooncake-transfer-engine
+              uv pip install nvidia-cuda-runtime-cu12
+              CUDA12_LIB=$(python -c "import nvidia.cuda_runtime; print(list(nvidia.cuda_runtime.__path__)[0] + '/lib')")
+              export LD_LIBRARY_PATH="${CUDA12_LIB}:${LD_LIBRARY_PATH:-}"
+              exec vllm serve \
+                Qwen/Qwen3-8B \
+                --disable-access-log-for-endpoints=/health,/metrics,/v1/models \
+                --tensor-parallel-size=1 \
+                --block-size=128 \
+                --gpu-memory-utilization=0.9 \
+                --kv-transfer-config '{"kv_connector":"MultiConnector","kv_role":"kv_producer","kv_connector_extra_config":{"connectors":[{"kv_connector":"MooncakeConnector","kv_role":"kv_producer"},{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_producer"}]}}'
+          env:
+            - name: MOONCAKE_CONFIG_PATH
+              value: /etc/mooncake/mooncake_config.json
+            - name: VLLM_MOONCAKE_BOOTSTRAP_PORT
+              value: "50052"
+            - name: PYTHONHASHSEED
+              value: "0"
+          volumeMounts:
+            - name: mooncake-config
+              mountPath: /etc/mooncake
+            - name: workspace
+              mountPath: /workspace
+      volumes:
+        - name: mooncake-config
+          configMap:
+            name: mooncake-config
+        - name: workspace
+          emptyDir: {}

--- a/guides/tiered-prefix-cache/cpu/README.md
+++ b/guides/tiered-prefix-cache/cpu/README.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-This guide provides recipes to offload prefix cache to CPU RAM via the vLLM native offloading connector, LMCache connector and tpu-inference KVCache connector. Offloading prefix cache to CPU helps in increasing overall throughput and mitigating memory starvation on HBM for large context models and frequent multi-turn user sessions.
+This guide provides recipes to offload prefix cache to CPU RAM via the vLLM native offloading connector, LMCache connector, Mooncake Store Connector, and tpu-inference KVCache connector. Offloading prefix cache to CPU helps in increasing overall throughput and mitigating memory starvation on HBM for large context models and frequent multi-turn user sessions.
 
 ## Default Configuration
 
@@ -114,6 +114,33 @@ export INFRA_PROVIDER=base # base | gke
 kubectl apply -n ${NAMESPACE} -k guides/tiered-prefix-cache/cpu/modelserver/gpu/vllm/${CONNECTOR}/${INFRA_PROVIDER}/
 ```
 
+<details>
+<summary><b>For NVIDIA GPU with Mooncake Store Connector</b></summary>
+
+The [Mooncake Store Connector](https://docs.vllm.ai/en/latest/features/mooncake_store_connector_usage/) pools CPU RAM across nodes into a distributed KV cache using the Mooncake transfer engine. This enables cross-node prefix cache sharing without GPU-to-GPU transfers.
+
+> [!NOTE]
+> `MooncakeStoreConnector` requires vLLM main (merged via [PR #40900](https://github.com/vllm-project/vllm/pull/40900)) and is not available in any released version as of v0.20.x. The model server pod clones vLLM from source and installs it at startup, which adds several minutes to the initial pod start time.
+
+This variant deploys:
+- The vLLM decode deployment (clones vLLM source at startup, runs as root)
+- A `mooncake-master` coordination service
+- A `mooncake-config` ConfigMap with the Mooncake connection settings
+
+**On OpenShift**, the pod runs as root to install packages at startup. Grant `anyuid` SCC to the model server service account first:
+
+```bash
+oc adm policy add-scc-to-user anyuid -z gpu-vllm-sa -n ${NAMESPACE}
+```
+
+Deploy:
+
+```bash
+kubectl apply -n ${NAMESPACE} -k guides/tiered-prefix-cache/cpu/modelserver/gpu/vllm/mooncake/base/
+```
+
+</details>
+
 **For Google TPU v7:**
 ```bash
 kubectl apply -n ${NAMESPACE} -k guides/tiered-prefix-cache/cpu/modelserver/tpu-v7/vllm/tpu-offloading-connector/
@@ -185,6 +212,14 @@ To clean up the applied deployment components:
 ```bash
 helm uninstall ${GUIDE_NAME} -n ${NAMESPACE}
 kubectl delete -n ${NAMESPACE} -k guides/tiered-prefix-cache/cpu/modelserver/gpu/vllm/${CONNECTOR}/${INFRA_PROVIDER}
+kubectl delete namespace ${NAMESPACE}
+```
+
+For the Mooncake Store Connector variant:
+
+```bash
+helm uninstall ${GUIDE_NAME} -n ${NAMESPACE}
+kubectl delete -n ${NAMESPACE} -k guides/tiered-prefix-cache/cpu/modelserver/gpu/vllm/mooncake/base/
 kubectl delete namespace ${NAMESPACE}
 ```
 

--- a/guides/tiered-prefix-cache/cpu/modelserver/gpu/vllm/mooncake/base/kustomization.yaml
+++ b/guides/tiered-prefix-cache/cpu/modelserver/gpu/vllm/mooncake/base/kustomization.yaml
@@ -1,0 +1,45 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - mooncake-master.yaml
+  - mooncake-config.yaml
+
+labels:
+  - pairs:
+      llm-d.ai/subguide: tiered-prefix-cache-cpu-mooncake
+    includeSelectors: true
+    includeTemplates: true
+    fields:
+      - version: v1
+        kind: ServiceAccount
+        path: metadata/labels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: metadata/labels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: spec/selector/matchLabels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: spec/template/metadata/labels
+        create: true
+      - group: monitoring.coreos.com
+        version: v1
+        kind: PodMonitor
+        path: metadata/labels
+        create: true
+      - group: monitoring.coreos.com
+        version: v1
+        kind: PodMonitor
+        path: spec/selector/matchLabels
+        create: true
+
+patches:
+  - path: patch-vllm.yaml

--- a/guides/tiered-prefix-cache/cpu/modelserver/gpu/vllm/mooncake/base/mooncake-config.yaml
+++ b/guides/tiered-prefix-cache/cpu/modelserver/gpu/vllm/mooncake/base/mooncake-config.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mooncake-config
+data:
+  mooncake_config.json: |
+    {
+      "metadata_server": "P2PHANDSHAKE",
+      "master_server_address": "mooncake-master:50051",
+      "global_segment_size": "60GB",
+      "local_buffer_size": "4GB",
+      "protocol": "tcp",
+      "device_name": ""
+    }

--- a/guides/tiered-prefix-cache/cpu/modelserver/gpu/vllm/mooncake/base/mooncake-master.yaml
+++ b/guides/tiered-prefix-cache/cpu/modelserver/gpu/vllm/mooncake/base/mooncake-master.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mooncake-master
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mooncake-master
+  template:
+    metadata:
+      labels:
+        app: mooncake-master
+    spec:
+      containers:
+        - name: mooncake-master
+          image: python:3.12-slim
+          command: ["/bin/sh", "-c"]
+          args:
+            - "apt-get update -qq && apt-get install -y --no-install-recommends libibverbs1 libnuma1 librdmacm1 ibverbs-providers && pip install mooncake-transfer-engine && mooncake_master --port 50051"
+          ports:
+            - containerPort: 50051
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mooncake-master
+spec:
+  selector:
+    app: mooncake-master
+  ports:
+    - port: 50051
+      targetPort: 50051

--- a/guides/tiered-prefix-cache/cpu/modelserver/gpu/vllm/mooncake/base/patch-vllm.yaml
+++ b/guides/tiered-prefix-cache/cpu/modelserver/gpu/vllm/mooncake/base/patch-vllm.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  replicas: 1
+  template:
+    spec:
+      securityContext:
+        runAsUser: 0
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values:
+                      - pokprod-b93r38s3
+      containers:
+        - name: modelserver
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              export PATH="/root/.local/bin:$PATH"; \
+              if ! command -v git > /dev/null 2>&1; then
+                apt-get update -qq && apt-get install -y -qq git
+              fi; \
+              rm -rf /workspace/vllm; \
+              cd /workspace; \
+              git clone https://github.com/vllm-project/vllm.git; \
+              cd vllm; \
+              git checkout ebeb09d822; \
+              uv venv .venv --python 3.12; \
+              source .venv/bin/activate; \
+              VLLM_USE_PRECOMPILED=1 \
+              VLLM_PRECOMPILED_WHEEL_COMMIT=bc150f50299199599673614f80d12a196f377655 \
+              uv pip install -e . --torch-backend=auto; \
+              uv pip install mooncake-transfer-engine; \
+              uv pip install nvidia-cuda-runtime-cu12; \
+              CUDA12_LIB=$(.venv/bin/python -c "import nvidia.cuda_runtime; print(list(nvidia.cuda_runtime.__path__)[0] + '/lib')"); \
+              export LD_LIBRARY_PATH="${CUDA12_LIB}:${LD_LIBRARY_PATH:-}"; \
+              exec /workspace/vllm/.venv/bin/vllm serve \
+                Qwen/Qwen3-32B \
+                --tensor-parallel-size 2 \
+                --max-num-seq 1024 \
+                --kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_both"}'
+          env:
+            - name: MOONCAKE_CONFIG_PATH
+              value: /etc/mooncake/mooncake_config.json
+            - name: PYTHONHASHSEED
+              value: "42"
+          resources:
+            limits:
+              memory: 500Gi
+            requests:
+              memory: 500Gi
+          volumeMounts:
+            - name: mooncake-config
+              mountPath: /etc/mooncake
+            - name: workspace
+              mountPath: /workspace
+      volumes:
+        - name: mooncake-config
+          configMap:
+            name: mooncake-config
+        - name: workspace
+          emptyDir: {}


### PR DESCRIPTION
I have been experimenting with adding mooncake support to llm-d. Mooncake has two connectors - mooncake store connector and mooncake connector. The store connector is responsible for a global kv cache pool and is used by the prefillers (read and write) as well as the decoders (write). The mooncake connector does direct gpu to gpu pd transfer. 

This PR enables both the mooncake store connector and the mooncake connector in llm-d.  It added the mooncake store connector (mooncake-master using mooncake terminology) in a pod and updates the vllm pods to start with both connectors using the kv multi connector, similar to how it's done in https://vllm.ai/blog/mooncake-store.  

I have also updated the pd-disaggregation and the tiering guides with instructions on how to enable mooncake.  

Note that this PR is opened as a draft PR.  The mooncake store manager was merged into vllm on Wed and was not in any vllm image when I did this work.  I had to do some ugly repo cloning to get all the code/libraries in place. The mooncake PR should be in the recent vllm 0.21 image and I will update this PR as needed.