### PR TITLE
guides/pd-disaggregation: add MoRI-IO + Wide-EP overlay (DSV3 1P1D, DP=EP=8,TP=1)

### DIFF
--- a/guides/pd-disaggregation/modelserver/amd/vllm/moriio/README.md
+++ b/guides/pd-disaggregation/modelserver/amd/vllm/moriio/README.md
@@ -1,0 +1,153 @@
+# AMD / vLLM / MoRI-IO P/D Disaggregation Overlay
+
+Single-pod **1P1D** P/D disaggregation overlay for DeepSeek-V3 on AMD
+Instinct GPUs, using the **MoRI-IO** KV-transfer connector and the
+**MoRI-EP** Wide-EP all-to-all backend (DP=8, EP=8, TP=1).
+
+This is the AMD-side companion to the existing NIXL overlay at
+`../base/`. Use this overlay when you want RDMA-Write KV transfer
+(MoRI-IO) instead of NIXL/UCX, and Wide-EP MoE expert parallelism
+inside a single pod instead of cross-pod TP.
+
+## Topology
+
+| Role    | Replicas | TP | DP | EP        | KV connector                    |
+| ------- | -------- | -- | -- | --------- | ------------------------------- |
+| Prefill | 1        | 1  | 8  | enabled   | `MoRIIOConnector` (kv_producer) |
+| Decode  | 1        | 1  | 8  | enabled   | `MoRIIOConnector` (kv_consumer) |
+
+Each pod consumes 8 GPUs on a single node; vLLM runs 8 data-parallel
+ranks locally with one OpenAI front-end per rank
+(`--api-server-count=8`). The routing sidecar in front of the decode
+pod hashes each request's UUID with blake2s and routes both the
+prefill and decode leg to the same DP rank, so a single conversation
+stays affinitised to one (P, D) rank pair.
+
+A small ZMQ "registration proxy" Deployment + Service
+(`moriio-zmq-proxy.yaml`) is included so the overlay is deployable
+on any cluster that satisfies the prerequisites below — no extra
+out-of-tree manifests required.
+
+## How it differs from `../base/`
+
+The sibling NIXL overlay (`pd-disaggregation/modelserver/amd/vllm/base/`)
+runs Llama-3.3-70B-Instruct-FP8-KV with TP=4 decode / TP=1 prefill and
+the upstream `NixlConnector` (kv_role=kv_both). This overlay adapts
+the same base recipe to:
+
+1. **Model**: `deepseek-ai/DeepSeek-V3` (~700 GiB MoE) instead of
+   Llama-3.3-70B-Instruct-FP8-KV (~70 GiB dense).
+2. **Connector**: `MoRIIOConnector` with split `kv_producer` /
+   `kv_consumer` roles (NIXL uses `kv_both`).
+3. **Parallelism**: TP=1, DP=8, EP enabled, with a **role-specific
+   MoRI all-to-all backend** &mdash; prefill uses
+   `--all2all-backend=mori_high_throughput` (backed by `InterNodeV1`,
+   optimised for large-batch throughput-bound prefill), decode uses
+   `--all2all-backend=mori_low_latency` (backed by `InterNodeV1LL`,
+   optimised for small-batch latency-bound decode). Both roles also
+   pass `--data-parallel-size{,-local}=8`, `--api-server-count=8`,
+   `--enable-expert-parallel`. The legacy single-name `mori` backend
+   was split upstream; do **not** use it here.
+4. **Resources**: 8 GPUs/pod (vs. 1 prefill / 4 decode on the NIXL
+   overlay), `hostNetwork: true`, RDMA NIC (`rdma/ib: 1`), and host
+   mounts for `/dev/kfd`, `/dev/dri`, `/dev/infiniband`,
+   `/sys/class/infiniband`, `/sys/class/net` &mdash; MoRI-IO needs
+   direct GPU-direct-RDMA NIC access.
+5. **Routing sidecar**: extra CLI flags (`--moriio-write-mode`,
+   `--moriio-dp-size=8`, `--moriio-tp-size=1`,
+   `--moriio-parallel-dispatch`, `--moriio-local-pod-ip=$(POD_IP)`)
+   plus a `POD_IP` downward-API env var. The sidecar image must be a
+   `llm-d-router` build that supports those flags (see "Required
+   overrides" below).
+
+Nothing about DP, TP, EP, or the model is hard-coded inside vLLM or
+`llm-d-router`; everything visible above is either a CLI flag or an
+env var, so this overlay can be cloned and re-tuned (e.g. DP=4 for
+half-pod runs, or TP=2/DP=4 hybrids) without touching binaries.
+
+## Required overrides
+
+`kustomization.yaml` declares two image references as **unbound
+placeholders**. `kustomize build` will fail until both are set.
+
+| Placeholder                       | Set to                                                                         |
+| --------------------------------- | ------------------------------------------------------------------------------ |
+| `REPLACE_MODEL_SERVER_IMAGE`      | A vLLM ROCm image with MoRI-IO + MoRI-EP support (see `docker/Dockerfile.rocm` and the companion vLLM PR adding MoRI-IO + MoRI-EP). |
+| `REPLACE_ROUTING_SIDECAR_IMAGE`   | A `llm-d-router` build that accepts the `--moriio-*` CLI flags (see the `llm-d-inference-scheduler` PR introducing them).            |
+
+Override both at deploy time:
+
+```bash
+kustomize edit set image \
+  REPLACE_MODEL_SERVER_IMAGE=<your-registry>/<vllm-rocm-moriio-image>:<tag> \
+  REPLACE_ROUTING_SIDECAR_IMAGE=<your-registry>/<llm-d-router-image>:<tag>
+```
+
+…or pin them in a per-cluster overlay one directory deeper.
+
+## Quickstart
+
+```bash
+# Pin the two images first (see "Required overrides" above), then:
+kustomize build guides/pd-disaggregation/modelserver/amd/vllm/moriio \
+  | kubectl apply -n llm-d -f -
+```
+
+Drive traffic at the decode pod's `Service` on port 8000 (the
+routing-proxy initContainer); it forwards to vLLM on 8200 after the
+MoRI-IO handshake is complete.
+
+## Prerequisites on the cluster
+
+- AMD Instinct GPU nodes with at least 8 GPUs per node and an RDMA
+  NIC exposed via the `k8s-rdma-shared-dev-plugin` (resource name
+  `rdma/ib`).
+- AMD GPU operator providing `amd.com/gpu`.
+- A working `Secret/llm-d-hf-token` (key `HF_TOKEN`) for the gated
+  DeepSeek-V3 weights, mounted via the recipe base. Create it with:
+
+  ```bash
+  kubectl -n llm-d create secret generic llm-d-hf-token \
+    --from-literal=HF_TOKEN="${HF_TOKEN:?set HF_TOKEN first}"
+  ```
+
+- Sufficient free space in the pod's writable layer for the
+  DeepSeek-V3 weights, **or** an out-of-tree overlay that mounts
+  pre-staged weights at `/models/DeepSeek-V3` and switches the
+  `vllm serve` first-positional arg from `deepseek-ai/DeepSeek-V3`
+  (HF Hub) to that path. `VLLM_ENGINE_READY_TIMEOUT_S` is set to a
+  permissive value to cover first-boot HF download.
+- A node label / nodeSelector strategy if you need to pin pods to
+  specific worker nodes; this overlay does not pin by default. Add a
+  small per-cluster overlay if you need that.
+
+See `../../../../prerequisites/` for cluster-bring-up details that
+apply to all P/D guides.
+
+## Verifying the deployment
+
+```bash
+kubectl -n llm-d get pods
+# Expect: pd-disaggregation-rocm-moriio-vllm-prefill-* Running
+#         pd-disaggregation-rocm-moriio-vllm-decode-*  Running
+#         moriio-zmq-proxy-*                          Running
+
+kubectl -n llm-d logs deploy/moriio-zmq-proxy
+# Expect a "register role=kv_producer ..." line per prefill DP rank
+# and a "register role=kv_consumer ..." line per decode DP rank.
+
+kubectl -n llm-d logs -l llm-d.ai/role=prefill --tail=50 \
+  | grep -E 'all2all-backend|MoRIIOConnector|engine ready'
+# Expect: --all2all-backend mori_high_throughput, kv_role=kv_producer
+
+kubectl -n llm-d logs -l llm-d.ai/role=decode --tail=50 \
+  | grep -E 'all2all-backend|MoRIIOConnector'
+# Expect: --all2all-backend mori_low_latency, kv_role=kv_consumer
+```
+
+## Tear down
+
+```bash
+kustomize build guides/pd-disaggregation/modelserver/amd/vllm/moriio \
+  | kubectl delete -n llm-d -f - --ignore-not-found
+```

