### PR TITLE
fix: precise-prefix require Helm v4 for plugin.yaml

### DIFF
--- a/.github/workflows/nightly-e2e-precise-prefix-cache-cks.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-cks.yaml
@@ -43,7 +43,6 @@ jobs:
         export GUIDE_NAME="precise-prefix-cache-aware"
         export INFRA_PROVIDER="base"
         kubectl apply -n ${NAMESPACE} -k guides/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}
-        helm plugin install guides/${GUIDE_NAME}/scheduler/patches/uds-tokenizer
         helm install ${GUIDE_NAME} \
           oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
           -f guides/recipes/scheduler/base.values.yaml \

--- a/.github/workflows/nightly-e2e-precise-prefix-cache-gke.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-gke.yaml
@@ -43,7 +43,6 @@ jobs:
         export GUIDE_NAME="precise-prefix-cache-aware"
         export INFRA_PROVIDER="gke"
         kubectl apply -n ${NAMESPACE} -k guides/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}
-        helm plugin install guides/${GUIDE_NAME}/scheduler/patches/uds-tokenizer
         helm install ${GUIDE_NAME} \
           oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
           -f guides/recipes/scheduler/base.values.yaml \


### PR DESCRIPTION
# Descripton 
 to fix nighlty from GHA on precise-prefix run , as 
  - plugin.yaml uses Helm v4 format, incompatible with v3 runner
  - `--post-renderer `already references the script directly, so use plugin nstall is causing issue
  - see comments from dry-run` # (helm v4 users instead run `helm plugin install .../uds-tokenizer``
