### PR TITLE
fix(nightly):   e2e for OCP on P/D + WideEP + WVA

### DIFF
--- a/.github/workflows/nightly-e2e-pd-disaggregation-ocp.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-ocp.yaml
@@ -1,7 +1,7 @@
 name: Nightly - PD Disaggregation E2E (OpenShift)
 
 # Nightly regression test for the pd-disaggregation guide on OpenShift.
-# Deploys via helmfile and validates with e2e-validate.sh.
+# Deploys via kustomize and validates with e2e-validate.sh.
 # Uses a slim model transformation to reduce GPU requirements.
 
 on:
@@ -9,15 +9,6 @@ on:
     - cron: '30 0 * * *'  # 00:30 UTC daily (staggered from optimized-baseline)
   workflow_dispatch:
     inputs:
-      helmfile_env:
-        description: 'Helmfile environment'
-        required: false
-        default: 'ocp'
-        type: choice
-        options:
-          - ocp
-          - istio
-          - kgateway
       skip_cleanup:
         description: 'Skip cleanup after tests (for debugging)'
         required: false
@@ -44,49 +35,44 @@ jobs:
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift.yaml@main
     with:
       guide_name: pd-disaggregation
-      namespace: llm-d-nightly-pd
-      helmfile_env: ${{ github.event.inputs.helmfile_env || 'ocp' }}
-      gateway_type: ${{ github.event.inputs.helmfile_env || 'istio' }}
+      namespace: llm-d-nightly-pd-ocp
+      gateway_host: 'pd-disaggregation-epp'
       accelerator_type: H100
       required_gpus: 2
       recommended_gpus: 4
       pod_wait_timeout: '30m'
       pod_readiness_delay: 180
-      # Slim transform: reduce model to Qwen3-0.6B, 1 GPU per pod, reduce memory
-      pre_deploy_script: |
-        export GAIE_VERSION=v1.5.0
-        export GUIDE_NAME="pd-disaggregation"
-        export INFRA_PROVIDER="base"
-        echo "Applying pd-disaggregation slim transforms..."
-        cd guides/pd-disaggregation
-        yq e '.modelArtifacts.uri = "hf://Qwen/Qwen3-0.6B"' -i ms-pd/values.yaml
-        yq e '.routing.modelName = "Qwen/Qwen3-0.6B"' -i ms-pd/values.yaml
-        yq e 'del(.decode.containers[0].args[] | select(. == "--max-model-len" or . == "32000"))' -i ms-pd/values.yaml
-        yq e 'del(.prefill.containers[0].args[] | select(. == "--max-model-len" or . == "32000"))' -i ms-pd/values.yaml
-        yq e 'del(.decode.containers[0].resources.limits.memory)' -i ms-pd/values.yaml
-        yq e 'del(.decode.containers[0].resources.requests.memory)' -i ms-pd/values.yaml
-        yq e 'del(.decode.containers[0].resources.limits.cpu)' -i ms-pd/values.yaml
-        yq e 'del(.decode.containers[0].resources.requests.cpu)' -i ms-pd/values.yaml
-        yq e 'del(.decode.containers[0].resources.limits."rdma/ib")' -i ms-pd/values.yaml
-        yq e 'del(.decode.containers[0].resources.requests."rdma/ib")' -i ms-pd/values.yaml
-        yq e 'del(.prefill.containers[0].resources.limits.memory)' -i ms-pd/values.yaml
-        yq e 'del(.prefill.containers[0].resources.requests.memory)' -i ms-pd/values.yaml
-        yq e 'del(.prefill.containers[0].resources.limits.cpu)' -i ms-pd/values.yaml
-        yq e 'del(.prefill.containers[0].resources.requests.cpu)' -i ms-pd/values.yaml
-        yq e 'del(.prefill.containers[0].resources.limits."rdma/ib")' -i ms-pd/values.yaml
-        yq e 'del(.prefill.containers[0].resources.requests."rdma/ib")' -i ms-pd/values.yaml
-        yq e '.decode.containers[0].resources.limits["nvidia.com/gpu"] = "1"' -i ms-pd/values.yaml
-        yq e '.decode.containers[0].resources.requests["nvidia.com/gpu"] = "1"' -i ms-pd/values.yaml
-        yq e '.decode.parallelism.tensor = 1' -i ms-pd/values.yaml
-        yq e '.prefill.replicas = 1' -i ms-pd/values.yaml
-        yq e '.decode.volumes[1].emptyDir.sizeLimit = "2Gi"' -i ms-pd/values.yaml
-        yq e '.prefill.volumes[1].emptyDir.sizeLimit = "2Gi"' -i ms-pd/values.yaml
-        echo "Slim transform applied — model: Qwen3-0.6B, 1 GPU decode, 1 prefill replica"
-        cd "$GITHUB_WORKSPACE"
       image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
       allow_gpu_preemption: true