--- a/guides/pd-disaggregation/modelserver/amd/vllm/moriio/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/vllm/moriio/kustomization.yaml
@@ -1,0 +1,110 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# MoRI-IO + Wide-EP overlay for the AMD/vLLM P/D disaggregation guide.
+#
+# Targets a single-pod 1P1D DeepSeek-V3 deployment with:
+#   - Tensor-parallel  = 1
+#   - Data-parallel    = 8        (intra-pod, "Wide-EP")
+#   - Expert-parallel  = enabled  (DP * TP = 8)
+#   - vLLM kv_connector = MoRIIOConnector  (RDMA Write of KV blocks
+#     between prefill and decode pods, instead of NIXL).
+#   - Routing sidecar  = llm-d-router with the --moriio-* flags so the
+#     proxy emits MoRI-IO-shaped kv_transfer_params and pins both legs
+#     of every disagg pair to the same DP rank H = blake2s(uuid).
+#
+# Differences vs. the sibling base/ overlay:
+#   1. Model: deepseek-ai/DeepSeek-V3 (~700 GiB MoE) instead of Llama-
+#      3.3-70B-Instruct-FP8-KV (~70 GiB dense).
+#   2. Resources: 8 GPUs/pod, hostNetwork, RDMA device mounts (MoRI-IO
+#      needs direct NIC access for the GPU-direct RDMA Write path).
+#   3. Connector: MoRIIOConnector with kv_role=kv_producer on prefill
+#      and kv_role=kv_consumer on decode (NixlConnector uses kv_both).
+#   4. Sidecar: extra --moriio-write-mode / --moriio-dp-size /
+#      --moriio-tp-size / --moriio-parallel-dispatch flags + POD_IP
+#      env var (downward API).
+#
+# Two image references are declared as unbound placeholders. Operators
+# MUST override both before deploy via `kustomize edit set image` or in
+# a per-cluster overlay; kustomize will fail loudly if either is left
+# unset.
+#
+#   - REPLACE_MODEL_SERVER_IMAGE -> a vLLM ROCm image with MoRI-EP and
+#     MoRI-IO compiled in (see the AMD vLLM image build instructions
+#     under docker/Dockerfile.rocm).
+#
+#   - REPLACE_ROUTING_SIDECAR_IMAGE -> a llm-d-router build that
+#     supports the --moriio-* CLI flags. See the README for the
+#     llm-d-inference-scheduler PR adding these flags.
+#
+# See README.md for the full list of required overrides
+# (model image, sidecar image, optional model-weights mount).
+
+resources:
+  - ../../../../../recipes/modelserver/base/single-host/pd/vllm
+  # In-cluster ZMQ registration proxy that every MoRIIO worker
+  # (prefill + decode rank) calls at startup. Exposed as a ClusterIP
+  # Service named moriio-zmq-proxy on port 10001; referenced from the
+  # prefill/decode patches' kv_connector_extra_config.proxy_ip /
+  # .proxy_ping_port keys.
+  - moriio-zmq-proxy.yaml
+
+namePrefix: pd-disaggregation-rocm-moriio-vllm-
+
+images:
+  - name: REPLACE_MODEL_SERVER_IMAGE
+  - name: REPLACE_ROUTING_SIDECAR_IMAGE
+
+labels:
+  - pairs:
+      llm-d.ai/model: DeepSeek-V3
+      llm-d.ai/guide: pd-disaggregation
+      llm-d.ai/accelerator-variant: gpu
+      llm-d.ai/accelerator-vendor: amd
+      llm-d.ai/kv-connector: moriio
+      inference.networking.k8s.io/engine-type: vllm
+    includeSelectors: true
+    includeTemplates: true
+    fields:
+      - version: v1
+        kind: ServiceAccount
+        path: metadata/labels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: metadata/labels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: spec/selector/matchLabels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: spec/template/metadata/labels
+        create: true
+      - group: monitoring.coreos.com
+        version: v1
+        kind: PodMonitor
+        path: metadata/labels
+        create: true
+      - group: monitoring.coreos.com
+        version: v1
+        kind: PodMonitor
+        path: spec/selector/matchLabels
+        create: true
+
+patches:
+  - path: patch-prefill.yaml
+  - path: patch-decode.yaml
+  # patch-sidecar overrides the recipe-default routing-proxy patch
+  # (recipes/.../vllm/patch-sidecar.yaml) with the MoRI-IO sidecar
+  # image and the additional --moriio-* CLI flags. Targets the decode
+  # Deployment by name (only decode runs the routing sidecar in P/D
+  # disagg).
+  - path: patch-sidecar.yaml
+    target:
+      kind: Deployment
+      name: decode

