### PR TITLE
[CI/CD] Add daily Slack report for nightly test status

### DIFF
--- a/.github/workflows/nightly-status-report.yaml
+++ b/.github/workflows/nightly-status-report.yaml
@@ -1,0 +1,132 @@
+name: Nightly Status Report
+
+# Runs daily at 12:00 UTC — after all nightly E2E workflows (which start at 10:00 UTC).
+# Fetches the last run result for every nightly workflow and posts a summary to Slack.
+#
+# Required secret: SLACK_NIGHTLY_WEBHOOK
+#   Set this in GitHub → Settings → Secrets → Actions → New repository secret
+#   Value: the incoming webhook URL for your Slack channel (e.g. #llm-d-ci)
+
+on:
+  schedule:
+    - cron: '0 12 * * *'  # 12:00 UTC daily
+  workflow_dispatch:       # also runnable manually for testing
+
+permissions:
+  actions: read
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch nightly results and post to Slack
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_NIGHTLY_WEBHOOK }}
+          REPO: llm-d/llm-d
+        run: |
+          NIGHTLIES=(
+            nightly-benchmark-cks
+            nightly-build-image
+            nightly-e2e-optimized-baseline-cks
+            nightly-e2e-optimized-baseline-gke
+            nightly-e2e-optimized-baseline-ocp
+            nightly-e2e-pd-disaggregation-cks
+            nightly-e2e-pd-disaggregation-gke
+            nightly-e2e-pd-disaggregation-ocp
+            nightly-e2e-precise-prefix-cache-cks
+            nightly-e2e-precise-prefix-cache-gke
+            nightly-e2e-precise-prefix-cache-ocp
+            nightly-e2e-predicted-latency-cks
+            nightly-e2e-predicted-latency-gke
+            nightly-e2e-predicted-latency-ocp
+            nightly-e2e-tiered-prefix-cache-cpu-offloading-gke
+            nightly-e2e-tiered-prefix-cache-cpu-offloading-lmcache-gke
+            nightly-e2e-tiered-prefix-cache-cpu-offloading-ocp
+            nightly-e2e-wide-ep-lws-cks
+            nightly-e2e-wide-ep-lws-gke
+            nightly-e2e-wide-ep-lws-ocp
+            nightly-e2e-wva-cks
+            nightly-e2e-wva-ocp
+          )
+
+          passed=0
+          failed=0
+          skipped=0
+          lines=""
+
+          for name in "${NIGHTLIES[@]}"; do
+            file="${name}.yaml"
+
+            # Fetch the most recent run for this workflow
+            result=$(gh api \
+              "repos/${REPO}/actions/workflows/${file}/runs?per_page=1" \
+              --jq '.workflow_runs[0] | {conclusion: .conclusion, url: .html_url}' 2>/dev/null)
+
+            conclusion=$(echo "$result" | jq -r '.conclusion // "no_runs"')
+            url=$(echo "$result" | jq -r '.url // ""')
+
+            case "$conclusion" in
+              success)
+                emoji="✅"
+                passed=$((passed + 1))
+                lines="${lines}\n${emoji} ${name}"
+                ;;
+              failure)
+                emoji="❌"
+                failed=$((failed + 1))
+                lines="${lines}\n${emoji} <${url}|${name}>"
+                ;;
+              cancelled)
+                emoji="⚠️"
+                skipped=$((skipped + 1))
+                lines="${lines}\n${emoji} ${name} (cancelled)"
+                ;;
+              skipped|no_runs)
+                emoji="⏭️"
+                skipped=$((skipped + 1))
+                lines="${lines}\n${emoji} ${name} (no recent run)"
+                ;;
+              *)
+                emoji="❓"
+                lines="${lines}\n${emoji} ${name} (${conclusion})"
+                ;;
+            esac
+          done
+
+          # Build summary header
+          date_str=$(date -u '+%Y-%m-%d')
+          if [ "$failed" -eq 0 ]; then
+            header="*llm-d nightly CI — ${date_str}* 🟢 All passing"
+          else
+            header="*llm-d nightly CI — ${date_str}* 🔴 ${failed} failing"
+          fi
+
+          summary="Passed: ${passed} | Failed: ${failed} | Skipped/cancelled: ${skipped}"
+
+          # Post to Slack
+          payload=$(jq -n \
+            --arg header "$header" \
+            --arg summary "$summary" \
+            --arg body "$(echo -e "$lines")" \
+            '{
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {"type": "mrkdwn", "text": $header}
+                },
+                {
+                  "type": "context",
+                  "elements": [{"type": "mrkdwn", "text": $summary}]
+                },
+                {
+                  "type": "section",
+                  "text": {"type": "mrkdwn", "text": $body}
+                }
+              ]
+            }')
+
+          curl -s -o /dev/null -w "%{http_code}" \
+            -X POST "$SLACK_WEBHOOK" \
+            -H 'Content-type: application/json' \
+            --data "$payload"


### PR DESCRIPTION
Closes #1548

adds `.github/workflows/nightly-status-report.yaml` — runs at 12:00 UTC every day, checks the last run for all 22 nightlies, and posts a summary to Slack. failed runs include a direct link so you can jump straight to the logs.

the workflow is ready but it needs a Slack webhook to actually post anywhere. someone with org admin access needs to create an incoming webhook for `#llm-d-ci` and add it as `SLACK_NIGHTLY_WEBHOOK` in the repo secrets — flagging here so it doesn't get lost.