### PR TITLE
removing helmfile and helmdiff plugin from deps

### DIFF
--- a/helpers/client-setup/install-deps.sh
+++ b/helpers/client-setup/install-deps.sh
@@ -8,10 +8,6 @@ set -euo pipefail
 ########################################
 # Helm version
 HELM_VER="v3.19.0"
-# Helmdiff version
-HELMDIFF_VERSION="v3.13.0"
-# Helmfile version
-HELMFILE_VERSION="1.2.1"
 # Kustomize version
 KUSTOMIZE_VERSION="v5.7.1"
 # chart-testing version
@@ -41,8 +37,6 @@ TOOLS INSTALLED:
     - yq (YAML processor)
     - kubectl (Kubernetes CLI)
     - helm (Helm package manager)
-    - helm diff plugin (optional but highly recommended)
-    - helmfile (Helm deployment tool)
     - kustomize
 
   Development tools (with --dev):
@@ -187,22 +181,6 @@ if ! command -v helm &> /dev/null; then
   install_from_tarball "${HELM_URL}" "${OS}-${ARCH}/helm" "helm"
 fi
 
-########################################
-#  Helm diff plugin
-########################################
-if ! helm plugin list | grep -q diff; then
-  echo "📦 helm-diff plugin not found. Installing ${HELMDIFF_VERSION}..."
-  helm plugin install --version "${HELMDIFF_VERSION}" https://github.com/databus23/helm-diff
-fi
-
-########################################
-#  helmfile
-########################################
-if ! command -v helmfile &> /dev/null; then
-  ARCHIVE="helmfile_${HELMFILE_VERSION}_${OS}_${ARCH}.tar.gz"
-  HELMFILE_URL="https://github.com/helmfile/helmfile/releases/download/v${HELMFILE_VERSION}/${ARCHIVE}"
-  install_from_tarball "${HELMFILE_URL}" "helmfile"
-fi
 
 ########################################
 #  kustomize


### PR DESCRIPTION
we no longer need the `helm diff` plugin or `helmfile`. Sad to see them go

cc @zdtsw 