--- a/guides/pd-disaggregation/modelserver/amd/vllm/moriio/moriio-zmq-proxy.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/vllm/moriio/moriio-zmq-proxy.yaml
@@ -103,6 +103,13 @@ spec:
                 || pip install --no-cache-dir 'pyzmq>=26,<27' 'msgpack>=1.0,<2'
               exec python3 /opt/proxy/moriio_zmq_registration_proxy.py \
                 --bind 0.0.0.0 --port 10001
+          # The container runs as a non-root UID without a homedir; pip
+          # otherwise resolves HOME to "/" and fails to create /.local
+          # for the implicit --user install. Point HOME at /tmp so the
+          # pyzmq + msgpack install lands somewhere writable.
+          env:
+            - name: HOME
+              value: /tmp
           ports:
             - name: zmq-reg
               containerPort: 10001

--- a/guides/pd-disaggregation/modelserver/amd/vllm/moriio/moriio-zmq-proxy.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/vllm/moriio/moriio-zmq-proxy.yaml
@@ -1,0 +1,147 @@
+# MoRI-IO ZMQ registration proxy.
+#
+# Every vLLM worker (prefill + decode rank) registers with this ROUTER
+# socket at startup via the proxy_ip / proxy_ping_port keys in the
+# kv_connector_extra_config block (see patch-prefill.yaml /
+# patch-decode.yaml). The proxy is *not* on the KV data path -- KV
+# blocks travel directly between worker pods over RDMA -- but the
+# registration channel is required by MoRIIOConfig.from_vllm_config in
+# vLLM's moriio_common.py.
+#
+# This deployment is intentionally minimal:
+#   - public python:3.11-slim base image (no AMD-specific dependencies);
+#   - ClusterIP Service named "moriio-zmq-proxy" so workers reach it via
+#     the in-cluster DNS name (workers run hostNetwork=true with
+#     dnsPolicy=ClusterFirstWithHostNet, so cluster DNS resolves);
+#   - no node pinning, no hostNetwork, no privileged caps.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: moriio-zmq-proxy-script
+  labels:
+    app: moriio-zmq-proxy
+data:
+  moriio_zmq_registration_proxy.py: |
+    #!/usr/bin/env python3
+    """Tiny ZMQ ROUTER that logs MoRI-IO worker registrations."""
+    import argparse
+    import logging
+    import msgpack
+    import zmq
+
+    log = logging.getLogger(__name__)
+
+    def main() -> None:
+        logging.basicConfig(level=logging.INFO, format="%(message)s")
+        ap = argparse.ArgumentParser()
+        ap.add_argument("--bind", default="0.0.0.0")
+        ap.add_argument("--port", type=int, default=10001)
+        args = ap.parse_args()
+        ctx = zmq.Context.instance()
+        sock = ctx.socket(zmq.ROUTER)
+        url = f"tcp://{args.bind}:{args.port}"
+        sock.bind(url)
+        log.info("MoRI-IO registration proxy listening on %s (ZMQ ROUTER)", url)
+        while True:
+            try:
+                frames = sock.recv_multipart()
+                if len(frames) < 2:
+                    log.warning("short frame len=%s", len(frames))
+                    continue
+                payload = frames[-1]
+                try:
+                    data = msgpack.unpackb(payload, raw=False)
+                except Exception as exc:
+                    log.warning("msgpack decode failed: %s", exc)
+                    continue
+                if isinstance(data, dict) and data.get("type") == "register":
+                    log.info(
+                        "register role=%s idx=%s req=%s hs=%s notify=%s "
+                        "tp=%s dp=%s mode=%s",
+                        data.get("role"), data.get("index"),
+                        data.get("request_address"),
+                        data.get("handshake_port"), data.get("notify_port"),
+                        data.get("tp_size"), data.get("dp_size"),
+                        data.get("transfer_mode"),
+                    )
+                else:
+                    log.info("recv: %s", data)
+            except KeyboardInterrupt:
+                log.info("shutdown")
+                break
+
+    if __name__ == "__main__":
+        main()
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: moriio-zmq-proxy
+  labels:
+    app: moriio-zmq-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: moriio-zmq-proxy
+  template:
+    metadata:
+      labels:
+        app: moriio-zmq-proxy
+    spec:
+      containers:
+        - name: proxy
+          image: python:3.11-slim
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              python3 -c 'import zmq, msgpack' 2>/dev/null \
+                || pip install --no-cache-dir 'pyzmq>=26,<27' 'msgpack>=1.0,<2'
+              exec python3 /opt/proxy/moriio_zmq_registration_proxy.py \
+                --bind 0.0.0.0 --port 10001
+          ports:
+            - name: zmq-reg
+              containerPort: 10001
+              protocol: TCP
+          volumeMounts:
+            - name: script
+              mountPath: /opt/proxy
+              readOnly: true
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            capabilities:
+              drop: ["ALL"]
+      volumes:
+        - name: script
+          configMap:
+            name: moriio-zmq-proxy-script
+            defaultMode: 0444
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: moriio-zmq-proxy
+  labels:
+    app: moriio-zmq-proxy
+spec:
+  type: ClusterIP
+  selector:
+    app: moriio-zmq-proxy
+  ports:
+    - name: zmq-reg
+      port: 10001
+      targetPort: 10001
+      protocol: TCP

