### PR TITLE
refactor(nightly/wva): extract custom_deploy_script into standalone shell scripts

### DIFF
--- a/.github/workflows/nightly-e2e-wva-cks.yaml
+++ b/.github/workflows/nightly-e2e-wva-cks.yaml
@@ -101,39 +101,8 @@ jobs:
       # Service name is truncated to 63 chars: ...-inferencepoo-epp (not ...-inferencepool-epp)
       gateway_host: 'workload-variant-autoscaler-inferencepoo-epp'
       custom_deploy_script: |
-        # WVA kustomize builds target namespace llm-d-autoscaler (do not pass a conflicting kubectl -n).
-        WVA_DEPLOY_NS=llm-d-autoscaler
-        yq '.spec.template.spec.priorityClassName="nightly-gpu-critical"' -i guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
-        yq '.spec.template.spec.volumes += {"name": "triton-cache", "emptyDir": {}}' -i guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
-        yq '.spec.template.spec.containers[0].volumeMounts += {"mountPath": "/.triton", "name": "triton-cache"}' -i guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
-        yq '.spec.replicas=2' -i guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
-        kubectl apply -k guides/optimized-baseline/modelserver/gpu/vllm/base -n ${NAMESPACE}
-        export ROUTER_CHART_VERSION=v0
-        helm install workload-variant-autoscaler-inferencepool-standalone \
-          oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev \
-          -f guides/recipes/router/base.values.yaml \
-          -f guides/optimized-baseline/router/optimized-baseline.values.yaml \
-          -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
-
-        # Override WVA controller image to the nightly build from this run
-        WVA_TAG="${{ needs.build-wva-image.outputs.image_tag || github.event.inputs.image_tag }}"
-        if [ -n "$WVA_TAG" ]; then
-          export WVA_TAG
-          yq -i '.images = [{"name": "controller", "newName": "ghcr.io/llm-d/llm-d-workload-variant-autoscaler", "newTag": strenv(WVA_TAG)}]' \
-            guides/workload-autoscaling/wva-config/base/kustomization.yaml
-        fi
-
-        # Kustomization validation dry run
-        kubectl kustomize guides/workload-autoscaling/wva-config/platform/cks >/dev/null
-
-        # apply WVA assets
-        kubectl apply -k guides/workload-autoscaling/wva-config/platform/cks
-
-        # Validate WVA controller is ready, then apply autoscaling resources
-        kubectl wait deployment/workload-variant-autoscaler-controller-manager \
-          -n "${WVA_DEPLOY_NS}" --for=condition=Available --timeout=300s
-        kubectl apply -k guides/workload-autoscaling/optimized-baseline-autoscaling -n "${NAMESPACE}"
-        kubectl get variantautoscaling,hpa -n "${NAMESPACE}"
+        export WVA_TAG="${{ needs.build-wva-image.outputs.image_tag || github.event.inputs.image_tag }}"
+        bash guides/workload-autoscaling/scripts/nightly-deploy-cks.sh
       required_gpus: 2
       recommended_gpus: 4
       pod_wait_timeout: '30m'

--- a/.github/workflows/nightly-e2e-wva-ocp.yaml
+++ b/.github/workflows/nightly-e2e-wva-ocp.yaml
@@ -101,46 +101,8 @@ jobs:
       # Service name is truncated to 63 chars: ...-inferencepoo-epp (not ...-inferencepool-epp)
       gateway_host: 'workload-variant-autoscaler-inferencepoo-epp'
       custom_deploy_script: |
