### PR TITLE
feat(ci): enable TPU v6e nightlies for tiered-prefix-cache and pd-disaggregation

### DIFF
--- a/.github/workflows/nightly-e2e-pd-disaggregation-gke-tpu.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-gke-tpu.yaml
@@ -33,9 +33,31 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Placeholder
-        run: |
-          echo "Skipping PD Disaggregation TPU nightly — v6e manifests not yet available."
-          echo "Unblock: add guides/pd-disaggregation/modelserver/tpu-v6e/ overlay and replace this job."
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke-tpu.yaml@main
+    with:
+      guide_name: pd-disaggregation
+      namespace: llm-d-nightly-pd-gke-tpu
+      gateway_host: 'pd-disaggregation-epp'
+      tpu_type: v6e-8
+      required_tpu_chips: 16
+      recommended_tpu_chips: 16
+      custom_deploy_script: |
+        export GAIE_VERSION=v1.5.0
+        export ROUTER_CHART_VERSION=v0
+        export GUIDE_NAME="pd-disaggregation"
+        kubectl apply -n ${NAMESPACE} -k guides/${GUIDE_NAME}/modelserver/tpu-v6/vllm
+        helm install ${GUIDE_NAME} \
+          oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev \
+          -f guides/recipes/router/base.values.yaml \
+          -f guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
+          -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
+      gke_cluster_name: llm-d-e2e-us-east5
+      gke_cluster_zone: us-east5
+      pod_wait_timeout: '45m'
+      pod_readiness_delay: 300
+      llm_d_ref: ${{ github.ref }}
+      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_repo: ${{ github.event.inputs.pr_repo }}
+    secrets: inherit
+

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-tpu.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-tpu.yaml
@@ -32,9 +32,31 @@ concurrency:
 jobs:
   nightly:
     if: github.repository == 'llm-d/llm-d'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Placeholder
-        run: |
-          echo "Skipping Tiered Prefix Cache TPU nightly — v6e manifests not yet available."
-          echo "Unblock: confirm TPUOffloadConnector v6e support, add tpu-v6e manifests, replace this job."
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke-tpu.yaml@main
+    with:
+      guide_name: tiered-prefix-cache
+      namespace: llm-d-nightly-pfc-cpu-gke-tpu
+      gateway_host: 'tiered-prefix-cache-cpu-epp'
+      tpu_type: v6e-8
+      required_tpu_chips: 8
+      recommended_tpu_chips: 8
+      custom_deploy_script: |
+        export GAIE_VERSION=v1.5.0
+        export ROUTER_CHART_VERSION=v0
+        export GUIDE_NAME="tiered-prefix-cache-cpu"
+        kubectl apply -n ${NAMESPACE} -k guides/tiered-prefix-cache/cpu/modelserver/tpu-v6/vllm/tpu-offloading-connector
+        helm install ${GUIDE_NAME} \
+          oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev \
+          -f guides/recipes/router/base.values.yaml \
+          -f guides/tiered-prefix-cache/cpu/router/${GUIDE_NAME}.values.yaml \
+          -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
+      gke_cluster_name: llm-d-e2e-us-east5
+      gke_cluster_zone: us-east5
+      pod_wait_timeout: '45m'
+      pod_readiness_delay: 300
+      llm_d_ref: ${{ github.ref }}
+      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_repo: ${{ github.event.inputs.pr_repo }}
+    secrets: inherit
+

--- a/guides/pd-disaggregation/modelserver/tpu-v6/vllm/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/tpu-v6/vllm/kustomization.yaml
@@ -1,0 +1,73 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../recipes/modelserver/base/single-host/pd/vllm
+
+namePrefix: pd-disaggregation-tpu-vllm-
+
+images:
+  - name: REPLACE_MODEL_SERVER_IMAGE
+    newName: docker.io/vllm/vllm-tpu
+    newTag: nightly-20260430-18ed615-5b39b26
+
+labels:
+  - pairs:
+      llm-d.ai/model: Qwen3.5-397B-A17B-FP8
+      llm-d.ai/guide: pd-disaggregation
+      llm-d.ai/accelerator-variant: tpu
+      llm-d.ai/accelerator-vendor: google
+      inference.networking.k8s.io/engine-type: vllm
+    includeSelectors: true
+    includeTemplates: true
+    fields:
+      - version: v1
+        kind: ServiceAccount
+        path: metadata/labels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: metadata/labels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: spec/selector/matchLabels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: spec/template/metadata/labels
+        create: true
+      - group: monitoring.coreos.com
+        version: v1
+        kind: PodMonitor
+        path: metadata/labels
+        create: true
+      - group: monitoring.coreos.com
+        version: v1
+        kind: PodMonitor
+        path: spec/selector/matchLabels
+        create: true
+
+patches:
+  - path: patch-decode.yaml
+  - path: patch-prefill.yaml
+  - target:
+      kind: Deployment
+      name: decode
+    patch: |-
+      - op: add
+        path: /spec/template/spec/nodeSelector
+        value:
+          cloud.google.com/gke-tpu-topology: "2x4"
+          cloud.google.com/gke-tpu-accelerator: "tpu-v6e-slice"
+  - target:
+      kind: Deployment
+      name: prefill
+    patch: |-
+      - op: add
+        path: /spec/template/spec/nodeSelector
+        value:
+          cloud.google.com/gke-tpu-topology: "2x4"
+          cloud.google.com/gke-tpu-accelerator: "tpu-v6e-slice"

