### PR TITLE
fix(guides): fix tokenizer container in precise guide for OpenShift

### DIFF
--- a/guides/precise-prefix-cache-routing/modelserver/gpu/vllm/base/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-routing/modelserver/gpu/vllm/base/patch-vllm.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: decode
 spec:
-  replicas: 8
+  replicas: 1
   template:
     spec:
       containers:

--- a/guides/precise-prefix-cache-routing/modelserver/gpu/vllm/base/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-routing/modelserver/gpu/vllm/base/patch-vllm.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: decode
 spec:
-  replicas: 1
+  replicas: 8
   template:
     spec:
       containers:

--- a/guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml
+++ b/guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml
@@ -15,6 +15,9 @@ router:
     # Required by llm-d-router chart v0 when tokenizer is enabled;
     # must match the deployed model server and the token-producer modelName below
     modelName: Qwen/Qwen3-32B
+    env:
+      - name: HF_HOME
+        value: /tmp/hf/hub
 
   epp:
     replicas: 2


### PR DESCRIPTION
### Problem
In OpenShift, the `/.cache` directory is read-only, which caused a `CrashLoopBackOff` when the tokenizer was starting up.

### Solution
Configured the tokenizer to use a writable cache path by adding an environment variable.
