### PR TITLE
fix: use llm-d.ai/engine-type for pod label

### DIFF
--- a/docs/architecture/core/model-servers.md
+++ b/docs/architecture/core/model-servers.md
@@ -48,7 +48,7 @@ To correctly map metrics names, model server Pods should be labeled with the mod
 ```yaml
 metadata:
   labels:
-    inference.networking.k8s.io/engine-type: vllm # other options: sglang, trtllm-serve, triton-tensorrt-llm
+    llm-d.ai/engine-type: vllm # other options: sglang, trtllm-serve, triton-tensorrt-llm
 
 ```
 

--- a/guides/pd-disaggregation/modelserver/amd/vllm/base/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/vllm/base/kustomization.yaml
@@ -17,7 +17,7 @@ labels:
       llm-d.ai/guide: pd-disaggregation
       llm-d.ai/accelerator-variant: gpu
       llm-d.ai/accelerator-vendor: amd
-      inference.networking.k8s.io/engine-type: vllm
+      llm-d.ai/engine-type: vllm
     includeSelectors: true
     includeTemplates: true
     fields:

--- a/guides/pd-disaggregation/modelserver/gpu/sglang/base/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/sglang/base/kustomization.yaml
@@ -17,7 +17,7 @@ labels:
       llm-d.ai/guide: pd-disaggregation
       llm-d.ai/accelerator-variant: gpu
       llm-d.ai/accelerator-vendor: nvidia
-      inference.networking.k8s.io/engine-type: sglang
+      llm-d.ai/engine-type: sglang
     includeSelectors: true
     includeTemplates: true
     fields:

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/base/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/base/kustomization.yaml
@@ -17,7 +17,7 @@ labels:
       llm-d.ai/guide: pd-disaggregation
       llm-d.ai/accelerator-variant: gpu
       llm-d.ai/accelerator-vendor: nvidia
-      inference.networking.k8s.io/engine-type: vllm
+      llm-d.ai/engine-type: vllm
     includeSelectors: true
     includeTemplates: true
     fields:

--- a/guides/pd-disaggregation/modelserver/hpu/vllm/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/hpu/vllm/kustomization.yaml
@@ -21,7 +21,7 @@ labels:
       llm-d.ai/guide: pd-disaggregation
       llm-d.ai/accelerator-variant: hpu
       llm-d.ai/accelerator-vendor: intel
-      inference.networking.k8s.io/engine-type: vllm
+      llm-d.ai/engine-type: vllm
     includeSelectors: true
     includeTemplates: true
     fields:

--- a/guides/pd-disaggregation/modelserver/tpu/vllm/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/tpu/vllm/kustomization.yaml
@@ -17,7 +17,7 @@ labels:
       llm-d.ai/guide: pd-disaggregation
       llm-d.ai/accelerator-variant: tpu
       llm-d.ai/accelerator-vendor: google
-      inference.networking.k8s.io/engine-type: vllm
+      llm-d.ai/engine-type: vllm
     includeSelectors: true
     includeTemplates: true
     fields:

--- a/guides/pd-disaggregation/modelserver/xpu/vllm/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/xpu/vllm/kustomization.yaml
@@ -21,7 +21,7 @@ labels:
       llm-d.ai/guide: pd-disaggregation
       llm-d.ai/accelerator-variant: xpu
       llm-d.ai/accelerator-vendor: intel
-      inference.networking.k8s.io/engine-type: vllm
+      llm-d.ai/engine-type: vllm
     includeSelectors: true
     includeTemplates: true
     fields:


### PR DESCRIPTION
# Notes
 llm-d-router renamed the metric-mapping pod label `inference.networking.k8s.io/engine-type` to `llm-d.ai/engine-type` in https://github.com/llm-d/llm-d-router/pull/922 