### PR TITLE
feat: add guide for SGLang in precise-prefix-cache-routing

### DIFF
--- a/.github/workflows/ci-kustomize-dry-run.yaml
+++ b/.github/workflows/ci-kustomize-dry-run.yaml
@@ -304,30 +304,32 @@ jobs:
       - name: Kustomize build and dry-run all model server overlays
         run: |
           failed=0
-          for overlay_dir in guides/precise-prefix-cache-routing/modelserver/*/; do
-            for kust_dir in "${overlay_dir}"*/; do
-              [ -f "${kust_dir}kustomization.yaml" ] || continue
-              name="${kust_dir#guides/precise-prefix-cache-routing/modelserver/}"
-              name="${name%/}"
-              echo ""
-              echo "========================================"
-              echo "precise-prefix-cache-routing: ${name}"
-              echo "========================================"
-              echo "--- kustomize build ---"
-              if ! kustomize build "${kust_dir}" > /tmp/rendered.yaml; then
-                echo "FAIL: kustomize build failed for ${name}"
-                failed=1
-                continue
-              fi
-              echo "--- kubectl apply --dry-run=server ---"
-              if kubectl apply --dry-run=server -f /tmp/rendered.yaml; then
-                echo "PASS: precise-prefix-cache-routing / ${name}"
-              else
-                echo "FAIL: precise-prefix-cache-routing / ${name}"
-                failed=1
-              fi
-            done
-          done
+          base=guides/precise-prefix-cache-routing/modelserver
+          # Recurse to any depth: overlays nest unevenly (e.g. amd/vllm/ but
+          # gpu/vllm/base/, gpu/vllm/gke/, gpu/sglang/base/). Find every
+          # kustomization.yaml so each backend/server overlay is covered.
+          while IFS= read -r -d '' kustfile; do
+            kust_dir="${kustfile%kustomization.yaml}"
+            name="${kust_dir#"${base}"/}"
+            name="${name%/}"
+            echo ""
+            echo "========================================"
+            echo "precise-prefix-cache-routing: ${name}"
+            echo "========================================"
+            echo "--- kustomize build ---"
+            if ! kustomize build "${kust_dir}" > /tmp/rendered.yaml; then
+              echo "FAIL: kustomize build failed for ${name}"
+              failed=1
+              continue
+            fi
+            echo "--- kubectl apply --dry-run=server ---"
+            if kubectl apply --dry-run=server -f /tmp/rendered.yaml; then
+              echo "PASS: precise-prefix-cache-routing / ${name}"
+            else
+              echo "FAIL: precise-prefix-cache-routing / ${name}"
+              failed=1
+            fi
+          done < <(find "${base}" -name kustomization.yaml -print0 | sort -z)
           exit $failed
 
   dry-run-workload-autoscaling:

--- a/.github/workflows/ci-kustomize-dry-run.yaml
+++ b/.github/workflows/ci-kustomize-dry-run.yaml
@@ -306,7 +306,7 @@ jobs:
           failed=0
           base=guides/precise-prefix-cache-routing/modelserver
           # Recurse to any depth: overlays nest unevenly (e.g. amd/vllm/ but
-          # gpu/vllm/base/, gpu/vllm/gke/, gpu/sglang/base/). Find every
+          # gpu/vllm/base/, gpu/vllm/gke/, gpu/sglang/). Find every
           # kustomization.yaml so each backend/server overlay is covered.
           while IFS= read -r -d '' kustfile; do
             kust_dir="${kustfile%kustomization.yaml}"

--- a/guides/optimized-baseline/modelserver/amd/sglang/kustomization.yaml
+++ b/guides/optimized-baseline/modelserver/amd/sglang/kustomization.yaml
@@ -8,7 +8,7 @@ namePrefix: optimized-baseline-rocm-sglang-
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: docker.io/lmsysorg/sglang
-    newTag: v0.5.10.post1-rocm720-mi30x # TODO: bump version
+    newTag: v0.5.10.post1-rocm720-mi30x
 
 labels:
   - pairs:

--- a/guides/precise-prefix-cache-routing/README.md
+++ b/guides/precise-prefix-cache-routing/README.md
@@ -372,4 +372,29 @@ Output tokens/sec — higher is better; TTFT in seconds — lower is better.
 
 #### Comparing llm-d Scheduling to a Simple Kubernetes Service
 