--- a/guides/pd-disaggregation/modelserver/amd/vllm/moriio/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/vllm/moriio/patch-decode.yaml
@@ -1,0 +1,170 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  replicas: 1
+  template:
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: modelserver
+          command: ["vllm", "serve"]
+          args:
+            # See patch-prefill.yaml for rationale (HF download via
+            # llm-d-hf-token, or replace with a hostPath/PVC overlay).
+            - "deepseek-ai/DeepSeek-V3"
+            - "--served-model-name=deepseek-ai/DeepSeek-V3"
+            - "--disable-uvicorn-access-log"
+            - "--tensor-parallel-size=1"
+            # Wide-EP: same 8-rank shape as prefill so DP-rank-N
+            # decode can pair with DP-rank-N prefill (the routing
+            # sidecar picks N via blake2s(uuid) for each request).
+            - "--data-parallel-size=8"
+            - "--data-parallel-size-local=8"
+            - "--api-server-count=8"
+            - "--enable-expert-parallel"
+            # Decode is latency-bound (small batches, autoregressive),
+            # so use the MoRI low-latency InterNodeV1LL kernels.
+            - "--all2all-backend=mori_low_latency"
+            # block-size=16 is the smallest value known to be stable
+            # on the current MoRI-IO + AITER-MLA stack.
+            - "--block-size=16"
+            - "--no-enable-prefix-caching"
+            - "--max-model-len=32768"
+            - "--compilation-config"
+            - '{"cudagraph_mode":"NONE"}'
+            - "--kv-transfer-config"
+            # See patch-prefill.yaml -- same in-cluster ZMQ proxy
+            # Service.
+            - '{"kv_connector":"MoRIIOConnector","kv_role":"kv_consumer","kv_connector_extra_config":{"proxy_ip":"moriio-zmq-proxy","proxy_ping_port":"10001","http_port":"8200","handshake_port":"6301","notify_port":"61005"}}'
+            # vLLM listens on 8200; the routing-proxy initContainer
+            # (patch-sidecar.yaml) listens on 8000 and forwards to
+            # 8200. Same convention as the sibling base/ NIXL overlay.
+            - "--port=8200"
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
+            - name: HUGGING_FACE_HUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
+            - name: VLLM_MORIIO_CONNECTOR_READ_MODE
+              value: "0"
+            - name: VLLM_ENGINE_READY_TIMEOUT_S
+              value: "7200"
+            - name: VLLM_USE_V1
+              value: "1"
+            - name: VLLM_ROCM_USE_AITER
+              value: "1"
+            - name: VLLM_ROCM_USE_AITER_MOE
+              value: "1"
+            - name: VLLM_USE_AITER_TRITON_FUSED_MOE
+              value: "1"
+            - name: VLLM_ROCM_USE_AITER_PAGED_ATTN
+              value: "0"
+            - name: VLLM_ROCM_USE_AITER_RMSNORM
+              value: "1"
+            - name: VLLM_USE_AITER_TRITON_SILU_MUL
+              value: "0"
+            - name: VLLM_ROCM_USE_AITER_MLA
+              value: "0"
+            - name: VLLM_CUDAGRAPH_MODE
+              value: "NONE"
+            - name: HSA_ENABLE_SDMA
+              value: "1"
+            - name: HSA_FORCE_FINE_GRAIN_PCIE
+              value: "1"
+          ports:
+            - containerPort: 8200
+              name: vllm
+              protocol: TCP
+            - containerPort: 6301
+              name: mori-handshake
+              protocol: TCP
+            - containerPort: 61005
+              name: mori-notify
+              protocol: TCP
+          resources:
+            limits:
+              cpu: "200"
+              memory: 1500Gi
+              amd.com/gpu: "8"
+              rdma/ib: "1"
+            requests:
+              cpu: "200"
+              memory: 1500Gi
+              amd.com/gpu: "8"
+              rdma/ib: "1"
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["IPC_LOCK", "SYS_PTRACE", "NET_RAW"]
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /.cache
+              name: torch-compile-cache
+            - mountPath: /dev/kfd
+              name: dev-kfd
+            - mountPath: /dev/dri
+              name: dev-dri
+            - mountPath: /dev/infiniband
+              name: dev-ib
+            - mountPath: /sys/class/infiniband
+              name: sys-class-ib
+              readOnly: true
+            - mountPath: /sys/class/net
+              name: sys-class-net
+              readOnly: true
+          # See patch-prefill.yaml for the named-port probe override
+          # rationale. Decode probes vLLM directly on 8200; the
+          # routing-sidecar initContainer fronts 8000 and forwards
+          # to 8200.
+          startupProbe:
+            httpGet: { path: /v1/models, port: 8200 }
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 240
+          livenessProbe:
+            httpGet: { path: /health, port: 8200 }
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet: { path: /v1/models, port: 8200 }
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 12
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Gi
+        - name: torch-compile-cache
+          emptyDir: {}
+        - name: dev-kfd
+          hostPath:
+            path: /dev/kfd
+        - name: dev-dri
+          hostPath:
+            path: /dev/dri
+        - name: dev-ib
+          hostPath:
+            path: /dev/infiniband
+        - name: sys-class-ib
+          hostPath:
+            path: /sys/class/infiniband
+        - name: sys-class-net
+          hostPath:
+            path: /sys/class/net

