### PR TITLE
Add Community Managers section to MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,6 +9,14 @@
 | Clayton Coleman (inactive while on leave) | Google   | @smarterclayton      |
 | Robert Shaw                               | Red Hat  | @robertgshaw2-redhat |
 
+## Community Managers
+
+| Name                                      | Employer | GitHub ID            |
+|-------------------------------------------|----------|----------------------|
+| Pete Cheslock                             | Red Hat  | @petecheslock        |
+| David Simmons                             | Red Hat  | @davidgs             |
+| JJ Asghar                                 | IBM      | @jjasghar            |
+
 ## Special Interest Group Leadership
 
 See [SIG Detailed Descriptions in SIGS.md](SIGS.md#sig-detailed-descriptions) for SIG-level leadership.


### PR DESCRIPTION
Adding a block of community managers to the MAINTAINERS.md as this will help with us managing the different project related tools and tasks for the CNCF.