-      install_gateway_provider: false
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
       pr_number: ${{ github.event.inputs.pr_number }}
       pr_repo: ${{ github.event.inputs.pr_repo }}
+      pre_deploy_script: |
+        cd guides/pd-disaggregation/modelserver/gpu/vllm/base
+        echo "Applying pd-disaggregation slim transforms..."
+        for f in patch-decode.yaml patch-prefill.yaml; do
+          yq e '.spec.template.spec.containers[0].args[0] = "Qwen/Qwen3-0.6B"' -i "$f"
+          yq e '.spec.replicas = 1' -i "$f"
+          yq e '.spec.template.spec.containers[0].resources.limits["nvidia.com/gpu"] = "1"' -i "$f"
+          yq e '.spec.template.spec.containers[0].resources.requests["nvidia.com/gpu"] = "1"' -i "$f"
+          yq e 'del(.spec.template.spec.containers[0].resources.limits.cpu)' -i "$f"
+          yq e 'del(.spec.template.spec.containers[0].resources.requests.cpu)' -i "$f"
+          yq e 'del(.spec.template.spec.containers[0].resources.limits.memory)' -i "$f"
+          yq e 'del(.spec.template.spec.containers[0].resources.requests.memory)' -i "$f"
+          yq e '.spec.template.spec.volumes[0].emptyDir.sizeLimit = "2Gi"' -i "$f"
+          yq e '.spec.template.spec.priorityClassName = "nightly-gpu-critical"' -i "$f"
+        done
+        yq e '(.spec.template.spec.containers[0].args[] | select(. == "--tensor-parallel-size=4")) = "--tensor-parallel-size=1"' -i patch-decode.yaml
+        echo "Slim transform applied — model: Qwen3-0.6B, 1 GPU decode, 1 prefill replica"
+        cd "$GITHUB_WORKSPACE"
+      custom_deploy_script: |
+        export GAIE_VERSION=v1.5.0
+        export GUIDE_NAME="pd-disaggregation"
+        export INFRA_PROVIDER="base"
+        kubectl apply -n ${NAMESPACE} -k guides/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}
+        helm install ${GUIDE_NAME} \
+          oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
+          -f guides/recipes/router/base.values.yaml \
+          -f guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
+          -n ${NAMESPACE} --version ${GAIE_VERSION}
     secrets: inherit

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/base/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/base/patch-decode.yaml
@@ -42,6 +42,10 @@ spec:
               name: shm
             - mountPath: /.cache
               name: torch-compile-cache
+            - mountPath: /.config
+              name: vllm-config
+            - mountPath: /.triton
+              name: triton-cache
           startupProbe:
             initialDelaySeconds: 15
             periodSeconds: 30
@@ -61,4 +65,8 @@ spec:
             medium: Memory
             sizeLimit: 20Gi
         - name: torch-compile-cache
+          emptyDir: {}
+        - name: vllm-config
+          emptyDir: {}
+        - name: triton-cache
           emptyDir: {}

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/base/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/base/patch-prefill.yaml
@@ -42,6 +42,10 @@ spec:
               name: shm
             - mountPath: /.cache
               name: torch-compile-cache
+            - mountPath: /.config
+              name: vllm-config
+            - mountPath: /.triton
+              name: triton-cache
           startupProbe:
             initialDelaySeconds: 15
             periodSeconds: 30
@@ -61,4 +65,8 @@ spec:
             medium: Memory
             sizeLimit: 20Gi
         - name: torch-compile-cache
+          emptyDir: {}
+        - name: vllm-config
+          emptyDir: {}
+        - name: triton-cache
           emptyDir: {}


### PR DESCRIPTION
# Notes
- p/d use ksutomize patches than values.yaml from ms-pd + mount .triton for write on ocp because of scc
- wva: create namespace before it gets used
- wideep wrong path to servieraccount file, use GIE standalone chart, similar to gke and cks