### PR TITLE
fix(nightly-xpu): rename scheduler to router for xpu workflows

### DIFF
--- a/.github/workflows/nightly-e2e-optimized-baseline-xpu.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-xpu.yaml
@@ -26,8 +26,8 @@ jobs:
     with:
       guide_name: optimized-baseline
       namespace: llm-d-nightly-ob-xpu
-      scheduler_release_name: optimized-baseline
-      scheduler_values_files: |
+      router_release_name: optimized-baseline
+      router_values_files: |
         guides/recipes/router/base.values.yaml
         guides/optimized-baseline/router/optimized-baseline.values.yaml
       pod_wait_timeout: '10m'

--- a/.github/workflows/nightly-e2e-pd-disaggregation-xpu.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-xpu.yaml
@@ -26,8 +26,8 @@ jobs:
     with:
       guide_name: pd-disaggregation
       namespace: llm-d-nightly-pd-xpu
-      scheduler_release_name: pd-disaggregation
-      scheduler_values_files: |
+      router_release_name: pd-disaggregation
+      router_values_files: |
         guides/recipes/router/base.values.yaml
         guides/pd-disaggregation/router/pd-disaggregation.values.yaml
       pod_wait_timeout: '10m'

--- a/.github/workflows/nightly-e2e-precise-prefix-cache-xpu.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-xpu.yaml
@@ -26,8 +26,8 @@ jobs:
     with:
       guide_name: precise-prefix-cache-routing
       namespace: llm-d-nightly-pc-xpu
-      scheduler_release_name: precise-prefix-cache-routing
-      scheduler_values_files: |
+      router_release_name: precise-prefix-cache-routing
+      router_values_files: |
         guides/recipes/router/base.values.yaml
         guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml
       pod_wait_timeout: '10m'

--- a/.github/workflows/nightly-e2e-precise-prefix-cache-xpu.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-xpu.yaml
@@ -1,6 +1,6 @@
 name: Nightly - Precise Prefix Cache E2E (XPU)
 
-# Nightly regression test for the precise-prefix-cache-aware guide on XPU.
+# Nightly regression test for the precise-prefix-cache-routing guide on XPU.
 
 on:
   schedule:
@@ -24,13 +24,12 @@ jobs:
     if: github.repository == 'llm-d/llm-d'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-xpu.yaml@main
     with:
-      guide_name: precise-prefix-cache-aware
+      guide_name: precise-prefix-cache-routing
       namespace: llm-d-nightly-pc-xpu
-      scheduler_release_name: precise-prefix-cache-aware
+      scheduler_release_name: precise-prefix-cache-routing
       scheduler_values_files: |
         guides/recipes/router/base.values.yaml
-        guides/precise-prefix-cache-aware/router/precise-prefix-cache-aware.values.yaml
-      helm_post_renderer: guides/precise-prefix-cache-aware/router/patches/uds-tokenizer/post-renderer.sh
+        guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml
       pod_wait_timeout: '10m'
       llm_d_ref: ${{ github.ref }}
       skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}


### PR DESCRIPTION
## Summary
- rename variables from "scheduler" to "router" 
- Update guide name from "precise-prefix-cache-aware" to "precise-prefix-cache-routing"

## Dependency

 [llm-d/llm-d-infra#182](https://github.com/llm-d/llm-d-infra/pull/182)

## Test plan

Verified end-to-end on a self-hosted XPU runner (Intel Arc Pro B60) against `xiaojun-zhang/llm-d`, with the matching infra reusable from [llm-d/llm-d-infra#182](https://github.com/llm-d/llm-d-infra/pull/182):

| Workflow | Run | Duration |
|---|---|---|
| `nightly-e2e-optimized-baseline-xpu` | [26536177448](https://github.com/xiaojun-zhang/llm-d/actions/runs/26536177448) | 7m11s ✅ |
| `nightly-e2e-pd-disaggregation-xpu`  | [26538316736](https://github.com/xiaojun-zhang/llm-d/actions/runs/26538316736) | 4m16s ✅ |
| `nightly-e2e-precise-prefix-cache-xpu` | [26538544331](https://github.com/xiaojun-zhang/llm-d/actions/runs/26538544331) | 4m12s ✅ |

- [x] Caller paths point at the renamed guide.
- [x] Smoke test passes against the new `precise-prefix-cache-routing-epp` service name.