-Benchmark comparing SGLang + precise-prefix-cache-routing against a plain Kubernetes Service (round-robin, no EPP) — coming soon.
+Benchmark run with the canonical shared-prefix workload from this guide, comparing the precise path against a plain Kubernetes Service (round-robin, no EPP, no scoring) across the same SGLang pods. llm-d Precise shows a large improvement over the k8s baseline — roughly 2× output throughput with TTFT held near constant while the baseline degrades sharply under load.
+
+<details>
+<summary><b><i>Click</i></b> to view the per-rate breakdown across the full ladder</summary>
+
+Output tokens/sec — higher is better; TTFT in seconds — lower is better.
+
+| Rate | k8s Output | llm-d Output | k8s TTFT mean | llm-d TTFT mean | k8s TTFT p90 | llm-d TTFT p90 |
+| ---: | ---------: | -----------: | ------------: | --------------: | -----------: | -------------: |
+|  3   | 1,752      | 1,690        | 0.629         | 0.213           | 1.014        | 0.243          |
+| 10   | 4,377      | 5,013        | 0.926         | 0.213           | 1.655        | 0.295          |
+| 15   | 4,528      | 6,983        | 3.593         | 0.202           | 5.630        | 0.323          |
+| 20   | 5,799      | 9,439        | 26.500        | 0.529           | 60.170       | 0.511          |
+| 22   | 4,803      | 9,671        | 29.185        | 1.050           | 63.806       | 0.567          |
+| 25   | 5,559      | 9,772        | 29.125        | 0.985           | 63.950       | 0.650          |
+| 30   | 4,967      | 9,976        | 34.295        | 0.759           | 73.831       | 0.573          |
+| 35   | 5,816      | 9,962        | 34.191        | 0.972           | 73.837       | 0.596          |
+| 40   | 5,548      | 11,964       | 84.999        | 15.505          | 152.473      | 44.448         |
+| 43   | 5,374      | 12,049       | 87.271        | 17.201          | 157.532      | 52.145         |
+| 46   | 5,374      | 11,989       | 87.138        | 19.652          | 156.928      | 56.452         |
+| 49   | 5,692      | 11,744       | 85.618        | 18.361          | 157.622      | 52.982         |
+| 52   | 5,326      | 11,933       | 87.259        | 20.287          | 160.448      | 56.957         |
+
+</details>
+
+> Benchmark contributed by @liu-cong.

--- a/guides/precise-prefix-cache-routing/README.md
+++ b/guides/precise-prefix-cache-routing/README.md
@@ -142,25 +142,10 @@ helm install ${GUIDE_NAME} \
 Apply the Kustomize overlay for your backend (defaulting to NVIDIA GPU / vLLM):
 
 ```bash
+export MODEL_SERVER=vllm # vllm | sglang
 export INFRA_PROVIDER=base # base | gke
-kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}/
+kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/gpu/${MODEL_SERVER}/${INFRA_PROVIDER}/
 ```
