### PR TITLE
guides: add vLLM request draining configuration

### DIFF
--- a/guides/optimized-baseline/modelserver/amd/vllm/patch-vllm.yaml
+++ b/guides/optimized-baseline/modelserver/amd/vllm/patch-vllm.yaml
@@ -13,6 +13,7 @@ spec:
             - "Qwen/Qwen3-32B"
             - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
             - "--tensor-parallel-size=2"
+            - "--shutdown-timeout=30"
             # Uncomment for distributed tracing
             # - "--otlp-traces-endpoint=http://otel-collector:4317"
             # - "--collect-detailed-traces=all"
@@ -55,6 +56,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: shm
           emptyDir:

--- a/guides/optimized-baseline/modelserver/cpu/vllm/patch-vllm.yaml
+++ b/guides/optimized-baseline/modelserver/cpu/vllm/patch-vllm.yaml
@@ -15,6 +15,7 @@ spec:
             - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
             - "--disable-hybrid-kv-cache-manager"
             - "--max_model_len=8192"
+            - "--shutdown-timeout=30"
             # Uncomment for distributed tracing
             # - "--otlp-traces-endpoint=http://otel-collector:4317"
             # - "--collect-detailed-traces=all"
@@ -65,6 +66,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: dshm
           emptyDir:

--- a/guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
+++ b/guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
@@ -15,6 +15,7 @@ spec:
             - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
             - "--tensor-parallel-size=2"
             - "--gpu-memory-utilization=0.95"
+            - "--shutdown-timeout=30"
             # Uncomment for distributed tracing
             # - "--otlp-traces-endpoint=http://otel-collector:4317"
             # - "--collect-detailed-traces=all"
@@ -61,6 +62,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: shm
           emptyDir:

--- a/guides/optimized-baseline/modelserver/hpu/vllm/patch-vllm.yaml
+++ b/guides/optimized-baseline/modelserver/hpu/vllm/patch-vllm.yaml
@@ -16,6 +16,7 @@ spec:
             - "--max-model-len=2048"
             - "--max-num-batched-token=16000"
             - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+            - "--shutdown-timeout=30"
             # Uncomment for distributed tracing
             # - "--otlp-traces-endpoint=http://otel-collector:4317"
             # - "--collect-detailed-traces=all"
@@ -60,6 +61,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+      terminationGracePeriodSeconds: 60
       resourceClaims:
         - name: optimized-baseline-gaudi-claim
           resourceClaimTemplateName: optimized-baseline-gaudi-claim

--- a/guides/optimized-baseline/modelserver/tpu-v6/vllm/patch-vllm.yaml
+++ b/guides/optimized-baseline/modelserver/tpu-v6/vllm/patch-vllm.yaml
@@ -17,6 +17,7 @@ spec:
             - "--port=8000"
             - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
             - "--tensor-parallel-size=8"
+            - "--shutdown-timeout=30"
             # Uncomment for distributed tracing
             # - "--otlp-traces-endpoint=http://otel-collector:4317"
             # - "--collect-detailed-traces=all"
@@ -53,6 +54,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: torch-compile-cache
           emptyDir: {}

--- a/guides/optimized-baseline/modelserver/tpu-v7/vllm/patch-vllm.yaml
+++ b/guides/optimized-baseline/modelserver/tpu-v7/vllm/patch-vllm.yaml
@@ -17,6 +17,7 @@ spec:
             - "--port=8000"
             - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
             - "--tensor-parallel-size=8"
+            - "--shutdown-timeout=30"
             # Uncomment for distributed tracing
             # - "--otlp-traces-endpoint=http://otel-collector:4317"
             # - "--collect-detailed-traces=all"
@@ -57,6 +58,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: torch-compile-cache
           emptyDir: {}

--- a/guides/optimized-baseline/modelserver/xpu/vllm/patch-vllm.yaml
+++ b/guides/optimized-baseline/modelserver/xpu/vllm/patch-vllm.yaml
@@ -19,6 +19,7 @@ spec:
             - "--dtype=float16"
             - "--disable-sliding-window"
             - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+            - "--shutdown-timeout=30"
             # Uncomment for distributed tracing
             # - "--otlp-traces-endpoint=http://otel-collector:4317"
             # - "--collect-detailed-traces=all"
@@ -66,6 +67,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+      terminationGracePeriodSeconds: 60
       resourceClaims:
         - name: intel-decode-claim
           resourceClaimTemplateName: intel-claim-template-decode