--- a/guides/pd-disaggregation/modelserver/amd/vllm/moriio/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/vllm/moriio/patch-decode.yaml
@@ -31,6 +31,14 @@ spec:
             # block-size=16 is the smallest value known to be stable
             # on the current MoRI-IO + AITER-MLA stack.
             - "--block-size=16"
+            # Leave headroom for MoRI-IO RDMA + MoRI-EP all2all
+            # buffers. The vLLM default of 0.9 is too aggressive on
+            # MI300X for DeepSeek-V3 with EP=8.
+            - "--gpu-memory-utilization=0.75"
+            # Pin the KV cache to a predictable 20 GB rather than
+            # letting vLLM auto-size from gpu-memory-utilization.
+            # Pairs with the lower utilization above.
+            - "--kv-cache-memory-bytes=20000000000"
             - "--no-enable-prefix-caching"
             - "--max-model-len=32768"
             - "--compilation-config"
@@ -80,6 +88,11 @@ spec:
               value: "0"
             - name: VLLM_CUDAGRAPH_MODE
               value: "NONE"
+            # MoRI shmem heap size (16 GiB). Read by the MoRI library
+            # at init for the EP all2all path. The library default is
+            # too small for DeepSeek-V3 with DP=EP=8.
+            - name: MORI_SHMEM_HEAP_SIZE
+              value: "17179869184"
             - name: HSA_ENABLE_SDMA
               value: "1"
             - name: HSA_FORCE_FINE_GRAIN_PCIE

