### PR TITLE
fix: add timeout 90mins for nightly GithubAction

### DIFF
--- a/.github/workflows/nightly-benchmark-cks.yaml
+++ b/.github/workflows/nightly-benchmark-cks.yaml
@@ -31,6 +31,7 @@ concurrency:
 jobs:
   trigger-benchmark:
     if: github.repository == 'llm-d/llm-d'
+    timeout-minutes: 90
     name: Trigger CKS Benchmark
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nightly-build-image.yaml
+++ b/.github/workflows/nightly-build-image.yaml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   build:
     if: github.repository == 'llm-d/llm-d'
+    timeout-minutes: 90
     uses: ./.github/workflows/build-image.yaml
     with:
       force_build: true

--- a/.github/workflows/nightly-e2e-optimized-baseline-cks.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-cks.yaml
@@ -31,6 +31,7 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
+    timeout-minutes: 90
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-cks.yaml@main
     with:
       guide_name: optimized-baseline

--- a/.github/workflows/nightly-e2e-optimized-baseline-gke-tpu.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-gke-tpu.yaml
@@ -32,6 +32,7 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
+    timeout-minutes: 90
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke-tpu.yaml@main
     with:
       guide_name: optimized-baseline

--- a/.github/workflows/nightly-e2e-optimized-baseline-gke.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-gke.yaml
@@ -31,6 +31,7 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
+    timeout-minutes: 90
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke.yaml@main
     with:
       guide_name: optimized-baseline

--- a/.github/workflows/nightly-e2e-optimized-baseline-ocp.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-ocp.yaml
@@ -39,6 +39,7 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
+    timeout-minutes: 90
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift.yaml@main
     with:
       guide_name: optimized-baseline

--- a/.github/workflows/nightly-e2e-pd-disaggregation-cks.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-cks.yaml
@@ -31,6 +31,7 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
+    timeout-minutes: 90
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-cks.yaml@main
     with:
       guide_name: pd-disaggregation

--- a/.github/workflows/nightly-e2e-pd-disaggregation-gke-tpu.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-gke-tpu.yaml
@@ -33,6 +33,7 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
+    timeout-minutes: 90
     runs-on: ubuntu-latest
     steps:
       - name: Placeholder

--- a/.github/workflows/nightly-e2e-pd-disaggregation-gke.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-gke.yaml
@@ -31,6 +31,7 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
+    timeout-minutes: 90
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke.yaml@main
     with:
       guide_name: pd-disaggregation

--- a/.github/workflows/nightly-e2e-pd-disaggregation-ocp.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-ocp.yaml
@@ -41,6 +41,7 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
+    timeout-minutes: 90
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml@main
     with:
       guide_name: pd-disaggregation

--- a/.github/workflows/nightly-e2e-precise-prefix-cache-cks.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-cks.yaml
@@ -33,6 +33,7 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
+    timeout-minutes: 90
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-cks.yaml@main
     with:
       guide_name: precise-prefix-cache-aware

--- a/.github/workflows/nightly-e2e-precise-prefix-cache-gke.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-gke.yaml
@@ -33,6 +33,7 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
+    timeout-minutes: 90
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke.yaml@main
     with:
       guide_name: precise-prefix-cache-aware

--- a/.github/workflows/nightly-e2e-precise-prefix-cache-ocp.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-ocp.yaml
@@ -36,6 +36,7 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
+    timeout-minutes: 90
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift.yaml@main
     with:
       guide_name: precise-prefix-cache-aware

--- a/.github/workflows/nightly-e2e-predicted-latency-cks.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-cks.yaml
@@ -38,6 +38,7 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
+    timeout-minutes: 90
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-cks.yaml@main
     with:
       guide_name: predicted-latency-based-scheduling

--- a/.github/workflows/nightly-e2e-predicted-latency-gke.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-gke.yaml
@@ -38,6 +38,7 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
+    timeout-minutes: 90
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke.yaml@main
     with:
       guide_name: predicted-latency-based-scheduling

