### PR TITLE
docs: trim infra-provider guides for OpenShift and DigitalOcean

### DIFF
--- a/docs/infra-providers/digitalocean/README.md
+++ b/docs/infra-providers/digitalocean/README.md
@@ -2,6 +2,8 @@
 
 This document covers configuring DOKS clusters for running high performance LLM inference with llm-d.
 
+For deployment instructions, see the [well-lit path guides](../../../guides/).
+
 ## Prerequisites
 
 llm-d on DOKS is tested with the following configurations:
@@ -9,20 +11,6 @@ llm-d on DOKS is tested with the following configurations:
 * GPU types: NVIDIA H100, NVIDIA RTX 6000 Ada, NVIDIA RTX 4000 Ada, NVIDIA L40S
 * Versions: DOKS 1.33.1-do.3
 * Networking: VPC-native clusters (required)
-
-## Configuration Architecture
-
-The DigitalOcean deployment follows clean configuration principles:
-
-* **Base Configuration**: `values.yaml` files maintain original design intent with high-end specs
-* **Platform Overrides**: `digitalocean-values.yaml` files contain ONLY DigitalOcean-specific modifications
-* **Conditional Loading**: Using `digitalocean` environment selectively applies DigitalOcean overrides
-
-This approach ensures:
-
-* Original configurations remain unchanged for other platforms
-* DigitalOcean optimizations are isolated and maintainable
-* Clear separation between base architecture and platform adaptations
 
 ## Cluster Configuration
 
@@ -47,153 +35,24 @@ kubectl get pods -n nvidia-device-plugin-system
 kubectl get nodes -o custom-columns="NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu"
 ```
 
-## Quick Start
+### GPU Node Taints
 
-### Step 1: Install Prerequisites
-
-Before deploying llm-d workloads, install the required components:
-
-```bash
-# Navigate to gateway provider prerequisites
-cd guides/prereq/gateway-provider
-
-# Install Gateway API and Inference Extension CRDs
-./install-gateway-provider-dependencies.sh
-
-# Install Istio control plane
-helmfile apply -f istio.helmfile.yaml
-```
-
-### Step 2: Cluster Validation
-
-Verify your cluster setup:
-
-```bash
-# Verify cluster access and GPU nodes
-kubectl cluster-info
-kubectl get nodes -l doks.digitalocean.com/gpu-brand=nvidia
-
-# Verify components are ready
-kubectl get pods -n istio-system
-```
-
-### Step 3: Deploy Workloads
-
-Use the `digitalocean` environment to automatically load DigitalOcean-specific value overrides:
-
-```bash
-# For optimized baseline (2 decode pods)
-cd guides/optimized-baseline
-export NAMESPACE=llm-d-optimized-baseline
-helmfile apply -e digitalocean -n ${NAMESPACE}
-```
-
-**Key DigitalOcean Optimizations Applied Automatically:**
-
-* **Smaller Models**: Uses `Qwen3-0.6B` (optimized-baseline) that doesn't require HuggingFace tokens
-* **Stable Images**: Uses production-ready `ghcr.io/llm-d/llm-d-cuda:v0.5.1` instead of development builds
-* **DOKS-Optimized Resources**: Reduced memory/CPU requirements suitable for DOKS GPU nodes
-* **GPU Tolerations**: Automatic scheduling on DigitalOcean GPU nodes with `nvidia.com/gpu` taints
-* **No RDMA**: Removes InfiniBand requirements not available on DOKS
-
-**Architecture Overview:**
-
-* **optimized baseline**: 2 decode pods with intelligent routing via InferencePool
-
-### Step 4: Testing
-
-Verify deployment success:
-
-```bash
-# Check deployment status for optimized baseline
-kubectl get pods -n llm-d-optimized-baseline
-kubectl get gateway -n llm-d-optimized-baseline
-
-# Test inference endpoint (optimized baseline example)
-kubectl port-forward -n llm-d-optimized-baseline svc/infra-optimized-baseline-inference-gateway-istio 8080:80
-
-curl -X POST http://localhost:8080/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{"model": "Qwen/Qwen3-0.6B", "messages": [{"role": "user", "content": "hello"}], "max_tokens": 20}'
-```
-
-## Monitoring (Optional)
-
-Deploy Prometheus and Grafana for observability:
-
-```bash
-cd monitoring
-./setup-monitoring.sh
-
-# Access Grafana dashboard
-kubectl port-forward -n llm-d-monitoring svc/prometheus-grafana 3000:80
-```
-
-We recommend enabling the monitoring stack to track:
-
-* GPU utilization per deployment
-* Inference request latency and throughput
-* Memory usage and KV cache efficiency
-* Network performance between inference pods
-
-## DigitalOcean-Specific Configuration Details
-
-### Model Selection
-
-The DigitalOcean deployment uses smaller, optimized models:
-
-| Architecture         | Original Model          | DigitalOcean Model      | Benefits                   |
-|----------------------|-------------------------|-------------------------|----------------------------|
-| optimized baseline | `Qwen3-0.6B` + HF Token | `Qwen3-0.6B` (no token) | No authentication required |
-
-### Resource Optimization
-
-DigitalOcean deployment automatically optimizes resource allocation for DOKS GPU nodes:
-
-* **Reduced Memory**: Uses 16Gi instead of 64Gi for better node utilization
-* **Optimized CPU**: Uses 4 cores instead of 16 cores per pod
-* **Single GPU**: Uses 1 GPU per pod (optimal for DOKS node sizes)
-* **No RDMA**: Removes InfiniBand requirements not available on DOKS
-
-### GPU Node Configuration
-
-DigitalOcean DOKS GPU nodes use taints to prevent non-GPU workloads from scheduling:
+DOKS GPU nodes use taints to prevent non-GPU workloads from scheduling. Add the following toleration to model server deployments:
 
 ```yaml
