### PR TITLE
chore: add missing nightly test into slash command

### DIFF
--- a/.github/workflows/slash-test-nightly.yaml
+++ b/.github/workflows/slash-test-nightly.yaml
@@ -18,7 +18,6 @@ name: /test-nightly Slash Command
 # Temp branches are cleaned up by slash-test-nightly-cleanup.yaml.
 #
 # Available nightlies (the part after /test-nightly):
-#   benchmark-cks, build-image,
 #   optimized-baseline-cks, optimized-baseline-gke, optimized-baseline-gke-tpu, optimized-baseline-ocp,
 #   pd-disaggregation-cks, pd-disaggregation-gke, pd-disaggregation-gke-tpu, pd-disaggregation-ocp,
 #   precise-prefix-cache-cks, precise-prefix-cache-gke, precise-prefix-cache-ocp,
@@ -70,7 +69,6 @@ jobs:
               'wide-ep-lws-cks', 'wide-ep-lws-gke', 'wide-ep-lws-ocp',
               'wva-cks', 'wva-ocp',
             ];
-            const OTHER_NIGHTLIES = ['benchmark-cks', 'build-image'];
             const ALL_NIGHTLIES = [...E2E_NIGHTLIES, ...OTHER_NIGHTLIES].sort();
 
             function toWorkflowFile(name) {

--- a/.github/workflows/slash-test-nightly.yaml
+++ b/.github/workflows/slash-test-nightly.yaml
@@ -18,13 +18,14 @@ name: /test-nightly Slash Command
 # Temp branches are cleaned up by slash-test-nightly-cleanup.yaml.
 #
 # Available nightlies (the part after /test-nightly):
-#   benchmark-cks, build-image, optimized-baseline-cks,
-#   optimized-baseline-gke, optimized-baseline-gke-tpu, optimized-baseline-ocp,
-#   pd-disaggregation-cks, pd-disaggregation-gke, pd-disaggregation-gke-tpu,
-#   pd-disaggregation-ocp, precise-prefix-cache-ocp,
+#   benchmark-cks, build-image,
+#   optimized-baseline-cks, optimized-baseline-gke, optimized-baseline-gke-tpu, optimized-baseline-ocp,
+#   pd-disaggregation-cks, pd-disaggregation-gke, pd-disaggregation-gke-tpu, pd-disaggregation-ocp,
+#   precise-prefix-cache-cks, precise-prefix-cache-gke, precise-prefix-cache-ocp,
+#   predicted-latency-cks, predicted-latency-gke, predicted-latency-ocp,
 #   tiered-prefix-cache-cpu-offloading-gke, tiered-prefix-cache-cpu-offloading-lmcache-gke,
-#   tiered-prefix-cache-cpu-offloading-ocp, tiered-prefix-cache-gke-tpu, wide-ep-lws-cks,
-#   wide-ep-lws-gke, wide-ep-lws-ocp,
+#   tiered-prefix-cache-cpu-offloading-ocp, tiered-prefix-cache-gke-tpu,
+#   wide-ep-lws-cks, wide-ep-lws-gke, wide-ep-lws-ocp,
 #   wva-cks, wva-ocp
 
 on:
@@ -60,14 +61,13 @@ jobs:
 
             // Map name to workflow filename
             const E2E_NIGHTLIES = [
-              'optimized-baseline-cks', 'optimized-baseline-gke', 'optimized-baseline-gke-tpu',
-              'optimized-baseline-ocp', 'pd-disaggregation-cks',
-              'pd-disaggregation-gke', 'pd-disaggregation-gke-tpu', 'pd-disaggregation-ocp',
-              'precise-prefix-cache-ocp',
+              'optimized-baseline-cks', 'optimized-baseline-gke', 'optimized-baseline-gke-tpu', 'optimized-baseline-ocp',
+              'pd-disaggregation-cks', 'pd-disaggregation-gke', 'pd-disaggregation-gke-tpu', 'pd-disaggregation-ocp',
+              'precise-prefix-cache-cks', 'precise-prefix-cache-gke', 'precise-prefix-cache-ocp',
+              'predicted-latency-cks', 'predicted-latency-gke', 'predicted-latency-ocp',
               'tiered-prefix-cache-cpu-offloading-gke', 'tiered-prefix-cache-cpu-offloading-lmcache-gke',
               'tiered-prefix-cache-cpu-offloading-ocp', 'tiered-prefix-cache-gke-tpu',
-              'wide-ep-lws-cks',
-              'wide-ep-lws-gke', 'wide-ep-lws-ocp',
+              'wide-ep-lws-cks', 'wide-ep-lws-gke', 'wide-ep-lws-ocp',
               'wva-cks', 'wva-ocp',
             ];
             const OTHER_NIGHTLIES = ['benchmark-cks', 'build-image'];
@@ -223,7 +223,10 @@ jobs:
         run: |
           if [ "$IS_FORK" = "true" ]; then
             if [ -z "$WORKFLOW_TOKEN" ]; then
-              echo "::error::Fork PR /test-nightly runs require WORKFLOW_TOKEN to be configured with permission to push branches and trigger workflows (for example, a fine-grained PAT with Contents: write and Actions: write, or a classic PAT with repo and workflow scope)."
+              echo "::error::Fork PR /test-nightly runs require WORKFLOW_TOKEN to be configured" \
+                "with permission to push branches and trigger workflows (for example," \
+                "a fine-grained PAT with Contents: write and Actions: write, or a" \
+                "classic PAT with repo and workflow scope)."
               exit 1
             fi
             # Include comment ID to avoid races when multiple /test-nightly


### PR DESCRIPTION
# Notes
- predicted-latency-* group is missing
- precise-prefix-cache-cks and gks are missing too
- format and fix lint
- remove build-image and benchmark-cks


cc @diegocastanibm @maugustosilva