### PR TITLE
fix(docker): add default values for EFA env vars in CUDA scripts

### DIFF
--- a/docker/scripts/cuda/builder/install-base-packages.sh
+++ b/docker/scripts/cuda/builder/install-base-packages.sh
@@ -8,8 +8,11 @@ set -Eeux
 # - CUDA_MAJOR: CUDA major version (e.g., 12)
 # - TARGETOS: Target OS - either 'ubuntu' or 'rhel' (default: rhel)
 # - TARGETPLATFORM: platform target (linux/arm64 or linux/amd64)
+# Optional environment variables:
+# - ENABLE_EFA: Enable EFA support (true/false, default: false)
 
 TARGETOS="${TARGETOS:-rhel}"
+ENABLE_EFA="${ENABLE_EFA:-false}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # source shared utilities (check script dir first, fallback to /tmp for docker builds)

--- a/docker/scripts/cuda/common/install-efa.sh
+++ b/docker/scripts/cuda/common/install-efa.sh
@@ -12,6 +12,7 @@ set -Eeu
 : "${ENABLE_EFA:=false}"
 : "${EFA_INSTALLER_VERSION:=}"
 : "${EFA_MODE:=builder}"
+: "${TARGETOS:=rhel}"
 
 # Validate mode
 if [ "${EFA_MODE}" != "builder" ] && [ "${EFA_MODE}" != "runtime" ]; then
@@ -20,7 +21,7 @@ if [ "${EFA_MODE}" != "builder" ] && [ "${EFA_MODE}" != "runtime" ]; then
 fi
 
 # Skip EFA installation if not enabled, on Ubuntu, or missing installer version
-if [ "${ENABLE_EFA}" != "true" ] || [ "$TARGETOS" != "rhel" ]; then
+if [ "${ENABLE_EFA}" != "true" ] || [ "${TARGETOS}" != "rhel" ]; then
     echo "EFA installation skipped (ENABLE_EFA=${ENABLE_EFA}, TARGETOS=${TARGETOS})"
     # Create empty folder so Dockerfile COPY doesn't fail (builder mode only)
     if [ "${EFA_MODE}" = "builder" ]; then

--- a/docker/scripts/cuda/runtime/install-runtime-packages.sh
+++ b/docker/scripts/cuda/runtime/install-runtime-packages.sh
@@ -9,8 +9,11 @@ set -Eeux
 # - CUDA_MINOR: CUDA minor version (e.g., 9)
 # - TARGETOS: Target OS - either 'ubuntu' or 'rhel' (default: rhel)
 # - TARGETPLATFORM: TARGET PLATFORM - either linux/amd64 or linux/arm64
+# Optional environment variables:
+# - ENABLE_EFA: Enable EFA support (true/false, default: false)
 
 TARGETOS="${TARGETOS:-rhel}"
+ENABLE_EFA="${ENABLE_EFA:-false}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # source shared utilities (check script dir first, fallback to /tmp for docker builds)


### PR DESCRIPTION
Set ENABLE_EFA and TARGETOS defaults in builder, runtime, and common install scripts so EFA installation can be properly controlled without requiring explicit env var passing from the Dockerfile.

Consistent with other files:
* builder/build-nvshmem.sh 
* builder/build-nixl.sh 
* builder/build-ucx.sh