### PR TITLE
cicd: start the migrations for nightly e2e to nightly benchmark

### DIFF
--- a/.github/workflows/nightly-e2e-optimized-baseline-cks.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-cks.yaml
@@ -1,25 +1,109 @@
-name: Nightly - optimized baseline E2E (CKS)
-
-# Nightly regression test for the optimized-baseline guide on CoreWeave (CKS).
-# Deploys the guide and validates with e2e-validate.sh.
+name: Nightly - Optimized Baseline E2E (CKS GPU)
 
 on:
-  schedule:
-    - cron: '0 6 * * *'  # 06:00 UTC daily (staggered from OCP/GKE nightlies)
   workflow_dispatch:
     inputs:
-      skip_cleanup:
-        description: 'Skip cleanup after tests (for debugging)'
+      scenario_dir:
+        description: 'Directory housing the scenarios'
+        required: false
+        default: 'guides'
+      standup_method:
+        description: 'Standup method to be used ("standalone","fma","modelservice")'
+        required: false
+        default: 'kustomize'
+      standup_scenario:
+        description: 'Guide name'
+        required: false
+        default: 'optimized-baseline'
+      decode_pods:
+        description: 'Number of decode (vllm "standalone") pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      prefill_pods:
+        description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      accelerator_type:
+        description: 'Type of accelerator (gpu, cpu, sim, amd, xpu, hpu, tpu-v6, tpu-v7) (ONLY VALID FOR "kustomize" standyp method)'
+        required: false
+        type: 'string'
+        default: 'gpu'
+      backend_type:
+        description: 'Type of backend (vllm, sglang) (ONLY VALID FOR "kustomize" standyp method)'
+        required: false
+        type: 'string'
+        default: 'vllm'
+      infra_provider:
+        description: 'Target cloud provider (ONLY VALID FOR "kustomize" standyp method)'
+        required: false
+        type: 'string'
+        default: 'base'
+      connector:
+        description: 'Accelerator offloading connector (ONLY VALID FOR "kustomize" standyp method)'
+        required: false
+        type: 'string'
+        default: ''
+      cluster_namespace:
+        description: 'Cluster namespace'
+        required: false
+        default: 'llm-d-nightly-inference-cks-gpu'
+      helm_release:
+        description: 'Helm release name (for modelservice)'
+        required: false
+        default: 'llmdbenchcicdr-cks'
+      workspace_dir:
+        description: 'Workspace directory'
+        required: false
+        default: '/tmp/llmdbenchcicdk'
+      bucket_project:
+        description: 'Project associated to the object storage bucket'
+        required: false
+        default: 'llm-d-scale'
+      bucket_provider:
+        description: 'Type (provider of) the bucket'
+        required: false
+        default: 'gcs'
+      bucket_path:
+        description: 'Path to object storage bucket'
+        required: false
+        default: 'llm-d-benchmarks/regressions/optimized-baseline'
+      gateway_class:
+        description: 'Class of gateway used ("istio", "agentgateway", "epponly" (i.e., "standalone"), "none")'
+        required: false
+        default: 'epponly'
+      monitoring_enabled:
+        description: 'Enabled monitoring ("true", "false")'
+        required: true
+        type: 'string'
+        default: 'false'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode ("true", "false")'
         required: false
         default: 'false'
-      pr_number:
-        description: 'PR number for comment-back (set by /test-nightly)'
+      verbose:
+        description: 'Execute workflow in "verbose" mode ("true", "false")'
         required: false
-        default: ''
-      pr_repo:
-        description: 'Repo for PR comment-back'
+        default: 'false'
+        type: 'string'
+      harness:
+        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
         required: false
-        default: 'llm-d/llm-d'
+        default: 'inference-perf'
+        type: 'string'
+      workload:
+        description: 'Workload profile to be used during "run" operation (check list under "workload/profiles")'
+        required: false
+        default: 'guide_optimized-baseline_1.yaml'
+        type: 'string'
+
+#  push:
+#    branches:
+#      - main
+
+  schedule:
+    - cron: '0 10 * * *'  # 10:00 UTC daily (staggered from OCP nightlies)
 
 permissions:
   contents: read
@@ -30,31 +114,27 @@ concurrency:
 
 jobs:
   nightly:
