### PR TITLE
[Docs] Replace deprecated `kv_both` for NIXLConnector and with explicit P/D Roles

### DIFF
--- a/docs/resources/rdma/README.md
+++ b/docs/resources/rdma/README.md
@@ -76,16 +76,21 @@ NIXL selects the backend based on what is available and the memory types involve
 Enable NIXL-based KV Cache transfer via the `--kv-transfer-config` flag:
 
 ```bash
+# Prefill pods
 vllm serve <model> \
-  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}'
+
+# Decode pods
+vllm serve <model> \
+  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_consumer"}'
 ```
 
-The `kv_role` is `kv_both` for both prefill and decode pods — each pod can both send and receive KV Cache.
+Set `kv_role` to `kv_producer` on prefill pods and `kv_consumer` on decode pods.
 
 For XPU and HPU devices where KV transfer happens via CPU memory, add:
 
 ```bash
---kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"cpu"}'
+--kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_producer","kv_buffer_device":"cpu"}'
 ```
 
 #### Backend Selection
@@ -97,7 +102,7 @@ To configure NIXL with UCCL backend:
 ```bash
 vllm serve <model> \
   --kv-transfer-config '{"kv_connector":"NixlConnector",
-  "kv_role":"kv_both",
+  "kv_role":"kv_producer",
   "kv_connector_extra_config":
   {"backends":["UCCL"]}}'
 ```

--- a/guides/pd-disaggregation/modelserver/amd/vllm/base/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/vllm/base/patch-decode.yaml
@@ -15,7 +15,7 @@ spec:
             - "--tensor-parallel-size=4"
             - "--block-size=128"
             - "--kv-transfer-config"
-            - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+            - '{"kv_connector":"NixlConnector", "kv_role":"kv_consumer"}'
             # ROCM_ATTN required when prefill TP != decode TP; upcoming general fix.
             - "--attention-backend=ROCM_ATTN"
             - "--max-model-len=32000"

--- a/guides/pd-disaggregation/modelserver/amd/vllm/base/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/vllm/base/patch-prefill.yaml
@@ -15,7 +15,7 @@ spec:
             - "--tensor-parallel-size=1"
             - "--block-size=128"
             - "--kv-transfer-config"
-            - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+            - '{"kv_connector":"NixlConnector", "kv_role":"kv_producer"}'
             # ROCM_ATTN required when prefill TP != decode TP; upcoming general fix.
             - "--attention-backend=ROCM_ATTN"
             - "--max-model-len=32000"

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/base/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/base/patch-decode.yaml
@@ -15,7 +15,7 @@ spec:
             - "--tensor-parallel-size=4"
             - "--block-size=128"
             - "--kv-transfer-config"
-            - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+            - '{"kv_connector":"NixlConnector", "kv_role":"kv_consumer"}'
             - "--no-disable-hybrid-kv-cache-manager"
             - "--port=8200"
           env:

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/base/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/base/patch-prefill.yaml
@@ -15,7 +15,7 @@ spec:
             - "--tensor-parallel-size=1"
             - "--block-size=128"
             - "--kv-transfer-config"
-            - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+            - '{"kv_connector":"NixlConnector", "kv_role":"kv_producer"}'
             - "--no-disable-hybrid-kv-cache-manager"
             - "--gpu-memory-utilization=0.9"
           env:

--- a/guides/pd-disaggregation/modelserver/hpu/vllm/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/hpu/vllm/patch-decode.yaml
@@ -19,7 +19,7 @@ spec:
             - "--enforce-eager"
             - "--gpu-memory-utilization=0.9"
             - "--kv-transfer-config"
-            - '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"cpu"}'
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_consumer","kv_buffer_device":"cpu"}'
             - "--port=8200"
           env:
             - name: HF_TOKEN

--- a/guides/pd-disaggregation/modelserver/hpu/vllm/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/hpu/vllm/patch-prefill.yaml
@@ -19,7 +19,7 @@ spec:
             - "--enforce-eager"
             - "--gpu-memory-utilization=0.9"
             - "--kv-transfer-config"
-            - '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"cpu"}'
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_producer","kv_buffer_device":"cpu"}'
           env:
             - name: HF_TOKEN
               valueFrom:

--- a/guides/pd-disaggregation/modelserver/xpu/vllm-rdma/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/xpu/vllm-rdma/kustomization.yaml
@@ -76,7 +76,7 @@ patches:
           value: "0"
       - op: replace
         path: /spec/template/spec/containers/0/args/5
-        value: '{"kv_connector":"NixlConnector", "kv_role":"kv_both", "kv_buffer_device":"xpu"}'
+        value: '{"kv_connector":"NixlConnector", "kv_role":"kv_consumer", "kv_buffer_device":"xpu"}'
   # Prefill Deployment: switch to RDMA transport and XPU kv buffer
   - target:
       kind: Deployment
@@ -92,4 +92,4 @@ patches:
           value: "0"
       - op: replace
         path: /spec/template/spec/containers/0/args/5
