### PR TITLE
fix(guides): update tiered-prefix-cache-cpu config for new approximate prefix cache producer plugin

### DIFF
--- a/guides/tiered-prefix-cache/cpu/router/tiered-prefix-cache-cpu.values.yaml
+++ b/guides/tiered-prefix-cache/cpu/router/tiered-prefix-cache-cpu.values.yaml
@@ -19,11 +19,15 @@ router:
         - type: kv-cache-utilization-scorer
         - type: prefix-cache-scorer
           name: gpu-prefix-cache-scorer
-        - type: prefix-cache-scorer
-          name: cpu-prefix-cache-scorer
+        - type: approx-prefix-cache-producer
+          name: cpuPrefixProducer
           parameters:
             autoTune: false  # vLLM doesn't have the CPU capacity metric to enable autoTune yet
             lruCapacityPerServer: 41000  # Allocating ~100GB for Qwen-32B: 41,000 blocks * 2.5MB/block (based on 160KB/token * 16 block size).
+        - type: prefix-cache-scorer
+          name: cpu-prefix-cache-scorer
+          parameters:
+            prefixMatchInfoProducerName: cpuPrefixProducer
         schedulingProfiles:
         - name: default
           plugins:


### PR DESCRIPTION
# Summary
EPP crashloops when following the `tiered-prefix-cache-cpu` guide on the new helm charts from #1607. 
The guide passes `autoTune` and `lruCapacityPerServer` directly to `prefix-cache-scorer`, but those fields were moved into a separate `approx-prefix-cache-producer` plugin. 
The guide config wasn't updated alongside the chart bump.
# Fix
In `tiered-prefix-cache-cpu.values.yaml`:
- Add an `approx-prefix-cache-producer` named `cpuPrefixProducer` with the parameters that `cpu-prefix-cache scorer` had.
- Change `cpu-prefix-cache-scorer.parameters` to `prefixMatchInfoProducerName: cpuPrefixProducer`.