-    if: github.repository == 'llm-d/llm-d'
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-cks.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
-      guide_name: optimized-baseline
-      namespace: llm-d-nightly-inference-cks
-      gateway_host: 'optimized-baseline-epp'
-      custom_deploy_script: |
-        export GAIE_VERSION=v1.5.0
-        export ROUTER_CHART_VERSION=v0
-        export GUIDE_NAME="optimized-baseline"
-        export INFRA_PROVIDER="base"
-        kubectl apply -n ${NAMESPACE} -k guides/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}
-        helm install ${GUIDE_NAME} \
-          oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev \
-          -f guides/recipes/router/base.values.yaml \
-          -f guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
-          -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
-      accelerator_type: H100
-      required_gpus: 2
-      recommended_gpus: 4
-      pod_wait_timeout: '30m'
-      pod_readiness_delay: 180
-      image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
-      allow_gpu_preemption: true
-      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
-      pr_number: ${{ github.event.inputs.pr_number }}
-      pr_repo: ${{ github.event.inputs.pr_repo }}
+      scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
+      standup_method: ${{ inputs.standup_method || 'kustomize' }}
+      standup_scenario: ${{ inputs.standup_scenario || 'optimized-baseline' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'gpu' }}
+      backend_type: ${{ inputs.backend_type || 'vllm' }}
+      infra_provider: ${{ inputs.infra_provider || 'base' }}
+      connector: ${{ inputs.connector || '' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-inference-cks-gpu' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-cks' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicds-cks' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions/optimized-baseline' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'guide_optimized-baseline_1.yaml' }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-optimized-baseline-gke-tpu.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-gke-tpu.yaml
@@ -123,7 +123,7 @@ jobs:
       prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
       accelerator_type: ${{ inputs.accelerator_type || 'tpu-v6' }}
       backend_type: ${{ inputs.backend_type || 'vllm' }}
-      infra_provider: ${{ inputs.infra_provider || 'gke' }}
+      infra_provider: ${{ inputs.infra_provider || '' }}
       connector: ${{ inputs.connector || '' }}
       cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-inference-gke-tpu' }}
       helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-gke' }}

--- a/.github/workflows/nightly-e2e-optimized-baseline-gke-tpu.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-gke-tpu.yaml
@@ -1,61 +1,140 @@
 name: Nightly - Optimized Baseline E2E (GKE TPU)
 
-# Nightly regression test for the optimized-baseline guide on GKE with TPU accelerators.
-# Deploys the tpu-v6 modelserver kustomization and validates with e2e-validate.sh.
-# Tracks issue: https://github.com/llm-d/llm-d/issues/1471
-
 on:
-  schedule:
-    - cron: '0 2 * * *'  # 02:00 UTC daily (staggered from GPU nightlies)
   workflow_dispatch:
     inputs:
-      skip_cleanup:
-        description: 'Skip cleanup after tests (for debugging)'
+      scenario_dir:
+        description: 'Directory housing the scenarios'
+        required: false
+        default: 'guides'
+      standup_method:
+        description: 'Standup method to be used ("standalone","fma","modelservice")'
+        required: false
+        default: 'kustomize'
+      standup_scenario:
+        description: 'Guide name'
+        required: false
+        default: 'optimized-baseline'
+      decode_pods:
+        description: 'Number of decode (vllm "standalone") pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      prefill_pods:
+        description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      accelerator_type:
+        description: 'Type of accelerator (gpu, cpu, sim, amd, xpu, hpu, tpu-v6, tpu-v7) (ONLY VALID FOR "kustomize" standyp method)'
+        required: false
+        type: 'string'
+        default: 'tpu-v6'
+      backend_type:
+        description: 'Type of backend (vllm, sglang) (ONLY VALID FOR "kustomize" standyp method)'
+        required: false
+        type: 'string'
+        default: 'vllm'
+      infra_provider:
+        description: 'Target cloud provider (ONLY VALID FOR "kustomize" standyp method)'
+        required: false
+        type: 'string'
+        default: ''
+      connector:
+        description: 'Accelerator offloading connector (ONLY VALID FOR "kustomize" standyp method)'
+        required: false
+        type: 'string'
+        default: ''
+      cluster_namespace:
+        description: 'Cluster namespace'
+        required: false
+        default: 'llm-d-nightly-inference-gke-tpu'
+      helm_release:
+        description: 'Helm release name (for modelservice)'
+        required: false
+        default: 'llmdbenchcicdr-gke'
+      workspace_dir:
+        description: 'Workspace directory'
+        required: false
+        default: '/tmp/llmdbenchcicdk'
+      bucket_project:
+        description: 'Project associated to the object storage bucket'
+        required: false
+        default: 'llm-d-scale'
+      bucket_provider:
+        description: 'Type (provider of) the bucket'
+        required: false
+        default: 'gcs'
+      bucket_path:
+        description: 'Path to object storage bucket'
+        required: false
+        default: 'llm-d-benchmarks/regressions/optimized-baseline'
+      gateway_class:
+        description: 'Class of gateway used ("istio", "agentgateway", "epponly" (i.e., "standalone"), "none")'
+        required: false
+        default: 'epponly'
+      monitoring_enabled:
+        description: 'Enabled monitoring ("true", "false")'
+        required: true
+        type: 'string'
+        default: 'false'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode ("true", "false")'
         required: false
         default: 'false'
-      pr_number:
-        description: 'PR number for comment-back (set by /test-nightly)'
+      verbose:
+        description: 'Execute workflow in "verbose" mode ("true", "false")'
         required: false
-        default: ''
-      pr_repo:
-        description: 'Repo for PR comment-back'
+        default: 'false'
+        type: 'string'
+      harness:
+        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
         required: false
-        default: 'llm-d/llm-d'
+        default: 'inference-perf'
+        type: 'string'
+      workload:
+        description: 'Workload profile to be used during "run" operation (check list under "workload/profiles")'
+        required: false
+        default: 'guide_optimized-baseline_1.yaml'
+        type: 'string'
+
+#  push:
+#    branches:
+#      - main
+
+  schedule:
+    - cron: '0 10 * * *'  # 10:00 UTC daily (staggered from OCP nightlies)
 
 permissions:
   contents: read
 
 concurrency:
-  group: nightly-e2e-optimized-baseline-gke-tpu
+  group: nightly-e2e-optimized-baseline-gke
   cancel-in-progress: true
 
 jobs:
   nightly:
-    if: github.repository == 'llm-d/llm-d'
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke-tpu.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
-      guide_name: optimized-baseline
-      namespace: llm-d-nightly-inference-gke-tpu
-      gateway_host: 'optimized-baseline-epp'
-      tpu_type: v6e-8
-      required_tpu_chips: 8
-      recommended_tpu_chips: 8
-      custom_deploy_script: |
-        export GAIE_VERSION=v1.5.0
-        export ROUTER_CHART_VERSION=v0
-        export GUIDE_NAME="optimized-baseline"
-        kubectl apply -n ${NAMESPACE} -k guides/${GUIDE_NAME}/modelserver/tpu-v6/vllm
-        helm install ${GUIDE_NAME} \
-          oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev \
-          -f guides/recipes/router/base.values.yaml \
-          -f guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
-          -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
-      gke_cluster_name: llm-d-e2e-us-east5
-      gke_cluster_zone: us-east5
-      pod_wait_timeout: '45m'
-      pod_readiness_delay: 300
-      llm_d_ref: ${{ github.ref }}
-      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
-      pr_number: ${{ github.event.inputs.pr_number }}
-      pr_repo: ${{ github.event.inputs.pr_repo }}
+      scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
+      standup_method: ${{ inputs.standup_method || 'kustomize' }}
+      standup_scenario: ${{ inputs.standup_scenario || 'optimized-baseline' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'tpu-v6' }}
+      backend_type: ${{ inputs.backend_type || 'vllm' }}
+      infra_provider: ${{ inputs.infra_provider || 'gke' }}
+      connector: ${{ inputs.connector || '' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-inference-gke-tpu' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-gke' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicds-gke' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions/optimized-baseline' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'guide_optimized-baseline_1.yaml' }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-optimized-baseline-ocp.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-ocp.yaml
@@ -1,70 +1,140 @@
-name: Nightly - optimized baseline E2E (OpenShift)
-
-# Nightly regression test for the optimized-baseline guide on OpenShift.
-# Deploys via helmfile and validates with e2e-validate.sh.
+name: Nightly - Optimized Baseline E2E (OCP GPU)
 
 on:
-  schedule:
-    - cron: '0 0 * * *'  # Midnight UTC daily
   workflow_dispatch:
     inputs:
-      helmfile_env:
-        description: 'Helmfile environment'
+      scenario_dir:
+        description: 'Directory housing the scenarios'
         required: false
-        default: 'istio'
-        type: choice
-        options:
-          - istio
-          - kgateway
-      skip_cleanup:
-        description: 'Skip cleanup after tests (for debugging)'
+        default: 'guides'
+      standup_method:
+        description: 'Standup method to be used ("standalone","fma","modelservice")'
+        required: false
+        default: 'kustomize'
+      standup_scenario:
+        description: 'Guide name'
+        required: false
+        default: 'optimized-baseline'
+      decode_pods:
+        description: 'Number of decode (vllm "standalone") pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      prefill_pods:
+        description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      accelerator_type:
+        description: 'Type of accelerator (gpu, cpu, sim, amd, xpu, hpu, tpu-v6, tpu-v7) (ONLY VALID FOR "kustomize" standyp method)'
+        required: false
+        type: 'string'
+        default: 'gpu'
+      backend_type:
+        description: 'Type of backend (vllm, sglang) (ONLY VALID FOR "kustomize" standyp method)'
+        required: false
+        type: 'string'
+        default: 'vllm'
+      infra_provider:
+        description: 'Target cloud provider (ONLY VALID FOR "kustomize" standyp method)'
+        required: false
+        type: 'string'
+        default: 'base'
+      connector:
+        description: 'Accelerator offloading connector (ONLY VALID FOR "kustomize" standyp method)'
+        required: false
+        type: 'string'
+        default: ''
+      cluster_namespace:
+        description: 'Cluster namespace'
+        required: false
+        default: 'llm-d-nightly-inference-ocp-gpu'
+      helm_release:
+        description: 'Helm release name (for modelservice)'
+        required: false
+        default: 'llmdbenchcicdr-ocp'
+      workspace_dir:
+        description: 'Workspace directory'
+        required: false
+        default: '/tmp/llmdbenchcicdk'
+      bucket_project:
+        description: 'Project associated to the object storage bucket'
+        required: false
+        default: 'llm-d-scale'
+      bucket_provider:
+        description: 'Type (provider of) the bucket'
+        required: false
+        default: 'gcs'
+      bucket_path:
+        description: 'Path to object storage bucket'
+        required: false
+        default: 'llm-d-benchmarks/regressions/optimized-baseline'
+      gateway_class:
+        description: 'Class of gateway used ("istio", "agentgateway", "epponly" (i.e., "standalone"), "none")'
+        required: false
+        default: 'epponly'
+      monitoring_enabled:
+        description: 'Enabled monitoring ("true", "false")'
+        required: true
+        type: 'string'
+        default: 'false'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode ("true", "false")'
         required: false
         default: 'false'
-      pr_number:
-        description: 'PR number for comment-back (set by /test-nightly)'
+      verbose:
+        description: 'Execute workflow in "verbose" mode ("true", "false")'
         required: false
-        default: ''
-      pr_repo:
-        description: 'Repo for PR comment-back'
+        default: 'false'
+        type: 'string'
+      harness:
+        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
         required: false
-        default: 'llm-d/llm-d'
+        default: 'inference-perf'
+        type: 'string'
+      workload:
+        description: 'Workload profile to be used during "run" operation (check list under "workload/profiles")'
+        required: false
+        default: 'guide_optimized-baseline_1.yaml'
+        type: 'string'
+
+#  push:
+#    branches:
+#      - main
+
+  schedule:
+    - cron: '0 10 * * *'  # 10:00 UTC daily (staggered from OCP nightlies)
 
 permissions:
   contents: read
 
 concurrency:
-  group: nightly-e2e-optimized-baseline
+  group: nightly-e2e-optimized-baseline-ocp
   cancel-in-progress: true
 
 jobs:
   nightly:
-    if: github.repository == 'llm-d/llm-d'
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
-      guide_name: optimized-baseline
-      namespace: llm-d-nightly-inference-ocp
-      gateway_host: 'optimized-baseline-epp'
-      custom_deploy_script: |
-        export GAIE_VERSION=v1.5.0
-        export ROUTER_CHART_VERSION=v0
-        export GUIDE_NAME="optimized-baseline"
-        export INFRA_PROVIDER="base"
-        yq '.spec.template.spec.priorityClassName="nightly-gpu-critical"' -i guides/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}/patch-vllm.yaml
-        yq '.spec.replicas=2' -i guides/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}/patch-vllm.yaml
-        kubectl apply -k guides/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER} -n ${NAMESPACE}
-        helm install ${GUIDE_NAME} \
-          oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev \
-          -f guides/recipes/router/base.values.yaml \
-          -f guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
-          -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
-      accelerator_type: H100
-      required_gpus: 2
-      recommended_gpus: 4
-      pod_wait_timeout: '30m'
-      pod_readiness_delay: 180
-      image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
-      allow_gpu_preemption: true
-      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
-      pr_number: ${{ github.event.inputs.pr_number }}
-      pr_repo: ${{ github.event.inputs.pr_repo }}
+      scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
+      standup_method: ${{ inputs.standup_method || 'kustomize' }}
+      standup_scenario: ${{ inputs.standup_scenario || 'optimized-baseline' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'gpu' }}
+      backend_type: ${{ inputs.backend_type || 'vllm' }}
+      infra_provider: ${{ inputs.infra_provider || 'base' }}
+      connector: ${{ inputs.connector || '' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-inference-ocp-gpu' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-ocp' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicds-ocp' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions/optimized-baseline' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'guide_optimized-baseline_1.yaml' }}
     secrets: inherit

