### PR TITLE
docs(guides): install only the InferencePool CRD via v1-manifests.yaml

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -27,7 +27,7 @@ export NAMESPACE=llm-d-quickstart
 Install the Gateway API Inference Extension CRDs and create the namespace:
 
 ```bash
-kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
 kubectl create namespace ${NAMESPACE}
 ```
 

--- a/guides/optimized-baseline/README.md
+++ b/guides/optimized-baseline/README.md
@@ -63,7 +63,7 @@ This guide includes configurations for the following accelerators:
 - Install the Gateway API Inference Extension CRDs:
 
   ```bash
-    kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+    kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
   ```
 
 - Create a target namespace for the installation

--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -67,7 +67,7 @@ export MODEL_NAME="openai/gpt-oss-120b"
 * Install the Gateway API Inference Extension CRDs:
 
 ```bash
-kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
 ```
 * Create a target namespace for the installation
 

--- a/guides/precise-prefix-cache-routing/README.md
+++ b/guides/precise-prefix-cache-routing/README.md
@@ -67,7 +67,7 @@ export NAMESPACE="llm-d-${GUIDE_NAME}"
 - Install the Gateway API Inference Extension CRDs:
 
 ```bash
-kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
 ```
 
 - Create a target namespace for the installation

--- a/guides/predicted-latency-routing/README.md
+++ b/guides/predicted-latency-routing/README.md
@@ -44,7 +44,7 @@ Skip it when your pool is **heterogeneous** — mixed GPU types, model variants,
 - Install the Gateway API Inference Extension CRDs:
 
   ```bash
-    kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+    kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
   ```
 
 - Create a target namespace for the installation:

--- a/guides/prereq/gateways/agentgateway.md
+++ b/guides/prereq/gateways/agentgateway.md
@@ -24,7 +24,7 @@ GATEWAY_API_VERSION=v1.5.1
 GAIE_VERSION=v1.5.0
 
 kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api/config/crd?ref=${GATEWAY_API_VERSION}"
-kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
 ```
 
 Verify the APIs are available:
@@ -137,7 +137,7 @@ helm uninstall agentgateway-crds -n agentgateway-system
 kubectl delete namespace agentgateway-system
 kubectl delete gatewayclass agentgateway
 kubectl delete -k "https://github.com/kubernetes-sigs/gateway-api/config/crd?ref=${GATEWAY_API_VERSION}"
-kubectl delete -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+kubectl delete -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
 ```
 
 ## Troubleshooting

--- a/guides/prereq/gateways/gke.md
+++ b/guides/prereq/gateways/gke.md
@@ -25,7 +25,7 @@ For GKE versions `1.34.0-gke.1626000` or later, the InferencePool CRD is automat
 ```bash
 GAIE_VERSION=v1.5.0
 
-kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
 ```
 
 Verify the APIs are available:

--- a/guides/prereq/gateways/istio.md
+++ b/guides/prereq/gateways/istio.md
@@ -21,7 +21,7 @@ GATEWAY_API_VERSION=v1.5.1
 GAIE_VERSION=v1.5.0
 
 kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api/config/crd?ref=${GATEWAY_API_VERSION}"
-kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
 ```
 
 Verify the APIs are available:
@@ -109,7 +109,7 @@ istioctl uninstall --purge -y
 kubectl delete namespace istio-system
 kubectl delete gatewayclass istio istio-remote
 kubectl delete -k "https://github.com/kubernetes-sigs/gateway-api/config/crd?ref=${GATEWAY_API_VERSION}"
-kubectl delete -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+kubectl delete -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
 ```
 
 ## Troubleshooting

--- a/guides/recipes/gateway/install-gateway-crds.sh
+++ b/guides/recipes/gateway/install-gateway-crds.sh
@@ -44,7 +44,6 @@ kubectl $MODE -k https://github.com/kubernetes-sigs/gateway-api/config/crd/${GAT
 
 
 GATEWAY_API_INFERENCE_EXTENSION_CRD_REVISION=${GATEWAY_API_INFERENCE_EXTENSION_CRD_REVISION:-"v1.5.0"}
-GATEWAY_API_INFERENCE_EXTENSION_CRD_REF="?ref=${GATEWAY_API_INFERENCE_EXTENSION_CRD_REVISION}"
 ### GAIE CRDs
 log_success "🚪 GAIE CRDs: ${LOG_ACTION_NAME}..."
-kubectl $MODE -k https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd/${GATEWAY_API_INFERENCE_EXTENSION_CRD_REF} || true
+kubectl $MODE -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GATEWAY_API_INFERENCE_EXTENSION_CRD_REVISION}/v1-manifests.yaml || true

--- a/guides/tiered-prefix-cache/cpu/README.md
+++ b/guides/tiered-prefix-cache/cpu/README.md
@@ -62,7 +62,7 @@ This guide supports both GPU and TPU. GPU defaults to NVIDIA H100 and TPU defaul
 - Install the Gateway API Inference Extension CRDs:
 
   ```bash
-    kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+    kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
   ```
 
 - Create a target namespace for the installation

--- a/guides/tiered-prefix-cache/storage/README.md
+++ b/guides/tiered-prefix-cache/storage/README.md
@@ -71,7 +71,7 @@ For advanced configuration options and implementation details, see the [llm-d FS
 * Install the Gateway API Inference Extension CRDs:
 
   ```bash
-    kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+    kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
   ```
 
 * Create a target namespace for the installation:

--- a/guides/wide-ep-lws/README.md
+++ b/guides/wide-ep-lws/README.md
@@ -57,7 +57,7 @@ This guide includes configurations for the following accelerators:
 * Install the Gateway API Inference Extension CRDs:
 
   ```bash
-  kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
   ```
 * You have deployed the [LeaderWorkerSet controller](https://lws.sigs.k8s.io/docs/installation/)
 * Create a target namespace for the installation:


### PR DESCRIPTION
This is a follow up for #1640: Updates guides and getting-started docs to install the GAIE **InferencePool** CRD via the released `v1-manifests.yaml` manifest.

/cc @ahg-g