### PR TITLE
docs: fix broken Flow Control link in guides README

### DIFF
--- a/guides/README.md
+++ b/guides/README.md
@@ -24,7 +24,7 @@ We currently offer the following:
 
 ### Operational Excellence
 
-* [Flow Control](./flow-control.md): Intelligent request queuing for multi-tenant deployments and managing traffic spikes.
+* [Flow Control](./flow-control/README.md): Intelligent request queuing for multi-tenant deployments and managing traffic spikes.
 * [Workload Autoscaling](./workload-autoscaling/README.md) - autoscale the LLM service via proactive, SLO-aware signals that reflect the true state of the inference system — queue depth, in-flight request counts, and KV cache pressure — so that capacity can be added before end-user latency is impacted.
 
 ## Experimental Guides

--- a/guides/README.md
+++ b/guides/README.md
@@ -24,7 +24,7 @@ We currently offer the following:
 
 ### Operational Excellence
 
-* [Flow Control](./flow-control/README.md): Intelligent request queuing for multi-tenant deployments and managing traffic spikes.
+* [Flow Control](./flow-control/README.md) - Intelligent request queuing for multi-tenant deployments and managing traffic spikes.
 * [Workload Autoscaling](./workload-autoscaling/README.md) - autoscale the LLM service via proactive, SLO-aware signals that reflect the true state of the inference system — queue depth, in-flight request counts, and KV cache pressure — so that capacity can be added before end-user latency is impacted.
 
 ## Experimental Guides


### PR DESCRIPTION
`guides/README.md:27` links to `./flow-control.md`, which is not a real file (`https://raw.githubusercontent.com/llm-d/llm-d/main/guides/flow-control.md` returns 404). The Flow Control guide lives at `guides/flow-control/README.md`, which is the `./<guide>/README.md` pattern used by every other entry in this index.