--- a/guides/pd-disaggregation/modelserver/amd/vllm/base/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/vllm/base/patch-decode.yaml
@@ -20,6 +20,7 @@ spec:
             - "--attention-backend=ROCM_ATTN"
             - "--max-model-len=32000"
             - "--port=8200"
+            - "--shutdown-timeout=60"
           env:
             - name: VLLM_NIXL_SIDE_CHANNEL_HOST
               valueFrom:
@@ -52,6 +53,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+      terminationGracePeriodSeconds: 90
       volumes:
         - name: shm
           emptyDir:

--- a/guides/pd-disaggregation/modelserver/amd/vllm/base/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/vllm/base/patch-prefill.yaml
@@ -19,6 +19,7 @@ spec:
             # ROCM_ATTN required when prefill TP != decode TP; upcoming general fix.
             - "--attention-backend=ROCM_ATTN"
             - "--max-model-len=32000"
+            - "--shutdown-timeout=60"
           env:
             - name: VLLM_NIXL_SIDE_CHANNEL_HOST
               valueFrom:
@@ -51,6 +52,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+      terminationGracePeriodSeconds: 90
       volumes:
         - name: shm
           emptyDir:

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/base/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/base/patch-decode.yaml
@@ -18,6 +18,7 @@ spec:
             - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
             - "--no-disable-hybrid-kv-cache-manager"
             - "--port=8200"
+            - "--shutdown-timeout=60"
           env:
             - name: VLLM_NIXL_SIDE_CHANNEL_HOST
               valueFrom:
@@ -59,6 +60,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+      terminationGracePeriodSeconds: 90
       volumes:
         - name: shm
           emptyDir:

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/base/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/base/patch-prefill.yaml
@@ -18,6 +18,7 @@ spec:
             - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
             - "--no-disable-hybrid-kv-cache-manager"
             - "--gpu-memory-utilization=0.9"
+            - "--shutdown-timeout=60"
           env:
             - name: VLLM_NIXL_SIDE_CHANNEL_HOST
               valueFrom:
@@ -59,6 +60,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+      terminationGracePeriodSeconds: 90
       volumes:
         - name: shm
           emptyDir:

--- a/guides/pd-disaggregation/modelserver/hpu/vllm/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/hpu/vllm/patch-decode.yaml
@@ -21,6 +21,7 @@ spec:
             - "--kv-transfer-config"
             - '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"cpu"}'
             - "--port=8200"
+            - "--shutdown-timeout=60"
           env:
             - name: OMPI_MCA_btl_vader_single_copy_mechanism
               value: "none"
@@ -69,6 +70,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 6
+      terminationGracePeriodSeconds: 90
       resourceClaims:
         - name: hpu-decode-claim
           resourceClaimTemplateName: hpu-decode-claim

--- a/guides/pd-disaggregation/modelserver/hpu/vllm/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/hpu/vllm/patch-prefill.yaml
@@ -20,6 +20,7 @@ spec:
             - "--gpu-memory-utilization=0.9"
             - "--kv-transfer-config"
             - '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"cpu"}'
+            - "--shutdown-timeout=60"
           env:
             - name: OMPI_MCA_btl_vader_single_copy_mechanism
               value: "none"
@@ -68,6 +69,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 6
+      terminationGracePeriodSeconds: 90
       resourceClaims:
         - name: hpu-prefill-claim
           resourceClaimTemplateName: hpu-prefill-claim

--- a/guides/pd-disaggregation/modelserver/tpu/vllm/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/tpu/vllm/patch-decode.yaml
@@ -25,6 +25,7 @@ spec:
             - '{"kv_connector":"TPUConnectorHMA","kv_connector_module_path":"tpu_inference.distributed.tpu_connector_hma","kv_role":"kv_consumer"}'
             - "--port=8200"
             - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+            - "--shutdown-timeout=60"
           env:
             - name: POD_IP
               valueFrom:
@@ -70,6 +71,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+      terminationGracePeriodSeconds: 90
       volumes:
         - name: shm
           emptyDir:

--- a/guides/pd-disaggregation/modelserver/tpu/vllm/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/tpu/vllm/patch-prefill.yaml
@@ -25,6 +25,7 @@ spec:
             - '{"kv_connector":"TPUConnectorHMA","kv_connector_module_path":"tpu_inference.distributed.tpu_connector_hma","kv_role":"kv_producer"}'
             - "--port=8000"
             - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+            - "--shutdown-timeout=60"
           env:
             - name: POD_IP
               valueFrom:
@@ -70,6 +71,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+      terminationGracePeriodSeconds: 90
       volumes:
         - name: shm
           emptyDir:

--- a/guides/pd-disaggregation/modelserver/xpu/vllm/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/xpu/vllm/patch-decode.yaml
@@ -22,6 +22,7 @@ spec:
             - '{"kv_connector":"NixlConnector", "kv_role":"kv_both", "kv_buffer_device":"cpu"}'
             - "--max-model-len=32000"
             - "--port=8200"
+            - "--shutdown-timeout=60"
           env:
             - name: UCX_TLS
               value: "tcp"
@@ -64,6 +65,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 6
+      terminationGracePeriodSeconds: 90
       resourceClaims:
         - name: xpu-decode-claim
           resourceClaimTemplateName: xpu-decode-claim

--- a/guides/pd-disaggregation/modelserver/xpu/vllm/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/xpu/vllm/patch-prefill.yaml
@@ -21,6 +21,7 @@ spec:
             - "--kv-transfer-config"
             - '{"kv_connector":"NixlConnector", "kv_role":"kv_both", "kv_buffer_device":"cpu"}'
             - "--max-model-len=32000"
+            - "--shutdown-timeout=60"
           env:
             - name: UCX_TLS
               value: "tcp"
@@ -63,6 +64,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 6
+      terminationGracePeriodSeconds: 90
       resourceClaims:
         - name: xpu-prefill-claim
           resourceClaimTemplateName: xpu-prefill-claim

--- a/guides/precise-prefix-cache-routing/modelserver/amd/vllm/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-routing/modelserver/amd/vllm/patch-vllm.yaml
@@ -16,6 +16,7 @@ spec:
             - "--block-size=64"
             - "--kv-events-config"
             - '{"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"$(KV_EVENTS_ENDPOINT)","topic":"kv@$(POD_IP):$(POD_PORT)@Qwen/Qwen3-32B"}'
+            - "--shutdown-timeout=30"
             # Uncomment for distributed tracing
             # - "--otlp-traces-endpoint=http://otel-collector:4317"
             # - "--collect-detailed-traces=all"
@@ -75,6 +76,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: shm
           emptyDir:

--- a/guides/precise-prefix-cache-routing/modelserver/cpu/vllm/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-routing/modelserver/cpu/vllm/patch-vllm.yaml
@@ -22,6 +22,7 @@ spec:
             - "--block-size=64"
             - "--kv-events-config"
             - '{"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"$(KV_EVENTS_ENDPOINT)","topic":"kv@$(POD_IP):$(POD_PORT)@meta-llama/Llama-3.2-3B-Instruct"}'
+            - "--shutdown-timeout=30"
             # Uncomment for distributed tracing
             # - "--otlp-traces-endpoint=http://otel-collector:4317"
             # - "--collect-detailed-traces=all"
@@ -89,6 +90,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: dshm
           emptyDir:

--- a/guides/precise-prefix-cache-routing/modelserver/gpu/vllm/base/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-routing/modelserver/gpu/vllm/base/patch-vllm.yaml
@@ -17,6 +17,7 @@ spec:
             - "--gpu-memory-utilization=0.95"
             - "--kv-events-config"
             - '{"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"$(KV_EVENTS_ENDPOINT)","topic":"kv@$(POD_IP):$(POD_PORT)@Qwen/Qwen3-32B"}'
+            - "--shutdown-timeout=30"
             # Uncomment for distributed tracing
             # - "--otlp-traces-endpoint=http://otel-collector:4317"
             # - "--collect-detailed-traces=all"
@@ -82,6 +83,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: shm
           emptyDir:

--- a/guides/precise-prefix-cache-routing/modelserver/hpu/vllm/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-routing/modelserver/hpu/vllm/patch-vllm.yaml
@@ -23,6 +23,7 @@ spec:
             - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
             - "--kv-events-config"
             - '{"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"$(KV_EVENTS_ENDPOINT)","topic":"kv@$(POD_IP):$(POD_PORT)@Qwen/Qwen3-8B"}'
+            - "--shutdown-timeout=30"
             # Uncomment for distributed tracing
             # - "--otlp-traces-endpoint=http://otel-collector:4317"
             # - "--collect-detailed-traces=all"
@@ -81,6 +82,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+      terminationGracePeriodSeconds: 60
       resourceClaims:
         - name: precise-prefix-cache-routing-gaudi-claim
           resourceClaimTemplateName: precise-prefix-cache-routing-gaudi-claim