--- a/guides/pd-disaggregation/modelserver/tpu-v6/vllm/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/tpu-v6/vllm/patch-decode.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: modelserver
+          command: ["vllm", "serve"]
+          args:
+            - "Qwen/Qwen3.5-397B-A17B-FP8"
+            - "--max-model-len=9216"
+            - "--max-num-batched-tokens=8192"
+            - "--max-num-seqs=512"
+            - "--tensor-parallel-size=8"
+            - "--language-model-only"
+            - "--limit-mm-per-prompt"
+            - '{"image": 0, "video": 0}'
+            - "--kv-cache-dtype=fp8"
+            - "--enable-expert-parallel"
+            - "--no-disable-hybrid-kv-cache-manager"
+            - "--kv-transfer-config"
+            - '{"kv_connector":"TPUConnectorHMA","kv_connector_module_path":"tpu_inference.distributed.tpu_connector_hma","kv_role":"kv_consumer"}'
+            - "--port=8200"
+            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: TPU_SIDE_CHANNEL_PORT
+              value: "9600"
+            - name: TPU_KV_TRANSFER_PORT
+              value: "9100"
+          ports:
+            - containerPort: 9100
+              name: tpu-kv-transfer
+              protocol: TCP
+            - containerPort: 9600
+              name: tpu-pd-coord
+              protocol: TCP
+          resources:
+            limits:
+              cpu: "200"
+              memory: 800Gi
+              google.com/tpu: 8
+            requests:
+              cpu: "200"
+              memory: 800Gi
+              google.com/tpu: 8
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /.cache
+              name: torch-compile-cache
+            - mountPath: /.config
+              name: metrics-volume
+          startupProbe:
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 240
+          livenessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 100Gi
+        - name: torch-compile-cache
+          emptyDir: {}
+        - name: metrics-volume
+          emptyDir: {}

--- a/guides/pd-disaggregation/modelserver/tpu-v6/vllm/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/tpu-v6/vllm/patch-prefill.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prefill
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: modelserver
+          command: ["vllm", "serve"]
+          args:
+            - "Qwen/Qwen3.5-397B-A17B-FP8"
+            - "--max-model-len=9216"
+            - "--max-num-batched-tokens=8192"
+            - "--max-num-seqs=512"
+            - "--tensor-parallel-size=8"
+            - "--language-model-only"
+            - "--limit-mm-per-prompt"
+            - '{"image": 0, "video": 0}'
+            - "--kv-cache-dtype=fp8"
+            - "--enable-expert-parallel"
+            - "--no-disable-hybrid-kv-cache-manager"
+            - "--kv-transfer-config"
+            - '{"kv_connector":"TPUConnectorHMA","kv_connector_module_path":"tpu_inference.distributed.tpu_connector_hma","kv_role":"kv_producer"}'
+            - "--port=8000"
+            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: TPU_SIDE_CHANNEL_PORT
+              value: "9600"
+            - name: TPU_KV_TRANSFER_PORT
+              value: "9100"
+          ports:
+            - containerPort: 9100
+              name: tpu-kv-transfer
+              protocol: TCP
+            - containerPort: 9600
+              name: tpu-pd-coord
+              protocol: TCP
+          resources:
+            limits:
+              cpu: "200"
+              memory: 800Gi
+              google.com/tpu: 8
+            requests:
+              cpu: "200"
+              memory: 800Gi
+              google.com/tpu: 8
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /.cache
+              name: torch-compile-cache
+            - mountPath: /.config
+              name: metrics-volume
+          startupProbe:
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 240
+          livenessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 100Gi
+        - name: torch-compile-cache
+          emptyDir: {}
+        - name: metrics-volume
+          emptyDir: {}