-        # WVA kustomize builds target namespace llm-d-autoscaler (do not pass a conflicting kubectl -n).
-        WVA_DEPLOY_NS=llm-d-autoscaler
-        yq '.spec.template.spec.priorityClassName="nightly-gpu-critical"' -i guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
-        yq '.spec.template.spec.volumes += {"name": "triton-cache", "emptyDir": {}}' -i guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
-        yq '.spec.template.spec.containers[0].volumeMounts += {"mountPath": "/.triton", "name": "triton-cache"}' -i guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
-        yq '.spec.replicas=2' -i guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
-        kubectl apply -k guides/optimized-baseline/modelserver/gpu/vllm/base -n ${NAMESPACE}
-        export ROUTER_CHART_VERSION=v0
-        helm install workload-variant-autoscaler-inferencepool-standalone \
-          oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev \
-          -f guides/recipes/router/base.values.yaml \
-          -f guides/optimized-baseline/router/optimized-baseline.values.yaml \
-          -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
-
-        # Override WVA controller image to the nightly build from this run
-        WVA_TAG="${{ needs.build-wva-image.outputs.image_tag || github.event.inputs.image_tag }}"
-        if [ -n "$WVA_TAG" ]; then
-          export WVA_TAG
-          yq -i '.images = [{"name": "controller", "newName": "ghcr.io/llm-d/llm-d-workload-variant-autoscaler", "newTag": strenv(WVA_TAG)}]' \
-            guides/workload-autoscaling/wva-config/base/kustomization.yaml
-        fi
-
-        # Kustomization validation dry run
-        kubectl kustomize guides/workload-autoscaling/wva-config/platform/ocp >/dev/null
-
-        # apply WVA assets (creates llm-d-autoscaler namespace)
-        kubectl apply -k guides/workload-autoscaling/wva-config/platform/ocp
-
-        # TLS cert handling — must run after the namespace is created by the kustomize apply above
-        export PROMETHEUS_CA_CERT=$(kubectl get secret thanos-querier-tls -n openshift-monitoring -o jsonpath='{.data.tls\.crt}' | base64 -d)
-        WVA_TLS_OVERLAY_DIR=$(mktemp -d)
-        cp -R guides/workload-autoscaling/components/tls-overlay/. "${WVA_TLS_OVERLAY_DIR}"
-        printf "%s" "${PROMETHEUS_CA_CERT}" > "${WVA_TLS_OVERLAY_DIR}/ca.crt"
-        kubectl apply -k "${WVA_TLS_OVERLAY_DIR}" -n "${WVA_DEPLOY_NS}"
-
-        # Validate WVA controller is ready, then apply autoscaling resources
-        kubectl wait deployment/workload-variant-autoscaler-controller-manager \
-          -n "${WVA_DEPLOY_NS}" --for=condition=Available --timeout=300s
-        kubectl apply -k guides/workload-autoscaling/optimized-baseline-autoscaling -n "${NAMESPACE}"
-        kubectl get variantautoscaling,hpa -n "${NAMESPACE}"
+        export WVA_TAG="${{ needs.build-wva-image.outputs.image_tag || github.event.inputs.image_tag }}"
+        bash guides/workload-autoscaling/scripts/nightly-deploy-ocp.sh
       required_gpus: 2
       recommended_gpus: 4
       pod_wait_timeout: '30m'

--- a/guides/workload-autoscaling/scripts/nightly-deploy-cks.sh
+++ b/guides/workload-autoscaling/scripts/nightly-deploy-cks.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WVA kustomize builds target namespace llm-d-autoscaler (do not pass a conflicting kubectl -n).
+WVA_DEPLOY_NS=llm-d-autoscaler
+yq '.spec.template.spec.priorityClassName="nightly-gpu-critical"' -i guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
+yq '.spec.template.spec.volumes += {"name": "triton-cache", "emptyDir": {}}' -i guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
+yq '.spec.template.spec.containers[0].volumeMounts += {"mountPath": "/.triton", "name": "triton-cache"}' -i guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
+yq '.spec.replicas=2' -i guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
+kubectl apply -k guides/optimized-baseline/modelserver/gpu/vllm/base -n ${NAMESPACE}
+export ROUTER_CHART_VERSION=v0
+helm install workload-variant-autoscaler-inferencepool-standalone \
+  oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev \
+  -f guides/recipes/router/base.values.yaml \
+  -f guides/optimized-baseline/router/optimized-baseline.values.yaml \
+  -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
+
+# Override WVA controller image to the nightly build from this run
+if [ -n "$WVA_TAG" ]; then
+  export WVA_TAG
+  yq -i '.images = [{"name": "controller", "newName": "ghcr.io/llm-d/llm-d-workload-variant-autoscaler", "newTag": strenv(WVA_TAG)}]' \
+    guides/workload-autoscaling/wva-config/base/kustomization.yaml
+fi
+
+# Kustomization validation dry run
+kubectl kustomize guides/workload-autoscaling/wva-config/platform/cks >/dev/null
+
+# apply WVA assets
+kubectl apply -k guides/workload-autoscaling/wva-config/platform/cks
+
+# Validate WVA controller is ready, then apply autoscaling resources
+kubectl wait deployment/workload-variant-autoscaler-controller-manager \
+  -n "${WVA_DEPLOY_NS}" --for=condition=Available --timeout=300s
+kubectl apply -k guides/workload-autoscaling/optimized-baseline-autoscaling -n "${NAMESPACE}"
+kubectl get variantautoscaling,hpa -n "${NAMESPACE}"