-        value: '{"kv_connector":"NixlConnector", "kv_role":"kv_both", "kv_buffer_device":"xpu"}'
+        value: '{"kv_connector":"NixlConnector", "kv_role":"kv_producer", "kv_buffer_device":"xpu"}'

--- a/guides/pd-disaggregation/modelserver/xpu/vllm/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/xpu/vllm/patch-decode.yaml
@@ -19,7 +19,7 @@ spec:
             - "--tensor-parallel-size=1"
             - "--block-size=64"
             - "--kv-transfer-config"
-            - '{"kv_connector":"NixlConnector", "kv_role":"kv_both", "kv_buffer_device":"cpu"}'
+            - '{"kv_connector":"NixlConnector", "kv_role":"kv_consumer", "kv_buffer_device":"cpu"}'
             - "--max-model-len=32000"
             - "--port=8200"
           env:

--- a/guides/pd-disaggregation/modelserver/xpu/vllm/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/xpu/vllm/patch-prefill.yaml
@@ -19,7 +19,7 @@ spec:
             - "--tensor-parallel-size=1"
             - "--block-size=64"
             - "--kv-transfer-config"
-            - '{"kv_connector":"NixlConnector", "kv_role":"kv_both", "kv_buffer_device":"cpu"}'
+            - '{"kv_connector":"NixlConnector", "kv_role":"kv_producer", "kv_buffer_device":"cpu"}'
             - "--max-model-len=32000"
           env:
             - name: UCX_TLS

--- a/guides/wide-ep-lws/experimental-dp-aware/manifests/modelserver/base/decode.yaml
+++ b/guides/wide-ep-lws/experimental-dp-aware/manifests/modelserver/base/decode.yaml
@@ -127,7 +127,7 @@ spec:
                   --data-parallel-address="${LWS_LEADER_ADDRESS}" \
                   --data-parallel-rpc-port=5555 \
                   --enable-expert-parallel \
-                  --kv_transfer_config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_load_failure_policy":"fail"}' \
+                  --kv_transfer_config '{"kv_connector":"NixlConnector","kv_role":"kv_consumer","kv_load_failure_policy":"fail"}' \
                   --all2all-backend deepep_low_latency \
                   --max-model-len 65536 \
                   --kv-cache-memory-bytes=${KV_CACHE_MEMORY_BYTES-}

--- a/guides/wide-ep-lws/experimental-dp-aware/manifests/modelserver/base/prefill.yaml
+++ b/guides/wide-ep-lws/experimental-dp-aware/manifests/modelserver/base/prefill.yaml
@@ -73,7 +73,7 @@ spec:
                   --data-parallel-address="${LWS_LEADER_ADDRESS}" \
                   --data-parallel-rpc-port=5555 \
                   --enable-expert-parallel \
-                  --kv_transfer_config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_load_failure_policy":"fail"}' \
+                  --kv_transfer_config '{"kv_connector":"NixlConnector","kv_role":"kv_producer","kv_load_failure_policy":"fail"}' \
                   --all2all-backend deepep_high_throughput \
                   --max-model-len 65536
                   # To enable tracing, add:

--- a/guides/wide-ep-lws/modelserver/gpu/vllm/base/decode.yaml
+++ b/guides/wide-ep-lws/modelserver/gpu/vllm/base/decode.yaml
@@ -107,7 +107,7 @@ spec:
                   --data-parallel-rpc-port 5555 \
                   --data-parallel-start-rank $START_RANK \
                   --kv_transfer_config '{"kv_connector":"NixlConnector",
-                                          "kv_role":"kv_both",
+                                          "kv_role":"kv_consumer",
                                           "kv_load_failure_policy":"fail"}' \
                   --enable-dbo \
                   --dbo-decode-token-threshold 32 \

--- a/guides/wide-ep-lws/modelserver/gpu/vllm/base/prefill.yaml
+++ b/guides/wide-ep-lws/modelserver/gpu/vllm/base/prefill.yaml
@@ -78,7 +78,7 @@ spec:
                   --data-parallel-rpc-port 5555 \
                   --data-parallel-start-rank $START_RANK \
                   --kv_transfer_config '{"kv_connector":"NixlConnector",
-                                          "kv_role":"kv_both",
+                                          "kv_role":"kv_producer",
                                           "kv_load_failure_policy":"fail"}' \
                   --enable-dbo \
                   --dbo-prefill-token-threshold 32 \


### PR DESCRIPTION
We're deprecating `kv_both` in vLLM for the NixlConnector in favor of explicit roles https://github.com/vllm-project/vllm/issues/43807 so startup vllm serve commands for P and D will be asymmetric (they already are when configuring things like DeepEP but anyway..).
The TL;DR: this allows vLLM to have finer control at config time, that is prior to handshaking/pod discovery, to handle some important edge-cases more cleanly. 

This PR simply changes the docs to recommend setting roles.
Mind that at the time of writing `kv_both` isn't yet fully deprecated, so nothing is happening in the current release when setting kv_both.
