### PR TITLE
fix: fixed typo

### DIFF
--- a/docs/well-lit-paths/multimodal.md
+++ b/docs/well-lit-paths/multimodal.md
@@ -53,7 +53,7 @@ EPP uses two highly customizable **Token Estimation Strategies**:
 
 ##### A. Dimension-Based Approximation (e.g., Qwen-VL)
 Estimate tokens based on image width and height:
-$$\text{Tokens} = \frac{\text{Image Width} \times \text{Image Height}}{\text{Factor}} + 2$$
+$$\text{Tokens} = \frac{\text{Image Width} \times \text{Image Height}}{\text{Factor}}$$
 
 * The `Factor` parameter is configurable per-EPP:
   * For **Qwen 2.5 VL**: `factor = 784` (which is $28 \times 28$)

--- a/guides/multimodal/optimized-baseline/benchmark-templates/guide.yaml
+++ b/guides/multimodal/optimized-baseline/benchmark-templates/guide.yaml
@@ -51,8 +51,6 @@ workload:                         # yaml configuration for harness workload(s)
           duration: 100
         - rate: 35
           duration: 100
-        - rate: 40
-          duration: 100
   api:
     type: chat
     streaming: true
@@ -68,7 +66,7 @@ workload:                         # yaml configuration for harness workload(s)
       shared_prefix:
         multimodal:
           image:
-          count: { type: fixed, min: 3, max: 3, mean: 3 }  # items per request
+          count: { type: fixed, min: 4, max: 4, mean: 4 }  # items per request
           insertion_point: 0.0
           resolutions:
             - resolution: "720p"


### PR DESCRIPTION
I checked my previous benchmark config. I used image 4 instead of 3 and the maximum qps is 35 instead of 40

And in the approximate prefix cache routing, as it is estimate, we just ignore +2 token