### PR TITLE
fix: use explicit exception type in lint-dockerfile-envvars.py

### DIFF
--- a/scripts/lint-dockerfile-envvars.py
+++ b/scripts/lint-dockerfile-envvars.py
@@ -13,7 +13,7 @@ def parse_script_requirements(script_path: Path) -> Set[str]:
     """extract required env vars from script header block"""
     try:
         content = script_path.read_text()
-    except:
+    except Exception:
         return set()
 
     pattern = r'^#\s+-\s+([A-Z_][A-Z0-9_]*):.*$'


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in `parse_script_requirements()` to avoid silently catching `SystemExit` and `KeyboardInterrupt`