--- a/.github/workflows/nightly-e2e-optimized-baseline-rocm.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-rocm.yaml
@@ -1,4 +1,4 @@
-name: Nightly - Optimized Baseline E2E (GKE GPU)
+name: Nightly - Optimized Baseline E2E (AMD ROCM)
 
 on:
   workflow_dispatch:
@@ -29,7 +29,7 @@ on:
         description: 'Type of accelerator (gpu, cpu, sim, amd, xpu, hpu, tpu-v6, tpu-v7) (ONLY VALID FOR "kustomize" standyp method)'
         required: false
         type: 'string'
-        default: 'gpu'
+        default: 'amd'
       backend_type:
         description: 'Type of backend (vllm, sglang) (ONLY VALID FOR "kustomize" standyp method)'
         required: false
@@ -39,7 +39,7 @@ on:
         description: 'Target cloud provider (ONLY VALID FOR "kustomize" standyp method)'
         required: false
         type: 'string'
-        default: 'gke'
+        default: ''
       connector:
         description: 'Accelerator offloading connector (ONLY VALID FOR "kustomize" standyp method)'
         required: false
@@ -48,11 +48,11 @@ on:
       cluster_namespace:
         description: 'Cluster namespace'
         required: false
-        default: 'llm-d-nightly-inference-gke-gpu'
+        default: 'llm-d-nightly-inference-rocm-gpu'
       helm_release:
         description: 'Helm release name (for modelservice)'
         required: false
-        default: 'llmdbenchcicdr-gke'
+        default: 'llmdbenchcicdr-rocm'
       workspace_dir:
         description: 'Workspace directory'
         required: false
@@ -109,7 +109,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: nightly-e2e-optimized-baseline-gke
+  group: nightly-e2e-optimized-baseline-rocm
   cancel-in-progress: true
 
 jobs:
@@ -121,13 +121,13 @@ jobs:
       standup_scenario: ${{ inputs.standup_scenario || 'optimized-baseline' }}
       decode_pods: ${{ inputs.decode_pods || 'auto' }}
       prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
-      accelerator_type: ${{ inputs.accelerator_type || 'gpu' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'amd' }}
       backend_type: ${{ inputs.backend_type || 'vllm' }}
-      infra_provider: ${{ inputs.infra_provider || 'gke' }}
+      infra_provider: ${{ inputs.infra_provider || '' }}
       connector: ${{ inputs.connector || '' }}
-      cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-inference-gke-gpu' }}
-      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-gke' }}
-      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicds-gke' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-inference-rocm-gpu' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-rocm' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicds-rocm' }}
       bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
       bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
       bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions/optimized-baseline' }}


### PR DESCRIPTION
Starting with `optimized-baseline`