-# Automatically applied tolerations
 tolerations:
 - key: "nvidia.com/gpu"
   operator: "Exists"
   effect: "NoSchedule"
 ```
 
-### Architecture Differences
+## Deploying llm-d
 
-**optimized baseline on DOKS:**
-
-* 2 decode pods with InferencePool routing
-* Single GPU per pod (optimal for DOKS node sizes)
-* Intelligent request distribution
+Follow the [well-lit path guides](../../../guides/) to deploy llm-d workloads. Each guide includes DigitalOcean-specific steps where applicable.
 
 ## Troubleshooting
 
-### Common Issues
-
-#### 1. CRD Not Found Errors During Deployment
-
-**Error**: `resource mapping not found for name: "..." kind: "Gateway"`
-
-**Cause**: Required CRDs not installed before deployment
-
-**Solution**: Install CRDs before any helmfile deployment:
-
-```bash
-cd guides/prereq/gateway-provider
-./install-gateway-provider-dependencies.sh
-helmfile apply -f istio.helmfile.yaml
-```
-
-#### 2. LoadBalancer Pending or API Errors
+### LoadBalancer Pending or API Errors
 
 **Error**: LoadBalancer stuck in `<pending>` state with API errors
 
@@ -209,61 +68,26 @@ kubectl describe svc <service-name> -n <namespace>
 # Sequential deployments avoid conflicts
 ```
 
-#### 3. Pods Fail to Schedule on GPU Nodes
+### Pods Fail to Schedule on GPU Nodes
 
 **Error**: `untolerated taint {nvidia.com/gpu}`
 
-**Cause**: DigitalOcean GPU nodes have automatic taints to prevent non-GPU workloads
+**Cause**: DOKS GPU nodes have automatic taints to prevent non-GPU workloads
 
-**Solution**: DigitalOcean values automatically include required tolerations. Verify they're applied:
+**Solution**: Ensure your deployment includes the `nvidia.com/gpu` toleration. Verify it is applied:
 
 ```bash
 kubectl describe pod <pod-name> -n <namespace> | grep Tolerations
-
-# Should show:
-# Tolerations: nvidia.com/gpu:NoSchedule op=Exists
+# Should show: nvidia.com/gpu:NoSchedule op=Exists
 ```
 
-If tolerations are missing, ensure you're using the `digitalocean` environment which loads DigitalOcean overrides.
-
-#### 4. Gateway Not Programmed
+### Gateway Not Programmed
 
 **Error**: Gateway shows `PROGRAMMED: False`
 
-**Solution**: Verify Istio is running and LoadBalancer IP is assigned:
+**Solution**: Verify Istio is running and the LoadBalancer IP has been assigned:
 
 ```bash
 kubectl get pods -n istio-system
 kubectl get gateway -n <namespace>
 ```
-
-## Cleanup
-
-```bash
-# Remove specific deployment
-export NAMESPACE=llm-d-optimized-baseline
-helmfile destroy -e digitalocean -n ${NAMESPACE}
-
-# Remove prerequisites (affects all deployments)
-cd guides/prereq/gateway-provider
-helmfile destroy -f istio.helmfile.yaml
-./install-gateway-provider-dependencies.sh delete
-```
-
-## Configuration Files Reference
-
-### Base Configurations (Unchanged)
-
-* `guides/optimized-baseline/ms-optimized-baseline/values.yaml`
-
-### DigitalOcean Overrides (Platform-Specific)
-
-* `guides/optimized-baseline/ms-optimized-baseline/digitalocean-values.yaml`
-
-### Helmfile Configuration
-
-* Uses `digitalocean` environment to conditionally load DigitalOcean overrides
-* Only applies platform-specific configurations when explicitly using `-e digitalocean`
-* Follows clean configuration architecture principles with proper environment separation
-
-For detailed configuration options and advanced setups, see the main [llm-d guides](../../../guides/).

