### PR TITLE
[hardware-support] Build and publish flagos images for cuda and NPU ascend

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -23,7 +23,7 @@ on:
   workflow_dispatch:
     inputs:
       platforms:
-        description: "Platforms to build (comma-separated: cuda,aws,gb200,xpu,cpu,hpu)"
+        description: "Platforms to build (comma-separated: cuda,aws,gb200,xpu,cpu,hpu,flagos-cuda,flagos-ascend)"
         required: false
         default: "cuda"
         type: string
@@ -69,6 +69,8 @@ jobs:
       cpu: ${{ steps.force.outputs.cpu || steps.filter.outputs.cpu || steps.dispatch.outputs.cpu }}
       hpu: ${{ steps.force.outputs.hpu || steps.filter.outputs.hpu || steps.dispatch.outputs.hpu }}
       rdma-tools: ${{ steps.filter.outputs.rdma-tools }}
+      flagos-cuda: ${{ steps.force.outputs.flagos-cuda || steps.filter.outputs.flagos-cuda || steps.dispatch.outputs.flagos-cuda }}
+      flagos-ascend: ${{ steps.force.outputs.flagos-ascend || steps.filter.outputs.flagos-ascend || steps.dispatch.outputs.flagos-ascend }}
     steps:
       - name: Force all platforms
         if: inputs.force_build == true
@@ -81,6 +83,8 @@ jobs:
           echo "xpu=true" >> $GITHUB_OUTPUT
           echo "cpu=true" >> $GITHUB_OUTPUT
           echo "hpu=true" >> $GITHUB_OUTPUT
+          echo "flagos-cuda=true" >> $GITHUB_OUTPUT
+          echo "flagos-ascend=true" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || '' }}
@@ -134,6 +138,16 @@ jobs:
             rdma-tools:
               - 'docker/Dockerfile.rdma-tools'
               - 'docker/common-versions'
+            flagos-cuda:
+              - 'docker/flagos/Dockerfile.cuda'
+              - 'docker/flagos/**'
+              - 'docker/scripts/common/**'
+              - 'docker/packages/common/**'
+            flagos-ascend:
+              - 'docker/flagos/Dockerfile.ascend'
+              - 'docker/flagos/**'
+              - 'docker/scripts/common/**'
+              - 'docker/packages/common/**'
       # shim to convert comma-separated platforms input into same boolean outputs as path filter
       - name: Parse dispatch platforms
         if: github.event_name == 'workflow_dispatch'
