### PR TITLE
docs nitpick: remove RDMA from "RoCE RDMA"

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -57,7 +57,7 @@ By composing these layers, llm-d allows an inference pool to scale its effective
 
 ### Prefill/Decode Disaggregation
 
-Split inference into dedicated **prefill workers** (prompt processing) and **decode workers** (token generation) to reduce time-to-first-token (TTFT) and achieve more predictable time-per-output-token (TPOT). KV-cache is transferred between phases via [NIXL](https://github.com/ai-dynamo/nixl) over high-speed interconnects (InfiniBand, RoCE RDMA).
+Split inference into dedicated **prefill workers** (prompt processing) and **decode workers** (token generation) to reduce time-to-first-token (TTFT) and achieve more predictable time-per-output-token (TPOT). KV-cache is transferred between phases via [NIXL](https://github.com/ai-dynamo/nixl) over high-speed interconnects (InfiniBand, RoCE).
 
 ### Predicted Latency-Based Routing
 


### PR DESCRIPTION
RoCE is RDMA over Converged Ethernet. so "RoCE RDMA" is a tautology. 

https://en.wikipedia.org/wiki/RDMA_over_Converged_Ethernet

InfiniBand also provides RDMA, so RDMA does not make RoCE special in this aspect and there is no point to mention it. If RDMA should be mentioned, it can be put this way:

high-speed, RDMA interconnects (InfiniBand, RoCE)