### PR TITLE
docs(optimized-baseline): document no-hit-lru-scorer in overview

### DIFF
--- a/guides/optimized-baseline/README.md
+++ b/guides/optimized-baseline/README.md
@@ -8,7 +8,7 @@ This guide deploys the recommended out of the box [configuration](https://github
 
 The optimized-baseline defaults to two main routing criteria:
 
-- **Prefix-cache aware** using the [prefix cache scorer](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/scorer/prefix), which scores candidate endpoints by estimating prompt prefix cache reuse on each model server.
+- **Prefix-cache aware** using the [prefix cache scorer](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/scorer/prefix), which scores candidate endpoints by estimating prompt prefix cache reuse on each model server, complemented by the [`no-hit-lru-scorer`](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/scorer/nohitlru) that spreads cold requests (zero cache hits) evenly across endpoints to balance the "prefill" workload.
 
 - **Load-aware** using both the [kv-cache utilization](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/scorer/kvcacheutilization) and the [queue size](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/scorer/queuedepth) scorers.
 


### PR DESCRIPTION
## What

The optimized-baseline router config ([`optimized-baseline.values.yaml`](https://github.com/llm-d/llm-d/blob/main/guides/optimized-baseline/router/optimized-baseline.values.yaml)) uses four scorers, but the guide's Overview only described the prefix-cache and load-aware (kv-cache + queue) criteria. The `no-hit-lru-scorer` was not mentioned.

This adds a one-line note about it alongside the prefix-cache scorer, since it complements that scorer by spreading cold requests (zero cache hits) evenly across endpoints to balance the prefill workload.
