### PR TITLE
Update latency predictor guide with support for sglang

### DIFF
--- a/guides/predicted-latency-routing/README.md
+++ b/guides/predicted-latency-routing/README.md
@@ -115,7 +115,11 @@ export INFRA_PROVIDER=base # base | gke
 kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/predicted-latency-routing/modelserver/gpu/vllm/${INFRA_PROVIDER}/
 ```
 
-For other backends (AMD GPU, Intel XPU, Gaudi, TPU, CPU) or model servers (e.g. SGLang), see [optimized-baseline → Deploy the Model Server](../optimized-baseline/README.md#2-deploy-the-model-server).
+For other backends (AMD GPU, Intel XPU, Gaudi, TPU, CPU), see [optimized-baseline → Deploy the Model Server](../optimized-baseline/README.md#2-deploy-the-model-server). For example, for sglang deployments:
+
+```bash
+kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/optimized-baseline/modelserver/gpu/sglang/${INFRA_PROVIDER}/
+```
 
 ### 3. Enable monitoring (optional)
 
@@ -272,6 +276,8 @@ To remove the deployed components:
 ```bash
 helm uninstall ${GUIDE_NAME} -n ${NAMESPACE}
 kubectl delete  -n ${NAMESPACE} -k ${REPO_ROOT}/guides/predicted-latency-routing/modelserver/gpu/vllm/${INFRA_PROVIDER}
+# for sglang deployments
+kubectl delete  -n ${NAMESPACE} -k ${REPO_ROOT}/guides/optimized-baseline/modelserver/gpu/sglang/${INFRA_PROVIDER} --ignore-not-found
 kubectl delete namespace ${NAMESPACE}
 ```
 


### PR DESCRIPTION
Latency predictor presently works with sglang because the underlying metrics are supported (prefix cache hit, kv cache utilization etc). Update the docs to reflect the same.

**Testing**

Did functionally testing first and then ran the benchmark mentioned in the [README](https://github.com/llm-d/llm-d/blob/690c3fc566888198b13a6929159c30bbfc4ff3a9/guides/predicted-latency-routing/README.md) at default 40 concurrency, the following are the results:

**Time to First Token (TTFT) Comparison**

| Metric / Percentile | Latency Predictor (seconds) | K8s Service (seconds) |
| :--- | :---: | :---: |
| **Mean (Average)** | 1.706 | 2.218 |
| **p50 (Median)** | 0.704 | 0.972 |
| **p75** | 2.819 | 3.721 |
| **p90** | 4.123 | 5.195 |
| **p95** | 4.638 | 5.658 |


Addresses #1690 