### PR TITLE
correct predicted-latency-ocp to use existing reusable workflow

### DIFF
--- a/.github/workflows/nightly-e2e-predicted-latency-ocp.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-ocp.yaml
@@ -1,0 +1,71 @@
+name: Nightly - Predicted Latency E2E (OpenShift)
+
+# Nightly regression test for the predicted-latency-based-scheduling guide on
+# OpenShift. Deploys the optimized-baseline model server (the predicted-latency
+# guide reuses these pods via the `llm-d.ai/guide=optimized-baseline`
+# selector) plus the predicted-latency scheduler chart. Passes
+# --predicted-latency via e2e_validate_args so e2e-validate.sh dispatches to
+# e2e-validate-predicted-latency.sh after the smoke loop, sending 100 requests
+# and asserting the EPP's predicted-TTFT histogram populated — proving the
+# predictor returned predictions instead of silently falling back to the
+# composite KV/queue/prefix heuristic.
+
+on:
+  schedule:
+    - cron: '0 4 * * *'  # 04:00 UTC daily (staggered from other OCP nightlies)
+  workflow_dispatch:
+    inputs:
+      skip_cleanup:
+        description: 'Skip cleanup after tests (for debugging)'
+        required: false
+        default: 'false'
+      pr_number:
+        description: 'PR number for comment-back (set by /test-nightly)'
+        required: false
+        default: ''
+      pr_repo:
+        description: 'Repo for PR comment-back'
+        required: false
+        default: 'llm-d/llm-d'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-e2e-predicted-latency-ocp
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    if: github.repository == 'llm-d/llm-d'
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift.yaml@main
+    with:
+      guide_name: predicted-latency-based-scheduling
+      namespace: llm-d-nightly-predicted-latency-ocp
+      gateway_host: 'predicted-latency-based-scheduling-epp'
+      custom_deploy_script: |
+        export GAIE_VERSION=v1.5.0
+        export GUIDE_NAME="predicted-latency-based-scheduling"
+        yq '.spec.template.spec.priorityClassName="nightly-gpu-critical"' -i guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
+        yq '.spec.replicas=2' -i guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
+        kubectl apply -n ${NAMESPACE} -k guides/optimized-baseline/modelserver/gpu/vllm/base
+        # CI-only: disable EPP /metrics auth so the validate script's curl pod
+        # can scrape predicted/actual TTFT histograms without a bearer token.
+        helm install ${GUIDE_NAME} \
+          oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
+          -f guides/recipes/scheduler/base.values.yaml \
+          -f guides/${GUIDE_NAME}/scheduler/predicted-latency.values.yaml \
+          --set inferenceExtension.monitoring.prometheus.auth.enabled=false \
+          -n ${NAMESPACE} --version ${GAIE_VERSION}
+      e2e_validate_args: '--extra-validate predicted-latency'
+      accelerator_type: H100
+      required_gpus: 2
+      recommended_gpus: 4
+      pod_wait_timeout: '30m'
+      pod_readiness_delay: 180
+      image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
+      allow_gpu_preemption: true
+      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_repo: ${{ github.event.inputs.pr_repo }}
+    secrets: inherit


### PR DESCRIPTION
Closes #1567

## What was wrong

The `nightly-e2e-predicted-latency-ocp.yaml` workflow was empty and
previously referenced `reusable-nightly-e2e-ocp.yaml` in llm-d-infra,
which doesn't exist. Every scheduled run was failing at startup because
of this.

## Fix

Rewrote the workflow to use `reusable-nightly-e2e-openshift.yaml` — the
correct reusable that actually exists. Followed the same deploy pattern
as the other OCP nightlies (optimized-baseline-ocp), adapted the
deploy script from the GKE/CKS versions to work on OpenShift.