--- a/guides/pd-disaggregation/modelserver/amd/vllm/moriio/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/vllm/moriio/patch-prefill.yaml
@@ -33,6 +33,14 @@ spec:
             # block-size=16 is the smallest value known to be stable
             # on the current MoRI-IO + AITER-MLA stack.
             - "--block-size=16"
+            # Leave headroom for MoRI-IO RDMA + MoRI-EP all2all
+            # buffers. The vLLM default of 0.9 is too aggressive on
+            # MI300X for DeepSeek-V3 with EP=8.
+            - "--gpu-memory-utilization=0.75"
+            # Pin the KV cache to a predictable 20 GB rather than
+            # letting vLLM auto-size from gpu-memory-utilization.
+            # Pairs with the lower utilization above.
+            - "--kv-cache-memory-bytes=20000000000"
             - "--no-enable-prefix-caching"
             - "--max-model-len=32768"
             # Eager decode for stability. Operators may flip to
@@ -102,6 +110,11 @@ spec:
               value: "1"
             - name: HSA_FORCE_FINE_GRAIN_PCIE
               value: "1"
+            # MoRI shmem heap size (16 GiB). Read by the MoRI library
+            # at init for the EP all2all path. The library default is
+            # too small for DeepSeek-V3 with DP=EP=8.
+            - name: MORI_SHMEM_HEAP_SIZE
+              value: "17179869184"
           ports:
             - containerPort: 8000
               name: vllm

