### PR TITLE
fix(ci): satisfy chart v0 tokenizer modelName validation

### DIFF
--- a/guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml
+++ b/guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml
@@ -8,6 +8,8 @@
 router:
   tokenizer:
     enabled: true
+    # Required by llm-d-router chart v0 when tokenizer is enabled; must match model server + plugins below.
+    modelName: Qwen/Qwen3-32B
 
   epp:
     replicas: 2


### PR DESCRIPTION
Fixes `dry-run-precise-prefix-cache-routing` CI failure where `helm template` against `llm-d-router-standalone-dev:v0` exits with:

```text
.Values.router.tokenizer.modelName is required when the tokenizer is enabled.
```

/cc @zdtsw @ahg-g 