### PR TITLE
fix(ci): apply TLS overlay after namespace creation in WVA OCP nightly

### DIFF
--- a/.github/workflows/nightly-e2e-wva-ocp.yaml
+++ b/.github/workflows/nightly-e2e-wva-ocp.yaml
@@ -114,13 +114,6 @@ jobs:
           -f guides/optimized-baseline/router/optimized-baseline.values.yaml \
           -n ${NAMESPACE} --version v1.5.0
 
-        # TLS cert handling
-        export PROMETHEUS_CA_CERT=$(kubectl get secret thanos-querier-tls -n openshift-monitoring -o jsonpath='{.data.tls\.crt}' | base64 -d)
-        WVA_TLS_OVERLAY_DIR=$(mktemp -d)
-        cp -R guides/workload-autoscaling/components/tls-overlay/. "${WVA_TLS_OVERLAY_DIR}"
-        printf "%s" "${PROMETHEUS_CA_CERT}" > "${WVA_TLS_OVERLAY_DIR}/ca.crt"
-        kubectl apply -k "${WVA_TLS_OVERLAY_DIR}" -n "${WVA_DEPLOY_NS}"
-
         # Override WVA controller image to the nightly build from this run
         WVA_TAG="${{ needs.build-wva-image.outputs.image_tag || github.event.inputs.image_tag }}"
         if [ -n "$WVA_TAG" ]; then
@@ -132,8 +125,15 @@ jobs:
         # Kustomization validation dry run
         kubectl kustomize guides/workload-autoscaling/wva-config/platform/ocp >/dev/null
 
-        # apply WVA assets
+        # apply WVA assets (creates llm-d-autoscaler namespace)
         kubectl apply -k guides/workload-autoscaling/wva-config/platform/ocp
+
+        # TLS cert handling — must run after the namespace is created by the kustomize apply above
+        export PROMETHEUS_CA_CERT=$(kubectl get secret thanos-querier-tls -n openshift-monitoring -o jsonpath='{.data.tls\.crt}' | base64 -d)
+        WVA_TLS_OVERLAY_DIR=$(mktemp -d)
+        cp -R guides/workload-autoscaling/components/tls-overlay/. "${WVA_TLS_OVERLAY_DIR}"
+        printf "%s" "${PROMETHEUS_CA_CERT}" > "${WVA_TLS_OVERLAY_DIR}/ca.crt"
+        kubectl apply -k "${WVA_TLS_OVERLAY_DIR}" -n "${WVA_DEPLOY_NS}"
 
         # Validate WVA controller is ready, then apply autoscaling resources
         kubectl wait deployment/workload-variant-autoscaler-controller-manager \


### PR DESCRIPTION
WVA nightly failing with
`Error from server (NotFound): error when creating "/tmp/tmp.cBGpLy6SID": namespaces "llm-d-autoscaler" not found`
@lionelvillard 