--- a/.github/workflows/nightly-e2e-predicted-latency-ocp.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-ocp.yaml
@@ -28,6 +28,7 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
+    timeout-minutes: 90
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-ocp.yaml@main
     with:
       guide_name: predicted-latency-based-scheduling

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-gke.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-gke.yaml
@@ -31,6 +31,7 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
+    timeout-minutes: 90
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke.yaml@main
     with:
       guide_name: tiered-prefix-cache

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-lmcache-gke.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-lmcache-gke.yaml
@@ -31,6 +31,7 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
+    timeout-minutes: 90
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke.yaml@main
     with:
       guide_name: tiered-prefix-cache

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-ocp.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-cpu-offloading-ocp.yaml
@@ -40,7 +40,8 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift.yaml@main  
+    timeout-minutes: 90
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift.yaml@main
     with:
       guide_name: tiered-prefix-cache
       namespace: llm-d-nightly-pfc-cpu

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-tpu.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-tpu.yaml
@@ -32,6 +32,7 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
+    timeout-minutes: 90
     runs-on: ubuntu-latest
     steps:
       - name: Placeholder

--- a/.github/workflows/nightly-e2e-wide-ep-lws-cks.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-cks.yaml
@@ -33,6 +33,7 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
+    timeout-minutes: 90
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-cks.yaml@main
     with:
       guide_name: wide-ep-lws

--- a/.github/workflows/nightly-e2e-wide-ep-lws-gke.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-gke.yaml
@@ -34,6 +34,7 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
+    timeout-minutes: 90
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke.yaml@main
     with:
       guide_name: wide-ep-lws

--- a/.github/workflows/nightly-e2e-wide-ep-lws-ocp.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-ocp.yaml
@@ -41,6 +41,7 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
+    timeout-minutes: 90
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift-helmfile.yaml@main
     with:
       guide_name: wide-ep-lws

--- a/.github/workflows/nightly-e2e-wva-cks.yaml
+++ b/.github/workflows/nightly-e2e-wva-cks.yaml
@@ -71,6 +71,7 @@ jobs:
   # in the latest code, not in the last tagged release.
   build-wva-image:
     if: github.repository == 'llm-d/llm-d' && github.event.inputs.image_tag == ''
+    timeout-minutes: 90
     runs-on: ubuntu-latest
     outputs:
       image_tag: ${{ steps.build.outputs.image_tag }}
@@ -118,6 +119,7 @@ jobs:
   nightly:
     needs: build-wva-image
     if: github.repository == 'llm-d/llm-d' && always() && (needs.build-wva-image.result == 'success' || needs.build-wva-image.result == 'skipped')
+    timeout-minutes: 90
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-cks.yaml@main
     with:
       guide_name: workload-autoscaling

--- a/.github/workflows/nightly-e2e-wva-ocp.yaml
+++ b/.github/workflows/nightly-e2e-wva-ocp.yaml
@@ -71,6 +71,7 @@ jobs:
   # in the latest code, not in the last tagged release.
   build-wva-image:
     if: github.repository == 'llm-d/llm-d' && github.event.inputs.image_tag == ''
+    timeout-minutes: 90
     runs-on: ubuntu-latest
     outputs:
       image_tag: ${{ steps.build.outputs.image_tag }}
@@ -118,6 +119,7 @@ jobs:
   nightly:
     needs: build-wva-image
     if: github.repository == 'llm-d/llm-d' && always() && (needs.build-wva-image.result == 'success' || needs.build-wva-image.result == 'skipped')
+    timeout-minutes: 90
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift.yaml@main
     with:
       guide_name: workload-autoscaling


### PR DESCRIPTION
# Notes

- currently there is no timeout set in the job, take https://github.com/llm-d/llm-d/actions/runs/26084815193/job/76695097393 for example total duration is 23h59m19s then timeout.
- put 90mins to start with, probably can tune to 30-60min if needed