--- a/guides/precise-prefix-cache-routing/modelserver/tpu-v6/vllm/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-routing/modelserver/tpu-v6/vllm/patch-vllm.yaml
@@ -25,6 +25,7 @@ spec:
             - "--block-size=64"
             - "--kv-events-config"
             - '{"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"$(KV_EVENTS_ENDPOINT)","topic":"kv@$(POD_IP):$(POD_PORT)@meta-llama/Llama-3.1-70B-Instruct"}'
+            - "--shutdown-timeout=30"
             # Uncomment for distributed tracing
             # - "--otlp-traces-endpoint=http://otel-collector:4317"
             # - "--collect-detailed-traces=all"
@@ -83,6 +84,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: torch-compile-cache
           emptyDir: {}

--- a/guides/precise-prefix-cache-routing/modelserver/tpu-v7/vllm/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-routing/modelserver/tpu-v7/vllm/patch-vllm.yaml
@@ -27,6 +27,7 @@ spec:
             - "--block-size=64"
             - "--kv-events-config"
             - '{"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"$(KV_EVENTS_ENDPOINT)","topic":"kv@$(POD_IP):$(POD_PORT)@Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8"}'
+            - "--shutdown-timeout=30"
             # Uncomment for distributed tracing
             # - "--otlp-traces-endpoint=http://otel-collector:4317"
             # - "--collect-detailed-traces=all"
@@ -89,6 +90,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: torch-compile-cache
           emptyDir: {}

--- a/guides/precise-prefix-cache-routing/modelserver/xpu/vllm/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-routing/modelserver/xpu/vllm/patch-vllm.yaml
@@ -25,6 +25,7 @@ spec:
             - "--block-size=64"
             - "--kv-events-config"
             - '{"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"$(KV_EVENTS_ENDPOINT)","topic":"kv@$(POD_IP):$(POD_PORT)@Qwen/Qwen3-0.6B"}'
+            - "--shutdown-timeout=30"
             # Uncomment for distributed tracing
             # - "--otlp-traces-endpoint=http://otel-collector:4317"
             # - "--collect-detailed-traces=all"
@@ -87,6 +88,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+      terminationGracePeriodSeconds: 60
       resourceClaims:
         - name: intel-decode-claim
           resourceClaimTemplateName: intel-claim-template-decode

--- a/guides/tiered-prefix-cache/cpu/modelserver/gpu/vllm/lmcache-connector/base/patch-vllm.yaml
+++ b/guides/tiered-prefix-cache/cpu/modelserver/gpu/vllm/lmcache-connector/base/patch-vllm.yaml
@@ -18,6 +18,7 @@ spec:
             - "1024"
             - "--gpu-memory-utilization"
             - "0.8"
+            - "--shutdown-timeout=30"
           resources:
             limits:
               memory: 500Gi

--- a/guides/tiered-prefix-cache/cpu/modelserver/gpu/vllm/offloading-connector/base/patch-vllm.yaml
+++ b/guides/tiered-prefix-cache/cpu/modelserver/gpu/vllm/offloading-connector/base/patch-vllm.yaml
@@ -12,3 +12,4 @@ spec:
             - "--tensor-parallel-size=2"
             - "--kv-transfer-config"
             - '{"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"cpu_bytes_to_use":214748364800}}'
+            - "--shutdown-timeout=30"

--- a/guides/tiered-prefix-cache/cpu/modelserver/tpu-v7/vllm/tpu-offloading-connector/patch-vllm.yaml
+++ b/guides/tiered-prefix-cache/cpu/modelserver/tpu-v7/vllm/tpu-offloading-connector/patch-vllm.yaml
@@ -45,7 +45,8 @@ spec:
                 --kv-transfer-config '{"kv_connector":"TPUOffloadConnector","kv_connector_module_path":"tpu_inference.offload.tpu_offload_connector","kv_role":"kv_both"}' \
                 --port 8000 \
                 --tensor-parallel-size 8 \
-                --gpu-memory-utilization 0.9
+                --gpu-memory-utilization 0.9 \
+                --shutdown-timeout 30
           env:
             - name: PROMETHEUS_MULTIPROC_DIR
               value: "/tmp/prometheus_multiproc"
@@ -73,3 +74,4 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+      terminationGracePeriodSeconds: 60

--- a/guides/tiered-prefix-cache/storage/modelserver/gpu/vllm/llm-d-fs-connector/base/patch-vllm.yaml
+++ b/guides/tiered-prefix-cache/storage/modelserver/gpu/vllm/llm-d-fs-connector/base/patch-vllm.yaml
@@ -22,6 +22,7 @@ spec:
                 Qwen/Qwen3-32B \
                 --tensor-parallel-size 2 \
                 --max-num-seq 1024 \
