### PR TITLE
fix(e2e-xpu): pin router chart to v0, not GAIE_VERSION

### DIFF
--- a/.github/workflows/e2e-optimized-baseline-xpu.yaml
+++ b/.github/workflows/e2e-optimized-baseline-xpu.yaml
@@ -34,6 +34,7 @@ jobs:
     env:
       NAMESPACE: "llm-d-xpu-is"
       GAIE_VERSION: "v1.5.0"
+      ROUTER_CHART_VERSION: "v0"
       GUIDE_NAME: "optimized-baseline"
       SCHEDULER_RELEASE_NAME: "optimized-baseline"
 
@@ -124,7 +125,7 @@ jobs:
             -f guides/recipes/router/features/monitoring.values.yaml \
             -f guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
             -n "${NAMESPACE}" \
-            --version "${GAIE_VERSION}" \
+            --version "${ROUTER_CHART_VERSION}" \
             | tee ~/optimized-baseline-xpu-deployment.log
 
       - name: Deploy model server via kustomize

--- a/.github/workflows/e2e-pd-xpu.yaml
+++ b/.github/workflows/e2e-pd-xpu.yaml
@@ -34,6 +34,7 @@ jobs:
     env:
       NAMESPACE: "llm-d-xpu-pd"
       GAIE_VERSION: "v1.5.0"
+      ROUTER_CHART_VERSION: "v0"
       GUIDE_NAME: "pd-disaggregation"
       SCHEDULER_RELEASE_NAME: "pd-disaggregation"
 
@@ -123,7 +124,7 @@ jobs:
             -f guides/recipes/router/base.values.yaml \
             -f guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
             -n "${NAMESPACE}" \
-            --version "${GAIE_VERSION}" \
+            --version "${ROUTER_CHART_VERSION}" \
             | tee ~/pd-xpu-deployment.log
 
       - name: Deploy model server via kustomize

--- a/.github/workflows/e2e-prefix-cache-xpu.yaml
+++ b/.github/workflows/e2e-prefix-cache-xpu.yaml
@@ -2,17 +2,19 @@ name: XPU Precise Prefix Cache Test
 
 # Migrates the old helmfile-based XPU precise-prefix-cache test to the
 # kustomize + helm-standalone layout introduced by PR #1258. Mirrors the
-# e2e-optimized-baseline-xpu.yaml workflow (PR #1251), with two precise-prefix
-# specific additions:
+# e2e-optimized-baseline-xpu.yaml workflow (PR #1251), with one precise-prefix
+# specific addition:
 #
-# 1. The UDS tokenizer sidecar is grafted onto the scheduler pod via a helm
-#    post-renderer (guides/precise-prefix-cache-routing/router/patches/uds-tokenizer/).
-# 2. Before `helm install`, sed-rewrite Qwen/Qwen3-32B -> Qwen/Qwen3-0.6B in the
-#    shared scheduler values file so the tokenizer plugin and the scorer's
-#    tokenizersPoolConfig match what the XPU overlay deploys. The shared file
-#    ships the Qwen/Qwen3-32B nvidia-gpu default; this coupling is load-bearing
-#    — a mismatch silently collapses prefix-cache scores to 0. Matches the
-#    operator-facing NOTE in guides/precise-prefix-cache-routing/README.md.
+# Before `helm install`, sed-rewrite Qwen/Qwen3-32B -> Qwen/Qwen3-0.6B in the
+# shared scheduler values file so the tokenizer plugin and the scorer's
+# tokenizersPoolConfig match what the XPU overlay deploys. The shared file
+# ships the Qwen/Qwen3-32B nvidia-gpu default; this coupling is load-bearing
+# — a mismatch silently collapses prefix-cache scores to 0. Matches the
+# operator-facing NOTE in guides/precise-prefix-cache-routing/README.md.
+#
+# The UDS tokenizer is now enabled via the chart's `router.tokenizer.enabled`
+# field (set in the guide values file), replacing the old post-renderer hack
+# removed in #1607.
 
 on:
   schedule:
