### PR TITLE
fix(flow-control): migrate InferenceObjective to llm-d.ai/v1alpha2 API group

### DIFF
--- a/guides/flow-control/README.md
+++ b/guides/flow-control/README.md
@@ -83,10 +83,11 @@ Flow Control is a software-level scheduling feature at the EPP layer and is enti
   export MODEL_NAME="Qwen/Qwen3-32B"
   ```
 
-* Install the Gateway API Inference Extension CRDs:
+* Install the required CRDs (GAIE InferencePool + llm-d.ai InferenceObjective):
 
   ```bash
-  kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
+  kubectl apply -k "https://github.com/llm-d/llm-d-router/config/crd?ref=${ROUTER_CHART_VERSION}"
   ```
 
 * Create a target namespace for the installation:

--- a/guides/flow-control/objectives.yaml
+++ b/guides/flow-control/objectives.yaml
@@ -1,4 +1,4 @@
-apiVersion: inference.networking.x-k8s.io/v1alpha2
+apiVersion: llm-d.ai/v1alpha2
 kind: InferenceObjective
 metadata:
   name: premium-traffic
@@ -11,7 +11,7 @@ spec:
   poolRef:
     name: default-pool
 ---
-apiVersion: inference.networking.x-k8s.io/v1alpha2
+apiVersion: llm-d.ai/v1alpha2
 kind: InferenceObjective
 metadata:
   name: standard-traffic
@@ -24,7 +24,7 @@ spec:
   poolRef:
     name: default-pool
 ---
-apiVersion: inference.networking.x-k8s.io/v1alpha2
+apiVersion: llm-d.ai/v1alpha2
 kind: InferenceObjective
 metadata:
   name: best-effort-traffic


### PR DESCRIPTION
- `guides/flow-control/objectives.yaml`: update `apiVersion` for all three `InferenceObjective` objects from `inference.networking.x-k8s.io/v1alpha2` to `llm-d.ai/v1alpha2`
- `guides/flow-control/README.md`: update the CRD install command to use `llm-d-router/config/crd` instead of the upstream GAIE repo