@@ -147,6 +161,8 @@ jobs:
           echo "xpu=$(echo $platforms | grep -q xpu && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "cpu=$(echo $platforms | grep -q cpu && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "hpu=$(echo $platforms | grep -q hpu && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "flagos-cuda=$(echo $platforms | grep -q flagos-cuda && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "flagos-ascend=$(echo $platforms | grep -q flagos-ascend && echo true || echo false)" >> $GITHUB_OUTPUT
 
   cuda-build-llm-d-debug:
     needs: [detect-changes]
@@ -1611,6 +1627,183 @@ jobs:
           skip-dirs: /root/.cache/uv
         env:
           TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: "trivy-results.sarif"
+
+      - name: Display vulnerability summary
+        run: |
+          echo "=== Vulnerability Scan Summary ==="
+          if [ -f trivy-results.sarif ]; then
+            echo "Scan completed. Check the Security tab for detailed results."
+          else
+            echo "No vulnerabilities found or scan failed."
+          fi
+
+  flagos-cuda-build-llm-d:
+    needs: [detect-changes]
+    if: ${{ needs.detect-changes.outputs.flagos-cuda == 'true' }}
+    strategy:
+      fail-fast: false
+    runs-on: vllm-runner
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || '' }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          buildkitd-flags: --oci-worker-gc
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.GHCR_USER }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Compute short SHA from checkout
+        id: short-sha
+        run: echo "short_sha=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}-flagos-cuda-dev
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=raw,value=sha-${{ steps.short-sha.outputs.short_sha }}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Calculate Cache Bust Timestamp
+        id: cache_buster_timestamp
+        run: |
+          echo "cache_buster_timestamp=$(date)" >> $GITHUB_OUTPUT
+
+      - name: Build & Push
+        id: build-and-push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./docker/flagos/Dockerfile.cuda
+          platforms: linux/amd64
+          push: true
+          provenance: true
+          build-args: |
+            CACHE_BUSTER=${{ steps.cache_buster_timestamp.outputs.cache_buster_timestamp }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          github-token: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ github.repository }}-flagos-cuda-dev@${{ steps.build-and-push.outputs.digest }}
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH,MEDIUM"
+          scanners: vuln
+          timeout: 30m
+          skip-dirs: /root/.cache/uv
+        env:
+          TRIVY_USERNAME: ${{ secrets.GHCR_USER }}
+          TRIVY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: "trivy-results.sarif"
+
+      - name: Display vulnerability summary
+        run: |
+          echo "=== Vulnerability Scan Summary ==="
+          if [ -f trivy-results.sarif ]; then
+            echo "Scan completed. Check the Security tab for detailed results."
+          else
+            echo "No vulnerabilities found or scan failed."
+          fi
+
+  flagos-ascend-build-llm-d:
+    needs: [detect-changes]
+    if: ${{ needs.detect-changes.outputs.flagos-ascend == 'true' }}
+    strategy:
+      fail-fast: false
+    runs-on: vllm-runner
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || '' }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          buildkitd-flags: --oci-worker-gc
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.GHCR_USER }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Compute short SHA from checkout
+        id: short-sha
+        run: echo "short_sha=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}-flagos-ascend-dev
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=raw,value=sha-${{ steps.short-sha.outputs.short_sha }}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Calculate Cache Bust Timestamp
+        id: cache_buster_timestamp
+        run: |
+          echo "cache_buster_timestamp=$(date)" >> $GITHUB_OUTPUT
+
+      - name: Build & Push
+        id: build-and-push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./docker/flagos/Dockerfile.ascend
+          platforms: linux/amd64
+          push: true
+          provenance: true
+          build-args: |
+            CACHE_BUSTER=${{ steps.cache_buster_timestamp.outputs.cache_buster_timestamp }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          github-token: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ github.repository }}-flagos-ascend-dev@${{ steps.build-and-push.outputs.digest }}
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH,MEDIUM"
+          scanners: vuln
+          timeout: 30m
+        env:
+          TRIVY_USERNAME: ${{ secrets.GHCR_USER }}
           TRIVY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
 
       - name: Upload Trivy scan results to GitHub Security tab

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,12 @@ else ifeq ($(DEVICE), cpu)
 	DOCKERFILE ?= Dockerfile.cpu
 else ifeq ($(DEVICE), hpu)
 	DOCKERFILE ?= Dockerfile.hpu
+else ifeq ($(DEVICE), flagos-cuda)
+	DOCKERFILE_DIR = docker/flagos
+	DOCKERFILE ?= Dockerfile.cuda
+else ifeq ($(DEVICE), flagos-ascend)
+	DOCKERFILE_DIR = docker/flagos
+	DOCKERFILE ?= Dockerfile.ascend
 else
 	DOCKERFILE ?= Dockerfile.cuda
 endif # Maybe we break out version per image because they share no common bits --> independent release cycles
@@ -24,7 +30,7 @@ VERSION ?= v0.2.1
 # New tag to use if you would like to use `make image-retag`
 NEW_TAG ?= sha256...
 
-# DEVICE, options: ['cuda', 'xpu', 'cpu', 'hpu']
+# DEVICE, options: ['cuda', 'xpu', 'cpu', 'hpu', 'flagos-cuda', 'flagos-ascend']
 DEVICE ?= cuda
 
 # ARCH, options: ['amd64', 'arm64']

