### PR TITLE
ack-gateway support for alibaba cloud

### DIFF
--- a/guides/recipes/gateway/ack-gateway/backend-traffic-policy.yaml
+++ b/guides/recipes/gateway/ack-gateway/backend-traffic-policy.yaml
@@ -1,0 +1,12 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: ack-backend-traffic-policy
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: llm-d-inference-gateway
+  timeout:
+    http:
+      requestTimeout: 1h

--- a/guides/recipes/gateway/ack-gateway/client-traffic-policy.yaml
+++ b/guides/recipes/gateway/ack-gateway/client-traffic-policy.yaml
@@ -1,0 +1,11 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: ack-client-traffic-policy
+spec:
+  connection:
+    bufferLimit: 20Mi
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: llm-d-inference-gateway

--- a/guides/recipes/gateway/ack-gateway/envoy-proxy.yaml
+++ b/guides/recipes/gateway/ack-gateway/envoy-proxy.yaml
@@ -1,0 +1,10 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: ack-envoy-proxy-config
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyService:
+        type: ClusterIP

--- a/guides/recipes/gateway/ack-gateway/kustomization.yaml
+++ b/guides/recipes/gateway/ack-gateway/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - envoy-proxy.yaml
+  - client-traffic-policy.yaml
+  - backend-traffic-policy.yaml
+patches:
+  - target:
+      kind: Gateway
+      name: llm-d-inference-gateway
+    patch: |-
+      - op: add
+        path: /spec/gatewayClassName
+        value: ack-gateway
+      - op: add
+        path: /spec/infrastructure
+        value:
+          parametersRef:
+            group: gateway.envoyproxy.io
+            kind: EnvoyProxy
+            name: ack-envoy-proxy-config


### PR DESCRIPTION
Manifests for using `ack-gateway` out of the box with alibaba-cloud

Some of this is optional such as the backend traffic policy but I think its a strong addition since we can relay on envoyCRDs anyways in this case

cc @shmuelk @ahg-g 