### PR TITLE
fix: harden install helpers with retry and download-to-file

### DIFF
--- a/helpers/client-setup/install-deps.sh
+++ b/helpers/client-setup/install-deps.sh
@@ -125,7 +125,7 @@ install_binary() {
   trap 'rm -rf -- "$tmp_dir"' RETURN
 
   echo "Installing ${bin_name}..."
-  curl -sSL -o "${tmp_dir}/${bin_name}" "${url}"
+  curl -fsSL --retry 3 --retry-delay 5 -o "${tmp_dir}/${bin_name}" "${url}"
   sudo install -m 0755 "${tmp_dir}/${bin_name}" "/usr/local/bin/${bin_name}"
 }
 
@@ -142,7 +142,8 @@ install_from_tarball() {
   trap 'rm -rf -- "$tmp_dir"' RETURN
 
   echo "Installing ${bin_name}..."
-  curl -sSL "${url}" | tar -xz -C "${tmp_dir}"
+  curl -fsSL --retry 3 --retry-delay 5 -o "${tmp_dir}/archive.tar.gz" "${url}"
+  tar -xzf "${tmp_dir}/archive.tar.gz" -C "${tmp_dir}"
   sudo install -m 0755 "${tmp_dir}/${bin_in_archive}" "/usr/local/bin/${bin_name}"
 }
 


### PR DESCRIPTION
## Summary

- Replace `curl | tar` pipe in `install_from_tarball()` with download-to-file + extract
- Add `-f` (fail on HTTP errors) and `--retry 3 --retry-delay 5` to both install helpers
- Prevents "tar: Error is not recoverable" failures from transient GitHub asset errors in nightly CI

## Test plan

- [x] Valid URL: helmfile_1.2.1 downloaded and extracted successfully
- [x] Invalid URL (404): curl exits with error 404, script fails cleanly without "tar: Error is not recoverable"

Fixes llm-d/llm-d-infra#163