--- a/guides/workload-autoscaling/scripts/nightly-deploy-ocp.sh
+++ b/guides/workload-autoscaling/scripts/nightly-deploy-ocp.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WVA kustomize builds target namespace llm-d-autoscaler (do not pass a conflicting kubectl -n).
+WVA_DEPLOY_NS=llm-d-autoscaler
+yq '.spec.template.spec.priorityClassName="nightly-gpu-critical"' -i guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
+yq '.spec.template.spec.volumes += {"name": "triton-cache", "emptyDir": {}}' -i guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
+yq '.spec.template.spec.containers[0].volumeMounts += {"mountPath": "/.triton", "name": "triton-cache"}' -i guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
+yq '.spec.replicas=2' -i guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
+kubectl apply -k guides/optimized-baseline/modelserver/gpu/vllm/base -n ${NAMESPACE}
+export ROUTER_CHART_VERSION=v0
+helm install workload-variant-autoscaler-inferencepool-standalone \
+  oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev \
+  -f guides/recipes/router/base.values.yaml \
+  -f guides/optimized-baseline/router/optimized-baseline.values.yaml \
+  -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
+
+# Override WVA controller image to the nightly build from this run
+if [ -n "$WVA_TAG" ]; then
+  export WVA_TAG
+  yq -i '.images = [{"name": "controller", "newName": "ghcr.io/llm-d/llm-d-workload-variant-autoscaler", "newTag": strenv(WVA_TAG)}]' \
+    guides/workload-autoscaling/wva-config/base/kustomization.yaml
+fi
+
+# Kustomization validation dry run
+kubectl kustomize guides/workload-autoscaling/wva-config/platform/ocp >/dev/null
+
+# apply WVA assets (creates llm-d-autoscaler namespace)
+kubectl apply -k guides/workload-autoscaling/wva-config/platform/ocp
+
+# TLS cert handling — must run after the namespace is created by the kustomize apply above
+export PROMETHEUS_CA_CERT=$(kubectl get secret thanos-querier-tls -n openshift-monitoring -o jsonpath='{.data.tls\.crt}' | base64 -d)
+WVA_TLS_OVERLAY_DIR=$(mktemp -d)
+cp -R guides/workload-autoscaling/components/tls-overlay/. "${WVA_TLS_OVERLAY_DIR}"
+printf "%s" "${PROMETHEUS_CA_CERT}" > "${WVA_TLS_OVERLAY_DIR}/ca.crt"
+kubectl apply -k "${WVA_TLS_OVERLAY_DIR}" -n "${WVA_DEPLOY_NS}"
+
+# Validate WVA controller is ready, then apply autoscaling resources
+kubectl wait deployment/workload-variant-autoscaler-controller-manager \
+  -n "${WVA_DEPLOY_NS}" --for=condition=Available --timeout=300s
+kubectl apply -k guides/workload-autoscaling/optimized-baseline-autoscaling -n "${NAMESPACE}"
+kubectl get variantautoscaling,hpa -n "${NAMESPACE}"


### PR DESCRIPTION
## Summary

- Extracts the ~35-line inline bash body from `nightly-e2e-wva-ocp.yaml` and `nightly-e2e-wva-cks.yaml` into `guides/workload-autoscaling/scripts/nightly-deploy-ocp.sh` and `nightly-deploy-cks.sh`
- Hoists the `${{ needs.build-wva-image.outputs.image_tag || github.event.inputs.image_tag }}` GHA expression to the top of `custom_deploy_script` as an `export WVA_TAG=` assignment; the script files use plain `${WVA_TAG:-}` with no GHA syntax
- No logic changes — identical deploy steps, just reorganized