+                --shutdown-timeout 30 \
                 --kv-transfer-config '{
                   "kv_connector":"MultiConnector",
                   "kv_role":"kv_both",
@@ -86,6 +87,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 3
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: shm
           emptyDir:

--- a/guides/tiered-prefix-cache/storage/modelserver/gpu/vllm/lmcache-connector/base/patch-vllm.yaml
+++ b/guides/tiered-prefix-cache/storage/modelserver/gpu/vllm/lmcache-connector/base/patch-vllm.yaml
@@ -19,6 +19,7 @@ spec:
             - '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'
             - "--gpu-memory-utilization"
             - "0.8"
+            - "--shutdown-timeout=30"
           env:
             - name: LMCACHE_LOCAL_DISK
               value: "file:///mnt/files-storage/kv-cache/"
@@ -29,6 +30,7 @@ spec:
           volumeMounts:
             - name: files-storage
               mountPath: /mnt/files-storage
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: files-storage
           persistentVolumeClaim:

--- a/guides/wide-ep-lws/modelserver/gpu/vllm/base/decode.yaml
+++ b/guides/wide-ep-lws/modelserver/gpu/vllm/base/decode.yaml
@@ -50,6 +50,7 @@ spec:
             securityContext:
               allowPrivilegeEscalation: false
               runAsNonRoot: true
+        terminationGracePeriodSeconds: 330
         volumes:
           - name: dshm
             emptyDir:
@@ -118,6 +119,7 @@ spec:
                                   "log_balancedness":"False"}' \
                   --all2all-backend deepep_low_latency \
                   --moe-backend deep_gemm \
+                  --shutdown-timeout 300 \
                   --kv-cache-memory-bytes=${KV_CACHE_MEMORY_BYTES-}
                   # To enable tracing, add:
                   # --otlp-traces-endpoint http://otel-collector:4317 \

--- a/guides/wide-ep-lws/modelserver/gpu/vllm/base/prefill.yaml
+++ b/guides/wide-ep-lws/modelserver/gpu/vllm/base/prefill.yaml
@@ -20,6 +20,7 @@ spec:
           llm-d.ai/role: prefill
       spec:
         serviceAccountName: deepseek-r1
+        terminationGracePeriodSeconds: 330
         volumes:
           - name: dshm
             emptyDir:
@@ -89,6 +90,7 @@ spec:
                                   "log_balancedness":"False"}' \
                   --moe-backend deep_gemm \
                   --all2all-backend deepep_high_throughput \
+                  --shutdown-timeout 300
                   # To enable tracing, add:
                   # --otlp-traces-endpoint http://otel-collector:4317 \
                   # --collect-detailed-traces all


### PR DESCRIPTION
Configure `--shutdown-timeout` and `terminationGracePeriodSeconds` across all vLLM guides. Values chosen are as follows:
- optimized-baseline, precise-prefix-cache-routing: 30s and 60s
- tiered-prefix-cache: 30s and 60s for all except  (CPU offloading variants — lmcache-connector, offloading-connector) - they have 30s and 130s
- pd-disaggregation: 60s and 90s
- wide-ep-lws: 300s and 330s

Fixes #1525

Reason behind choosing these values:

1. optimized-baseline / precise-prefix-cache-routing → The benchmark reports an ITL mean of 47ms/token for Qwen3-32B on H100s. A 500-token response completes in ~24s, well within 30s. 
2. pd-disaggregation → The benchmark at 5k ISL / 250 OSL shows p99=6.53s and max=11.12s. The guide targets 10k ISL / 1k OSL workloads, which roughly doubles request latency (~20-25s). Additional headroom accounts for RDMA KV transfer cleanup between prefill and decode pods during shutdown.
3. wide-ep-lws → The benchmark at 2k ISL / 2k OSL shows min=137s, mean=175s, and max=259s for DeepSeek-R1. 300s covers the observed maximum of 259s with a ~40s buffer.
4. tiered-prefix-cache → Same compute profile as optimized-baseline. The base patch for  (CPU offloading variants — lmcache-connector, offloading-connector) already had terminationGracePeriodSeconds: 130, which satisfies the >= shutdown-timeout rule; left unchanged to preserve the existing value. The remaining (storage + TPU variants — llm-d-fs-connector, lmcache-connector, tpu-offloading-connector) is set to terminationGracePeriodSeconds: 60.