### PR TITLE
[PD Disaggregation][Sglang] Add GKE RDMA configs and related documentation updates

### DIFF
--- a/.github/workflows/ci-kustomize-dry-run.yaml
+++ b/.github/workflows/ci-kustomize-dry-run.yaml
@@ -222,6 +222,9 @@ jobs:
         run: |
           failed=0
           for overlay_dir in guides/pd-disaggregation/modelserver/*/; do
+            overlay_name="$(basename "${overlay_dir%/}")"
+            # skip the components directory
+            [ "${overlay_name}" = "components" ] && continue
             # Each accelerator dir may have one or more server subdirs (vllm, sglang)
             for kust_dir in "${overlay_dir}"*/; do
               [ -f "${kust_dir}kustomization.yaml" ] || continue

--- a/guides/pd-disaggregation/README.gke.md
+++ b/guides/pd-disaggregation/README.gke.md
@@ -4,88 +4,19 @@ This guide provides specific instructions for deploying PD-disaggregation with R
 
 ## Prerequisites
 
-1.  A GKE cluster in a region where A3 Ultra is available (e.g., `us-south1` or `us-central1`). Let's take `us-south1` for this guide.
-2.  The following environment variables set:
-    ```bash
-    export PROJECT_ID="your-project-id"
-    export REGION="us-south1"
-    export ZONE="us-south1-b"
-    export GVNIC_NETWORK_PREFIX="a3ultra-gvnic"
-    export RDMA_NETWORK_PREFIX="a3ultra-rdma"
-    export CLUSTER_NAME="a3-ultra-cluster"
-    export NAMESPACE="default"
-    ```
+Before deploying, follow the [official GKE AI Hypercompute guide](https://docs.cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute-custom) to complete the following steps:
 
-## 1. Setup Networking Infrastructure
+1. Create VPCs and subnets (GVNIC + 8 RDMA networks)
+2. Create the GKE cluster and A3 Ultra node pool with multi-networking enabled
+3. Apply the `GKENetworkParamSet` and `Network` Kubernetes resources, and install RDMA binaries via DaemonSet
 
-A3 Ultra requires multiple NICs: one for the Titanium CPU NIC (GVNIC) and eight for GPU-to-GPU RDMA (RoCE).
-
-### Create GVNIC VPC
-```bash
-gcloud compute networks create ${GVNIC_NETWORK_PREFIX}-net --subnet-mode=custom
-
-gcloud compute networks subnets create ${GVNIC_NETWORK_PREFIX}-sub \
-    --network=${GVNIC_NETWORK_PREFIX}-net \
-    --region=${REGION} \
-    --range=192.168.0.0/24
-
-gcloud compute firewall-rules create ${GVNIC_NETWORK_PREFIX}-internal \
-    --network=${GVNIC_NETWORK_PREFIX}-net \
-    --action=ALLOW \
-    --rules=tcp:0-65535,udp:0-65535,icmp \
-    --source-ranges=192.168.0.0/16
-```
-
-### Create HPC (RDMA) VPC
-```bash
-gcloud beta compute networks create ${RDMA_NETWORK_PREFIX}-net \
-    --network-profile=${ZONE}-vpc-roce \
-    --subnet-mode=custom
-
-for N in {0..7}; do
-  gcloud compute networks subnets create ${RDMA_NETWORK_PREFIX}-sub-$N \
-    --network=${RDMA_NETWORK_PREFIX}-net \
-    --region=${REGION} \
-    --range=192.168.$((N+1)).0/24
-done
-```
-
-## 2. Create the Node Pool
-
-Provision the H200 node pool with the additional network interfaces. Spot instances are recommended for availability in some regions.
+Once your cluster is ready, set the following environment variables:
 
 ```bash
-gcloud container node-pools create h200 \
-    --region=${REGION} \
-    --cluster=${CLUSTER_NAME} \
-    --node-locations=${ZONE} \
-    --machine-type=a3-ultragpu-8g \
-    --accelerator=type=nvidia-h200-141gb,count=8,gpu-driver-version=latest \
-    --enable-autoscaling \
-    --min-nodes=0 \
-    --max-nodes=8 \
-    --location-policy=ANY \
-    --spot \
-    --additional-node-network network=${GVNIC_NETWORK_PREFIX}-net,subnetwork=${GVNIC_NETWORK_PREFIX}-sub \
-    --additional-node-network network=${RDMA_NETWORK_PREFIX}-net,subnetwork=${RDMA_NETWORK_PREFIX}-sub-0 \
-    --additional-node-network network=${RDMA_NETWORK_PREFIX}-net,subnetwork=${RDMA_NETWORK_PREFIX}-sub-1 \
-    --additional-node-network network=${RDMA_NETWORK_PREFIX}-net,subnetwork=${RDMA_NETWORK_PREFIX}-sub-2 \
-    --additional-node-network network=${RDMA_NETWORK_PREFIX}-net,subnetwork=${RDMA_NETWORK_PREFIX}-sub-3 \
-    --additional-node-network network=${RDMA_NETWORK_PREFIX}-net,subnetwork=${RDMA_NETWORK_PREFIX}-sub-4 \
-    --additional-node-network network=${RDMA_NETWORK_PREFIX}-net,subnetwork=${RDMA_NETWORK_PREFIX}-sub-5 \
-    --additional-node-network network=${RDMA_NETWORK_PREFIX}-net,subnetwork=${RDMA_NETWORK_PREFIX}-sub-6 \
-    --additional-node-network network=${RDMA_NETWORK_PREFIX}-net,subnetwork=${RDMA_NETWORK_PREFIX}-sub-7
+export NAMESPACE="default"
 ```
 
-## 3. Apply Kubernetes Network Config
-
-Apply the `Network` and `GKENetworkParamSet` resources to expose the RDMA interfaces to Kubernetes. This step uses `envsubst` to inject your `RDMA_NETWORK_PREFIX` into the configuration.
-
-```bash
-envsubst < guides/pd-disaggregation/rdma-networks.yaml | kubectl apply -f -
-```
-
-## 4. Deploy the Model Server
+## 1. Deploy the Model Server
 
 Deploy SGLang with the GKE overlay. Note that the GKE overlay uses `privileged: true` for RDMA, which bypasses GPU isolation. To ensure stability for large models (120B+):
 
@@ -97,7 +28,7 @@ Deploy SGLang with the GKE overlay. Note that the GKE overlay uses `privileged: 
 kubectl apply -n ${NAMESPACE} -k guides/pd-disaggregation/modelserver/gpu/sglang/gke/
 ```
 
-## Verification & Logs
+## 2. Verification & Logs
 
 Monitor the startup as the 120B model takes significant time to load weights:
 

--- a/guides/pd-disaggregation/README.gke.md
+++ b/guides/pd-disaggregation/README.gke.md
@@ -24,6 +24,9 @@ Deploy SGLang with the GKE overlay. Note that the GKE overlay uses `privileged: 
 2.  **Tensor Parallel (TP)** is set to **8** to utilize the full node memory.
 3.  **Pod Anti-Affinity** is configured to keep roles separated.
 
+> [!IMPORTANT]
+> **Avoid CUDA OOM and Memory Imbalance:** For models like `gpt-oss-120b`, ensuring `TP=8` is critical. If deploying with lower TP sizes, you may encounter `torch.OutOfMemoryError`. Additionally, if pods restart frequently during setup, you might see `RuntimeError: The memory capacity is unbalanced`. In such cases, perform a hard cleanup by deleting the deployment entirely (`kubectl delete deployment ...`), waiting for GPU memory to clear, and then redeploying.
+
 ```bash
 kubectl apply -n ${NAMESPACE} -k guides/pd-disaggregation/modelserver/gpu/sglang/gke/
 ```

--- a/guides/pd-disaggregation/README.gke.md
+++ b/guides/pd-disaggregation/README.gke.md
@@ -1,10 +1,10 @@
-# PD-Disaggregation on GKE A3 Ultra (H200)
+# PD-Disaggregation on GKE
 
-This guide provides specific instructions for deploying PD-disaggregation with RDMA (RoCE) on GKE using NVIDIA H200 GPUs (A3 Ultra). **Note**: This is picked from [official GCP page](https://docs.cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute-custom). Follow the official GCP guide for latest updates and detailed instructions.
+This guide provides specific instructions for deploying PD-disaggregation with RDMA (RoCE) on GKE. For the puposes of this guide, we will be using NVIDIA H200 GPUs on A3 Ultra. **Note**: This is picked from [official GCP page](https://docs.cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute-custom). Follow the official GCP guide for latest updates and detailed instructions.
 
 ## Prerequisites
 
-1.  A GKE cluster in a region where A3 Ultra is available (e.g., `us-south1` or `us-central1`).
+1.  A GKE cluster in a region where A3 Ultra is available (e.g., `us-south1` or `us-central1`). Lets take `us-south1` for this guide.
 2.  The following environment variables set:
     ```bash
     export PROJECT_ID="your-project-id"

--- a/guides/pd-disaggregation/README.gke.md
+++ b/guides/pd-disaggregation/README.gke.md
@@ -25,7 +25,7 @@ Deploy SGLang with the GKE overlay. Note that the GKE overlay uses `privileged: 
 3.  **Pod Anti-Affinity** is configured to keep roles separated.
 
 > [!IMPORTANT]
-> **Avoid CUDA OOM and Memory Imbalance:** For models like `gpt-oss-120b`, ensuring `TP=8` is critical. If deploying with lower TP sizes, you may encounter `torch.OutOfMemoryError`. Additionally, if pods restart frequently during setup, you might see `RuntimeError: The memory capacity is unbalanced`. In such cases, perform a hard cleanup by deleting the deployment entirely (`kubectl delete deployment ...`), waiting for GPU memory to clear, and then redeploying.
+> **Avoid CUDA OOM and Memory Imbalance:** For models like `gpt-oss-120b`, try increasing `TP` to 8 if you encounter OOM errors. Also, ensure you have enough nodes to accommodate the TP. For A3 Ultra, you should have 8 nodes.
 
 ```bash
 kubectl apply -n ${NAMESPACE} -k guides/pd-disaggregation/modelserver/gpu/sglang/gke/

--- a/guides/pd-disaggregation/README.gke.md
+++ b/guides/pd-disaggregation/README.gke.md
@@ -1,10 +1,10 @@
 # PD-Disaggregation on GKE
 
-This guide provides specific instructions for deploying PD-disaggregation with RDMA (RoCE) on GKE. For the puposes of this guide, we will be using NVIDIA H200 GPUs on A3 Ultra. **Note**: This is picked from [official GCP page](https://docs.cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute-custom). Follow the official GCP guide for latest updates and detailed instructions.
+This guide provides specific instructions for deploying PD-disaggregation with RDMA (RoCE) on GKE. For the purposes of this guide, we will be using NVIDIA H200 GPUs on A3 Ultra. **Note**: This is picked from [official GCP page](https://docs.cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute-custom). Follow the official GCP guide for latest updates and detailed instructions.
 
 ## Prerequisites
 
-1.  A GKE cluster in a region where A3 Ultra is available (e.g., `us-south1` or `us-central1`). Lets take `us-south1` for this guide.
+1.  A GKE cluster in a region where A3 Ultra is available (e.g., `us-south1` or `us-central1`). Let's take `us-south1` for this guide.
 2.  The following environment variables set:
     ```bash
     export PROJECT_ID="your-project-id"
@@ -13,6 +13,7 @@ This guide provides specific instructions for deploying PD-disaggregation with R
     export GVNIC_NETWORK_PREFIX="a3ultra-gvnic"
     export RDMA_NETWORK_PREFIX="a3ultra-rdma"
     export CLUSTER_NAME="a3-ultra-cluster"
+    export NAMESPACE="default"
     ```
 
 ## 1. Setup Networking Infrastructure

--- a/guides/pd-disaggregation/README.gke.md
+++ b/guides/pd-disaggregation/README.gke.md
@@ -1,0 +1,106 @@
+# PD-Disaggregation on GKE A3 Ultra (H200)
+
+This guide provides specific instructions for deploying PD-disaggregation with RDMA (RoCE) on GKE using NVIDIA H200 GPUs (A3 Ultra). **Note**: This is picked from [official GCP page](https://docs.cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute-custom). Follow the official GCP guide for latest updates and detailed instructions.
+
+## Prerequisites
+
+1.  A GKE cluster in a region where A3 Ultra is available (e.g., `us-south1` or `us-central1`).
+2.  The following environment variables set:
+    ```bash
+    export PROJECT_ID="your-project-id"
+    export REGION="us-south1"
+    export ZONE="us-south1-b"
+    export GVNIC_NETWORK_PREFIX="a3ultra-gvnic"
+    export RDMA_NETWORK_PREFIX="a3ultra-rdma"
+    export CLUSTER_NAME="a3-ultra-cluster"
+    ```
+
+## 1. Setup Networking Infrastructure
+
+A3 Ultra requires multiple NICs: one for the Titanium CPU NIC (GVNIC) and eight for GPU-to-GPU RDMA (RoCE).
+
+### Create GVNIC VPC
+```bash
+gcloud compute networks create ${GVNIC_NETWORK_PREFIX}-net --subnet-mode=custom
+
+gcloud compute networks subnets create ${GVNIC_NETWORK_PREFIX}-sub \
+    --network=${GVNIC_NETWORK_PREFIX}-net \
+    --region=${REGION} \
+    --range=192.168.0.0/24
+
+gcloud compute firewall-rules create ${GVNIC_NETWORK_PREFIX}-internal \
+    --network=${GVNIC_NETWORK_PREFIX}-net \
+    --action=ALLOW \
+    --rules=tcp:0-65535,udp:0-65535,icmp \
+    --source-ranges=192.168.0.0/16
+```
+
+### Create HPC (RDMA) VPC
+```bash
+gcloud beta compute networks create ${RDMA_NETWORK_PREFIX}-net \
+    --network-profile=${ZONE}-vpc-roce \
+    --subnet-mode=custom
+
+for N in {0..7}; do
+  gcloud compute networks subnets create ${RDMA_NETWORK_PREFIX}-sub-$N \
+    --network=${RDMA_NETWORK_PREFIX}-net \
+    --region=${REGION} \
+    --range=192.168.$((N+1)).0/24
+done
+```
+
+## 2. Create the Node Pool
+
+Provision the H200 node pool with the additional network interfaces. Spot instances are recommended for availability in some regions.
+
+```bash
+gcloud container node-pools create h200 \
+    --region=${REGION} \
+    --cluster=${CLUSTER_NAME} \
+    --node-locations=${ZONE} \
+    --machine-type=a3-ultragpu-8g \
+    --accelerator=type=nvidia-h200-141gb,count=8,gpu-driver-version=latest \
+    --enable-autoscaling \
+    --min-nodes=0 \
+    --max-nodes=8 \
+    --location-policy=ANY \
+    --spot \
+    --additional-node-network network=${GVNIC_NETWORK_PREFIX}-net,subnetwork=${GVNIC_NETWORK_PREFIX}-sub \
+    --additional-node-network network=${RDMA_NETWORK_PREFIX}-net,subnetwork=${RDMA_NETWORK_PREFIX}-sub-0 \
+    --additional-node-network network=${RDMA_NETWORK_PREFIX}-net,subnetwork=${RDMA_NETWORK_PREFIX}-sub-1 \
+    --additional-node-network network=${RDMA_NETWORK_PREFIX}-net,subnetwork=${RDMA_NETWORK_PREFIX}-sub-2 \
+    --additional-node-network network=${RDMA_NETWORK_PREFIX}-net,subnetwork=${RDMA_NETWORK_PREFIX}-sub-3 \
+    --additional-node-network network=${RDMA_NETWORK_PREFIX}-net,subnetwork=${RDMA_NETWORK_PREFIX}-sub-4 \
+    --additional-node-network network=${RDMA_NETWORK_PREFIX}-net,subnetwork=${RDMA_NETWORK_PREFIX}-sub-5 \
+    --additional-node-network network=${RDMA_NETWORK_PREFIX}-net,subnetwork=${RDMA_NETWORK_PREFIX}-sub-6 \
+    --additional-node-network network=${RDMA_NETWORK_PREFIX}-net,subnetwork=${RDMA_NETWORK_PREFIX}-sub-7
+```
+
+## 3. Apply Kubernetes Network Config
+
+Apply the `Network` and `GKENetworkParamSet` resources to expose the RDMA interfaces to Kubernetes. This step uses `envsubst` to inject your `RDMA_NETWORK_PREFIX` into the configuration.
+
+```bash
+envsubst < guides/pd-disaggregation/rdma-networks.yaml | kubectl apply -f -
+```
+
+## 4. Deploy the Model Server
+
+Deploy SGLang with the GKE overlay. Note that the GKE overlay uses `privileged: true` for RDMA, which bypasses GPU isolation. To ensure stability for large models (120B+):
+
+1.  Each pod (prefill and decode) requests **8 GPUs** to ensure it has a dedicated node.
+2.  **Tensor Parallel (TP)** is set to **8** to utilize the full node memory.
+3.  **Pod Anti-Affinity** is configured to keep roles separated.
+
+```bash
+kubectl apply -n ${NAMESPACE} -k guides/pd-disaggregation/modelserver/gpu/sglang/gke/
+```
+
+## Verification & Logs
+
+Monitor the startup as the 120B model takes significant time to load weights:
+
+```bash
+kubectl get pods -n ${NAMESPACE} -w
+kubectl logs -n ${NAMESPACE} -l llm-d.ai/role=decode -c modelserver --tail=100
+```

--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -39,8 +39,8 @@ This guide includes configuration for the following accelerators:
 | Backend             | Directory                  | Notes                                                    |
 | ------------------- | -------------------------- | -------------------------------------------------------- |
 | NVIDIA GPU (vLLM)   | `modelserver/gpu/vllm/`    | vLLM, tested nightly                                     |
-| NVIDIA GPU (SGLang) | `modelserver/gpu/sglang/`  | SGLang, validated each release                           |
-| Google TPU          | `modelserver/tpu/vllm/`    | GKE TPU, validated each release                          |
+| NVIDIA GPU (SGLang) | `modelserver/gpu/sglang/`  | SGLang, validated each release (see [GKE guide](./README.gke.md)) |
+| Google TPU          | `modelserver/tpu/vllm/`    | GKE TPU, validated each release (see [TPU guide](./README.tpu.md)) |
 | AMD GPU             | `modelserver/amd/vllm/`    | AMD GPU, community contributed                           |
 | Intel XPU           | `modelserver/xpu/vllm/`    | Intel Data Center GPU Max 1550+, community contributed   |
 | Intel XPU + RDMA    | `modelserver/xpu/vllm-rdma/` | Intel XPU with RDMA via UCX (`ib,rc,ze_copy`), requires RDMA DRA driver |

--- a/guides/pd-disaggregation/modelserver/components/gke-rdma/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/components/gke-rdma/kustomization.yaml
@@ -1,0 +1,106 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+components:
+  - ../../../../recipes/modelserver/components/disable-gke-nccl-tuner-patch
+
+patches:
+  # Common: privileged container, RDMA multi-NIC annotations, disable GDRCopy
+  - target:
+      kind: Deployment
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/securityContext
+        value:
+          privileged: true
+      - op: add
+        path: /spec/template/metadata/annotations
+        value:
+          networking.gke.io/default-interface: 'eth0'
+          networking.gke.io/interfaces: |
+            [
+              {"interfaceName":"eth0","network":"default"},
+              {"interfaceName":"eth2","network":"rdma-0"},
+              {"interfaceName":"eth3","network":"rdma-1"},
+              {"interfaceName":"eth4","network":"rdma-2"},
+              {"interfaceName":"eth5","network":"rdma-3"},
+              {"interfaceName":"eth6","network":"rdma-4"},
+              {"interfaceName":"eth7","network":"rdma-5"},
+              {"interfaceName":"eth8","network":"rdma-6"},
+              {"interfaceName":"eth9","network":"rdma-7"}
+            ]
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: NVSHMEM_DISABLED_GDRCOPY
+          value: "true"
+
+  # Prefill: role labels and colocation/separation affinity
+  - target:
+      kind: Deployment
+      name: prefill
+    patch: |-
+      - op: add
+        path: /metadata/labels/llm-d.ai~1role
+        value: prefill
+      - op: add
+        path: /spec/template/metadata/labels/llm-d.ai~1role
+        value: prefill
+      - op: add
+        path: /spec/template/spec/affinity
+        value:
+          podAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 2
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    llm-d.ai/role: prefill
+                topologyKey: cloud.google.com/gce-topology-block
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    llm-d.ai/role: prefill
+                topologyKey: cloud.google.com/gce-topology-subblock
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  llm-d.ai/role: decode
+              topologyKey: kubernetes.io/hostname
+
+  # Decode: role labels and colocation/separation affinity
+  - target:
+      kind: Deployment
+      name: decode
+    patch: |-
+      - op: add
+        path: /metadata/labels/llm-d.ai~1role
+        value: decode
+      - op: add
+        path: /spec/template/metadata/labels/llm-d.ai~1role
+        value: decode
+      - op: add
+        path: /spec/template/spec/affinity
+        value:
+          podAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 2
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    llm-d.ai/role: decode
+                topologyKey: cloud.google.com/gce-topology-block
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    llm-d.ai/role: decode
+                topologyKey: cloud.google.com/gce-topology-subblock
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  llm-d.ai/role: prefill
+              topologyKey: kubernetes.io/hostname

--- a/guides/pd-disaggregation/modelserver/components/gke-rdma/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/components/gke-rdma/kustomization.yaml
@@ -16,22 +16,21 @@ patches:
         value:
           privileged: true
       - op: add
-        path: /spec/template/metadata/annotations/networking.gke.io~1default-interface
-        value: 'eth0'
-      - op: add
-        path: /spec/template/metadata/annotations/networking.gke.io~1interfaces
-        value: |
-          [
-            {"interfaceName":"eth0","network":"default"},
-            {"interfaceName":"eth2","network":"rdma-0"},
-            {"interfaceName":"eth3","network":"rdma-1"},
-            {"interfaceName":"eth4","network":"rdma-2"},
-            {"interfaceName":"eth5","network":"rdma-3"},
-            {"interfaceName":"eth6","network":"rdma-4"},
-            {"interfaceName":"eth7","network":"rdma-5"},
-            {"interfaceName":"eth8","network":"rdma-6"},
-            {"interfaceName":"eth9","network":"rdma-7"}
-          ]
+        path: /spec/template/metadata/annotations
+        value:
+          networking.gke.io/default-interface: 'eth0'
+          networking.gke.io/interfaces: |
+            [
+              {"interfaceName":"eth0","network":"default"},
+              {"interfaceName":"eth2","network":"rdma-0"},
+              {"interfaceName":"eth3","network":"rdma-1"},
+              {"interfaceName":"eth4","network":"rdma-2"},
+              {"interfaceName":"eth5","network":"rdma-3"},
+              {"interfaceName":"eth6","network":"rdma-4"},
+              {"interfaceName":"eth7","network":"rdma-5"},
+              {"interfaceName":"eth8","network":"rdma-6"},
+              {"interfaceName":"eth9","network":"rdma-7"}
+            ]
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:

--- a/guides/pd-disaggregation/modelserver/components/gke-rdma/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/components/gke-rdma/kustomization.yaml
@@ -5,7 +5,9 @@ components:
   - ../../../../recipes/modelserver/components/disable-gke-nccl-tuner-patch
 
 patches:
-  # Common: privileged container, RDMA multi-NIC annotations, disable GDRCopy
+  # Common: privileged container, RDMA multi-NIC annotations, disable GDRCopy.
+  # privileged: true is required for direct RDMA/RoCE device access on GKE A3 Ultra nodes;
+  # avoid removing it unless the workload no longer needs raw GPU-to-GPU RDMA.
   - target:
       kind: Deployment
     patch: |-
@@ -14,26 +16,27 @@ patches:
         value:
           privileged: true
       - op: add
-        path: /spec/template/metadata/annotations
-        value:
-          networking.gke.io/default-interface: 'eth0'
-          networking.gke.io/interfaces: |
-            [
-              {"interfaceName":"eth0","network":"default"},
-              {"interfaceName":"eth2","network":"rdma-0"},
-              {"interfaceName":"eth3","network":"rdma-1"},
-              {"interfaceName":"eth4","network":"rdma-2"},
-              {"interfaceName":"eth5","network":"rdma-3"},
-              {"interfaceName":"eth6","network":"rdma-4"},
-              {"interfaceName":"eth7","network":"rdma-5"},
-              {"interfaceName":"eth8","network":"rdma-6"},
-              {"interfaceName":"eth9","network":"rdma-7"}
-            ]
+        path: /spec/template/metadata/annotations/networking.gke.io~1default-interface
+        value: 'eth0'
+      - op: add
+        path: /spec/template/metadata/annotations/networking.gke.io~1interfaces
+        value: |
+          [
+            {"interfaceName":"eth0","network":"default"},
+            {"interfaceName":"eth2","network":"rdma-0"},
+            {"interfaceName":"eth3","network":"rdma-1"},
+            {"interfaceName":"eth4","network":"rdma-2"},
+            {"interfaceName":"eth5","network":"rdma-3"},
+            {"interfaceName":"eth6","network":"rdma-4"},
+            {"interfaceName":"eth7","network":"rdma-5"},
+            {"interfaceName":"eth8","network":"rdma-6"},
+            {"interfaceName":"eth9","network":"rdma-7"}
+          ]
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
-          name: NVSHMEM_DISABLED_GDRCOPY
-          value: "true"
+          name: NVSHMEM_DISABLE_GDRCOPY
+          value: "1"
 
   # Prefill: role labels and colocation/separation affinity
   - target:

--- a/guides/pd-disaggregation/modelserver/gpu/sglang/base/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/sglang/base/patch-decode.yaml
@@ -15,6 +15,7 @@ spec:
             - "--host=0.0.0.0"
             - "--disaggregation-mode=decode"
             - "--disaggregation-transfer-backend=nixl"
+            # For 120B model, TP=4 or TP=8 is required to avoid CUDA OOM.
             - "--tensor-parallel-size=4"
             - "--log-level=info"
             - "--enable-metrics"

--- a/guides/pd-disaggregation/modelserver/gpu/sglang/base/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/sglang/base/patch-prefill.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: prefill
 spec:
-  replicas: 8
+  replicas: 4 # Reduced replicas to fit TP=4/TP=8 on A3 Ultra nodes.
   template:
     spec:
       containers:
@@ -15,19 +15,21 @@ spec:
             - "--host=0.0.0.0"
             - "--disaggregation-mode=prefill"
             - "--disaggregation-transfer-backend=nixl"
-            - "--tensor-parallel-size=1"
+            # For 120B model, TP=4 or TP=8 is required to avoid CUDA OOM.
+            # If restarts cause "unbalanced memory" errors, delete the deployment entirely and redeploy.
+            - "--tensor-parallel-size=4"
             - "--log-level=info"
             - "--enable-metrics"
             - "--uvicorn-access-log-exclude-prefixes=/metrics"
           resources:
             limits:
-              cpu: "8"
-              memory: 16Gi
-              nvidia.com/gpu: "1"
+              cpu: "16"
+              memory: 64Gi
+              nvidia.com/gpu: "4"
             requests:
-              cpu: "8"
-              memory: 16Gi
-              nvidia.com/gpu: "1"
+              cpu: "16"
+              memory: 64Gi
+              nvidia.com/gpu: "4"
           volumeMounts:
             - mountPath: /dev/shm
               name: shm

--- a/guides/pd-disaggregation/modelserver/gpu/sglang/gke/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/sglang/gke/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 resources:
   - ../base
 components:
-  - ../../../../../recipes/modelserver/components/disable-gke-nccl-tuner-patch
+  - ../../../components/gke-rdma

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/gke/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/gke/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 resources:
   - ../base
 components:
-  - ../../../../../recipes/modelserver/components/disable-gke-nccl-tuner-patch
+  - ../../../components/gke-rdma


### PR DESCRIPTION
Add starter guide for PD for Sglang on GKE with RDMA configs. 
Validated the deployments on my a3 cluster. 
We can follow these up with performance fine tuning and an optimized baseline. The current configs serve as a good starter for a user looking to deploy sglang with llm-d on GKE.
Addresses #1075 . 