-
-To run the same model on **SGLang** instead of vLLM, apply the SGLang overlay (the
-router is unchanged; the overlay's `llm-d.ai/engine-type: sglang` pod label selects
-SGLang's metric names):
-
-```bash
-kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/gpu/sglang/
-```
-
-To verify that cache-aware routing is active, send a shared-prefix prompt longer than the value set for `--page-size` several times, then check the SGLang pod logs:
-
-```bash
-kubectl logs -n ${NAMESPACE} -l llm-d.ai/engine-type=sglang | grep cached-token
-```
-
-Subsequent requests sharing the same long prefix should show a non-zero `#cached-token` count on the pod the router has pinned them to, confirming the KV-cache index is working.
 
 ### 4. (Optional) Enable Monitoring
 

--- a/guides/precise-prefix-cache-routing/README.md
+++ b/guides/precise-prefix-cache-routing/README.md
@@ -29,6 +29,7 @@ Two scorers make up the routing decision alongside the load-aware stack:
 | Backend              | Directory                  | Default model                           | Notes                                                    |
 | -------------------- | -------------------------- | --------------------------------------- | -------------------------------------------------------- |
 | NVIDIA GPU           | `modelserver/gpu/vllm/`    | Qwen/Qwen3-32B                          | Default configuration                                    |
+| NVIDIA GPU (SGLang)  | `modelserver/gpu/sglang/`  | Qwen/Qwen3-32B                          | SGLang; `--page-size=64` matches scorer `blockSize`      |
 | AMD GPU              | `modelserver/amd/vllm/`    | Qwen/Qwen3-32B                          | AMD GPU                                                  |
 | Intel XPU            | `modelserver/xpu/vllm/`    | Qwen/Qwen3-0.6B                         | CI-sized; update router `modelName` for real use         |
 | Intel Gaudi (HPU)    | `modelserver/hpu/vllm/`    | Qwen/Qwen3-8B                           | `--block-size=128`; update scorer `blockSize` to match   |
@@ -111,6 +112,8 @@ helm install ${GUIDE_NAME} \
   -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
 ```
 
+The release name `${GUIDE_NAME}` is mandatory for standard deployments — the inference pool selector matches a guide label that pairs with this release.
+
 <details>
 <summary><b>Gateway Mode</b></summary>
 
@@ -142,6 +145,22 @@ Apply the Kustomize overlay for your backend (defaulting to NVIDIA GPU / vLLM):
 export INFRA_PROVIDER=base # base | gke
 kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}/
 ```
+
+To run the same model on **SGLang** instead of vLLM, apply the SGLang overlay (the
+router is unchanged; the overlay's `llm-d.ai/engine-type: sglang` pod label selects
+SGLang's metric names):
+
+```bash
+kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/gpu/sglang/
+```
+
+To verify that cache-aware routing is active, send a shared-prefix prompt longer than the value set for `--page-size` several times, then check the SGLang pod logs:
+
+```bash
+kubectl logs -n ${NAMESPACE} -l llm-d.ai/engine-type=sglang | grep cached-token
+```
+
+Subsequent requests sharing the same long prefix should show a non-zero `#cached-token` count on the pod the router has pinned them to, confirming the KV-cache index is working.
 
 ### 4. (Optional) Enable Monitoring
 
@@ -287,20 +306,25 @@ llmdbenchmark \
 
 ```bash
 helm uninstall ${GUIDE_NAME} -n ${NAMESPACE}
+# For vLLM (default):
 kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}/
+# For SGLang:
+kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/gpu/sglang/
 ```
 
 ## How It Works
 
-1. **vLLM pods publish KV-cache events** — each pod runs `vllm serve ... --kv-events-config '{...,"publisher":"zmq","endpoint":"$(KV_EVENTS_ENDPOINT)","topic":"kv@$(POD_IP):$(POD_PORT)@<model>"}'` with `KV_EVENTS_ENDPOINT=tcp://*:5556`, binding its own ZMQ socket. On every KV block allocation/eviction, vLLM emits a ZMQ message.
-2. **Router subscribes per pod** — pod-discovery (`kvEventsConfig.discoverPods: true`) registers the `precise-prefix-cache-producer` as an extractor on the data-layer `endpoint-notification-source`, so each router replica installs a ZMQ subscriber per vLLM pod independently. All replicas converge to the same index.
+1. **Model server pods publish KV-cache events** — each pod (vLLM or SGLang) runs with `--kv-events-config '{...,"publisher":"zmq","endpoint":"$(KV_EVENTS_ENDPOINT)","topic":"kv@$(POD_IP):$(POD_PORT)@<model>"}'` and `KV_EVENTS_ENDPOINT=tcp://*:5556`, binding its own ZMQ socket. On every KV block allocation/eviction, the server emits a ZMQ message.
+2. **Router subscribes per pod** — pod-discovery (`kvEventsConfig.discoverPods: true`) registers the `precise-prefix-cache-producer` as an extractor on the data-layer `endpoint-notification-source`, so each router replica installs a ZMQ subscriber per model server pod independently. All replicas converge to the same index.
 3. **Scoring** — the `prefix-cache-scorer` returns the fraction of the request's prefix blocks that are resident on each candidate pod. The `max-score-picker` routes to the highest-scoring pod.
 
 ## Benchmarking Report
 
+### vLLM
+
 The benchmark runs on 16× H100 GPUs, distributed across 8 model servers (2 H100s per server with TP=2).
 
-### Comparing llm-d Scheduling to a Simple Kubernetes Service
+#### Comparing llm-d Scheduling to a Simple Kubernetes Service
 
 Graphs below compare the precise path to a stock Kubernetes Service that round-robins requests across the same 8 vLLM pods (no EPP, no scoring).
 
@@ -343,3 +367,9 @@ Output tokens/sec — higher is better; TTFT in seconds — lower is better.
 | 60   | 6,551      | 15,733       | 75.586        | 0.214           | 138.663      | 0.300          |
 
 </details>
+
+### SGLang
+
+#### Comparing llm-d Scheduling to a Simple Kubernetes Service
+
+Benchmark comparing SGLang + precise-prefix-cache-routing against a plain Kubernetes Service (round-robin, no EPP) — coming soon.

--- a/guides/precise-prefix-cache-routing/modelserver/gpu/sglang/kustomization.yaml
+++ b/guides/precise-prefix-cache-routing/modelserver/gpu/sglang/kustomization.yaml
@@ -3,19 +3,20 @@ kind: Kustomization
 resources:
   - ../../../../recipes/modelserver/base/single-host/default
 
-namePrefix: optimized-baseline-rocm-sglang-
+namePrefix: precise-prefix-cache-routing-gpu-sglang-
 
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: docker.io/lmsysorg/sglang
-    newTag: v0.5.10.post1-rocm720-mi30x # TODO: bump version
+    newTag: v0.5.12.post1
 
 labels:
   - pairs:
-      llm-d.ai/guide: optimized-baseline
+      llm-d.ai/guide: precise-prefix-cache-routing
       llm-d.ai/model: Qwen3-32B
       llm-d.ai/accelerator-variant: gpu
-      llm-d.ai/accelerator-vendor: amd
+      llm-d.ai/accelerator-vendor: nvidia
+      llm-d.ai/engine-type: sglang
     includeSelectors: true
     includeTemplates: true
     fields:
@@ -48,6 +49,5 @@ labels:
         kind: PodMonitor
         path: spec/selector/matchLabels
         create: true
-
 patches:
   - path: patch-sglang.yaml

--- a/guides/precise-prefix-cache-routing/modelserver/gpu/sglang/patch-sglang.yaml
+++ b/guides/precise-prefix-cache-routing/modelserver/gpu/sglang/patch-sglang.yaml
@@ -1,0 +1,98 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  replicas: 8
+  template:
+    spec:
+      containers:
+        - name: modelserver
+          command: ["python3", "-m", "sglang.launch_server"]
+          args:
+            - "--model-path=Qwen/Qwen3-32B"
+            - "--host=0.0.0.0"
+            - "--port=8000"
+            - "--tensor-parallel-size=2"
+            # KV-block granularity. Must match the router scorer's
+            # tokenProcessorConfig.blockSize (default 64); SGLang's knob is
+            # --page-size, where vLLM uses --block-size.
+            - "--page-size=64"
+            - "--enable-metrics"
+            - "--kv-events-config"
+            # unlike vLLM, do NOT add {"enable_kv_cache_events":true};
+            - '{"publisher":"zmq","endpoint":"$(KV_EVENTS_ENDPOINT)","topic":"kv@$(POD_IP):$(POD_PORT)@Qwen/Qwen3-32B"}'
+          ports:
+            # Exposed so each router replica can dial the per-pod ZMQ socket
+            # bound by SGLang (KV_EVENTS_ENDPOINT=tcp://*:5556). Only
+            # attn_tp_rank==0 publishes, so each pod binds exactly one socket.
+            - containerPort: 5556
+              name: kv-events
+              protocol: TCP
+          env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            # Matches the `modelserver` container port (--port=8000). Used in
+            # the kv-events topic (kv@$(POD_IP):$(POD_PORT)@<model>) so pods are
+            # identified by their inference endpoint.
+            - name: POD_PORT
+              value: "8000"
+            # Pod-discovery mode: SGLang PUBs bind per-pod so every router
+            # replica can dial each pod's socket independently (required for
+            # active-active HA across routers).
+            - name: KV_EVENTS_ENDPOINT
+              value: "tcp://*:5556"
+          resources:
+            limits:
+              cpu: '16'
+              memory: 128Gi
+              nvidia.com/gpu: 2
+            requests:
+              cpu: '8'
+              memory: 96Gi
+              nvidia.com/gpu: 2
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: shm
+            # SGLang image did not set $HOME, so under a restricted SecurityContext
+            # (random non-root UID, e.g. OpenShift) ~/ resolves to the non-writable
+            # "/". Back the cache dirs SGLang writes at startup with emptyDirs:
+            #   /.cache  — HF model downloads, FlashInfer JIT, Torch compile cache
+            #   /.triton — Triton kernel autotune cache
+            - mountPath: /.cache
+              name: sglang-cache
+            - mountPath: /.triton
+              name: triton-cache
+          startupProbe:
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 120
+          livenessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 20Gi
+        - name: sglang-cache
+          emptyDir: {}
+        - name: triton-cache
+          emptyDir: {}


### PR DESCRIPTION
# Changes
- add new guide on SGLang for precise-prefix-cache (this is now based on the vllm render tokenizer)
- update dry-run in CI to verify render manifests but no add nightly e2e for that
- fix lint in CI
- set to use `llm-d.ai/engine-type` than old` inference.networking.k8s.io/engine-type` , the rest guide will be updated in PR  https://github.com/llm-d/llm-d/pull/1642 to follow up

ref https://github.com/llm-d/llm-d/issues/1632

# Test
on a small cluster with only 1node8GPU, trim replicas from 8 to 2 for sglang pods
1. basic test precise prefix routing -- following README.md steps 
```
export GUIDE_NAME=precise-prefix-cache-routing
export NAMESPACE=wenzhou-dev
IP=$(kubectl get service ${GUIDE_NAME}-epp -n ${NAMESPACE} -o jsonpath='{.spec.clusterIP}')
 kubectl run curl-debug --rm -it \
    --image=cfmanteiga/alpine-bash-curl-jq \
    --env="IP=$IP" --env="NAMESPACE=$NAMESPACE" \
    -- /bin/bash
```
then send long prompt (more than 64 to match - "--page-size=64") 3-4 times but with some different appended words in each curl 
then check 2 sglang pods log, 
> k logs pod/precise-prefix-cache-routing-gpu-sglang-decode-f6f6d4cf6-z77mw | grep cached-token
```
...
[2026-06-03 11:38:45 TP0] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 512, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, cuda graph: True, input throughput (token/s): 33.26
[2026-06-03 11:38:48 TP0] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 512, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, cuda graph: True, input throughput (token/s): 21.08
[2026-06-03 11:38:51 TP0] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 512, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, cuda graph: True, input throughput (token/s): 21.06
[2026-06-03 11:38:53 TP0] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, cuda graph: True, input throughput (token/s): 31.99
...
```

3. small benchmark
skip creating pvc 
based on the guide.yaml from benchmark, generate a small-config.yaml 
```
endpoint:
  stack_name: &stack_name precise-guide-Qwen3-32B
  model: &model Qwen/Qwen3-32B
  namespace: &namespace wenzhou-dev
  base_url: &url http://10.16.0.132
  hf_token_secret: llm-d-hf-token

control:
  work_dir: /tmp/llm-d-bench-work
  kubectl: kubectl

harness:
  name: &harness_name inference-perf
  results_pvc: sglang-benchmark-pvc
  namespace: *namespace
  parallelism: 1
  wait_timeout: 1800
  image: ghcr.io/llm-d/llm-d-benchmark:v0.5.2

env:
  - name: RAYON_NUM_THREADS
    value: "4"

workload:
  shared_prefix:
    load:
      type: poisson
      interval: 30.0
      stages:
      - rate: 5
        duration: 20
      - rate: 3
        duration: 20
      - rate: 6
        duration: 20
      - rate: 10
        duration: 20
    api:
      type: completion
      streaming: true
    server:
      type: vllm
      model_name: *model
      base_url: *url
      ignore_eos: true
    tokenizer:
      pretrained_model_name_or_path: *model
    data:
      type: shared_prefix
      shared_prefix:
        num_groups: 8
        num_prompts_per_group: 4
        system_prompt_len: 1000
        question_len: 200
        output_len: 100
        enable_multi_turn_chat: false
    report:
      request_lifecycle:
        summary: true
        per_stage: true
        per_request: true
    storage:
      local_storage:
        path: /workspace
```
```
./run_only.sh -c small-config.yaml -o ./results 
```
<img width="2100" height="600" alt="latency_vs_qps" src="https://github.com/user-attachments/assets/95811313-aa7a-455c-b2f3-6acaa0373c33" />
<img width="2100" height="600" alt="throughput_vs_latency" src="https://github.com/user-attachments/assets/3f9c6628-58df-4c77-a05b-e767b79fc1e4" />
<img width="2100" height="600" alt="throughput_vs_qps" src="https://github.com/user-attachments/assets/d669ed5b-da76-42e9-9457-ca146709fbc5" />


cc @ezrasilvera 