### PR TITLE
Fix optimized baseline path in multimodal guide

### DIFF
--- a/guides/multimodal/optimized-baseline/README.md
+++ b/guides/multimodal/optimized-baseline/README.md
@@ -65,7 +65,7 @@ Deploy the llm-d Router in **Standalone Mode** overlaying router custom configur
 helm install ${GUIDE_NAME} \
     oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev \
     -f guides/recipes/router/base.values.yaml \
-    -f guides/multimodal/optimized-baseline/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
+    -f guides/multimodal/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
     -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
 ```
 


### PR DESCRIPTION
The path for optimized baseline is broken in multimodal guide. 