--- a/docker/flagos/Dockerfile.ascend
+++ b/docker/flagos/Dockerfile.ascend
@@ -1,0 +1,186 @@
+######################## SYSTEM CONFIGURATION ########################
+
+ARG CANN_VERSION=8.5.1
+ARG CANN_CHIP=a3
+ARG UBUNTU_VERSION=22.04
+ARG PYTHON_VERSION=3.11
+
+######################## COMPONENT VERSIONS ########################
+
+# vLLM: installed from PyPI (Ascend uses VLLM_TARGET_DEVICE=empty)
+ARG VLLM_VERSION=0.19.0
+
+# Optional components
+ARG INSTALL_MOONCAKE=true
+ARG MOONCAKE_TAG=v0.3.8.post1
+
+# Ascend SoC
+ARG SOC_VERSION=ascend910_9391
+
+# vllm-plugin-FL
+ARG FLAGOS_FL_PLUGIN_REPO=https://github.com/flagos-ai/vllm-plugin-FL.git
+ARG FLAGOS_FL_PLUGIN_VERSION=20abe1fe0ca81f24a7e352074b2ee673eeca96fc
+
+# FlagGems: unified operator library (NPU backend for Ascend)
+ARG FLAGOS_FLAGGEMS_VERSION=v5.0.0
+
+# FlagTree: Ascend-specific acceleration
+ARG FLAGOS_FLAGTREE_VERSION=0.4.0+ascend3.2
+
+# ============================================================================
+# BASE STAGE
+# ============================================================================
+FROM quay.io/ascend/cann:${CANN_VERSION}-${CANN_CHIP}-ubuntu${UBUNTU_VERSION}-py${PYTHON_VERSION} AS base
+
+ARG CACHE_BUSTER
+RUN if [ -n "${CACHE_BUSTER}" ]; then \
+        echo "$CACHE_BUSTER" > /tmp/builder-buster; \
+    fi;
+
+ARG INSTALL_MOONCAKE
+ARG MOONCAKE_TAG
+ARG SOC_VERSION
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV SOC_VERSION=${SOC_VERSION} \
+    TASK_QUEUE_ENABLE=1 \
+    OMP_NUM_THREADS=1
+
+# Add BiShengIR compiler to PATH
+ENV PATH="${ASCEND_TOOLKIT_HOME}/tools/bishengir/bin:${PATH}"
+
+# ---- uv + pip upgrade ----
+RUN export UV_INSTALL_DIR=/usr/local/bin && \
+    curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    uv pip install --system --upgrade pip setuptools
+
+# ---- System dependencies ----
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update -y && \
+    apt-get install -y \
+        git \
+        vim \
+        wget \
+        net-tools \
+        gcc \
+        g++ \
+        cmake \
+        numactl \
+        libnuma-dev \
+        libjemalloc2 \
+        clang-15 \
+    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20 \
+    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20 \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---- Mooncake (distributed KV cache, optional) ----
+COPY docker/scripts/common/build-mooncake.sh /tmp/build-mooncake.sh
+RUN if [ "${INSTALL_MOONCAKE}" = "true" ]; then \
+        MOONCAKE_VERSION=${MOONCAKE_TAG} \
+        MOONCAKE_TARGET_ACCELERATOR=ascend \
+        bash /tmp/build-mooncake.sh; \
+    fi && rm /tmp/build-mooncake.sh
+
+# ---- triton-ascend + runtime deps ----
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system \
+        triton-ascend==3.2.0 \
+        'ray>=2.47.1,<=2.48.0' \
+        'protobuf>3.20.0'
+
+# jemalloc preload + devlib LD_LIBRARY_PATH
+RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:\${LD_PRELOAD}" >> ~/.bashrc && \
+    echo "export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}:/usr/local/lib" >> ~/.bashrc
+
+WORKDIR /workspace
+
+# ============================================================================
+# RUNTIME STAGE
+# ============================================================================
+FROM base
+
+ARG VLLM_VERSION
+ARG FLAGOS_FL_PLUGIN_REPO
+ARG FLAGOS_FL_PLUGIN_VERSION
+ARG FLAGOS_FLAGGEMS_VERSION
+ARG FLAGOS_FLAGTREE_VERSION
+
+# ---- vLLM (Ascend uses VLLM_TARGET_DEVICE=empty, uninstall x86 triton) ----
+RUN --mount=type=cache,target=/root/.cache/uv \
+    VLLM_TARGET_DEVICE="empty" uv pip install --system \
+        "vllm==${VLLM_VERSION}" \
+        --extra-index-url https://download.pytorch.org/whl/cpu/ \
+    && uv pip uninstall --system triton
+
+# ---- vllm-plugin-FL ----
+RUN --mount=type=cache,target=/root/.cache/uv \
+    git clone ${FLAGOS_FL_PLUGIN_REPO} /workspace/vllm-plugin-FL && \
+    cd /workspace/vllm-plugin-FL && \
+    git checkout ${FLAGOS_FL_PLUGIN_VERSION} && \
+    uv pip install --system --no-build-isolation .
+
+# ---- FlagGems (NPU backend) ----
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system scikit-build-core==0.11 pybind11 && \
+    git clone --depth 1 --branch ${FLAGOS_FLAGGEMS_VERSION} \
+        https://github.com/flagos-ai/FlagGems /workspace/FlagGems && \
+    uv pip install --system --no-build-isolation \
+        --config-settings=cmake.define.FLAGGEMS_BACKEND=NPU \
+        /workspace/FlagGems
+
+# ---- FlagTree (Ascend-specific) ----
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system \
+        "flagtree==${FLAGOS_FLAGTREE_VERSION}" \
+        --index-url=https://resource.flagos.net/repository/flagos-pypi-hosted/simple \
+        --trusted-host=resource.flagos.net
+
+# ============================================================================
+# RUNTIME CONFIGURATION
+# ============================================================================
+
+# OTEL packages for distributed tracing (llm-d convention)
+COPY docker/packages/common/runtime-otel-package-requirements.txt /workspace/runtime-otel-package-requirements.txt
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system -r /workspace/runtime-otel-package-requirements.txt
+
+# Cleanup build artifacts
+RUN rm -rf /workspace/vllm-plugin-FL/.git \
+    && rm -rf /workspace/FlagGems/.git
+
+# Non-root user (llm-d convention: uid 2000, gid 0 for OpenShift)
+RUN useradd --uid 2000 --gid 0 -m vllm && \
+    touch /home/vllm/.bashrc
+
+# Model storage directories (llm-d convention)
+ENV LLM_D_MODELS_DIR=/var/lib/llm-d/models \
+    HF_HOME=/var/lib/llm-d/.hf
+
+RUN mkdir -p "$LLM_D_MODELS_DIR" "$HF_HOME" && \
+    chown -R root:0 /var/lib/llm-d && \
+    chmod -R g+rwX /var/lib/llm-d && \
+    find /var/lib/llm-d -type d -exec chmod g+s {} \; && \
+    ln -snf /var/lib/llm-d/models /models
+
+# Workspace permissions for non-root user
+RUN chown -R 2000:0 /workspace && \
+    chmod -R g+rwX /workspace
+
+# FlagOS + Ascend-specific environment
+ENV VLLM_PLUGINS=fl \
+    TRITON_ALL_BLOCKS_PARALLEL=1
+
+# Standard llm-d runtime environment
+ENV HOME=/home/vllm \
+    VLLM_USAGE_SOURCE=production-docker-image \
+    VLLM_WORKER_MULTIPROC_METHOD=fork \
+    OUTLINES_CACHE_DIR=/tmp/outlines \
+    NUMBA_CACHE_DIR=/tmp/numba \
+    TRITON_CACHE_DIR=/tmp/triton \
+    VLLM_CACHE_ROOT=/tmp/vllm
+
+USER 2000
+WORKDIR /home/vllm
+
+ENTRYPOINT ["python", "-m", "vllm.entrypoints.openai.api_server"]