@@ -49,6 +51,7 @@ jobs:
     env:
       NAMESPACE: "llm-d-xpu-pc"
       GAIE_VERSION: "v1.5.0"
+      ROUTER_CHART_VERSION: "v0"
       GUIDE_NAME: "precise-prefix-cache-routing"
       SCHEDULER_RELEASE_NAME: "precise-prefix-cache-routing"
       ACCEL: "xpu"
@@ -147,16 +150,15 @@ jobs:
           echo "After:"
           grep -nE 'modelName:' "${VALUES_FILE}"
 
-      - name: Deploy scheduler via helm (standalone + UDS post-renderer)
+      - name: Deploy scheduler via helm (standalone)
         run: |
           echo "Installing precise-prefix-cache-routing scheduler (standalone chart) via helm..."
           helm install "${SCHEDULER_RELEASE_NAME}" \
             oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev \
             -f guides/recipes/router/base.values.yaml \
             -f guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
-            --post-renderer ./guides/${GUIDE_NAME}/router/patches/uds-tokenizer/post-renderer.sh \
             -n "${NAMESPACE}" \
-            --version "${GAIE_VERSION}" \
+            --version "${ROUTER_CHART_VERSION}" \
             | tee ~/prefix-cache-xpu-deployment.log
 
       - name: Deploy model server via kustomize


### PR DESCRIPTION
## Summary

The XPU e2e workflows migrated to the new `llm-d-router-standalone-dev` chart in [#1607](https://github.com/llm-d/llm-d/pull/1607) but still passed `--version ${GAIE_VERSION}` (v1.5.0) to `helm install`. That chart only publishes `v0`, so every run fails at the deploy step with:

```
Error: INSTALLATION FAILED: ghcr.io/llm-d/charts/llm-d-router-standalone-dev:v1.5.0: not found
```

(e.g. [run 26633694208](https://github.com/llm-d/llm-d/actions/runs/26633694208/job/78488520241)). `GAIE_VERSION` is still correct for the Gateway API Inference Extension CRD apply — only the helm chart version was wrong.

Fix, mirroring the GKE/CKS callers' `ROUTER_CHART_VERSION` pattern:
- Add a `ROUTER_CHART_VERSION: "v0"` env var and use it for `--version`.
- For `e2e-prefix-cache-xpu`, also drop the `--post-renderer` flag — the referenced `guides/precise-prefix-cache-routing/router/patches/uds-tokenizer/post-renderer.sh` was deleted in #1607 when the UDS tokenizer moved into the chart's `router.tokenizer.enabled` field (already set in the guide values file).

Affects `e2e-optimized-baseline-xpu`, `e2e-pd-xpu`, `e2e-prefix-cache-xpu`. (`e2e-*-hpu` are still helmfile-based and unaffected; the `nightly-e2e-*-xpu` workflows delegate to the llm-d-infra reusable, which is fixed separately in [#182](https://github.com/llm-d/llm-d-infra/pull/182).)

## Test plan

Verified end-to-end on a self-hosted XPU runner (Intel Arc Pro B60) against `xiaojun-zhang/llm-d`:

| Workflow | Run | Duration |
|---|---|---|
| `e2e-optimized-baseline-xpu` | [26654341360](https://github.com/xiaojun-zhang/llm-d/actions/runs/26654341360) | 4m8s ✅ |
| `e2e-pd-xpu`                  | [26654553650](https://github.com/xiaojun-zhang/llm-d/actions/runs/26654553650) | 4m14s ✅ |
| `e2e-prefix-cache-xpu`       | [26654772205](https://github.com/xiaojun-zhang/llm-d/actions/runs/26654772205) | 4m10s ✅ |

- [x] `helm install` succeeds against `llm-d-router-standalone-dev@v0`.
- [x] precise-prefix-cache deploys without the post-renderer (chart injects the UDS tokenizer sidecar via `router.tokenizer.enabled`).
- [x] All three pass the inference smoke test.

> Note: the pd run scaled `prefill` 3 → 2 replicas on the test branch to fit the test host's free XPU cards; that change is **not** in this PR.
