### PR TITLE
fix: e2e nightly on OCP

### DIFF
--- a/.github/workflows/nightly-e2e-pd-disaggregation-ocp.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-ocp.yaml
@@ -41,7 +41,7 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift.yaml@main
     with:
       guide_name: pd-disaggregation
       namespace: llm-d-nightly-pd

--- a/.github/workflows/nightly-e2e-predicted-latency-ocp.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-ocp.yaml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-ocp.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift.yaml@main
     with:
       guide_name: predicted-latency-based-scheduling
       namespace: llm-d-nightly-predicted-latency-ocp
@@ -49,8 +49,6 @@ jobs:
           --set inferenceExtension.monitoring.prometheus.auth.enabled=false \
           -n ${NAMESPACE} --version ${GAIE_VERSION}
       e2e_validate_args: '--extra-validate predicted-latency'
-      gke_cluster_name: llm-d-e2e-us-east5
-      gke_cluster_zone: us-east5
       required_gpus: 2
       recommended_gpus: 4
       accelerator_type: H100

--- a/.github/workflows/nightly-e2e-wide-ep-lws-ocp.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-ocp.yaml
@@ -41,7 +41,7 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift.yaml@main
     with:
       guide_name: wide-ep-lws
       guide_path: guides/wide-ep-lws


### PR DESCRIPTION
# Changes
Try fix https://github.com/llm-d/llm-d/tree/main/release for nightly result on wideep, slo-aware , p/d
- wrong reuseable template name
- remove gke related input for ocp
- switch to use kustomize template than helmfile
ref #1567