--- a/docker/flagos/Dockerfile.cuda
+++ b/docker/flagos/Dockerfile.cuda
@@ -1,0 +1,230 @@
+######################## SYSTEM CONFIGURATION ########################
+
+ARG CUDA_VERSION=13.0.2
+ARG UBUNTU_VERSION=22.04
+ARG PYTHON_VERSION=3.12
+
+######################## OPTIONAL COMPONENTS ########################
+
+ARG INSTALL_MOONCAKE=false
+ARG MOONCAKE_TAG=v0.3.8.post1
+
+######################## COMPONENT VERSIONS ########################
+
+# vLLM: built from upstream source
+ARG FLAGOS_VLLM_REPO=https://github.com/vllm-project/vllm.git
+ARG FLAGOS_VLLM_VERSION=v0.20.2
+
+# vllm-plugin-FL
+ARG FLAGOS_FL_PLUGIN_REPO=https://github.com/flagos-ai/vllm-plugin-FL.git
+ARG FLAGOS_FL_PLUGIN_VERSION=20abe1fe0ca81f24a7e352074b2ee673eeca96fc
+
+# FlagGems: unified operator library
+ARG FLAGOS_FLAGGEMS_VERSION=v5.0.0
+
+# FlagCX: unified communication library
+ARG FLAGOS_FLAGCX_VERSION=v0.9.0
+
+# DeepGEMM: optimized GEMM kernels
+ARG FLAGOS_DEEPGEMM_REPO=https://github.com/deepseek-ai/DeepGEMM.git
+ARG FLAGOS_DEEPGEMM_VERSION=35c4bc8
+
+# Build tuning
+ARG TORCH_CUDA_ARCH_LIST="8.0;8.6;8.9;9.0;9.0a;10.0;12.0+PTX"
+ARG MAX_JOBS=3
+
+# ============================================================================
+# BUILD + RUNTIME STAGE
+# Single stage: FlagGems requires CUDA devel headers at runtime for Triton JIT
+# ============================================================================
+FROM nvcr.io/nvidia/cuda:${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION}
+
+ARG CACHE_BUSTER
+RUN if [ -n "${CACHE_BUSTER}" ]; then \
+        echo "$CACHE_BUSTER" > /tmp/builder-buster; \
+    fi;
+
+ARG PYTHON_VERSION
+ARG MAX_JOBS
+ARG TORCH_CUDA_ARCH_LIST
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# ---- System dependencies ----
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        ccache \
+        git \
+        curl \
+        ca-certificates \
+        wget \
+        libibverbs-dev \
+        gcc-10 \
+        g++-10 \
+        librdmacm-dev \
+        libnuma-dev \
+        software-properties-common \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 110 \
+       --slave /usr/bin/g++ g++ /usr/bin/g++-10 \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python${PYTHON_VERSION} \
+        python${PYTHON_VERSION}-dev \
+        python${PYTHON_VERSION}-venv \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python${PYTHON_VERSION} 1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---- uv + Python virtual environment ----
+RUN export UV_INSTALL_DIR=/usr/local/bin && \
+    curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    uv venv /opt/vllm --python ${PYTHON_VERSION} && \
+    rm -f /usr/bin/python3 /usr/bin/python3-config /usr/bin/pip && \
+    ln -s /opt/vllm/bin/python3 /usr/bin/python3 && \
+    ln -s /opt/vllm/bin/python3-config /usr/bin/python3-config && \
+    ln -s /opt/vllm/bin/pip /usr/bin/pip && \
+    uv pip install --no-cache -U wheel
+
+ENV VIRTUAL_ENV=/opt/vllm
+ENV PATH="${VIRTUAL_ENV}/bin:/usr/local/bin:${PATH}"
+ENV CUDA_HOME=/usr/local/cuda
+ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
+ENV VLLM_ENABLE_CUDA_COMPATIBILITY=0
+ENV UV_HTTP_TIMEOUT=500
+ENV UV_INDEX_STRATEGY=unsafe-best-match
+ENV UV_LINK_MODE=copy
+
+# ---- Python build dependencies ----
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install \
+        "setuptools>=77.0.3,<81.0.0" \
+        "setuptools-scm>=8.0" \
+        scikit-build-core==0.11 \
+        pybind11 \
+        ninja \
+        cmake
+
+# ---- Mooncake (distributed KV cache, optional) ----
+ARG INSTALL_MOONCAKE
+ARG MOONCAKE_TAG
+
+COPY docker/scripts/common/build-mooncake.sh /tmp/build-mooncake.sh
+RUN if [ "${INSTALL_MOONCAKE}" = "true" ]; then \
+        MOONCAKE_VERSION=${MOONCAKE_TAG} \
+        MOONCAKE_TARGET_ACCELERATOR=cuda \
+        bash /tmp/build-mooncake.sh; \
+    fi && rm /tmp/build-mooncake.sh
+
+# ---- vLLM from source ----
+ARG FLAGOS_VLLM_REPO
+ARG FLAGOS_VLLM_VERSION
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=cache,target=/var/cache/git \
+    git clone --depth 1 --branch ${FLAGOS_VLLM_VERSION} \
+        ${FLAGOS_VLLM_REPO} /workspace/vllm && \
+    cd /workspace/vllm && \
+    MAX_JOBS=${MAX_JOBS} TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" \
+        VLLM_TARGET_DEVICE=cuda \
+        uv pip install --no-build-isolation -e .
+
+# ---- vllm-plugin-FL ----
+ARG FLAGOS_FL_PLUGIN_REPO
+ARG FLAGOS_FL_PLUGIN_VERSION
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    git clone ${FLAGOS_FL_PLUGIN_REPO} /workspace/vllm-plugin-FL && \
+    cd /workspace/vllm-plugin-FL && \
+    git checkout ${FLAGOS_FL_PLUGIN_VERSION} && \
+    uv pip install --no-build-isolation .
+
+# ---- FlagGems ----
+ARG FLAGOS_FLAGGEMS_VERSION
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    git clone --depth 1 --branch ${FLAGOS_FLAGGEMS_VERSION} \
+        https://github.com/flagos-ai/FlagGems /workspace/FlagGems && \
+    uv pip install --no-build-isolation /workspace/FlagGems
+
+# ---- FlagCX (native build + torch plugin) ----
+ARG FLAGOS_FLAGCX_VERSION
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    git clone --depth 1 --branch ${FLAGOS_FLAGCX_VERSION} \
+        https://github.com/flagos-ai/FlagCX.git /workspace/FlagCX && \
+    cd /workspace/FlagCX && \
+    git submodule update --init --recursive && \
+    sed -i 's/NCCL_VERSION_CODE > NCCL_VERSION(2, 28, 0)/NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)/g' \
+        flagcx/adaptor/ccl/nccl_adaptor.cc && \
+    make USE_NVIDIA=1 -j$(nproc) && \
+    cd plugin/torch && \
+    FLAGCX_ADAPTOR=nvidia uv pip install --no-build-isolation .
+
+# ---- DeepGEMM ----
+ARG FLAGOS_DEEPGEMM_REPO
+ARG FLAGOS_DEEPGEMM_VERSION
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    git clone ${FLAGOS_DEEPGEMM_REPO} /workspace/DeepGEMM && \
+    cd /workspace/DeepGEMM && \
+    git checkout ${FLAGOS_DEEPGEMM_VERSION} && \
+    git submodule update --init --recursive && \
+    TORCH_DEVICE_BACKEND_AUTOLOAD=0 uv pip install --no-build-isolation .
+
+# ============================================================================
+# RUNTIME CONFIGURATION
+# ============================================================================
+
+# OTEL packages for distributed tracing (llm-d convention)
+COPY docker/packages/common/runtime-otel-package-requirements.txt /workspace/runtime-otel-package-requirements.txt
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install -r /workspace/runtime-otel-package-requirements.txt
+
+# Cleanup build artifacts
+RUN rm -rf /workspace/vllm/.git /workspace/vllm/docs /workspace/vllm/tests && \
+    rm -rf /workspace/vllm-plugin-FL/.git && \
+    rm -rf /workspace/FlagGems/.git && \
+    rm -rf /workspace/DeepGEMM
+
+# Non-root user (llm-d convention: uid 2000, gid 0 for OpenShift)
+RUN useradd --uid 2000 --gid 0 -m vllm && \
+    touch /home/vllm/.bashrc
+
+# Model storage directories (llm-d convention)
+ENV LLM_D_MODELS_DIR=/var/lib/llm-d/models \
+    HF_HOME=/var/lib/llm-d/.hf
+
+RUN mkdir -p "$LLM_D_MODELS_DIR" "$HF_HOME" && \
+    chown -R root:0 /var/lib/llm-d && \
+    chmod -R g+rwX /var/lib/llm-d && \
+    find /var/lib/llm-d -type d -exec chmod g+s {} \; && \
+    ln -snf /var/lib/llm-d/models /models
+
+# Workspace permissions for non-root user
+RUN chown -R 2000:0 /workspace && \
+    chmod -R g+rwX /workspace
+
+# FlagOS-specific environment
+ENV VLLM_PLUGINS=fl \
+    FLAGCX_PATH=/workspace/FlagCX \
+    NVIDIA_VISIBLE_DEVICES=all \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility
+
+# Standard llm-d runtime environment
+ENV PATH="${VIRTUAL_ENV}/bin:${CUDA_HOME}/bin:/usr/local/nvidia/bin:${PATH}" \
+    HOME=/home/vllm \
+    VLLM_USAGE_SOURCE=production-docker-image \
+    VLLM_WORKER_MULTIPROC_METHOD=fork \
+    OUTLINES_CACHE_DIR=/tmp/outlines \
+    NUMBA_CACHE_DIR=/tmp/numba \
+    TRITON_CACHE_DIR=/tmp/triton \
+    VLLM_SKIP_P2P_CHECK=1 \
+    VLLM_CACHE_ROOT=/tmp/vllm
+
+USER 2000
+WORKDIR /home/vllm
+
+ENTRYPOINT ["python", "-m", "vllm.entrypoints.openai.api_server"]

