### PR TITLE
Use released manifests to install the inferencepool api

### DIFF
--- a/.github/workflows/e2e-optimized-baseline-hpu.yaml
+++ b/.github/workflows/e2e-optimized-baseline-hpu.yaml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Install Gateway API Inference Extension CRDs
         run: |
-          kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+          kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
 
       - name: Install monitoring stack
         run: |

--- a/.github/workflows/e2e-optimized-baseline-xpu.yaml
+++ b/.github/workflows/e2e-optimized-baseline-xpu.yaml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Install Gateway API Inference Extension CRDs
         run: |
-          kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+          kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
 
       - name: Install monitoring stack
         run: |

--- a/.github/workflows/e2e-pd-xpu.yaml
+++ b/.github/workflows/e2e-pd-xpu.yaml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Install Gateway API Inference Extension CRDs
         run: |
-          kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+          kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
 
       - name: Install monitoring stack
         run: |

--- a/.github/workflows/e2e-prefix-cache-xpu.yaml
+++ b/.github/workflows/e2e-prefix-cache-xpu.yaml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Install Gateway API Inference Extension CRDs
         run: |
-          kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+          kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
 
       - name: Install monitoring stack
         run: |

--- a/docs/getting-started/artifacts.md
+++ b/docs/getting-started/artifacts.md
@@ -27,7 +27,7 @@ Manifests are published at [kubernetes-sigs/gateway-api-inference-extension/conf
 
 ```bash
 export GAIE_VERSION=v1.5.0
-kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
 ```
 
 ## 2. llm-d Router

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -27,7 +27,7 @@ export NAMESPACE=llm-d-quickstart
 Install the Gateway API Inference Extension CRDs and create the namespace:
 
 ```bash
-kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
 kubectl create namespace ${NAMESPACE}
 ```
 

--- a/guides/multimodal/optimized-baseline/README.md
+++ b/guides/multimodal/optimized-baseline/README.md
@@ -45,7 +45,7 @@ This guide includes configurations for the following accelerators and inference 
    ```
 4. Install the Gateway API Inference Extension CRDs:
    ```bash
-   kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+   kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
    ```
 5. Create the namespace:
    ```bash

--- a/guides/optimized-baseline/README.md
+++ b/guides/optimized-baseline/README.md
@@ -63,7 +63,7 @@ This guide includes configurations for the following accelerators:
 - Install the Gateway API Inference Extension CRDs:
 
   ```bash
-    kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+    kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
   ```
 
 - Create a target namespace for the installation

--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -67,7 +67,7 @@ export MODEL_NAME="openai/gpt-oss-120b"
 * Install the Gateway API Inference Extension CRDs:
 
 ```bash
-kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
 ```
 * Create a target namespace for the installation
 

--- a/guides/precise-prefix-cache-routing/README.md
+++ b/guides/precise-prefix-cache-routing/README.md
@@ -70,7 +70,7 @@ export PROVIDER_NAME=istio   # options: none, gke, agentgateway, istio
 - Install the Gateway API Inference Extension CRDs:
 
 ```bash
-kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
 ```
 
 - Create a target namespace for the installation

--- a/guides/predicted-latency-routing/README.md
+++ b/guides/predicted-latency-routing/README.md
@@ -44,7 +44,7 @@ Skip it when your pool is **heterogeneous** — mixed GPU types, model variants,
 - Install the Gateway API Inference Extension CRDs:
 
   ```bash
-    kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+    kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
   ```
 
 - Create a target namespace for the installation:

--- a/guides/prereq/gateways/agentgateway.md
+++ b/guides/prereq/gateways/agentgateway.md
@@ -24,7 +24,7 @@ GATEWAY_API_VERSION=v1.5.1
 GAIE_VERSION=v1.5.0
 
 kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api/config/crd?ref=${GATEWAY_API_VERSION}"
-kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
 ```
 
 Verify the APIs are available:

--- a/guides/prereq/gateways/gke.md
+++ b/guides/prereq/gateways/gke.md
@@ -25,7 +25,7 @@ For GKE versions `1.34.0-gke.1626000` or later, the InferencePool CRD is automat
 ```bash
 GAIE_VERSION=v1.5.0
 
-kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
 ```
 
 Verify the APIs are available:

--- a/guides/prereq/gateways/istio.md
+++ b/guides/prereq/gateways/istio.md
@@ -21,7 +21,7 @@ GATEWAY_API_VERSION=v1.5.1
 GAIE_VERSION=v1.5.0
 
 kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api/config/crd?ref=${GATEWAY_API_VERSION}"
-kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
 ```
 
 Verify the APIs are available:

--- a/guides/tiered-prefix-cache/cpu/README.md
+++ b/guides/tiered-prefix-cache/cpu/README.md
@@ -62,7 +62,7 @@ This guide supports both GPU and TPU. GPU defaults to NVIDIA H100 and TPU defaul
 - Install the Gateway API Inference Extension CRDs:
 
   ```bash
-    kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+    kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
   ```
 
 - Create a target namespace for the installation

--- a/guides/tiered-prefix-cache/storage/README.md
+++ b/guides/tiered-prefix-cache/storage/README.md
@@ -71,7 +71,7 @@ For advanced configuration options and implementation details, see the [llm-d FS
 * Install the Gateway API Inference Extension CRDs:
 
   ```bash
-    kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+    kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
   ```
 
 * Create a target namespace for the installation:

--- a/guides/wide-ep-lws/README.md
+++ b/guides/wide-ep-lws/README.md
@@ -57,7 +57,7 @@ This guide includes configurations for the following accelerators:
 * Install the Gateway API Inference Extension CRDs:
 
   ```bash
-  kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
   ```
 * You have deployed the [LeaderWorkerSet controller](https://lws.sigs.k8s.io/docs/installation/)
 * Create a target namespace for the installation:


### PR DESCRIPTION
Use released manifests to install the inferencepool api; v1-manifests.yaml will only deploy the inferencePool api and avoid installing InferenceObjective and InferenceModelRewrite from the gaie repo. The latter two apis should be installed from the llm-d-router released manifests.