--- a/guides/pd-disaggregation/modelserver/amd/vllm/moriio/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/vllm/moriio/patch-prefill.yaml
@@ -1,0 +1,192 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prefill
+spec:
+  replicas: 1
+  template:
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: modelserver
+          command: ["vllm", "serve"]
+          args:
+            # Model id resolved via HF Hub using the llm-d-hf-token
+            # Secret. Operators with locally-staged weights should add
+            # a per-cluster overlay that mounts a hostPath / PVC at
+            # /models/DeepSeek-V3 and replaces this argument with that
+            # path (and re-enables HF_HUB_OFFLINE below).
+            - "deepseek-ai/DeepSeek-V3"
+            - "--served-model-name=deepseek-ai/DeepSeek-V3"
+            - "--disable-uvicorn-access-log"
+            - "--tensor-parallel-size=1"
+            # Wide-EP: 8 DP ranks all local to this single pod (no
+            # cross-pod DP), one OAI front-end per rank.
+            - "--data-parallel-size=8"
+            - "--data-parallel-size-local=8"
+            - "--api-server-count=8"
+            - "--enable-expert-parallel"
+            # Prefill is throughput-bound (large prompt batches), so
+            # use the MoRI high-throughput InterNodeV1 kernels.
+            - "--all2all-backend=mori_high_throughput"
+            # block-size=16 is the smallest value known to be stable
+            # on the current MoRI-IO + AITER-MLA stack.
+            - "--block-size=16"
+            - "--no-enable-prefix-caching"
+            - "--max-model-len=32768"
+            # Eager decode for stability. Operators may flip to
+            # PIECEWISE in a per-cluster overlay if desired.
+            - "--compilation-config"
+            - '{"cudagraph_mode":"NONE"}'
+            - "--kv-transfer-config"
+            # proxy_ip / proxy_ping_port refer to the moriio-zmq-proxy
+            # ClusterIP Service declared in moriio-zmq-proxy.yaml;
+            # workers reach it via in-cluster DNS even though the pod
+            # runs hostNetwork=true (dnsPolicy=ClusterFirstWithHostNet
+            # above wires the cluster DNS resolver in).
+            #
+            # Required keys per moriio_common.py::MoRIIOConfig.from_vllm_config.
+            - '{"kv_connector":"MoRIIOConnector","kv_role":"kv_producer","kv_connector_extra_config":{"proxy_ip":"moriio-zmq-proxy","proxy_ping_port":"10001","http_port":"8000","handshake_port":"6301","notify_port":"61005"}}'
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            # vLLM HEAD-checks HF Hub on startup for the latest
+            # config/tokenizer manifest. Wire HF_TOKEN from the
+            # recipe-managed Secret so the lookup is authenticated and
+            # not rate-limited.
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
+            - name: HUGGING_FACE_HUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
+            # MoRIIOConnector defaults to WRITE mode; "0" means "not
+            # READ" and pairs with the routing sidecar's
+            # --moriio-write-mode flag.
+            - name: VLLM_MORIIO_CONNECTOR_READ_MODE
+              value: "0"
+            # First-boot DSV3 weight download plus DP=8 AITER JIT
+            # warm-up exceeds the upstream 600s engine-ready timeout.
+            # Tune down once weights are staged.
+            - name: VLLM_ENGINE_READY_TIMEOUT_S
+              value: "7200"
+            - name: VLLM_USE_V1
+              value: "1"
+            - name: VLLM_ROCM_USE_AITER
+              value: "1"
+            - name: VLLM_ROCM_USE_AITER_MOE
+              value: "1"
+            - name: VLLM_USE_AITER_TRITON_FUSED_MOE
+              value: "1"
+            - name: VLLM_ROCM_USE_AITER_PAGED_ATTN
+              value: "0"
+            - name: VLLM_ROCM_USE_AITER_RMSNORM
+              value: "1"
+            - name: VLLM_USE_AITER_TRITON_SILU_MUL
+              value: "0"
+            # Use TRITON_MLA rather than the AITER mla_a8w8 kernel
+            # for stability with EP=8 + MoRI-IO. Pair with
+            # VLLM_CUDAGRAPH_MODE=NONE.
+            - name: VLLM_ROCM_USE_AITER_MLA
+              value: "0"
+            - name: VLLM_CUDAGRAPH_MODE
+              value: "NONE"
+            - name: HSA_ENABLE_SDMA
+              value: "1"
+            - name: HSA_FORCE_FINE_GRAIN_PCIE
+              value: "1"
+          ports:
+            - containerPort: 8000
+              name: vllm
+              protocol: TCP
+            - containerPort: 6301
+              name: mori-handshake
+              protocol: TCP
+            - containerPort: 61005
+              name: mori-notify
+              protocol: TCP
+          resources:
+            limits:
+              cpu: "200"
+              memory: 1500Gi
+              amd.com/gpu: "8"
+              rdma/ib: "1"
+            requests:
+              cpu: "200"
+              memory: 1500Gi
+              amd.com/gpu: "8"
+              rdma/ib: "1"
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["IPC_LOCK", "SYS_PTRACE", "NET_RAW"]
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /.cache
+              name: torch-compile-cache
+            - mountPath: /dev/kfd
+              name: dev-kfd
+            - mountPath: /dev/dri
+              name: dev-dri
+            - mountPath: /dev/infiniband
+              name: dev-ib
+            - mountPath: /sys/class/infiniband
+              name: sys-class-ib
+              readOnly: true
+            - mountPath: /sys/class/net
+              name: sys-class-net
+              readOnly: true
+          # The upstream llm-d-modelservice chart's probe block
+          # references a named container port "modelserver" that the
+          # chart never creates on the container, so kubelet errors
+          # with `strconv.Atoi: parsing "modelserver": invalid syntax`
+          # and the kubelet kills the container after the liveness
+          # threshold is reached. Override every probe with an
+          # explicit numeric port (8000 = vLLM API server, since
+          # prefill has hostNetwork=true and no routing sidecar).
+          startupProbe:
+            httpGet: { path: /v1/models, port: 8000 }
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 240
+          livenessProbe:
+            httpGet: { path: /health, port: 8000 }
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet: { path: /v1/models, port: 8000 }
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 12
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Gi
+        - name: torch-compile-cache
+          emptyDir: {}
+        - name: dev-kfd
+          hostPath:
+            path: /dev/kfd
+        - name: dev-dri
+          hostPath:
+            path: /dev/dri
+        - name: dev-ib
+          hostPath:
+            path: /dev/infiniband
+        - name: sys-class-ib
+          hostPath:
+            path: /sys/class/infiniband
+        - name: sys-class-net
+          hostPath:
+            path: /sys/class/net

