### PR TITLE
update: migrate precise-prefix-cache-scorer and a bunch of default configs

### DIFF
--- a/docs/architecture/advanced/kv-management/kv-indexer.md
+++ b/docs/architecture/advanced/kv-management/kv-indexer.md
@@ -7,7 +7,7 @@ The **KV-Cache Indexer** is a component of the **llm-d Router** (residing within
 
 ## Functionality
 
-The kv-cache indexer subscribes to `KVEvents` emitted from model servers to maintain a near-realtime view of the KV cache state. The `precise-prefix-cache-scorer` uses this information during the EPP filter → score → pick flow.
+The kv-cache indexer subscribes to `KVEvents` emitted from model servers to maintain a near-realtime view of the KV cache state. The `precise-prefix-cache-producer` (consumed by the `prefix-cache-scorer`) uses this information during the EPP filter → score → pick flow.
 
 The precise view offers improved precision for harder-to-approximate scenarios:
 
@@ -105,13 +105,12 @@ The Index is the hot data structure of the system: every scoring call queries it
 
 The Data Producer runs early in the scheduling cycle: it renders chat templates and tokenizes the prompt once per request (and extracts any multimodal features), writing the result onto the request so downstream components — the Scorer included — read from it rather than re-tokenizing.
 
-Today this role is implemented by the `tokenizer` plugin (being renamed `token-producer` to align with plugin naming conventions).
+Today this role is implemented by the `token-producer` plugin.
 
-Tokenizers can be sourced three ways:
+The plugin tokenizes by calling vLLM's render endpoints — `/v1/completions/render` and `/v1/chat/completions/render` over HTTP. This is the default backend, pointed at `http://localhost:8000`. Those endpoints are served by `vllm serve <model>` or by the GPU-less `vllm launch render <model>`, deployed either as a sidecar in the EPP pod (loopback) or as a dedicated render Service shared across EPP replicas.
 
-1. **UDS sidecar** (recommended for production) — a tokenizer sidecar container serves tokenization requests over a Unix domain socket. The sidecar resolves the model identifier as a local path if the path exists on disk, and otherwise downloads and caches from HuggingFace (or ModelScope) on first use.
-2. **In-process local files** — the indexer's embedded tokenizer scans a directory (default `/mnt/models`) for `tokenizer.json`.
-3. **In-process HuggingFace Hub** — the indexer's embedded tokenizer downloads on demand. Convenient for development; adds startup latency.
+> [!NOTE]
+> The earlier gRPC-over-UDS tokenizer sidecar (the `udsTokenizerConfig` backend) is **deprecated** and will be removed in a future release. Existing configs keep working but emit a deprecation warning at startup; migrate to the `vllm` HTTP backend.
 
 ### Scorer
 
@@ -154,4 +153,4 @@ Many deployment patterns cache KV blocks based on more than text. The indexer su
 ## Further Reading
 
 - [**llm-d-kv-cache**](https://github.com/llm-d/llm-d-kv-cache) — the indexer library. See [architecture.md](https://github.com/llm-d/llm-d-kv-cache/blob/main/docs/architecture.md) for the in-depth technical architecture (block-key hashing, dual-key design, event adapters, module breakdown) and [configuration.md](https://github.com/llm-d/llm-d-kv-cache/blob/main/docs/configuration.md) for the full configuration reference.
-- [**llm-d Router**](https://github.com/llm-d/llm-d-router) — source for the `precise-prefix-cache-scorer` and `tokenizer` plugins. Plugin lifecycle, EPP extension-point wiring, and request scheduling profile examples.
+- [**llm-d Router**](https://github.com/llm-d/llm-d-router) — source for the `precise-prefix-cache-producer`, `prefix-cache-scorer`, and `token-producer` plugins. Plugin lifecycle, EPP extension-point wiring, and request scheduling profile examples.

--- a/docs/architecture/advanced/kv-management/prefix-cache-aware-routing.md
+++ b/docs/architecture/advanced/kv-management/prefix-cache-aware-routing.md
@@ -36,22 +36,23 @@ The precise implementation provides 100% accuracy by leveraging actual token dat
 
 ### Components
 
-- [**`tokenizer`**](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer) (DataProducer plugin)
-- [**`precise-prefix-cache-scorer`**](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache) (Scorer plugin)
+- [**`token-producer`**](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/requestcontrol/dataproducer/tokenizer) (DataProducer plugin)
+- [**`precise-prefix-cache-producer`**](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache) (DataProducer plugin) — owns the KV-block index
+- [**`prefix-cache-scorer`**](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/scorer/prefix) (Scorer plugin) — scores using the producer's match info via `prefixMatchInfoProducerName: precise-prefix-cache-producer`
 - **KV-Cache Indexer** (EPP Data Layer component)
 
 ### How it Works
 
-1. **Exact Tokenization**: The `tokenizer` plugin sends the prompt to a high-performance tokenizer service (typically running as a sidecar or a local UDS service) to get exact Token IDs.
+1. **Exact Tokenization**: The `token-producer` plugin sends the prompt to vLLM's HTTP render endpoint (`/v1/completions/render`) — typically a `vllm launch render` sidecar in the EPP pod (loopback) or a shared render Service — to get exact Token IDs. (The legacy gRPC-over-UDS tokenizer backend is deprecated.)
 2. **Real-time Events**: Model servers (like vLLM) are configured to emit `KVEvents` over ZeroMQ (ZMQ) whenever their internal KV cache changes (blocks added or evicted).
 3. **Global Index**: The **KV-Cache Indexer** subscribes to these events and maintains a precise, globally consistent view of exactly which token blocks reside on which Pods.
-4. **Precise Matching**: The `precise-prefix-cache-scorer` matches the exact Token IDs against this global index.
-5. **Speculative Indexing**: To close the "blind spot" between a routing decision and the arrival of the subsequent `KVEvent`, the plugin can proactively add "speculative" entries to the index immediately after routing.
+4. **Precise Matching**: The `prefix-cache-scorer`, reading the `precise-prefix-cache-producer`'s match info, scores each candidate pod by how much of the exact Token-ID prefix is resident in this global index.
+5. **Speculative Indexing**: To close the "blind spot" between a routing decision and the arrival of the subsequent `KVEvent`, the producer can proactively add "speculative" entries to the index immediately after routing.
 
 ### Pros & Cons
 
 - **Pros**: 100% precision; handles complex cache eviction policies; natively supports Prefill/Decode disaggregation (by identifying specific blocks for transfer).
-- **Cons**: Requires additional infrastructure (tokenizer service, ZMQ connectivity); slightly higher resource overhead; requires model server support for emitting KV-cache events.
+- **Cons**: Requires additional infrastructure (vLLM render endpoint, ZMQ connectivity); slightly higher resource overhead; requires model server support for emitting KV-cache events.
 
 ---
 
@@ -61,7 +62,7 @@ The precise implementation provides 100% accuracy by leveraging actual token dat
 |---|---|---|
 | **Precision** | Heuristic (Character-based) | 100% (Token-based) |
 | **State Source** | Local EPP assumptions | Real-time `KVEvents` from Model Servers |
-| **Dependencies** | None | Tokenizer Service, ZMQ |
+| **Dependencies** | None | vLLM render endpoint, ZMQ |
 | **Use Case** | Simple, homogeneous workloads | Complex, high-scale production serving |
 | **P/D Disagg Support** | Basic | Advanced/Native |
 

--- a/docs/architecture/core/router/epp/configuration.md
+++ b/docs/architecture/core/router/epp/configuration.md
@@ -323,7 +323,7 @@ schedulingProfiles:
 - name: default
   plugins:
   - pluginRef: label-selector-filter # Optional: not in default profile
-  - pluginRef: precise-prefix-cache-scorer # Recommended: not in default profile
+  - pluginRef: prefix-cache-scorer # Recommended: not in default profile
     weight: 3.0
   - pluginRef: kv-cache-utilization-scorer # Recommended: not in default profile
     weight: 2.0
@@ -331,6 +331,9 @@ schedulingProfiles:
     weight: 2.0
   - pluginRef: max-score-picker # Default picker (auto-injected if omitted)
 ```
+
+> [!NOTE]
+> To use **precise** prefix-cache routing (exact, KV-event-driven) instead of the approximate default, declare a `precise-prefix-cache-producer` in the top-level `plugins` section and set `prefixMatchInfoProducerName: precise-prefix-cache-producer` on the `prefix-cache-scorer`; otherwise the scorer falls back to the approximate producer. See the [Precise Prefix Cache Routing guide](../../../../../guides/precise-prefix-cache-routing/README.md).
 
 #### Scheduling Profile Fields
 
@@ -352,7 +355,7 @@ The system applies a multi-tiered defaulting logic for scheduling profiles:
 
 - **Tier 1: Omitted `schedulingProfiles`**: If the `schedulingProfiles` section is entirely omitted, a profile named `default` is automatically created. This profile will reference **all Filter, Scorer, and Picker plugins** defined in the top-level `plugins` section.
 - **Tier 2: Empty `plugins` in a profile**: If you define a profile but leave the `plugins` list empty, it is valid but only gets the auto-injected picker (see Tier 3).
-- **Tier 3: Missing Picker in a profile**: If a profile does not reference a picker plugin, the system automatically injects `max-score-picker`.
+- **Tier 3: Missing Picker in a profile**: If a profile does not reference a picker plugin, the system automatically injects `max-score-picker` with its default `maxNumOfEndpoints: 1`. To use a different value or picker, declare it explicitly and reference it in the profile.
 
 </details>
 
@@ -379,7 +382,7 @@ plugins:
 # Also add the approx-prefix-cache-producer (data producer) when passing parameters to the prefix cache scorer.
 - type: approx-prefix-cache-producer
   parameters:
-    blockSizeTokens: 64 # Default
+    blockSizeTokens: 64
     maxPrefixBlocksToMatch: 256 # Default
     lruCapacityPerServer: 31250 # Default
 
@@ -389,7 +392,7 @@ schedulingProfiles:
 - name: default
   plugins:
   - pluginRef: prefix-cache-scorer
-    weight: 3.0 # Default
+    weight: 3.0
 ```
 
 <details>
@@ -409,20 +412,16 @@ plugins:
   type: another-filter
 - name: scorer-1
   type: some-scorer
-- name: max-score-picker
-  type: max-score-picker
 
 schedulingProfiles:
 - name: profile-a
   plugins:
   - pluginRef: filter-a
   - pluginRef: scorer-1
-  - pluginRef: max-score-picker
 - name: profile-b
   plugins:
   - pluginRef: filter-b
   - pluginRef: scorer-1
-  - pluginRef: max-score-picker
 ```
 
 **Important:** Only one profile handler plugin is allowed in the configuration. If multiple profiles are defined, you must provide a handler that supports them (the default `single-profile-handler` does not support multiple profiles).

--- a/docs/architecture/core/router/epp/scheduling.md
+++ b/docs/architecture/core/router/epp/scheduling.md
@@ -93,17 +93,17 @@ When a profile runs, it first filters the candidate endpoints. If any remain, it
 * **[`queue-depth-scorer`](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/scorer/queuedepth)**: Prefers endpoints with shorter request queues.
 * **[`running-requests-size-scorer`](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/scorer/runningrequests)**: Scores based on the number of currently active requests.
 * **[`token-load-scorer`](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/scorer/tokenload)**: Scores based on the total token load (input + output) handled by the endpoint.
-* **[`precise-prefix-cache-scorer`](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache)**: Scores requests based on real-time KV-cache locality. While the `prefix-scorer` relies on historical scheduling estimates, this version tracks actual cache states via model server events to ensure higher precision.
+* **[`precise-prefix-cache-producer`](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache)** (DataProducer, paired with `prefix-cache-scorer`): Enables scoring on real-time KV-cache locality. While `prefix-scorer` relies on historical scheduling estimates, this tracks actual cache states via model server events for higher precision. Configure the producer and point the scorer at it with `prefixMatchInfoProducerName: precise-prefix-cache-producer`.
 
   > [!NOTE]
-  > If you configure this plugin but do not explicitly configure its required data producer (`approx-prefix-cache-producer`), the loader will automatically instantiate it with the same parameters. This was done for historical reasons to simplify configuration when data producers were introduced.
+  > Without an explicit `prefixMatchInfoProducerName`, `prefix-cache-scorer` falls back to the auto-instantiated `approx-prefix-cache-producer`. (The older single-plugin `precise-prefix-cache-scorer` is deprecated in favor of this producer + `prefix-cache-scorer` pair.)
 
 * **[`session-affinity-scorer`](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity)**: Assigns a maximum score to the specific endpoint that handled previous requests for the same session, while all other endpoints receive the minimum score.
 * **[`no-hit-lru-scorer`](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/scorer/nohitlru)**: For cold requests (zero cache hits), the scorer prioritizes endpoints that have never handled one, followed by those used least recently. This ensures an even distribution of the intensive "prefill" workload across the cluster. If a request has existing cache hits, the scorer assigns equal scores to all endpoints (scorer has no impact).
 
 ### Pickers
 
-* **[`max-score-picker`](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/picker/maxscore)**: Selects the endpoint with the absolute highest score.
+* **[`max-score-picker`](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/picker/maxscore)**: Selects the endpoint with the absolute highest score. This is the **default picker** — auto-injected into any profile that references no picker with its default `maxNumOfEndpoints: 1` (return the single best endpoint).
 * **[`random-picker`](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/picker/random)**: Selects an endpoint randomly from the candidates.
 * **[`weighted-random-picker`](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/picker/weightedrandom)**: Selects an endpoint randomly, using the scores as relative probabilities (lottery scheduling).
 
@@ -111,6 +111,11 @@ When a profile runs, it first filters the candidate endpoints. If any remain, it
 
 * **[`single-profile-handler`](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/profilehandler/single)**: Runs a single configured primary profile.
 * **[`disagg-profile-handler`](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/profilehandler/disagg)**: Runs two scheduling profiles, one for prefill and one for decode. The **decode endpoint** is set as the primary destination for the proxy to forward the original request, while the **prefill endpoint** is injected into the request as a specialized header.
+
+> [!NOTE]
+> Two older handlers are **deprecated** and kept only for backward compatibility:
+> - `pd-profile-handler` — use `disagg-profile-handler` instead.
+> - `data-parallel-profile-handler` — use `single-profile-handler` instead.
 
 ---
 

--- a/docs/getting-started/artifacts.md
+++ b/docs/getting-started/artifacts.md
@@ -52,7 +52,6 @@ llm-d releases the core EPP image as well as additional sidecar images for advan
 | Image | Description | Version |
 |-------|-------------|---------|
 | `ghcr.io/llm-d/llm-d-router-endpoint-picker-dev` | Core EPP image | main |
-| `ghcr.io/llm-d/llm-d-uds-tokenizer`       | Optional sidecar for EPP, enabling tokenization for precise cache aware routing | v0.8.0 |
 | `ghcr.io/llm-d/llm-d-routing-sidecar`     | Optional sidecar for model servers, enabling KV cache transfer for P/D | v0.8.0 |
 | `registry.k8s.io/gateway-api-inference-extension/latency-training-server` | Optional sidecar for EPP, for predicted-latency model training | v1.5.0 |
 | `registry.k8s.io/gateway-api-inference-extension/latency-prediction-server` | Optional sidecar for EPP, for predicted-latency scheduling | v1.5.0 |

--- a/guides/no-kubernetes-deployment/router/epp/config.yaml
+++ b/guides/no-kubernetes-deployment/router/epp/config.yaml
@@ -17,7 +17,6 @@ plugins:
   - type: prefix-cache-scorer
   - type: no-hit-lru-scorer
 
-  - type: max-score-picker
   - type: single-profile-handler
 
   - name: metrics-source
@@ -36,7 +35,6 @@ schedulingProfiles:
         weight: 3
       - pluginRef: no-hit-lru-scorer
         weight: 2
-      - pluginRef: max-score-picker
 
 dataLayer:
   injectDefaults: false

--- a/guides/no-kubernetes-deployment/router/epp/config.yaml
+++ b/guides/no-kubernetes-deployment/router/epp/config.yaml
@@ -17,8 +17,6 @@ plugins:
   - type: prefix-cache-scorer
   - type: no-hit-lru-scorer
 
-  - type: single-profile-handler
-
   - name: metrics-source
     type: metrics-data-source
   - name: metrics-extractor

--- a/guides/pd-disaggregation/router/pd-disaggregation.values.yaml
+++ b/guides/pd-disaggregation/router/pd-disaggregation.values.yaml
@@ -23,7 +23,6 @@ router:
         - type: queue-scorer
         - type: kv-cache-utilization-scorer
         - type: active-request-scorer
-        - type: max-score-picker
         schedulingProfiles:
         - name: prefill
           plugins:
@@ -34,7 +33,6 @@ router:
             weight: 2
           - pluginRef: kv-cache-utilization-scorer
             weight: 2
-          - pluginRef: max-score-picker
         - name: decode
           plugins:
           - pluginRef: decode-filter
@@ -42,7 +40,6 @@ router:
             weight: 2
           - pluginRef: prefix-cache-scorer
             weight: 3
-          - pluginRef: max-score-picker
 
   modelServers:
     matchLabels:

--- a/guides/precise-prefix-cache-routing/README.md
+++ b/guides/precise-prefix-cache-routing/README.md
@@ -8,7 +8,7 @@ This guide routes requests on precise per-pod KV-cache state rather than request
 
 Two scorers make up the routing decision alongside the load-aware stack:
 
-- **Precise prefix-cache aware** — the [precise-prefix-cache-scorer](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/scorer/preciseprefixcache) indexes real KV-block events from vLLM and returns the exact resident-block fraction. Indexer internals (event ingestion, block hashing, dual-key design) are documented in [llm-d-kv-cache architecture](https://github.com/llm-d/llm-d-kv-cache/blob/main/docs/architecture.md).
+- **Precise prefix-cache aware** — the [precise-prefix-cache-producer](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache) indexes real KV-block events from vLLM and publishes the exact resident-block fraction. The generic [prefix-cache-scorer](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/scorer/prefix) then reads `prefixMatchInfoProducerName`. Indexer internals (event ingestion, block hashing, dual-key design) are documented in [llm-d-kv-cache architecture](https://github.com/llm-d/llm-d-kv-cache/blob/main/docs/architecture.md).
 - **Load-aware** — such as the [kv-cache utilization](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization) and [queue size](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/scorer/queuedepth) scorers balance against pod pressure.
 
 ## Default Configuration
@@ -230,8 +230,8 @@ kubectl delete -n ${NAMESPACE} -k guides/${GUIDE_NAME}/modelserver/gpu/vllm/${IN
 ## How It Works
 
 1. **vLLM pods publish KV-cache events** — each pod runs `vllm serve ... --kv-events-config '{...,"publisher":"zmq","endpoint":"$(KV_EVENTS_ENDPOINT)","topic":"kv@$(POD_IP):$(POD_PORT)@<model>"}'` with `KV_EVENTS_ENDPOINT=tcp://*:5556`, binding its own ZMQ socket. On every KV block allocation/eviction, vLLM emits a ZMQ message.
-2. **Router subscribes per pod** — pod-discovery (`kvEventsConfig.discoverPods: true`) wires the data-layer `endpoint-notification-source` into the scorer's `ExtractEndpoint`, so each router replica installs a ZMQ subscriber per vLLM pod independently. All replicas converge to the same index.
-3. **Scoring** — the `precise-prefix-cache-scorer` returns the fraction of the request's prefix blocks that are resident on each candidate pod. The `max-score-picker` routes to the highest-scoring pod.
+2. **Router subscribes per pod** — pod-discovery (`kvEventsConfig.discoverPods: true`) registers the `precise-prefix-cache-producer` as an extractor on the data-layer `endpoint-notification-source`, so each router replica installs a ZMQ subscriber per vLLM pod independently. All replicas converge to the same index.
+3. **Scoring** — the `prefix-cache-scorer` returns the fraction of the request's prefix blocks that are resident on each candidate pod. The `max-score-picker` routes to the highest-scoring pod.
 
 ## Benchmarking Report
 

--- a/guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml
+++ b/guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml
@@ -64,7 +64,6 @@ router:
           - type: kv-cache-utilization-scorer
           - type: queue-scorer
           - type: no-hit-lru-scorer
-          - type: max-score-picker
         dataLayer: # metrics-data-source + core-metrics-extractor injected by default
           sources:
             - pluginRef: endpoint-notification-source
@@ -81,7 +80,6 @@ router:
                 weight: 3.0
               - pluginRef: no-hit-lru-scorer
                 weight: 2.0
-              - pluginRef: max-score-picker
 
   extraServicePorts:
     - name: http

--- a/guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml
+++ b/guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml
@@ -12,7 +12,7 @@
 router:
   tokenizer:
     enabled: true
-    # Required by llm-d-router chart v0 when tokenizer is enabled; 
+    # Required by llm-d-router chart v0 when tokenizer is enabled;
     # must match the deployed model server and the token-producer modelName below
     modelName: Qwen/Qwen3-32B
 
@@ -44,7 +44,7 @@ router:
               vllm:
                 url: "http://localhost:8000"
           - type: endpoint-notification-source
-          - type: precise-prefix-cache-scorer
+          - type: precise-prefix-cache-producer # `precise-prefix-cache-scorer` is deprecated
             parameters:
               tokenProcessorConfig:
                 blockSize: 64
@@ -58,6 +58,9 @@ router:
                 discoverPods: true
                 podDiscoveryConfig:
                   socketPort: 5556
+          - type: prefix-cache-scorer
+            parameters:
+              prefixMatchInfoProducerName: precise-prefix-cache-producer
           - type: kv-cache-utilization-scorer
           - type: queue-scorer
           - type: no-hit-lru-scorer
@@ -66,7 +69,7 @@ router:
           sources:
             - pluginRef: endpoint-notification-source
               extractors:
-                - pluginRef: precise-prefix-cache-scorer
+                - pluginRef: precise-prefix-cache-producer
         schedulingProfiles:
           - name: default
             plugins:
@@ -74,7 +77,7 @@ router:
                 weight: 2.0
               - pluginRef: queue-scorer
                 weight: 2.0
-              - pluginRef: precise-prefix-cache-scorer
+              - pluginRef: prefix-cache-scorer
                 weight: 3.0
               - pluginRef: no-hit-lru-scorer
                 weight: 2.0

--- a/guides/predicted-latency-routing/router/predicted-latency-slo.values.yaml
+++ b/guides/predicted-latency-routing/router/predicted-latency-slo.values.yaml
@@ -25,12 +25,8 @@ router:
         - type: queue-scorer
         - type: kv-cache-utilization-scorer
         - type: prefix-cache-scorer
-        - type: metrics-data-source
-          parameters:
-            insecureSkipVerify: true
-            path: /metrics
-            scheme: http
-        - type: core-metrics-extractor
+        # metrics-data-source + core-metrics-extractor are auto-injected with these
+        # exact defaults (scheme: http, path: /metrics, insecureSkipVerify: true).
         - type: predicted-latency-producer
           parameters:
             streamingMode: true

--- a/guides/wide-ep-lws/experimental-dp-aware/manifests/inferencepool.values.yaml
+++ b/guides/wide-ep-lws/experimental-dp-aware/manifests/inferencepool.values.yaml
@@ -41,9 +41,7 @@ router:
           plugins:
           - pluginRef: decode-filter
           - pluginRef: active-request-scorer
-            weight: 1
           - pluginRef: queue-scorer
-            weight: 1
 
   monitoring:
     interval: "10s"

--- a/guides/wide-ep-lws/router/wide-ep-lws.values.yaml
+++ b/guides/wide-ep-lws/router/wide-ep-lws.values.yaml
@@ -23,7 +23,6 @@ router:
         - type: queue-scorer
         - type: kv-cache-utilization-scorer
         - type: active-request-scorer
-        - type: max-score-picker
         schedulingProfiles:
         - name: prefill
           plugins:
@@ -34,7 +33,6 @@ router:
             weight: 2
           - pluginRef: kv-cache-utilization-scorer
             weight: 2
-          - pluginRef: max-score-picker
         - name: decode
           plugins:
           - pluginRef: decode-filter
@@ -42,7 +40,6 @@ router:
             weight: 2
           - pluginRef: prefix-cache-scorer
             weight: 3
-          - pluginRef: max-score-picker
 
   modelServers:
     matchLabels:


### PR DESCRIPTION
# Notes
- use prefix-cache-scorer with  precise-prefix-cache-producer instead
- follow up comments in https://github.com/llm-d/llm-d/pull/1507#discussion_r3340432050
- drop max-score-picker in epp
- drop weight:1
- drop metrics-data-source and core-metrics-extractor
- drop single-profile-handler
- update docs 