### PR TITLE
docs: migrate rollout guides from gateway-api-inference-extension

### DIFF
--- a/guides/README.md
+++ b/guides/README.md
@@ -26,6 +26,7 @@ We currently offer the following:
 
 * [Flow Control](./flow-control.md): Intelligent request queuing for multi-tenant deployments and managing traffic spikes.
 * [Workload Autoscaling](./workload-autoscaling/README.md) - autoscale the LLM service via proactive, SLO-aware signals that reflect the true state of the inference system — queue depth, in-flight request counts, and KV cache pressure — so that capacity can be added before end-user latency is impacted.
+* [Rollouts](./rollouts/README.md) - perform incremental rollout operations for LoRA adapters, base models, and model server versions with minimal service disruption using traffic splitting and gradual deployment strategies.
 
 ## Experimental Guides
 

--- a/guides/rollouts/README.md
+++ b/guides/rollouts/README.md
@@ -1,0 +1,55 @@
+# Rollout Guides
+
+Rollout guides demonstrate how to perform incremental deployment operations that gradually introduce new versions of your inference infrastructure with minimal service disruption.
+
+## Overview
+
+These guides cover three critical rollout scenarios for LLM inference deployments:
+
+1. **Rolling out a new model version** - Deploy new base model versions while maintaining service availability
+2. **Rolling out a new LoRA adapter** - Update LoRA adapters without disrupting the underlying infrastructure
+3. **Rolling out a new model server version** - Upgrade serving frameworks (e.g., vLLM versions) safely
+
+## Available Guides
+
+### [LoRA Adapter Rollout](./adapter-rollout.md)
+
+Demonstrates how to perform gradual rollouts of LoRA adapter versions using the `InferenceModelRewrite` resource and traffic splitting. This guide shows how to:
+
+* Establish a baseline with version aliases
+* Perform gradual traffic splits (90/10, 50/50, 100/0)
+* Test traffic distribution
+* Complete the rollout and clean up old versions
+
+**Use this guide when:** You need to deploy new versions of LoRA adapters without disrupting service.
+
+### [InferencePool Rollout](./inferencepool-rollout.md)
+
+Demonstrates how to perform infrastructure and model updates using InferencePool rollouts with HTTPRoute-based traffic splitting. This guide covers:
+
+* Node (compute/accelerator) updates
+* Base model version rollouts  
+* Model server framework updates (e.g., vLLM version upgrades)
+* Traffic splitting with HTTPRoute
+* Rollback capabilities
+
+**Use this guide when:** You need to update infrastructure, base models, or serving frameworks.
+
+## General Rollout Strategy
+
+All rollout guides follow a similar pattern:
+
+1. **Deploy new infrastructure** - Create the new version alongside the existing one
+2. **Configure traffic splitting** - Gradually shift traffic to the new version (e.g., 10% → 50% → 100%)
+3. **Monitor and validate** - Verify the new version performs correctly at each stage
+4. **Complete rollout** - Direct 100% of traffic to the new version
+5. **Clean up** - Remove the old version once the new version is stable
+
+## Prerequisites
+
+Before following these guides, ensure you have:
+
+* A working llm-d deployment (see [getting started guide](../prereq/README.md))
+* Access to kubectl and the Kubernetes cluster
+* Understanding of Kubernetes Gateway API concepts
+* Familiarity with your model serving infrastructure (vLLM, etc.)

--- a/guides/rollouts/README.md
+++ b/guides/rollouts/README.md
@@ -4,38 +4,73 @@ Rollout guides demonstrate how to perform incremental deployment operations that
 
 ## Overview
 
-These guides cover three critical rollout scenarios for LLM inference deployments:
+These guides cover rollout strategies for LLM inference deployments, helping you choose the right approach based on your requirements.
 
-1. **Rolling out a new model version** - Deploy new base model versions while maintaining service availability
-2. **Rolling out a new LoRA adapter** - Update LoRA adapters without disrupting the underlying infrastructure
-3. **Rolling out a new model server version** - Upgrade serving frameworks (e.g., vLLM versions) safely
+## Rollout Strategies
 
-## Available Guides
+### Rolling Update
 
