### PR TITLE
Add Grafana dashboard setup documentation for flow control

### DIFF
--- a/docs/architecture/core/router/epp/flow-control.md
+++ b/docs/architecture/core/router/epp/flow-control.md
@@ -433,4 +433,6 @@ The Flow Control layer exposes detailed metrics to track queuing dynamics and sy
 
 A pre-configured Grafana dashboard is available to visualize these metrics, making it easy to monitor queue depths, dispatch latency, and saturation state transitions.
 
+To load this dashboard, follow the [Observability Setup guide](../../../../operations/observability/setup.md), which installs Prometheus and Grafana and loads the llm-d dashboards.
+
 ![Flow Control Dashboard](../../images/flow_control_dashboard.png)


### PR DESCRIPTION
## Summary

Added reference to the Grafana dashboard loading script in the flow control documentation to help users set up observability for flow control metrics.

## Changes

- **flow-control.md**: Added reference to the dashboard loading script and monitoring README in the Metrics & Observability section

## Related

- Monitoring setup documentation improvements suggested in PR #1542