### PR TITLE
optimized-baseline: mount /.triton and /.config emptyDirs on non-gpu vllm variants

### DIFF
--- a/guides/optimized-baseline/modelserver/amd/vllm/patch-vllm.yaml
+++ b/guides/optimized-baseline/modelserver/amd/vllm/patch-vllm.yaml
@@ -48,6 +48,10 @@ spec:
               name: shm
             - mountPath: /.cache
               name: torch-compile-cache
+            - mountPath: /.triton
+              name: triton-cache
+            - mountPath: /.config
+              name: vllm-config
           startupProbe:
             initialDelaySeconds: 15
             periodSeconds: 30
@@ -67,4 +71,8 @@ spec:
             medium: Memory
             sizeLimit: 20Gi
         - name: torch-compile-cache
+          emptyDir: {}
+        - name: triton-cache
+          emptyDir: {}
+        - name: vllm-config
           emptyDir: {}

--- a/guides/optimized-baseline/modelserver/cpu/vllm/patch-vllm.yaml
+++ b/guides/optimized-baseline/modelserver/cpu/vllm/patch-vllm.yaml
@@ -57,6 +57,10 @@ spec:
               name: dshm
             - mountPath: /.cache
               name: torch-compile-cache
+            - mountPath: /.triton
+              name: triton-cache
+            - mountPath: /.config
+              name: vllm-config
           startupProbe:
             initialDelaySeconds: 15
             periodSeconds: 30
@@ -76,4 +80,8 @@ spec:
             medium: Memory
             sizeLimit: 4Gi
         - name: torch-compile-cache
+          emptyDir: {}
+        - name: triton-cache
+          emptyDir: {}
+        - name: vllm-config
           emptyDir: {}

--- a/guides/optimized-baseline/modelserver/hpu/vllm/patch-vllm.yaml
+++ b/guides/optimized-baseline/modelserver/hpu/vllm/patch-vllm.yaml
@@ -47,6 +47,9 @@ spec:
           resources:
             claims:
               - name: optimized-baseline-gaudi-claim
+          volumeMounts:
+            - mountPath: /.triton
+              name: triton-cache
           startupProbe:
             initialDelaySeconds: 15
             periodSeconds: 30
@@ -63,3 +66,6 @@ spec:
       resourceClaims:
         - name: optimized-baseline-gaudi-claim
           resourceClaimTemplateName: optimized-baseline-gaudi-claim
+      volumes:
+        - name: triton-cache
+          emptyDir: {}

--- a/guides/optimized-baseline/modelserver/tpu-v6/vllm/patch-vllm.yaml
+++ b/guides/optimized-baseline/modelserver/tpu-v6/vllm/patch-vllm.yaml
@@ -45,6 +45,10 @@ spec:
           volumeMounts:
             - mountPath: /.cache
               name: torch-compile-cache
+            - mountPath: /.triton
+              name: triton-cache
+            - mountPath: /.config
+              name: vllm-config
           startupProbe:
             initialDelaySeconds: 15
             periodSeconds: 30
@@ -60,4 +64,8 @@ spec:
             failureThreshold: 3
       volumes:
         - name: torch-compile-cache
+          emptyDir: {}
+        - name: triton-cache
+          emptyDir: {}
+        - name: vllm-config
           emptyDir: {}

--- a/guides/optimized-baseline/modelserver/tpu-v7/vllm/patch-vllm.yaml
+++ b/guides/optimized-baseline/modelserver/tpu-v7/vllm/patch-vllm.yaml
@@ -49,6 +49,10 @@ spec:
           volumeMounts:
             - mountPath: /.cache
               name: torch-compile-cache
+            - mountPath: /.triton
+              name: triton-cache
+            - mountPath: /.config
+              name: vllm-config
           startupProbe:
             initialDelaySeconds: 15
             periodSeconds: 30
@@ -64,4 +68,8 @@ spec:
             failureThreshold: 3
       volumes:
         - name: torch-compile-cache
+          emptyDir: {}
+        - name: triton-cache
+          emptyDir: {}
+        - name: vllm-config
           emptyDir: {}

--- a/guides/optimized-baseline/modelserver/xpu/vllm/patch-vllm.yaml
+++ b/guides/optimized-baseline/modelserver/xpu/vllm/patch-vllm.yaml
@@ -53,6 +53,10 @@ spec:
           volumeMounts:
             - mountPath: /.cache
               name: torch-compile-cache
+            - mountPath: /.triton
+              name: triton-cache
+            - mountPath: /.config
+              name: vllm-config
           startupProbe:
             initialDelaySeconds: 15
             periodSeconds: 30
@@ -71,4 +75,8 @@ spec:
           resourceClaimTemplateName: intel-claim-template-decode
       volumes:
         - name: torch-compile-cache
+          emptyDir: {}
+        - name: triton-cache
+          emptyDir: {}
+        - name: vllm-config
           emptyDir: {}


### PR DESCRIPTION
The `vllm/vllm-openai` engine writes a Triton compiler cache to `/.triton` (fatal) and a usage_lib config to `/.config` (non-fatal) at the filesystem root, since `HOME=/` for non-root containers. On clusters that enforce non-root execution (OpenShift restricted-v2 SCC, or k8s under PSA restricted), both writes fail with `PermissionError` and the `/.triton` failure crashes the model server, as reported in #1311.

PR #1450 baked these emptyDir mounts into the gpu variant. The remaining vllm variants of this guide were not updated and still hit the crash under a restricted SecurityContext. This applies the same mounts to amd, cpu, tpu-v6, tpu-v7 and xpu, matching the gpu variant and the precise-prefix-cache-routing guide (which already mounts `/.triton` on all of its variants). hpu already sets `DO_NOT_TRACK=1`, so it does not write `/.config` and only needed the `/.triton` mount. sglang variants are unaffected (they do not write the Triton cache).

Verified with `kustomize build` and `kubectl apply --dry-run` on each variant; the rendered Deployments carry the triton-cache and vllm-config volumes. Worth a maintainer run of `/test-nightly optimized-baseline-ocp`.

Closes #1311
