### PR TITLE
Fix bug in CI

### DIFF
--- a/.github/workflows/ci-pr-test.yaml
+++ b/.github/workflows/ci-pr-test.yaml
@@ -89,10 +89,8 @@ jobs:
     if: ${{ !cancelled() && !failure() }}
     runs-on: ubuntu-latest
     outputs:
-      xpu-optimized-baseline: ${{ steps.filter.outputs.xpu-optimized-baseline }}
       xpu-pd-disaggregation: ${{ steps.filter.outputs.xpu-pd-disaggregation }}
       xpu-prefix-cache: ${{ steps.filter.outputs.xpu-prefix-cache }}
-      hpu-optimized-baseline: ${{ steps.filter.outputs.hpu-optimized-baseline }}
       hpu-pd-disaggregation: ${{ steps.filter.outputs.hpu-pd-disaggregation }}
     steps:
       - uses: actions/checkout@v6
@@ -102,14 +100,6 @@ jobs:
         id: filter
         with:
           filters: |
-            xpu-optimized-baseline:
-              - .github/workflows/ci-pr-test.yaml
-              - .github/workflows/e2e-optimized-baseline-xpu.yaml
-              - .github/scripts/e2e/**
-              - docker/common-versions
-              - guides/**/values_xpu.yaml
-              - guides/optimized-baseline/ms-optimized-baseline/values_xpu.yaml
-              - guides/optimized-baseline/helmfile.yaml.gotmpl
             xpu-pd-disaggregation:
               - .github/workflows/ci-pr-test.yaml
               - .github/workflows/e2e-pd-xpu.yaml
@@ -127,14 +117,6 @@ jobs:
               - guides/**/values_xpu.yaml
               - guides/precise-prefix-cache-routing/**/values_xpu.yaml
               - guides/precise-prefix-cache-routing/helmfile.yaml.gotmpl
-            hpu-optimized-baseline:
-              - .github/workflows/ci-pr-test.yaml
-              - .github/workflows/e2e-optimized-baseline-hpu.yaml
-              - .github/scripts/e2e/**
-              - docker/Dockerfile.hpu
-              - guides/**/values-hpu.yaml
-              - guides/optimized-baseline/ms-optimized-baseline/values-hpu.yaml
-              - guides/optimized-baseline/helmfile.yaml.gotmpl
             hpu-pd-disaggregation:
               - .github/workflows/ci-pr-test.yaml
               - .github/workflows/e2e-pd-hpu.yaml
@@ -153,29 +135,6 @@ jobs:
     uses: ./.github/workflows/build-image.yaml
     with:
       ref: ${{ github.event.pull_request.head.sha || '' }}
-    secrets: inherit
-
-  # Call the XPU optimized baseline test workflow
-  test-xpu-optimized-baseline:
-    needs: [detect-changes, build-images]
-    # Run tests if:
-    # 1. It's a manual workflow_dispatch, OR
-    # 2. Related files changed AND (build succeeded OR build was skipped)
-    if: >-
-      ${{ (github.event_name == 'workflow_dispatch' ||
-      needs.detect-changes.outputs.xpu-optimized-baseline == 'true') &&
-      (needs.build-images.result == 'success' || needs.build-images.result == 'skipped') }}
-    uses: ./.github/workflows/e2e-optimized-baseline-xpu.yaml
-    with:
-      pr_or_branch: ${{ github.event.inputs.pr_or_branch || github.event.pull_request.number }}
-      # Only use custom image tag if user provides it, or if XPU image was actually built in this PR
-      # Otherwise, let the test use the default image from values_xpu.yaml
-      custom_image_tag: >-
-        ${{ github.event.inputs.custom_image_tag != '' &&
-        github.event.inputs.custom_image_tag ||
-        (needs.build-images.outputs.xpu == 'true' &&
-        github.event.pull_request.number != '' &&
-        format('pr-{0}', github.event.pull_request.number) || '') }}
     secrets: inherit
 
   # Call the XPU PD test workflow
@@ -220,29 +179,6 @@ jobs:
         ${{ github.event.inputs.custom_image_tag != '' &&
         github.event.inputs.custom_image_tag ||
         (needs.build-images.outputs.xpu == 'true' &&
-        github.event.pull_request.number != '' &&
-        format('pr-{0}', github.event.pull_request.number) || '') }}
-    secrets: inherit
-
-  # Call the HPU optimized baseline test workflow
-  test-hpu-optimized-baseline:
-    needs: [detect-changes, build-images]
-    # Run tests if:
-    # 1. It's a manual workflow_dispatch, OR
-    # 2. Related files changed AND (build succeeded OR build was skipped)
-    if: >-
-      ${{ (github.event_name == 'workflow_dispatch' ||
-      needs.detect-changes.outputs.hpu-optimized-baseline == 'true') &&
-      (needs.build-images.result == 'success' || needs.build-images.result == 'skipped') }}
-    uses: ./.github/workflows/e2e-optimized-baseline-hpu.yaml
-    with:
-      pr_or_branch: ${{ github.event.inputs.pr_or_branch || github.event.pull_request.number }}
-      # Only use custom image tag if user provides it, or if HPU image was actually built in this PR
-      # Otherwise, let the test use the default image from values-hpu.yaml
-      custom_image_tag: >-
-        ${{ github.event.inputs.custom_image_tag != '' &&
-        github.event.inputs.custom_image_tag ||
-        (needs.build-images.outputs.hpu == 'true' &&
         github.event.pull_request.number != '' &&
         format('pr-{0}', github.event.pull_request.number) || '') }}
     secrets: inherit


### PR DESCRIPTION
In https://github.com/llm-d/llm-d/pull/1693 the files `e2e-optimized-baseline-xpu.yaml` and `e2e-optimized-baseline-xpu.yaml` were converted into `nightlies`.
However, `ci-pr-test.yaml` was still using them. This PR remove them from the workflow