### PR TITLE
[PD] Increase keep-alive timeout in well-lit P/D guides

### DIFF
--- a/guides/pd-disaggregation/modelserver/hpu/vllm/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/hpu/vllm/patch-prefill.yaml
@@ -35,6 +35,10 @@ spec:
               value: "5600"
             - name: VLLM_LOGGING_LEVEL
               value: "DEBUG"
+            # Default keep-alive timeout of 5s is shorter than the sidecar's 90s idle conn timeout,
+            # causing TCP RSTs.
+            - name: VLLM_HTTP_TIMEOUT_KEEP_ALIVE
+              value: "120"
             - name: VLLM_SKIP_WARMUP
               value: "true"
             - name: PT_HPU_LAZY_MODE

--- a/guides/wide-ep-lws/experimental-dp-aware/manifests/modelserver/base/prefill.yaml
+++ b/guides/wide-ep-lws/experimental-dp-aware/manifests/modelserver/base/prefill.yaml
@@ -117,6 +117,10 @@ spec:
                 value: eth0
               - name: VLLM_LOGGING_LEVEL
                 value: INFO
+              # Default keep-alive timeout of 5s is shorter than the sidecar's 90s idle conn timeout,
+              # causing TCP RSTs.
+              - name: VLLM_HTTP_TIMEOUT_KEEP_ALIVE
+                value: "120"
               - name: NVSHMEM_DISABLE_CUDA_VMM
                 value: "0"
               - name: VLLM_NIXL_SIDE_CHANNEL_HOST

--- a/guides/wide-ep-lws/modelserver/gpu/vllm/base/prefill.yaml
+++ b/guides/wide-ep-lws/modelserver/gpu/vllm/base/prefill.yaml
@@ -135,6 +135,10 @@ spec:
                 value: eth0
               - name: VLLM_LOGGING_LEVEL
                 value: INFO
+              # Default keep-alive timeout of 5s is shorter than the sidecar's 90s idle conn timeout,
+              # causing TCP RSTs.
+              - name: VLLM_HTTP_TIMEOUT_KEEP_ALIVE
+                value: "120"
               - name: VLLM_NIXL_SIDE_CHANNEL_HOST
                 valueFrom:
                   fieldRef:


### PR DESCRIPTION
Set VLLM_HTTP_TIMEOUT_KEEP_ALIVE=120 on all prefill server configs in the P/D well-lit paths (wide-ep-lws, experimental-dp-aware, pd-disaggregation HPU)

## Problem
The decode sidecar's Go HTTP transport keeps idle connections in its pool for 90 seconds (IdleConnTimeout: 90 * time.Second in proxy.go), but uvicorn's default keep-alive timeout is only 5 seconds (VLLM_HTTP_TIMEOUT_KEEP_ALIVE=5).

When a prefill connection goes idle for >5s, uvicorn closes it. If the sidecar reuses that connection before its own 90s timeout, the request arrives on a socket that uvicorn is closing — the kernel sees unread data and sends RST.

This was observed under load on GB200 NVL72 with DeepSeek-R1, P2D8 setup, where gaps between consecutive prefill requests on a single connection from time to time exceed 5 seconds.

