### PR TITLE
fix(ci): decouple router chart version from GAIE_VERSION

### DIFF
--- a/.github/workflows/e2e-optimized-baseline-hpu.yaml
+++ b/.github/workflows/e2e-optimized-baseline-hpu.yaml
@@ -34,6 +34,7 @@ jobs:
     env:
       NAMESPACE: "llm-d-hpu-is"
       GAIE_VERSION: "v1.5.0"
+      ROUTER_CHART_VERSION: "v0"
       GUIDE_NAME: "optimized-baseline"
       SCHEDULER_RELEASE_NAME: "optimized-baseline"
 
@@ -124,7 +125,7 @@ jobs:
             -f guides/recipes/router/features/monitoring.values.yaml \
             -f guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
             -n "${NAMESPACE}" \
-            --version "${GAIE_VERSION}" \
+            --version "${ROUTER_CHART_VERSION}" \
             | tee ~/optimized-baseline-hpu-deployment.log
 
       - name: Deploy model server via kustomize

--- a/.github/workflows/e2e-optimized-baseline-xpu.yaml
+++ b/.github/workflows/e2e-optimized-baseline-xpu.yaml
@@ -34,6 +34,7 @@ jobs:
     env:
       NAMESPACE: "llm-d-xpu-is"
       GAIE_VERSION: "v1.5.0"
+      ROUTER_CHART_VERSION: "v0"
       GUIDE_NAME: "optimized-baseline"
       SCHEDULER_RELEASE_NAME: "optimized-baseline"
 
@@ -124,7 +125,7 @@ jobs:
             -f guides/recipes/router/features/monitoring.values.yaml \
             -f guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
             -n "${NAMESPACE}" \
-            --version "${GAIE_VERSION}" \
+            --version "${ROUTER_CHART_VERSION}" \
             | tee ~/optimized-baseline-xpu-deployment.log
 
       - name: Deploy model server via kustomize

--- a/.github/workflows/e2e-pd-xpu.yaml
+++ b/.github/workflows/e2e-pd-xpu.yaml
@@ -34,6 +34,7 @@ jobs:
     env:
       NAMESPACE: "llm-d-xpu-pd"
       GAIE_VERSION: "v1.5.0"
+      ROUTER_CHART_VERSION: "v0"
       GUIDE_NAME: "pd-disaggregation"
       SCHEDULER_RELEASE_NAME: "pd-disaggregation"
 
@@ -123,7 +124,7 @@ jobs:
             -f guides/recipes/router/base.values.yaml \
             -f guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
             -n "${NAMESPACE}" \
-            --version "${GAIE_VERSION}" \
+            --version "${ROUTER_CHART_VERSION}" \
             | tee ~/pd-xpu-deployment.log
 
       - name: Deploy model server via kustomize

--- a/.github/workflows/e2e-prefix-cache-xpu.yaml
+++ b/.github/workflows/e2e-prefix-cache-xpu.yaml
@@ -49,6 +49,7 @@ jobs:
     env:
       NAMESPACE: "llm-d-xpu-pc"
       GAIE_VERSION: "v1.5.0"
+      ROUTER_CHART_VERSION: "v0"
       GUIDE_NAME: "precise-prefix-cache-routing"
       SCHEDULER_RELEASE_NAME: "precise-prefix-cache-routing"
       ACCEL: "xpu"
@@ -156,7 +157,7 @@ jobs:
             -f guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
             --post-renderer ./guides/${GUIDE_NAME}/router/patches/uds-tokenizer/post-renderer.sh \
             -n "${NAMESPACE}" \
-            --version "${GAIE_VERSION}" \
+            --version "${ROUTER_CHART_VERSION}" \
             | tee ~/prefix-cache-xpu-deployment.log
 
       - name: Deploy model server via kustomize


### PR DESCRIPTION

The 4 XPU/HPU e2e workflows reuse GAIE_VERSION (v1.5.0) for both the Gateway API Inference Extension CRD installation and the helm install --version flag for llm-d-router-standalone-dev. 

These are different artifacts with independent versioning: GAIE CRDs follow upstream kubernetes-sigs/gateway-api-inference-extension tags, while the router chart uses its own semver (currently v0 series).

Passing GAIE_VERSION=v1.5.0 as the chart version causes helm to look for a non-existent chart version, failing the 'Deploy scheduler via helm' step in all 4 workflows.

Add ROUTER_CHART_VERSION=v0 to each job's env block and use it for helm install --version, matching the pattern already used by all nightly e2e workflows. GAIE_VERSION remains for CRD installation.