--- a/docker/scripts/common/build-mooncake.sh
+++ b/docker/scripts/common/build-mooncake.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -Eeux
+
+# Builds and installs Mooncake (distributed KV cache) from source.
+#
+# Required environment variables:
+# - MOONCAKE_VERSION: git tag/branch/SHA to checkout
+# - MOONCAKE_TARGET_ACCELERATOR: target accelerator, one of:
+#     cuda    - NVIDIA GPU (default cmake, auto-detects CUDA toolkit)
+#     ascend  - Huawei Ascend NPU (enables ASCEND_DIRECT transport)
+#     cpu     - CPU-only (no accelerator-specific transport)
+#
+# Optional environment variables:
+# - MOONCAKE_REPO: git repo URL (default: https://github.com/kvcache-ai/Mooncake.git)
+# - MOONCAKE_CMAKE_EXTRA_FLAGS: additional cmake flags appended after the accelerator defaults
+
+: "${MOONCAKE_REPO:=https://github.com/kvcache-ai/Mooncake.git}"
+: "${MOONCAKE_TARGET_ACCELERATOR:=cuda}"
+
+cd /tmp
+
+git clone --depth 1 --branch "${MOONCAKE_VERSION}" "${MOONCAKE_REPO}" mooncake
+cd mooncake
+
+bash dependencies.sh -y
+
+# Set up accelerator-specific cmake flags and environment
+CMAKE_FLAGS=""
+case "${MOONCAKE_TARGET_ACCELERATOR}" in
+    cuda)
+        ;;
+    ascend)
+        CMAKE_FLAGS="-DUSE_ASCEND_DIRECT=ON"
+        if [ -n "${ASCEND_TOOLKIT_HOME:-}" ]; then
+            ARCH=$(uname -m)
+            # shellcheck disable=SC1091
+            source "${ASCEND_TOOLKIT_HOME}/../set_env.sh" || source /usr/local/Ascend/ascend-toolkit/set_env.sh
+            export LD_LIBRARY_PATH="/usr/local/Ascend/ascend-toolkit/latest/${ARCH}-linux/devlib:/usr/local/Ascend/ascend-toolkit/latest/${ARCH}-linux/lib64:${LD_LIBRARY_PATH:-}"
+        fi
+        ;;
+    cpu)
+        ;;
+    *)
+        echo "ERROR: unknown MOONCAKE_TARGET_ACCELERATOR='${MOONCAKE_TARGET_ACCELERATOR}'" >&2
+        echo "Valid values: cuda, ascend, cpu" >&2
+        exit 1
+        ;;
+esac
+
+mkdir -p build && cd build
+# shellcheck disable=SC2086
+cmake .. ${CMAKE_FLAGS} ${MOONCAKE_CMAKE_EXTRA_FLAGS:-}
+make -j"$(nproc)"
+make install
+
+cd /tmp && rm -rf /tmp/mooncake


### PR DESCRIPTION
vllm-plugin-FL is a plugin for the [vLLM](https://github.com/vllm-project/vllm) inference/serving framework, built on FlagOS's unified multi-chip backend — including the unified operator library [FlagGems](https://github.com/flagos-ai/FlagGems) and the unified communication library [FlagCX](https://github.com/flagos-ai/FlagCX). It extends vLLM's capabilities and performance across diverse hardware environments. Without changing vLLM's original interfaces or usage patterns, the same command can run model inference/serving on different chips.

For more information see: https://github.com/flagos-ai/vllm-plugin-FL