--- a/guides/pd-disaggregation/modelserver/amd/vllm/moriio/patch-sidecar.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/vllm/moriio/patch-sidecar.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: routing-proxy
+          # Override the recipe-default NIXLv2 sidecar image with a
+          # llm-d-router build that supports the --moriio-* CLI flags
+          # below (WRITE-mode wire shape and blake2s(uuid)-based
+          # DP-rank pinning).
+          image: REPLACE_ROUTING_SIDECAR_IMAGE
+          imagePullPolicy: IfNotPresent
+          # Strategic-merge replaces (does not append to) the args
+          # list, so re-emit the recipe defaults plus the MoRI-IO
+          # flags. Keep in sync with
+          # recipes/modelserver/base/single-host/pd/vllm/patch-sidecar.yaml.
+          args:
+            - --port=8000
+            - --vllm-port=8200
+            - --connector=nixlv2
+            - --zap-log-level=1
+            - --secure-proxy=false
+            # MoRI-IO WRITE-mode toggle. When set, the prefill leg of
+            # buildKVTransferParamsForPrefill emits the full
+            # remote_host / remote_notify_port / remote_dp_rank /
+            # remote_handshake_port / "tx"-prefixed transfer_id tuple
+            # that vLLM's MoRIIOConnector WRITE branch requires.
+            - --moriio-write-mode
+            # Wide-EP shape: blake2s(uuid) -> rank in [0, dp-size) and
+            # both legs of every disagg pair pin to that rank. dp-size
+            # MUST match the vLLM --data-parallel-size on prefill and
+            # decode (8 in this overlay).
+            - --moriio-dp-size=8
+            - --moriio-tp-size=1
+            # Concurrent prefill/decode dispatch: fire both legs in
+            # parallel goroutines so decode block-allocation overlaps
+            # with prefill compute. Off-by-default in the sidecar;
+            # opt in here because WRITE-mode does not depend on
+            # prefill-supplied kv_transfer_params and is safe to
+            # parallelise.
+            - --moriio-parallel-dispatch
+            # Pod IP that prefill should RDMA-write KV blocks back
+            # to. Read at startup from the POD_IP env var below; if
+            # left empty / 127.0.0.1 the prefill engine would
+            # handshake with itself and hang.
+            - --moriio-local-pod-ip=$(POD_IP)
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          ports:
+            - containerPort: 8000
+              name: sidecar
+              protocol: TCP
+          resources: {}
+          restartPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true


### PR DESCRIPTION
Adds an AMD/vLLM 1P1D P/D-disaggregation example for DeepSeek-V3 that uses the MoRI-IO KV-transfer connector and the MoRI-EP all-to-all backend instead of NIXL/UCX.  Sibling overlay to base/ (NIXL + Llama-3.3-70B-FP8-KV).

The overlay deploys with a single `kustomize build | kubectl apply` once two image placeholders are pinned (a vLLM ROCm image with MoRI-IO + MoRI-EP support and an llm-d-router build that supports the new --moriio-* CLI flags).

- Prefill: DP=8 / EP enabled / TP=1, --all2all-backend=mori_high_throughput, MoRIIOConnector kv_role=kv_producer.
- Decode: DP=8 / EP enabled / TP=1, --all2all-backend=mori_low_latency, MoRIIOConnector kv_role=kv_consumer.
- Routing sidecar: opt-in --moriio-write-mode / --moriio-dp-size=8 / --moriio-tp-size=1 / --moriio-parallel-dispatch / --moriio-local-pod-ip=$(POD_IP).
- In-cluster ZMQ registration proxy (Deployment + ClusterIP Service, public python:3.11-slim image) so the overlay is self-contained.
- Weights resolved via HF Hub using the recipe-managed llm-d-hf-token Secret; per-cluster overlays may swap in a hostPath / PVC mount.
- The PR will address https://github.com/llm-d/llm-d/issues/1470 and https://github.com/llm-d/llm-d/issues/1469