--- a/docs/infra-providers/openshift/README.md
+++ b/docs/infra-providers/openshift/README.md
@@ -1,314 +1,53 @@
 # llm-d on OpenShift
 
-This document will guide you through deploying llm-d on an OpenShift cluster.
+This document covers configuring OpenShift clusters for running high performance LLM inference with llm-d.
 
-Note: Comparable Openshift infrastructure and/or older OCP versions may work but have not been tested.
+For deployment instructions, see the [well-lit path guides](../../../guides/).
 
 ## Prerequisites
 
-### Infrastructure Setup
+llm-d on OpenShift is tested with the following configurations:
 
-- AWS - An [ec2](https://aws.amazon.com/ec2/instance-types/m6a/) instance of m6a.4xlarge was used for the Openshift control plane nodes. Later in the instructions this is scaled up to 3 nodes in total. If your a Red Hat associate, partner, or customer you can provision through the demo redhat system.
+* Versions: OpenShift 4.19, 4.20, 4.21
+* Ensure no ServiceMesh(OSSM) or Istio installations exist on the cluster — included CRDs may conflict with the llm-d gateway component
+* Cluster administrator privileges are required to install cluster-scoped resources
 
-### Platform Setup
+## Cluster Configuration
 
-At a high level the following conditions are assumed.
+### GPU Setup
 
-- OpenShift - This guide was tested on OpenShift 4.17, 4.19, and 4.20.
-- Ensure no Service Mesh or Istio installations exist on the cluster as the included CRDs may conflict with the llm-d gateway component.
-- If installing everything from scratch, Cluster administrator privileges are required to install the llm-d cluster scoped resources. Otherwise you only need namespace scoped permissions.
-- NVIDIA GPU Operator and NFD Operator - The original installation instructions can be found [here](https://docs.nvidia.com/datacenter/cloud-native/openshift/latest/steps-overview.html). However below are convenient steps for setting up via configuration given by RedHat AI Business Unit.
+Install the NFD (Node Feature Discovery) and NVIDIA GPU Operators before deploying llm-d workloads.
 
-### GPU, Operator, and Additional Configuration Steps
+The [ocp-gpu-setup](https://github.com/rh-aiservices-bu/ocp-gpu-setup) repo provides guided scripts for provisioning GPU nodes and deploying the required operators on AWS:
 
-Make sure you first clone the following repo and work from its directory for the prereq setup.
-
-```
+```bash
 git clone https://github.com/rh-aiservices-bu/ocp-gpu-setup.git
 cd ocp-gpu-setup
-```
 
-#### Prepare GPUs
+# Configure GPU MachineSet
+./machine-set/gpu-machineset.sh
 
-1. Configure the gpu machinesets by invoking the guided script.
+# Deploy NFD Operator
+oc apply -f ./nfd
 
-    ```
-    ./machine-set/gpu-machineset.sh
-    ```
+# Deploy NVIDIA GPU Operator
+oc apply -f ./gpu-operator
 
-1. For this setup the following settings were selected when prompted by the script:
-    - Select option `12` for `L40S Single GPU`
-    - Select option `p` for `private`
-    - Enter AWS region (e.g. `us-east-2`)
-    - Enter Availability zone (e.g. `1`)
-    - Answer `n` for spot instances
-1. Check if you have the default machineset available (in the web console, see Compute -> MahineSets). If not, then run the above command twice.
-1. Once the first gpu machine set is provisioned, set the MachineSet count to 2.
-1. Configure the default MachineSet count (or extra one provisioned above) to 6.
-1. After the machines have provisioned the configuration should look similar to the following:
-![machinesets](./images/machinesets.png)
-
-#### Deploy the Supporting Operators
-
-1. Deploy the NFD Operator
-
-    ```
-    oc apply -f ./nfd
-    ```
-
-1. Deploy the NVIDIA GPU Operator
-
-    ```
-    oc apply -f ./gpu-operator
-    ```
-
-1. Wait for the Node Feature Discovery and NVIDIA GPU Operator to be installed
-![operators](./images/installed_operators.png)
-
-#### Deploy the Supporting CRs
-
-```sh
+# Apply supporting CRs
 oc apply -f ./crs
 ```
 
-## llm-d Installation
+### GPU Node Taints
 
-### Clone this repository
+GPU nodes on OpenShift may have taints applied (e.g. `nvidia.com/gpu: NVIDIA-L40S-PRIVATE`). If model server pods are stuck in `Pending`, add the appropriate toleration to the deployment:
 
-```sh
-git clone https://github.com/llm-d/llm-d.git
-cd llm-d
-```
-
-### Install Dependencies
-
-Go to the `guides/prereq` directory and run `client-setup/install-deps.sh`.
-This script detects your OS and uses its package management to install required utilities like `yq`, `helm`, etc.
-
-```sh
-cd guides/prereq
-./client-setup/install-deps.sh
-```
-
-### Deploy the gateway and infrastructure
-
-Switch to the `gateway-providers` directory and run the `install-gateway-provider-dependencies.sh` script located in `guides/prereqs/gateway-provider`
-
-```sh
-cd gateway-provider
-./install-gateway-provider-dependencies.sh
-helmfile apply -f istio.helmfile.yaml
-```
-
-### Deploy the example `precise prefix cache routing`
-
-Go to the `guides/precise-prefix-cache-routing` example directory.
-
-```sh
-cd ../../precise-prefix-cache-routing
-```
-
-Create a namespace for your deployment.
-
-```sh
-export NAMESPACE=llm-d
-oc new-project ${NAMESPACE}
-```
-
-Set Hugging Face credentials. See <https://huggingface.co/settings/tokens>
-
-```sh
-export HF_TOKEN=<token from hugginface>
-export HF_TOKEN_NAME=${HF_TOKEN_NAME:-llm-d-hf-token}
-```
-
-Create a Kubernetes secret for the Hugging Face token:
-
-```sh
-oc create secret generic ${HF_TOKEN_NAME} \
-  --from-literal="HF_TOKEN=${HF_TOKEN}" \
-  --namespace "${NAMESPACE}" \
-  --dry-run=client -o yaml | oc apply -f -
-```
-
-Apply Helmfile in the namespace.
-
-```sh
-helmfile apply -n ${NAMESPACE}
-```
-
-### Handle GPU node taints
-
-At this point, the ms-kv-events-llm-d-modelservice-decode pods might be stuck in a Pending state.
-This typically happens when GPU nodes have taints applied; for example, for NVIDIA-L40S-PRIVATE (the GPUs we're using in this example).
-
-```
-Handle GPU Node taints
-
-0/9 nodes are available: 2 node(s) had untolerated taint {nvidia.com/gpu: NVIDIA-L40S-PRIVATE}, 7 Insufficient nvidia.com/gpu. preemption: 0/9 nodes are available: 2 Preemption is not helpful for scheduling, 7 No preemption victims found for incoming pod.
-```
-
-To allow scheduling, add the proper tolerations:
-
-```sh
-oc patch deployment ms-kv-events-llm-d-modelservice-decode \
+```bash
+oc patch deployment <deployment-name> \
   -p '{"spec":{"template":{"spec":{"tolerations":[{"key":"nvidia.com/gpu","operator":"Equal","value":"NVIDIA-L40S-PRIVATE","effect":"NoSchedule"}]}}}}'
 ```
 
-### Create the HTTPRoute
+## Deploying llm-d
 
-In the same directory, run
+Follow the [well-lit path guides](../../../guides/) to deploy llm-d workloads. Each guide includes OpenShift-specific steps where applicable.
 
-```sh
-oc apply -f httproute.yaml -n ${NAMESPACE}
-```
-
-### Verify pods are running
-
-After a few minutes, your pods should be running. Confirm with:
-
-```sh
-oc get pods -n ${NAMESPACE}
-```
-
-Example output:
-
-```
-NAME                                                      READY   STATUS    RESTARTS   AGE
-gaie-kv-events-epp-588f77495f-8fn7q                       1/1     Running   0          24m
-infra-kv-events-inference-gateway-istio-799c7b8f-nwvwl    1/1     Running   0          24m
-ms-kv-events-llm-d-modelservice-decode-5888b4ff9f-dw6hk   2/2     Running   0          24m
-ms-kv-events-llm-d-modelservice-decode-5888b4ff9f-vtb2b   2/2     Running   0          18m
-```
-
-### Test deployment
-
-#### Setup port forwarding
-
-```sh
-oc port-forward -n ${NAMESPACE} service/infra-kv-events-inference-gateway-istio 8000:80
-```
-
-#### Test KV cache-aware routing
-
-```
-curl localhost:8000/v1/models | jq
-```
-
-Output:
-
-```
-{
-  "data": [
-    {
-      "created": 1764013724,
-      "id": "Qwen/Qwen3-0.6B",
-      "max_model_len": 40960,
-      "object": "model",
-      "owned_by": "vllm",
-      "parent": null,
-      "permission": [
-        {
-          "allow_create_engine": false,
-          "allow_fine_tuning": false,
-          "allow_logprobs": true,
-          "allow_sampling": true,
-          "allow_search_indices": false,
-          "allow_view": true,
-          "created": 1764013724,
-          "group": null,
-          "id": "modelperm-806876f87f384832a29200d2e93d1295",
-          "is_blocking": false,
-          "object": "model_permission",
-          "organization": "*"
-        }
-      ],
-      "root": "Qwen/Qwen3-0.6B"
-    }
-  ],
-  "object": "list"
-}
-```
-
-#### Send prompts through llm-d router
-
-```sh
-curl -X POST  localhost:8000/v1/completions     -H "Content-Type: application/json"     -d '{
-      "model": "Qwen/Qwen3-0.6B",
-      "prompt": "Hello, how are you?",
-      "max_tokens": 50
-    }'
-```
-
-Output:
-
-```
-{"choices":[{"finish_reason":"length","index":0,"logprobs":null,"prompt_logprobs":null,"prompt_token_ids":null,"stop_reason":null,"text":" I'm sorry to hear about the incident. I'm sorry to hear about the incident, and I'm sorry to hear about the incident again. I'm sorry to hear about the incident, and I'm sorry to hear about the incident again. I","token_ids":null}],"created":1764013750,"id":"cmpl-29ce2940-8500-4c81-95e7-acc26f81fb2c","kv_transfer_params":null,"model":"Qwen/Qwen3-0.6B","object":"text_completion","service_tier":null,"system_fingerprint":null,"usage":{"completion_tokens":50,"prompt_tokens":6,"prompt_tokens_details":null,"total_tokens":56}}
-```
-
-## Promethus and Grafana
-
-Clone the monitoring repo from:  <https://github.com/deewhyweb/hello-chris-llm-d.git>
-
-```
-git clone https://github.com/deewhyweb/hello-chris-llm-d.git
-cd hello-chris-llm-d
-```
-
-### Deploy prometheus and grafana
-
-```sh
-oc create namespace llm-d-monitoring || true
-
-oc apply -f monitoring/grafana.yaml
-
-oc apply -f monitoring/grafana-service.yaml
-
-oc apply -f monitoring/prometheus.yaml
-
-oc apply -f monitoring/grafana-datasources.yaml
-
-oc apply -f monitoring/grafana-dashboards-config.yaml
-
-oc apply -f monitoring/grafana-config.yaml
-
-oc apply -f monitoring/prometheus-config.yaml
-
-oc create configmap grafana-dashboard-llm-performance --from-file=monitoring/grafana-dashboard-llm-performance.json -n  llm-d-monitoring --dry-run=client -o yaml | oc apply -f -
-```
-
-### Add Prometheus annotations to model service pods for metrics discovery
-
-```
-for pod in $(oc get pods -n llm-d -l llm-d.ai/inferenceServing=true -o name); do
-  oc annotate $pod prometheus.io/scrape=true prometheus.io/port=8000 prometheus.io/path=/metrics -n llm-d
-done
-```
-
-### Login and configure dashboard
-
-Open the Grafana route from Networking -> Routes.
-
-Login with admin/admin and set the password.
-
-Open up the LLM-D Performance Dashboard.
-
-![Grafana dashboard empty of data](images/grafana_empty.png)
-
-## Configure AnythingLLM
-
-If you have not yet installed AnythingLLM, follow the steps here: <https://anythingllm.com/desktop>
-
-In AnythingLLM, configure Settings -> AI Providers -> LLMProvider to `LocalAI`.
-
-Copy the service ingress:
-
-Use this for the AnythingLLM local base url in this format: `http://localhost:8000/v1`
-
-Choose the Qwen3-0.6B model.
-
-![AnythingLLM Configuration](images/anythingllm.png)
-
-You are now ready to test llm-d.  Start some conversations with AnythingLLM and watch the Grafana dashboard light up.
-
-![Grafana dashboard full of data](images/grafana_full.png)
+Use `oc` in place of `kubectl` for OpenShift CLI commands, or configure `kubectl` to use your OpenShift cluster credentials via `oc login`.


### PR DESCRIPTION
Both guides had full deployment walkthroughs, monitoring setup, and
platform-specific config details that duplicated the well-lit path guides.
Stripped each down to only provider-specific cluster setup steps and added
a reference to guides/ for deployment instructions.

Fixes #1599

Related: #1600