-### [LoRA Adapter Rollout](./adapter-rollout.md)
+A Rolling Update is the standard Kubernetes deployment strategy that updates pods gradually within a single InferencePool. This approach works in both standalone and llm-d router gateway modes.
 
-Demonstrates how to perform gradual rollouts of LoRA adapter versions using the `InferenceModelRewrite` resource and traffic splitting. This guide shows how to:
+**How it works:**
+- Updates pods incrementally (e.g., 25% at a time)
+- Old pods continue serving traffic until new pods are healthy
+- Built into Kubernetes Deployments
 
-* Establish a baseline with version aliases
-* Perform gradual traffic splits (90/10, 50/50, 100/0)
-* Test traffic distribution
-* Complete the rollout and clean up old versions
+**Use Rolling Updates for:**
+- General, non-critical updates where strict traffic percentages do not matter
+- Scenarios where you want to conserve compute resources
+- Development and staging environments
 
-**Use this guide when:** You need to deploy new versions of LoRA adapters without disrupting service.
+**Learn more:** [Kubernetes Rolling Update Tutorial](https://kubernetes.io/docs/tutorials/kubernetes-basics/update/update-intro/)
 
-### [InferencePool Rollout](./inferencepool-rollout.md)
+### Blue-Green Update (HTTPRoute Traffic Splitting)
 
-Demonstrates how to perform infrastructure and model updates using InferencePool rollouts with HTTPRoute-based traffic splitting. This guide covers:
+A Blue-Green Update creates a second complete InferencePool and uses HTTPRoute to control traffic distribution between the old (blue) and new (green) versions. This strategy requires llm-d router gateway mode.
 
-* Node (compute/accelerator) updates
-* Base model version rollouts  
-* Model server framework updates (e.g., vLLM version upgrades)
-* Traffic splitting with HTTPRoute
-* Rollback capabilities
+**How it works:**
+- Deploy a complete new InferencePool alongside the existing one
+- Use HTTPRoute to gradually shift traffic (e.g., 1% → 5% → 10% → 50% → 100%)
+- Instant rollback by adjusting HTTPRoute weights
 
-**Use this guide when:** You need to update infrastructure, base models, or serving frameworks.
+**Use Blue-Green Updates for:**
+- Critical, high-risk production deployments that require gradual canary rollouts
+- Scenarios requiring fast rollbacks
+- Header-based routing (e.g., routing beta users to new version)
+- Updates that need precise traffic control
 
-## General Rollout Strategy
+**Guide:** [Blue-Green Update](./blue-green-update.md)
+
+**Comparison:**
+
+| Feature | Rolling Update | Blue-Green Update |
+|---------|---------------|-------------------|
+| **Routing Control** | Random/Even across all healthy pods | Precise Percentage (e.g., exactly 1% or 10%) |
+| **Blast Radius** | High (All users exposed randomly) | Low (Isolated to specified target weight) |
+| **Rollback Speed** | Slow (Requires creating new pods in reverse) | Instant (Flip HTTPRoute weight back to 0) |
+| **Resource Costs** | Low (Only temporary surge of pods) | High (Requires running two full environments) |
+| **Version Coexistence** | Simultaneously active inside one Service | Strictly separated across two distinct Services |
+| **Deployment Mode** | Standalone and Gateway | Gateway only |
+
+**Note:** Capacity management may also play a role in choosing between these strategies.
+
+### LoRA Adapter Rollout
+
+LoRA (Low-Rank Adaptation) adapter rollouts allow you to update model customizations without changing the base model or infrastructure. This works in both standalone and llm-d router gateway modes.
+
+**How it works:**
+- Use `InferenceModelRewrite` to map model names to specific adapter versions
+- Gradually shift traffic between adapter versions
+- No infrastructure changes required
+
+**Use LoRA Adapter Rollouts when:**
+- You need to deploy new versions of LoRA adapters without disrupting service
+- You want to test adapter changes with a subset of traffic
+- You need to maintain multiple adapter versions simultaneously
+
+**Guide:** [LoRA Adapter Rollout](./adapter-rollout.md)
+
+## General Rollout Pattern
 
 All rollout guides follow a similar pattern:
 
@@ -49,7 +84,7 @@ All rollout guides follow a similar pattern:
 
 Before following these guides, ensure you have:
 
-* A working llm-d deployment (see [getting started guide](../prereq/README.md))
+* A working llm-d deployment (see [getting started guide](../../docs/getting-started/README.md))
 * Access to kubectl and the Kubernetes cluster
-* Understanding of Kubernetes Gateway API concepts
+* Understanding of Kubernetes Gateway API concepts (for gateway mode)
 * Familiarity with your model serving infrastructure (vLLM, etc.)

--- a/guides/rollouts/adapter-rollout-example/kustomization.yaml
+++ b/guides/rollouts/adapter-rollout-example/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../recipes/modelserver/base/single-host/default
+
+namePrefix: lora-adapter-rollout-
+
+images:
+  - name: REPLACE_MODEL_SERVER_IMAGE
+    newName: vllm/vllm-openai
+    newTag: v0.19.1
+
+patches:
+  - path: patch-lora-config.yaml
+

--- a/guides/rollouts/adapter-rollout-example/patch-lora-config.yaml
+++ b/guides/rollouts/adapter-rollout-example/patch-lora-config.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  template:
+    spec:
+      containers:
+        - name: modelserver
+          command: ["vllm", "serve"]
+          args:
+            - "Qwen/Qwen3-32B"
+            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+          env:
+            - name: VLLM_ALLOW_RUNTIME_LORA_UPDATING
+              value: "True"
+            - name: VLLM_PLUGINS
+              value: "lora_filesystem_resolver"
+            - name: VLLM_LORA_RESOLVER_CACHE_DIR
+              value: "/adapters"
+          volumeMounts:
+            - mountPath: /adapters
+              name: lora-adapters
+            - mountPath: /dev/shm
+              name: shm
+          resources:
+            limits:
+              cpu: '8'
+              memory: 64Gi
+              nvidia.com/gpu: 1
+            requests:
+              cpu: '4'
+              memory: 32Gi
+              nvidia.com/gpu: 1
+      volumes:
+        - name: lora-adapters
+          emptyDir: {}
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 10Gi
+

--- a/guides/rollouts/adapter-rollout.md
+++ b/guides/rollouts/adapter-rollout.md
@@ -1,0 +1,266 @@
+# LoRA Adapter Rollout
+
+The goal of this guide is to show you how to perform incremental roll out operations,
+which gradually deploy new versions of your inference infrastructure.
+You can update LoRA adapters in an InferencePool with minimal service disruption.
+
+LoRA adapter rollouts let you deploy new versions of LoRA adapters in phases,
+without altering the underlying base model or infrastructure.
+Use LoRA adapter rollouts to test improvements, bug fixes, or new features in your LoRA adapters.
+
+The [`InferenceModelRewrite`](../../docs/api-reference/inferencemodelrewrite.md) resource allows platform administrators and model owners to control how inference requests are routed to specific models within an InferencePool.
+This capability is essential for managing model/adapter lifecycles without disrupting client applications.
+
+## Prerequisites & Setup
+
+Follow the [getting started guide](../../docs/getting-started/README.md) to set up the llm-d stack.
+
+In this guide, we use vLLM's native `lora_filesystem_resolver` to load adapters dynamically from a local directory. To enable this, configure your vLLM deployment with the following environment variables and ensure your adapters are accessible in the cache directory (e.g., mounted via a PVC or synchronized by an initContainer).
+
+### vLLM Configuration
+
+Add the following environment variables to your vLLM container:
+
+```yaml
+env:
+- name: VLLM_ALLOW_RUNTIME_LORA_UPDATING
+  value: "True"
+- name: VLLM_PLUGINS
+  value: "lora_filesystem_resolver"
+- name: VLLM_LORA_RESOLVER_CACHE_DIR
+  value: "/adapters"
+```
+
+Ensure your adapters are organized in subdirectories under the cache directory:
+- `/adapters/small-segment-lora-v1/`
+- `/adapters/small-segment-lora-v2/`
+
+For more details on the expected directory structure and plugins, see the [vLLM documentation](https://docs.vllm.ai/en/stable/design/lora_resolver_plugins/).
+
+
+**Verify Available Models**: You can query the `/v1/models` endpoint to confirm the adapters are loaded:
+
+```bash
+curl http://${IP}/v1/models | jq .
+```
+
+## Step 1: Establishing A Baseline (Alias v1)
+
+First, we establish a stable baseline where all requests for `small-segment-lora` are served by the existing version, `small-segment-lora-v1`. This decouples the client's request (for "small-segment-lora") from the specific version running on the backend.
+
+A client requests the model `small-segment-lora`. We want to ensure this maps strictly to `small-segment-lora-v1`.
+
+### InferenceModelRewrite
+
+Apply the following `InferenceModelRewrite` CR to map `small-segment-lora` → `small-segment-lora-v1`:
+
+```yaml
+apiVersion: inference.networking.x-k8s.io/v1alpha2
+kind: InferenceModelRewrite
+metadata:
+  name: small-segment-lora-rewrite
+spec:
+  poolRef:
+    group: inference.networking.k8s.io
+    name: vllm-qwen3-32b
+  rules:
+    - matches:
+        - model:
+            type: Exact
+            value: small-segment-lora
+      targets:
+        - modelRewrite: "small-segment-lora-v1"
+```
+
+When a client requests `"model": "small-segment-lora"`, the system serves the request using `small-segment-lora-v1`.
+
+```bash
+curl http://${IP}/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+"model": "small-segment-lora",
+"messages": [
+  {
+    "role": "user",
+    "content": "If you had a time machine, but could only go to the past or the future once and never return, which would you choose and why?"
+  }
+],
+"max_completion_tokens": 10
+}' | jq .
+```
+
+Response:
+```json
+{
+  "choices": [
+    {
+      "finish_reason": "length",
+      "index": 0,
+      "logprobs": null,
+      "message": {
+        "content": "I would choose to go to the future because I",
+        "reasoning_content": null,
+        "role": "assistant",
+        "tool_calls": []
+      },
+      "stop_reason": null
+    }
+  ],
+  "created": 1764786158,
+  "id": "chatcmpl-b10d939f-39bc-41ba-85c0-fe9b9d1ed3d9",
+  "model": "small-segment-lora-v1",
+  "object": "chat.completion",
+  "prompt_logprobs": null,
+  "usage": {
+    "completion_tokens": 10,
+    "prompt_tokens": 43,
+    "prompt_tokens_details": null,
+    "total_tokens": 53
+  }
+}
+```
+
+## Step 2: Gradual Rollout
+
+Now that `small-segment-lora-v2` is loaded (from the Prerequisites step), we can begin splitting traffic. Traffic splitting allows you to divide incoming traffic for a single model name across different adapters. This is critical for A/B testing or gradual updates.
+You want to direct 90% of `small-segment-lora` traffic to the stable `small-segment-lora-v1` and 10% to the new `small-segment-lora-v2`.
+
+### InferenceModelRewrites (90 / 10 split)
+
+Update the existing `InferenceModelRewrite`:
+
+```yaml
+apiVersion: inference.networking.x-k8s.io/v1alpha2
+kind: InferenceModelRewrite
+metadata:
+  name: small-segment-lora-rewrite
+spec:
+  poolRef:
+    group: inference.networking.k8s.io
+    name: vllm-qwen3-32b
+  rules:
+    - matches:
+        - model:
+            type: Exact
+            value: small-segment-lora
+      targets:
+        - modelRewrite: "small-segment-lora-v1"
+          weight: 90
+        - modelRewrite: "small-segment-lora-v2"
+          weight: 10
+```
+
+Run the [test traffic script](#test-traffic-script) as follows:
+
+```bash
+❯ ./test-traffic-splitting.sh
+---
+Traffic Split Results, total requests: 20
+small-segment-lora-v1: 17 requests
+small-segment-lora-v2: 3 requests
+```
+
+### InferenceModelRewrites (50 / 50 split)
+
+To increase traffic to the new model, simply adjust the weights.
+
+```yaml
+      targets:
+        - modelRewrite: "small-segment-lora-v1"
+          weight: 50
+        - modelRewrite: "small-segment-lora-v2"
+          weight: 50
+```
+
+Run the [test traffic script](#test-traffic-script) again:
+
+```bash
+❯ ./test-traffic-splitting.sh
+___
+Traffic Split Results, total requests: 20
+small-segment-lora-v1: 10 requests
+small-segment-lora-v2: 10 requests
+```
+
+### InferenceModelRewrites (0 / 100 split)
+
+Once the new model is verified, shift all traffic to it.
+
+```yaml
+      targets:
+        - modelRewrite: "small-segment-lora-v2"
+          weight: 100
+```
+
+Run the [test traffic script](#test-traffic-script) one last time:
+
+```bash
+❯ ./test-traffic-splitting.sh
+------------------------------------------------
+Traffic Split Results, total requests: 20
+small-segment-lora-v1: 0 requests
+small-segment-lora-v2: 20 requests
+```
+
+Now that 100% of traffic is routed to `small-segment-lora-v2`, you can safely unload the older version.
+
+With the file-based resolver, you can simply remove the `small-segment-lora-v1` directory from the cache path to ensure it is no longer loaded or cached by vLLM.
+
+```bash
+rm -rf /adapters/small-segment-lora-v1
+```
+
+> [!IMPORTANT]
+> While deleting the folder stops vLLM from *newly* loading the adapter, it might still remain in vLLM's internal VRAM cache until evicted. To deterministically free up VRAM immediately, use vLLM's `/v1/unload_lora_adapter` HTTP endpoint.
+
+
+With this, the old adapter is removed, and the rollout is complete.
+
+## Appendix
+
+### Test Traffic Script
+
+```bash
+#!/bin/bash
+
+# --- Configuration ---
+# Replace this with your actual IP address or hostname
+target_ip="${IP}"
+# How many requests you want to send
+total_requests=20
+
+# Initialize counters
+count_v1=0
+count_v2=0
+
+echo "Starting $total_requests requests to http://$target_ip..."
+echo "------------------------------------------------"
+
+for ((i=1; i<=total_requests; i++)); do
+  # 1. Send the request
+  # jq -r '.model': Extracts the raw string of the model name
+  model_name=$(curl -s "http://${target_ip}/v1/chat/completions" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "small-segment-lora",
+      "messages": [{"role": "user", "content": "test"}],
+      "max_completion_tokens": 1
+    }' | jq -r '.model')
+
+  # 2. Check the response and update counters
+  if [[ "$model_name" == "small-segment-lora-v1" ]]; then
+    ((count_v1++))
+    echo "Request $i: Hit small-segment-lora-v1"
+  elif [[ "$model_name" == "small-segment-lora-v2" ]]; then
+    ((count_v2++))
+    echo "Request $i: Hit small-segment-lora-v2"
+  else
+    echo "Request $i: Received unexpected model: $model_name"
+  fi
+done
+
+# 3. Print the final report
+echo "------------------------------------------------"
+echo "Traffic Split Results:"
+echo "small-segment-lora-v1: $count_v1 requests"
+echo "small-segment-lora-v2: $count_v2 requests"

--- a/guides/rollouts/adapter-rollout.md
+++ b/guides/rollouts/adapter-rollout.md
@@ -11,6 +11,9 @@ Use LoRA adapter rollouts to test improvements, bug fixes, or new features in yo
 The [`InferenceModelRewrite`](../../docs/api-reference/inferencemodelrewrite.md) resource allows platform administrators and model owners to control how inference requests are routed to specific models within an InferencePool.
 This capability is essential for managing model/adapter lifecycles without disrupting client applications.
 
+> [!IMPORTANT]
+> This guide applies to both llm-d router standalone and gateway modes.
+
 ## Prerequisites & Setup
 
 Follow the [getting started guide](../../docs/getting-started/README.md) to set up the llm-d stack.
@@ -30,6 +33,13 @@ env:
 - name: VLLM_LORA_RESOLVER_CACHE_DIR
   value: "/adapters"
 ```
+
+**Quick Start:** You can deploy a vLLM instance with these configurations using kustomize:
+```bash
+kubectl apply -k guides/rollouts/adapter-rollout-example/
+```
+
+This will create a deployment with the LoRA adapter environment variables pre-configured. See [`kustomization.yaml`](adapter-rollout-example/kustomization.yaml) and [`patch-lora-config.yaml`](adapter-rollout-example/patch-lora-config.yaml) for the full configuration.
 
 Ensure your adapters are organized in subdirectories under the cache directory:
 - `/adapters/small-segment-lora-v1/`

--- a/guides/rollouts/blue-green-update.md
+++ b/guides/rollouts/blue-green-update.md
@@ -1,11 +1,15 @@
-# InferencePool Rollout
+# Blue-Green Update
+
 The goal of this guide is to show you how to perform incremental roll out operations,
 which gradually deploy new versions of your inference infrastructure.
-You can update Inference Pool with minimal service disruption.
-This page also provides guidance on traffic splitting and rollbacks to help ensure reliable deployments for InferencePool rollout.
+You can update InferencePool with minimal service disruption.
+This page also provides guidance on traffic splitting and rollbacks to help ensure reliable deployments for Blue-Green updates.
 
-InferencePool rollout is a powerful technique for performing various infrastructure and model updates with minimal disruption and built-in rollback capabilities.
+Blue-Green update is a powerful technique for performing various infrastructure and model updates with minimal disruption and built-in rollback capabilities.
 This method allows you to introduce changes incrementally, monitor their impact, and revert to the previous state if necessary.
+
+> [!IMPORTANT]
+> This guide applies to llm-d router gateway mode only. For standalone mode, use rolling updates or adapter rollouts.
 
 ## Use Cases
 Use Cases for InferencePool Rollout:
@@ -39,12 +43,15 @@ teams can ensure stability and performance, quickly identifying and reverting an
 ## Example
 This is an example of InferencePool rollout with node(compute, accelerator) update roll out
 
-###  Prerequisites
-Follow the [getting started guide](../../docs/getting-started/README.md) to set up the llm-d stack.
+### Prerequisites
+
+To deploy llm-d Router in Gateway Mode follow the below instructions:
+1. Deploy a Kubernetes Gateway (see [gateway guides](../prereq/gateways))
+2. Install llm-d router with HTTPRoute enabled (see [optimized-baseline guide](../optimized-baseline/README.md#gateway-mode))
 
 ### Deploy new infrastructure
 You start with an existing InferencePool named vllm-qwen3-32b.
-To replace the original InferencePool, you create a new InferencePool, configured to select the pods with the `nvidia-h100-80gb` accelerator type.
+To replace the original InferencePool, you create a new InferencePool (the green InferencePool) with your desired configuration.
 
 Assuming the new model servers already exist, simply:
 **Create a new helm-managed InferencePool of a different name, with a new selector specified**

--- a/guides/rollouts/inferencepool-rollout.md
+++ b/guides/rollouts/inferencepool-rollout.md
@@ -1,0 +1,137 @@
+# InferencePool Rollout
+The goal of this guide is to show you how to perform incremental roll out operations,
+which gradually deploy new versions of your inference infrastructure.
+You can update Inference Pool with minimal service disruption.
+This page also provides guidance on traffic splitting and rollbacks to help ensure reliable deployments for InferencePool rollout.
+
+InferencePool rollout is a powerful technique for performing various infrastructure and model updates with minimal disruption and built-in rollback capabilities.
+This method allows you to introduce changes incrementally, monitor their impact, and revert to the previous state if necessary.
+
+## Use Cases
+Use Cases for InferencePool Rollout:
+
+- Node(compute, accelerator) update roll out
+- Base model roll out
+- Model server framework rollout
+
+### Node(compute, accelerator) update roll out
+Node update roll outs safely migrate inference workloads to new node hardware or accelerator configurations.
+This process happens in a controlled manner without interrupting model service.
+Use node update roll outs to minimize service disruption during hardware upgrades, driver updates, or security issue resolution.
+
+### Base model roll out
+Base model updates roll out in phases to a new base LLM, retaining compatibility with existing LoRA adapters.
+You can use base model update roll outs to upgrade to improved model architectures or to address model-specific issues.
+
+### Model server framework rollout
+Model server framework rollouts enable the seamless deployment of new versions or entirely different serving frameworks,
+like updating from an older vLLM version to a newer one, or even migrating from a custom serving solution to a managed one.
+This type of rollout is critical for introducing performance enhancements, new features, or security patches within the serving layer itself,
+without requiring changes to the underlying base models or application logic. By incrementally rolling out framework updates,
+teams can ensure stability and performance, quickly identifying and reverting any regressions before they impact the entire inference workload.
+
+## How to do InferencePool rollout
+
+1. **Deploy new infrastructure**: Create a new InferencePool configured with the new node(compute/accelerator) / model server / base model that you chose.
+1. **Configure traffic splitting**: Use an HTTPRoute to split traffic between the existing InferencePool and the new InferencePool. The `backendRefs.weight` field controls the traffic percentage allocated to each pool.
+1. **Preserve rollback capability**: Retain the original nodes and InferencePool during the roll out to facilitate a rollback if necessary.
+
+## Example
+This is an example of InferencePool rollout with node(compute, accelerator) update roll out
+
+###  Prerequisites
+Follow the [getting started guide](../../docs/getting-started/README.md) to set up the llm-d stack.
+
+### Deploy new infrastructure
+You start with an existing InferencePool named vllm-qwen3-32b.
+To replace the original InferencePool, you create a new InferencePool, configured to select the pods with the `nvidia-h100-80gb` accelerator type.
+
+Assuming the new model servers already exist, simply:
+**Create a new helm-managed InferencePool of a different name, with a new selector specified**
+
+### Direct traffic to the new inference pool
+By configuring an **HTTPRoute**, as shown below, you can incrementally split traffic between the original `vllm-qwen3-32b` and new `vllm-qwen3-32b-new`.
+
+```bash
+kubectl edit httproute llm-route
+```
+
+Change the backendRefs list in HTTPRoute to match the following:
+
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: llm-route
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: inference-gateway
+  rules:
+    - backendRefs:
+        - group: inference.networking.k8s.io
+          kind: InferencePool
+          name: vllm-qwen3-32b
+          weight: 90
+        - group: inference.networking.k8s.io
+          kind: InferencePool
+          name: vllm-qwen3-32b-new
+          weight: 10
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+```
+
+The above configuration means one in every ten requests should be sent to the new version. Try it out:
+
+1. Get the gateway IP:
+```bash
+IP=$(kubectl get gateway/inference-gateway -o jsonpath='{.status.addresses[0].value}'); PORT=80
+```
+
+2. Send a few requests as follows:
+```bash
+curl -i ${IP}:${PORT}/v1/completions -H 'Content-Type: application/json' -d '{
+"model": "small-segment-lora",
+"prompt": "Write as if you were a critic: San Francisco",
+"max_tokens": 100,
+"temperature": 0
+}'
+```
+
+### Finish the rollout
+
+
+Modify the HTTPRoute to direct 100% of the traffic to the latest version of the InferencePool.
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: llm-route
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: inference-gateway
+  rules:
+    - backendRefs:
+        - group: inference.networking.k8s.io
+          kind: InferencePool
+          name: vllm-qwen3-32b-new
+          weight: 100
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+```
+
+### Delete old version of InferencePool and Endpoint Picker Extension
+```shell
+helm uninstall <old-inference-pool-name>
+```
+
+With this, all requests should be served by the new Inference Pool.


### PR DESCRIPTION
## What type of PR is this?
/kind documentation

## What this PR does / why we need it:
Migrates the rollout guides from gateway-api-inference-extension to llm-d repo. These guides cover different rollout scenarios that users need when updating their inference infrastructure.

## Changes made:
- Added `guides/rollouts/` directory with three guides:
  - `README.md` - overview of the rollout scenarios
  - `adapter-rollout.md` - for LoRA adapter rollouts
  - `inferencepool-rollout.md` - for infrastructure rollouts
- Updated `guides/README.md` to include rollouts under Operational Excellence
- Fixed all internal links to point to llm-d docs structure

## Which issue(s) this PR fixes:
Fixes #1473

## Notes:
Followed the existing llm-d guides structure where each guide gets its own directory (similar to flow-control/, workload-autoscaling/, etc.). All links have been tested and point to the correct locations in the llm-d repo.