### PR TITLE
add benchmark results for kv cache cpu offload on gpt-oss-120b 

### DIFF
--- a/guides/tiered-prefix-cache/README.md
+++ b/guides/tiered-prefix-cache/README.md
@@ -127,6 +127,18 @@ For advanced configuration options and implementation details, see the [llm-d FS
 | HBM Staging Buffer Size   | 1000 Blocks (~34 GB)                                    |
 | CPU Cache Offload Size    | 25000 Chunks (~780 GB)                                  |
 
+
+## Additional Configuration
+
+### GPU 
+
+| Parameter                 | Value                                                   |
+| ------------------------- | ------------------------------------------------------- |
+| Model                     | [openai/gpt-oss-120b](https://huggingface.co/openai/gpt-oss-120b) |
+| GPUs per replica (TP)     | 1                                                       |
+| GPU Accelerator           | NVIDIA H100                                             |
+| CPU Cache Offload Size    | 100 GB          
+
 This guide supports both GPU and TPU. The Kustomize overlays are available in `modelserver/gpu/vllm/` and `modelserver/tpu-v7/vllm/`.
 
 ---
@@ -459,3 +471,11 @@ LMCache configuration: `LMCACHE_MAX_LOCAL_CPU_SIZE=20GB`, `LMCACHE_MAX_LOCAL_DIS
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 | **Baseline vLLM + CPU offloading** | 27.11 | 41.71 | 57.06 | 72.28 | 18333 | 350 | 18682 | 0.029 |
 | **vLLM + CPU offloading + Lustre** | 15.25 (-43.7%) | 24.71 (-40.8%) | 38.55 (-32.4%) | 48.01 (-33.6%) | 27091 (+47.8%) | 517 (+47.7%) | 27609 (+47.8%) | 0.022 (-24.1%) |
+
+
+
+### gpt-oss-120B Benchmarking Results  
+
+The benchmark runs on 16 × H100 GPUs, distributed across 16 model servers (1 H100s per server with TP=1) using gpt-oss-120B and the same workload as in [default configuration benchmark results](#cpu-offloading-benchmarking-results). The benchmark compares to optimized baseline configuration.
+
+For detailed results see [gpt-oss-120B benchmarking results](#benchmark-results-gpt-oss-120b.md).

--- a/guides/tiered-prefix-cache/benchmark-results-gpt-oss-120b.md
+++ b/guides/tiered-prefix-cache/benchmark-results-gpt-oss-120b.md
@@ -38,41 +38,23 @@ The benchmark runs on 16 × H100 GPUs, distributed across 16 model servers (1 H1
 | External cache queries (tokens) | N/A | 135.3M |
 
 
-### Previous Benchmarking Results
+### Per-Stage Breakdown (5–40 QPS)
 
-> [!NOTE]
-> The following benchmark results were from a previous release and does not match the deployment of the current release. A follow up benchmark will be conducted and the results will be updated accordingly. See <https://github.com/llm-d/llm-d/issues/680>.
-
-### GPU
-
-#### High Cache Scenario (HBM < KVCache < HBM + CPU RAM)
-
-| Medium Configuration | Mean TTFT (second) | P90 TTFT (second) | Mean E2E Latency (second) | P90 E2E Latency (second) | Overall Throughput (token per second) |
-| :--- | :--- | :--- | :--- | :--- | :--- |
-| **Baseline vLLM** | 9.0 | 20.9 | 37.8 | 49.7 | 38,534.8 |
-| **vLLM + CPU offloading 100GB** | 6.7 (-25.6%) | 20.2 (-3.3%) | 30.9 (-18.3%) | 44.2 (-11.1%) | 46,751.0 (+21.3%) |
-| **vLLM + LMCache CPU offloading 100GB** | 6.5 (-27.8%) | 18.8 (-10.0%) | 30.8 (-18.5%) | 43.0 (-13.5%) | 46,910.6 (+21.7%) |
-
-#### Low Cache Scenario (KVCache < HBM)
-
-| Medium Configuration | Mean TTFT (second) | P90 TTFT (second) | Mean E2E Latency (second) | P90 E2E Latency (second) | Overall Throughput (token per second) |
-| :--- | :--- | :--- | :--- | :--- | :--- |
-| **Baseline vLLM** | 0.12 | 0.09 | 18.4 | 19.6 | 23,389.6 |
-| **vLLM + CPU offloading 100GB** | 0.13 | 0.11 | 18.6 | 20.6 | 23,032.6 |
-| **vLLM + LMCache CPU offloading 100GB** | 0.15 | 0.10 | 18.9 | 19.6 | 22,772.5 |
-
-### TPU
-
-#### High Cache Scenario (HBM < KVCache < HBM + CPU RAM)
-
-| Medium Configuration | Mean TTFT (second) | P90 TTFT (second) | Mean E2E Latency (second) | P90 E2E Latency (second) | Overall Throughput (token per second) |
-| :--- | :--- | :--- | :--- | :--- | :--- |
-| **Baseline vLLM** | 0.98 | 2.1 | 22.1 | 26.2 | 67262.3 |
-| **vLLM + CPU offloading 25000 Chunks** | 0.56 (-49%) | 0.5 (-75.7%) | 20.3 (-8.1%) | 23.6 (-9.9%) | 73178.1 (+8.9%) |
-
-#### Low Cache Scenario (KVCache < HBM)
-
-| Medium Configuration | Mean TTFT (second) | P90 TTFT (second) | Mean E2E Latency (second) | P90 E2E Latency (second) | Overall Throughput (token per second) |
-| :--- | :--- | :--- | :--- | :--- | :--- |
-| **Baseline vLLM** | 0.24 | 0.23 | 16.9 | 19.9 | 25715.9 |
-| **vLLM + CPU offloading 25000 Chunks** | 0.26 | 0.24 | 17.4 | 20.2 | 23,032.6 |
+| Target Rate | Configuration | Mean TTFT | P90 TTFT | Mean E2E Latency | P90 E2E Latency | Throughput (tok/s) |
+| :---: | :--- | :---: | :---: | :---: | :---: | :---: |
+| **5 QPS** | optimized-baseline | 0.45s | 0.57s | 1.80s | 2.05s | 1,983 |
+| | cpu-offload | 0.43s (-3.7%) | 0.56s (-2.1%) | 1.80s (-0.1%) | 2.04s (-0.2%) | 1,738 (-12.3%) |
+| **10 QPS** | optimized-baseline | 0.44s | 0.56s | 1.98s | 2.38s | 3,664 |
+| | cpu-offload | 0.37s (-17.9%) | 0.55s (-1.7%) | 1.91s (-3.3%) | 2.28s (-4.3%) | 3,799 (+3.7%) |
+| **15 QPS** | optimized-baseline | 0.45s | 0.57s | 2.73s | 3.45s | 5,653 |
+| | cpu-offload | 0.35s (-22.4%) | 0.55s (-2.4%) | 2.17s (-20.4%) | 2.65s (-23.2%) | 5,171 (-8.5%) |
+| **20 QPS** | optimized-baseline | 0.73s | 1.04s | 5.59s | 9.72s | 6,581 |
+| | cpu-offload | 0.32s (-55.8%) | 0.56s (-46.3%) | 2.60s (-53.5%) | 3.39s (-65.1%) | 6,967 (+5.9%) |
+| **25 QPS** | optimized-baseline | 6.16s | 10.71s | 14.29s | 18.62s | 7,229 |
+| | cpu-offload | 0.34s (-94.5%) | 0.57s (-94.7%) | 3.46s (-75.8%) | 4.61s (-75.3%) | 8,777 (+21.4%) |
+| **30 QPS** | optimized-baseline | 14.07s | 26.17s | 22.51s | 34.04s | 6,822 |
+| | cpu-offload | 0.33s (-97.6%) | 0.58s (-97.8%) | 4.24s (-81.2%) | 5.50s (-83.8%) | 9,767 (+43.2%) |
+| **35 QPS** | optimized-baseline | 18.44s | 35.16s | 26.52s | 41.82s | 7,178 |
+| | cpu-offload | 0.50s (-97.3%) | 0.84s (-97.6%) | 6.16s (-76.8%) | 7.41s (-82.3%) | 11,677 (+62.7%) |
+| **40 QPS** | optimized-baseline | 24.78s | 45.42s | 32.78s | 52.03s | 6,722 |
+| | cpu-offload | 4.24s (-82.9%) | 8.76s (-80.7%) | 10.33s (-68.5%) | 14.63s (-71.9%) | 11,742 (+74.7%) |

--- a/guides/tiered-prefix-cache/benchmark-results-gpt-oss-120b.md
+++ b/guides/tiered-prefix-cache/benchmark-results-gpt-oss-120b.md
@@ -1,6 +1,6 @@
 ## High Cache Scenario (HBM < KVCache < HBM + CPU RAM)
 
-The benchmark runs on 16 × H100 GPUs, distributed across 16 model servers (1 H100s per server with TP=2) using gpt-oss-120B and the same workload as in [default configuration benchmark results](#README.md/benchmarking-results). The benchmark compares to optimized baseline configuration.
+The benchmark runs on 16 × H100 GPUs, distributed across 16 model servers (1 H100s per server with TP=1) using gpt-oss-120B and the same workload as in [default configuration benchmark results](#README.md/benchmarking-results). The benchmark compares to optimized baseline configuration.
 
 ### Throughput
 

--- a/guides/tiered-prefix-cache/benchmark-results-gpt-oss-120b.md
+++ b/guides/tiered-prefix-cache/benchmark-results-gpt-oss-120b.md
@@ -1,0 +1,78 @@
+## High Cache Scenario (HBM < KVCache < HBM + CPU RAM)
+
+The benchmark runs on 16 × H100 GPUs, distributed across 16 model servers (1 H100s per server with TP=2) using gpt-oss-120B and the same workload as in [default configuration benchmark results](#README.md/benchmarking-results). The benchmark compares to optimized baseline configuration.
+
+### Throughput
+
+| Metric | llm-d baseline | KV cache offload | Delta |
+| --- | --- | --- | --- |
+| Requests/sec (successful) | 9.69 | 11.48 | **+1.8 (+18.4%)** |
+| Output tokens/sec | 3,704 | 4,120 | **+416.0 (+11.2%)** |
+| Total tokens/sec | 166,056 | 196,332 | **+30276 (+18.2%)** |
+| Input tokens/sec | 162,353 | 192,212 | **+29859 (+18.4%)** |
+
+### Latency (successful requests only)
+
+| Metric | llm-d baseline | KV cache offload | Delta |
+| --- | --- | --- | --- |
+| Mean request latency | 19.2s | 5.3s | **-13.9 (-72.3%)** |
+| Median request latency | 15.9s | 4.4s | **-11.5 (-72.4%)** |
+| P90 request latency | 41.6s | 10.9s | **-30.7 (-73.9%)** |
+| Mean TTFT | 12.5s | 1.2s | **-11.2 (-90.0%)** |
+| Median TTFT | 7.6s | 0.5s | **-7.0 (-92.9%)** |
+| P90 TTFT | 33.8s | 4.5s | **-29.3 (-86.7%)** |
+| **Mean TPOT** | 26.1ms | 15.7ms | **-10.4 (-39.8%)** |
+| Median TPOT | 30.2ms | 15.2ms | **-15.0 (-49.7%)** |
+| P90 TPOT | 36.4ms | 25.4ms | **-11.0 (-30.3%)** |
+| ITL mean | 26.1ms | 15.7ms | **-10.4 (-39.8%)** |
+
+### vLLM Server Metrics (fleet aggregate)
+
+| Metric | llm-d baseline | KV cache offload |
+| --- | --- | --- |
+| **Internal GPU cache hit rate** | **1.1%** | **5.3%** |
+| Internal cache hits (tokens) | 27.0M | 45.6M |
+| Internal cache queries (tokens) | 2564.7M | 853.6M |
+| **External (CPU offload) hit rate** | N/A | **45.1%** |
+| External cache hits (tokens) | N/A | 61.0M |
+| External cache queries (tokens) | N/A | 135.3M |
+
+
+### Previous Benchmarking Results
+
+> [!NOTE]
+> The following benchmark results were from a previous release and does not match the deployment of the current release. A follow up benchmark will be conducted and the results will be updated accordingly. See <https://github.com/llm-d/llm-d/issues/680>.
+
+### GPU
+
+#### High Cache Scenario (HBM < KVCache < HBM + CPU RAM)
+
+| Medium Configuration | Mean TTFT (second) | P90 TTFT (second) | Mean E2E Latency (second) | P90 E2E Latency (second) | Overall Throughput (token per second) |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| **Baseline vLLM** | 9.0 | 20.9 | 37.8 | 49.7 | 38,534.8 |
+| **vLLM + CPU offloading 100GB** | 6.7 (-25.6%) | 20.2 (-3.3%) | 30.9 (-18.3%) | 44.2 (-11.1%) | 46,751.0 (+21.3%) |
+| **vLLM + LMCache CPU offloading 100GB** | 6.5 (-27.8%) | 18.8 (-10.0%) | 30.8 (-18.5%) | 43.0 (-13.5%) | 46,910.6 (+21.7%) |
+
+#### Low Cache Scenario (KVCache < HBM)
+
+| Medium Configuration | Mean TTFT (second) | P90 TTFT (second) | Mean E2E Latency (second) | P90 E2E Latency (second) | Overall Throughput (token per second) |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| **Baseline vLLM** | 0.12 | 0.09 | 18.4 | 19.6 | 23,389.6 |
+| **vLLM + CPU offloading 100GB** | 0.13 | 0.11 | 18.6 | 20.6 | 23,032.6 |
+| **vLLM + LMCache CPU offloading 100GB** | 0.15 | 0.10 | 18.9 | 19.6 | 22,772.5 |
+
+### TPU
+
+#### High Cache Scenario (HBM < KVCache < HBM + CPU RAM)
+
+| Medium Configuration | Mean TTFT (second) | P90 TTFT (second) | Mean E2E Latency (second) | P90 E2E Latency (second) | Overall Throughput (token per second) |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| **Baseline vLLM** | 0.98 | 2.1 | 22.1 | 26.2 | 67262.3 |
+| **vLLM + CPU offloading 25000 Chunks** | 0.56 (-49%) | 0.5 (-75.7%) | 20.3 (-8.1%) | 23.6 (-9.9%) | 73178.1 (+8.9%) |
+
+#### Low Cache Scenario (KVCache < HBM)
+
+| Medium Configuration | Mean TTFT (second) | P90 TTFT (second) | Mean E2E Latency (second) | P90 E2E Latency (second) | Overall Throughput (token per second) |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| **Baseline vLLM** | 0.24 | 0.23 | 16.9 | 19.9 | 25715.9 |
+| **vLLM + CPU offloading 25000 Chunks** | 0.26 | 0.24 | 17.4 | 20.2 | 23,032.6 |

--- a/guides/tiered-prefix-cache/modelserver/gpu/vllm/base/kustomization-gpt-oss-120b.yaml
+++ b/guides/tiered-prefix-cache/modelserver/gpu/vllm/base/kustomization-gpt-oss-120b.yaml
@@ -1,0 +1,44 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../../../../recipes/modelserver/base/single-host/default
+
+namePrefix: optimized-baseline-
+
+images:
+  - name: REPLACE_MODEL_SERVER_IMAGE
+    newName: vllm/vllm-openai
+    newTag: v0.22.0
+
+labels:
+  - pairs:
+      llm-d.ai/model: gpt-oss-120b
+      llm-d.ai/guide: tiered-prefix-cache
+      llm-d.ai/accelerator-variant: gpu
+      llm-d.ai/accelerator-vendor: nvidia
+    includeSelectors: true
+    includeTemplates: true
+    fields:
+      - version: v1
+        kind: ServiceAccount
+        path: metadata/labels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: metadata/labels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: spec/selector/matchLabels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: spec/template/metadata/labels
+        create: true
+
+patches:
+  - path: patch-vllm-gpt-oss-120b.yaml

--- a/guides/tiered-prefix-cache/modelserver/gpu/vllm/base/patch-vllm-gpt-oss-120b.yaml
+++ b/guides/tiered-prefix-cache/modelserver/gpu/vllm/base/patch-vllm-gpt-oss-120b.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  replicas: 16
+  template:
+    spec:
+      containers:
+        - name: modelserver
+          command: ["vllm", "serve"]
+          args:
+            - "openai/gpt-oss-120b"
+            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+            - "--tensor-parallel-size=1"
+            - "--gpu-memory-utilization=0.95"
+            - "--served-model-name=openai/gpt-oss-120b"
+            - "--enable-auto-tool-choice"
+            - "--tool-call-parser=openai"
+            - "--reasoning-parser=openai_gptoss"
+            - "--block-size=128"
+            - "--max-num-seqs=512"
+            - "--kv-transfer-config"
+            - '{"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"cpu_bytes_to_use":107374182400}}'
+          env:
+            - name: PYTORCH_ALLOC_CONF
+              value: "expandable_segments:True"
+            - name: LOGNAME
+              value: "vllm"
+          resources:
+            limits:
+              cpu: '16'
+              memory: 512Gi
+              nvidia.com/gpu: 1
+            requests:
+              cpu: '8'
+              memory: 256Gi
+              nvidia.com/gpu: 1
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /.cache
+              name: torch-compile-cache
+            - mountPath: /.triton
+              name: triton-cache
+            - mountPath: /.local
+              name: local-cache
+            - mountPath: /.config
+              name: config-cache
+            - mountPath: /model-cache
+              name: model-cache
+          startupProbe:
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 120
+          livenessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 20Gi
+        - name: torch-compile-cache
+          emptyDir: {}
+        - name: triton-cache
+          emptyDir: {}
+        - name: local-cache
+          emptyDir: {}
+        - name: config-cache
+          emptyDir: {}


### PR DESCRIPTION
Add gpt-oss-120b as an additional configuration for tiered-prefix-cache/cpu guide, including benchmark results.