--- a/guides/tiered-prefix-cache/cpu/modelserver/tpu-v6/vllm/tpu-offloading-connector/kustomization.yaml
+++ b/guides/tiered-prefix-cache/cpu/modelserver/tpu-v6/vllm/tpu-offloading-connector/kustomization.yaml
@@ -1,0 +1,49 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../../../recipes/modelserver/base/single-host/default
+
+namePrefix: tpu-v6-vllm-
+
+labels:
+  - pairs:
+      llm-d.ai/model: Qwen3-32B
+      llm-d.ai/guide: tiered-prefix-cache
+      llm-d.ai/subguide: tiered-prefix-cache-tpu
+      llm-d.ai/accelerator-variant: tpu
+      llm-d.ai/accelerator-vendor: google
+    includeSelectors: true
+    includeTemplates: true
+    fields:
+      - version: v1
+        kind: ServiceAccount
+        path: metadata/labels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: metadata/labels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: spec/selector/matchLabels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: spec/template/metadata/labels
+        create: true
+      - group: monitoring.coreos.com
+        version: v1
+        kind: PodMonitor
+        path: metadata/labels
+        create: true
+      - group: monitoring.coreos.com
+        version: v1
+        kind: PodMonitor
+        path: spec/selector/matchLabels
+        create: true
+
+patches:
+  - path: patch-vllm.yaml

--- a/guides/tiered-prefix-cache/cpu/modelserver/tpu-v6/vllm/tpu-offloading-connector/patch-vllm.yaml
+++ b/guides/tiered-prefix-cache/cpu/modelserver/tpu-v6/vllm/tpu-offloading-connector/patch-vllm.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        llm-d.ai/inference-serving: "true"
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
+        cloud.google.com/gke-tpu-topology: 2x4
+      initContainers:
+        - name: tpu-node-setup
+          image: busybox
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              # WARNING: This changes the HOST memory settings, not just the container.
+              # Required to prevent vLLM crashes due to memory mapping limits.
+              sysctl -w vm.max_map_count=33554432
+
+              # Check if the VFIO IOMMU module parameter exists, and if so, increase the
+              # limit on DMA mappings. This allows the TPU driver to pin and map a
+              # larger number of memory pages for direct hardware access.
+              if [ -f /sys/module/vfio_iommu_type1/parameters/dma_entry_limit ]; then
+                echo 8000000 > /sys/module/vfio_iommu_type1/parameters/dma_entry_limit
+                echo "Successfully increased dma_entry_limit to 8000000"
+              else
+                echo "Warning: vfio_iommu_type1 module parameter not found. Ensure the module is loaded."
+              fi
+
+              echo "Final vm.max_map_count: $(cat /proc/sys/vm.max_map_count)"
+          securityContext:
+            privileged: true
+      containers:
+        - name: modelserver
+          image: vllm/vllm-tpu:nightly-20260504-e2a6582-67058ca
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              vllm serve Qwen/Qwen3-32B \
+                --kv-transfer-config '{"kv_connector":"TPUOffloadConnector","kv_connector_module_path":"tpu_inference.offload.tpu_offload_connector","kv_role":"kv_both"}' \
+                --port 8000 \
+                --tensor-parallel-size 8 \
+                --gpu-memory-utilization 0.9
+          env:
+            - name: PROMETHEUS_MULTIPROC_DIR
+              value: "/tmp/prometheus_multiproc"
+            - name: SKIP_JAX_PRECOMPILE
+              value: "0"
+            - name: TPU_OFFLOAD_NUM_CPU_CHUNKS
+              value: "25000"
+            - name: TPU_OFFLOAD_NUM_STAGING_BLOCKS
+              value: "1000"
+          resources:
+            requests:
+              google.com/tpu: 8
+            limits:
+              google.com/tpu: 8
+          startupProbe:
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 120
+          livenessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+      volumes:
+        - name: torch-compile-cache
+          emptyDir: {}


### PR DESCRIPTION
Enables the real nightly GKE TPU workflows for:
1. Tiered Prefix Cache CPU Offloading
2. Prefill/Decode PD Disaggregation

Also adds the corresponding TPU v6e modelserver kustomize overlays for both guides.