### PR TITLE
Add agentic-inference umbrella well-lit path

### DIFF
--- a/docs/well-lit-paths/README.md
+++ b/docs/well-lit-paths/README.md
@@ -23,9 +23,10 @@ Well-lit paths are curated, end-to-end guides for common LLM inference patterns 
 - **[Workload Autoscaling](workload-autoscaling.md)**: From simple Kubernetes autoscaling supplemented by EPP load metrics to advanced, SLO-aware capacity optimization for heterogeneous pools via the Workload Variant Autoscaler.
 - **[Batch Gateway](batch-gateway.md)**: Managing large-scale batch inference coexisting with interactive workloads via an OpenAI-compatible Batch API.
 
-### Multimodal Serving
+### Workloads
 
-* [Optimized Baseline](./multimodal-serving/optimized-baseline/README.md) - Deploy vLLM with multimodal prefix-cache and load-aware routing enabled by the llm-d EPP.
+- **[Agentic Inference](agentic-inference.md)**: A workload-centric umbrella for serving long, multi-turn, tool-using agentic programs — composing prefix-aware routing, KV-cache offloading, and P/D disaggregation into a ladder of deployment options.
+- **[Multimodal Serving](./multimodal-serving/optimized-baseline/README.md)**: Deploy vLLM with multimodal prefix-cache and load-aware routing enabled by the llm-d EPP.
 
 ### Experimental
 

--- a/docs/well-lit-paths/agentic-inference.md
+++ b/docs/well-lit-paths/agentic-inference.md
@@ -18,7 +18,7 @@ Three properties of agentic workloads break those request-centric assumptions:
 
 The next large efficiency gain for these workloads does not come from micro-optimizing isolated
 requests — it comes from making the stack understand the structure of the agentic program, with
-the **KV-cache as the medium that coordinates it.**
+**model state — today primarily the KV-cache — as the medium that coordinates it.**
 
 ```text
 Request-centric (today's default)        Program-aware (the direction)
@@ -28,6 +28,11 @@ Request-centric (today's default)        Program-aware (the direction)
  turn 3 ─▶ RE-prefill    ─▶ decode         turn 3 ─▶ reuse cache  ─▶ decode
    (KV evicted between turns)                (KV retained / offloaded, restored on resume)
 ```
+
+A single engine already reuses cache across turns when a session happens to land on the same
+replica with free memory; the failure is fleet-level — no cross-replica coordination, eviction
+blind to which blocks a live session still needs, and no notion of the program behind the
+requests.
 
 ## Canonical Workloads
 
@@ -70,11 +75,18 @@ treating the **session as a graph of typed state blocks** the control plane plan
 - **Program-aware scheduling** — schedule on program-level metrics and the critical path that
   stalls the whole loop, not per-request fairness. Extends the Inference Scheduler.
 - **State reuse and lifecycle ("zero-recompute")** — if a reusable context exists anywhere (HBM,
-  host memory, storage), no node burns compute to regenerate it; durable context is pinned and
-  dead branches dropped via typed retention. Builds on KV-disaggregation, tiered offloading, and
-  KV-centric stores such as Mooncake.
+  host memory, storage), no node recomputes it whenever reuse is cheaper than regeneration;
+  durable context is pinned and dead branches dropped via typed retention. Builds on
+  KV-disaggregation, tiered offloading, and KV-centric stores such as Mooncake.
 - **Proactive state** — when an agent fans out, context is pre-positioned where the new compute
-  will land, rather than pulled on demand.
+  will land rather than pulled on demand, with placement co-planned with scheduling from the
+  session graph and declared fan-out.
+
+The contract is two-layer: applications express intent through the caching and metadata APIs
+they already use, and llm-d does the cross-session, cluster-wide work underneath — better hints
+sharpen the orchestration, but the stack functions on inferred structure without them. Agent
+control flow and cognitive decisions stay in the logic layer (agent frameworks, MCP and Skills
+servers); llm-d provides the hooks to serve them efficiently.
 
 The guiding boundary: **the engine is the mechanism, llm-d is the meaning** — the semantic layer
 lives one level above the engine, so the work spans vLLM, SGLang, and beyond.

--- a/docs/well-lit-paths/agentic-inference.md
+++ b/docs/well-lit-paths/agentic-inference.md
@@ -3,7 +3,7 @@
 Agents are becoming the dominant shape of production LLM traffic. A single user goal expands into
 a long *program* of model calls interleaved with tool execution — coding agents, deep-research
 loops, tool-using copilots, multi-agent pipelines. But inference stacks are still tuned for the
-isolated request: each call is served as if standalone, so the stack recomputes context it has
+isolated request: each call is served as if it is standalone, so the stack recomputes context it has
 already seen, evicts long-lived sessions under memory pressure, and hot-spots whichever replica
 holds a popular prefix.
 
@@ -36,7 +36,7 @@ requests.
 
 ## Canonical Workloads
 
-The llm-d Agentic Inference SIG anchors its work to concrete workload shapes, each stressing the
+The llm-d project anchors its work to concrete workload shapes, each stressing the
 stack differently:
 
 - **Long-horizon loops** (coding agents, computer use): one agent iterating reason → act →
@@ -65,15 +65,15 @@ workload and how the options compose.
 ## Direction
 
 These mechanisms are the first concrete steps toward serving that is *program-aware* rather than
-request-aware. The [Agentic Inference SIG northstar][northstar] is driving the stack toward
+request-aware. The [llm-d project agentic northstar][northstar] is driving the stack towards
 treating the **session as a graph of typed state blocks** the control plane plans over:
 
 - **Session-graph orchestration** — model a session as a graph of typed blocks (system prompt,
   tool catalog, conversation turn, reasoning branch), built from external hints (e.g. Anthropic
   `cache_control`, OpenAI `prompt_cache_key`) where available and inferred otherwise. Precise
   KV-state indexing is the substrate this rides on.
-- **Program-aware scheduling** — schedule on program-level metrics and the critical path that
-  stalls the whole loop, not per-request fairness. Extends the Inference Scheduler.
+- **Program-aware scheduling** — schedule based on program-level metrics and the critical path that
+  stalls the whole loop, not per-request fairness. Extends the llm-d Router.
 - **State reuse and lifecycle ("zero-recompute")** — if a reusable context exists anywhere (HBM,
   host memory, storage), no node recomputes it whenever reuse is cheaper than regeneration;
   durable context is pinned and dead branches dropped via typed retention. Builds on

--- a/docs/well-lit-paths/agentic-inference.md
+++ b/docs/well-lit-paths/agentic-inference.md
@@ -51,9 +51,8 @@ stack differently:
 The [agentic-inference guide](../../guides/agentic-inference) is the operational counterpart. It
 composes llm-d's existing well-lit paths into a deployment stack — the
 [optimized baseline](optimized-baseline.md) for prefix- and load-aware routing,
-[tiered KV-cache offloading](tiered-prefix-cache.md) (CPU and storage) to keep idle sessions
-resident, [precise prefix-cache routing](precise-prefix-cache-routing.md) for exact KV-state
-visibility, and [P/D disaggregation](pd-disaggregation.md) for interactivity under load — and
+[tiered KV-cache offloading](tiered-prefix-cache.md) to keep idle sessions resident,
+[precise prefix-cache routing](precise-prefix-cache-routing.md) for exact KV-state visibility, and [P/D disaggregation](pd-disaggregation.md) for interactivity under load — and
 exposes them as deployment options on a complexity ladder, benchmarked against a shared, realistic
 agentic workload so options are directly comparable. See the guide for how each layer maps to the
 workload and how the options compose.
@@ -72,19 +71,12 @@ treating the **session as a graph of typed state blocks** the control plane plan
   stalls the whole loop, not per-request fairness. Extends the Inference Scheduler.
 - **State reuse and lifecycle ("zero-recompute")** — if a reusable context exists anywhere (HBM,
   host memory, storage), no node burns compute to regenerate it; durable context is pinned and
-  dead branches dropped via typed retention. Builds on KV-disaggregation, storage offloading, and
+  dead branches dropped via typed retention. Builds on KV-disaggregation, tiered offloading, and
   KV-centric stores such as Mooncake.
 - **Proactive state** — when an agent fans out, context is pre-positioned where the new compute
   will land, rather than pulled on demand.
 
 The guiding boundary: **the engine is the mechanism, llm-d is the meaning** — the semantic layer
 lives one level above the engine, so the work spans vLLM, SGLang, and beyond.
-
-### Further Reading
-
-- [llm-d Agentic Inference SIG Northstar][northstar] — the vision, canonical workloads, and focus areas.
-- [KV-Cache Orchestration for Agentic Inference](https://docs.google.com/document/d/1IHMoVuvfroK6-jZbj3uI5dpr1zyAqUh1HcpkAY_CdFY) — reuse, placement, and lifecycle of cache state.
-- [Session-Graph Orchestration for Agentic Inference](https://docs.google.com/document/d/1oet1juFV8oaJC7fswUSMH4L45gFi3Hbux5doEbBzQZo) — the session-graph planning layer in detail.
-- [OTel Trace Replay — Agentic Workload Simulation](https://docs.google.com/document/d/1qI3DXj9wYy6WY6-lk7viuzHVvftosCiRSP6DONT-dPI) — program-level, trace-driven benchmarking.
 
 [northstar]: https://docs.google.com/document/d/1DCUVHp9Z8CZUnKiP04nnD_31M3gRishW-cWZ657Cn5U

--- a/docs/well-lit-paths/agentic-inference.md
+++ b/docs/well-lit-paths/agentic-inference.md
@@ -1,0 +1,90 @@
+# Agentic Inference
+
+Agents are becoming the dominant shape of production LLM traffic. A single user goal expands into
+a long *program* of model calls interleaved with tool execution — coding agents, deep-research
+loops, tool-using copilots, multi-agent pipelines. But inference stacks are still tuned for the
+isolated request: each call is served as if standalone, so the stack recomputes context it has
+already seen, evicts long-lived sessions under memory pressure, and hot-spots whichever replica
+holds a popular prefix.
+
+Three properties of agentic workloads break those request-centric assumptions:
+
+- **Massive context reuse** — branches of a reasoning tree, turns of a tool loop, and children of
+  a swarm share most of their context (system prompts, tool definitions, conversation so far).
+- **Program-level objectives** — users care about whole-program completion time, not the latency
+  of any single call; one stalled branch can hold up the entire program.
+- **Typed, predictable lifecycles** — durable system prompts and tools versus ephemeral
+  scratchpad thoughts, with predictable flow the stack could anticipate but instead reacts to.
+
+The next large efficiency gain for these workloads does not come from micro-optimizing isolated
+requests — it comes from making the stack understand the structure of the agentic program, with
+the **KV-cache as the medium that coordinates it.**
+
+```text
+Request-centric (today's default)        Program-aware (the direction)
+─────────────────────────────────        ─────────────────────────────
+ turn 1 ─▶ prefill 160K  ─▶ decode         turn 1 ─▶ prefill 160K ─▶ decode
+ turn 2 ─▶ RE-prefill    ─▶ decode         turn 2 ─▶ reuse cache  ─▶ decode
+ turn 3 ─▶ RE-prefill    ─▶ decode         turn 3 ─▶ reuse cache  ─▶ decode
+   (KV evicted between turns)                (KV retained / offloaded, restored on resume)
+```
+
+## Canonical Workloads
+
+The llm-d Agentic Inference SIG anchors its work to concrete workload shapes, each stressing the
+stack differently:
+
+- **Long-horizon loops** (coding agents, computer use): one agent iterating reason → act →
+  observe over many turns. Stresses cross-turn KV persistence, typed retention, and context
+  growth. **Covered today.**
+- **Parallel fan-out** (best-of-N, tree search, RL rollouts, subagents): one shared context
+  spawns many concurrent children. Stresses prefix reuse, proactive replication, and join
+  (slowest-child) latency. *Roadmap.*
+- **Multi-agent pipelines** (programs spanning distinct agents across pods, sequential or
+  fork/join). Stresses reuse and program identity spanning pools, and program-level accounting.
+  *Roadmap.*
+- **Reasoning-heavy generation** (long internal reasoning before answering): shifts work to
+  decode and grows per-request KV footprint. *Roadmap.*
+
+## Deploy
+
+The [agentic-inference guide](../../guides/agentic-inference) is the operational counterpart. It
+composes llm-d's existing well-lit paths into a deployment stack — the
+[optimized baseline](optimized-baseline.md) for prefix- and load-aware routing,
+[tiered KV-cache offloading](tiered-prefix-cache.md) (CPU and storage) to keep idle sessions
+resident, [precise prefix-cache routing](precise-prefix-cache-routing.md) for exact KV-state
+visibility, and [P/D disaggregation](pd-disaggregation.md) for interactivity under load — and
+exposes them as deployment options on a complexity ladder, benchmarked against a shared, realistic
+agentic workload so options are directly comparable. See the guide for how each layer maps to the
+workload and how the options compose.
+
+## Direction
+
+These mechanisms are the first concrete steps toward serving that is *program-aware* rather than
+request-aware. The [Agentic Inference SIG northstar][northstar] is driving the stack toward
+treating the **session as a graph of typed state blocks** the control plane plans over:
+
+- **Session-graph orchestration** — model a session as a graph of typed blocks (system prompt,
+  tool catalog, conversation turn, reasoning branch), built from external hints (e.g. Anthropic
+  `cache_control`, OpenAI `prompt_cache_key`) where available and inferred otherwise. Precise
+  KV-state indexing is the substrate this rides on.
+- **Program-aware scheduling** — schedule on program-level metrics and the critical path that
+  stalls the whole loop, not per-request fairness. Extends the Inference Scheduler.
+- **State reuse and lifecycle ("zero-recompute")** — if a reusable context exists anywhere (HBM,
+  host memory, storage), no node burns compute to regenerate it; durable context is pinned and
+  dead branches dropped via typed retention. Builds on KV-disaggregation, storage offloading, and
+  KV-centric stores such as Mooncake.
+- **Proactive state** — when an agent fans out, context is pre-positioned where the new compute
+  will land, rather than pulled on demand.
+
+The guiding boundary: **the engine is the mechanism, llm-d is the meaning** — the semantic layer
+lives one level above the engine, so the work spans vLLM, SGLang, and beyond.
+
+### Further Reading
+
+- [llm-d Agentic Inference SIG Northstar][northstar] — the vision, canonical workloads, and focus areas.
+- [KV-Cache Orchestration for Agentic Inference](https://docs.google.com/document/d/1IHMoVuvfroK6-jZbj3uI5dpr1zyAqUh1HcpkAY_CdFY) — reuse, placement, and lifecycle of cache state.
+- [Session-Graph Orchestration for Agentic Inference](https://docs.google.com/document/d/1oet1juFV8oaJC7fswUSMH4L45gFi3Hbux5doEbBzQZo) — the session-graph planning layer in detail.
+- [OTel Trace Replay — Agentic Workload Simulation](https://docs.google.com/document/d/1qI3DXj9wYy6WY6-lk7viuzHVvftosCiRSP6DONT-dPI) — program-level, trace-driven benchmarking.
+
+[northstar]: https://docs.google.com/document/d/1DCUVHp9Z8CZUnKiP04nnD_31M3gRishW-cWZ657Cn5U

--- a/guides/README.md
+++ b/guides/README.md
@@ -28,9 +28,12 @@ We currently offer the following:
 * [Workload Autoscaling](./workload-autoscaling/README.md) - autoscale the LLM service via proactive, SLO-aware signals that reflect the true state of the inference system — queue depth, in-flight request counts, and KV cache pressure — so that capacity can be added before end-user latency is impacted.
 * [Rollouts](./rollouts/README.md) - perform incremental rollout operations for LoRA adapters, base models, and model server versions with minimal service disruption using traffic splitting and gradual deployment strategies.
 
-### Multimodal Serving
+### Workloads
 
-* [Optimized Baseline](./multimodal-serving/optimized-baseline/README.md) - Deploy vLLM with multimodal prefix-cache and load-aware routing enabled by the llm-d EPP.
+Horizontal, workload-centric paths that compose the capability guides above into a stack tuned for a specific traffic pattern.
+
+* [Agentic Inference](./agentic-inference/README.md) - serve long, multi-turn, tool-using agentic workloads (e.g. coding agents) via a ladder of deployment options that combine prefix-aware routing, KV-cache offloading, and P/D disaggregation.
+* [Multimodal Serving](./multimodal-serving/optimized-baseline/README.md) - Deploy vLLM with multimodal prefix-cache and load-aware routing enabled by the llm-d EPP.
 
 ## Experimental Guides
 

--- a/guides/agentic-inference/README.md
+++ b/guides/agentic-inference/README.md
@@ -24,7 +24,6 @@ the agentic workload; the deployment options below compose them.
 | **[Tiered KV offloading](../tiered-prefix-cache/README.md)** | Offload KV cache beyond accelerator memory across tiers, so idle sessions restore on resume instead of recomputing prefill. |
 | **[Precise prefix-cache routing](../precise-prefix-cache-routing/README.md)** — advanced | An exact, global view of cache state, enabling session-centric orchestration and non-naive (beyond-LRU) KV-cache offloading & retention. |
 | **[P/D disaggregation](../pd-disaggregation/README.md)** — large models / interactivity | Separate prefill and decode pools so heavy prefill never stalls token generation, stabilizing ITL. |
-
 These layers are the available subset of a larger direction. The
 [Agentic Inference SIG northstar](https://docs.google.com/document/d/1DCUVHp9Z8CZUnKiP04nnD_31M3gRishW-cWZ657Cn5U)
 drives toward *program-aware* serving — **session-graph orchestration**, **program-aware

--- a/guides/agentic-inference/README.md
+++ b/guides/agentic-inference/README.md
@@ -4,7 +4,7 @@ The **agentic-inference well-lit path** is a horizontal, workload-centric umbrel
 agentic *programs* on llm-d by composing the capability paths into a stack and exposing a ladder
 of deployment options that trade complexity for capability. For the workload model, canonical
 shapes, and the direction this path is driving toward, see the
-[Agentic Inference concept page](../../docs/well-lit-paths/agentic-inference.md); this guide is
+[Agentic Inference well-lit path](../../docs/well-lit-paths/agentic-inference.md); this guide is
 the operational counterpart, and the canonical guide of the llm-d Agentic Inference SIG.
 
 The reference workload here is **long-horizon loops** (agentic code generation): deep multi-turn
@@ -16,116 +16,41 @@ arrivals (tool pauses leave sessions idle, then resume in bursts).
 ## The Optimization Stack
 
 The guide composes llm-d's capability paths into layers that each relieve a specific pressure of
-the agentic workload; the [deployment options](#deployment-options) below select among them.
+the agentic workload; the deployment options below compose them.
 
 | Layer | What it does for the workload |
 | :--- | :--- |
-| **[Optimized baseline](../optimized-baseline/README.md)** — routing foundation | Prefix-cache scorer routes a turn to the replica already holding its prefix; load-aware scorers (KV-utilization, queue) keep bursts off hot replicas. Every option starts here. |
-| **[Tiered KV offloading](../tiered-prefix-cache/README.md)** — CPU → storage | Idle sessions spill from HBM to CPU RAM (low overhead) and to storage (RWX PVC; cross-pod sharing, persistence), so resumes restore instead of recomputing prefill. |
-| **[Precise prefix-cache routing](../precise-prefix-cache-routing/README.md)** — advanced | Exact global KV-block index from KV-events, enabling session-centric orchestration and non-naive (beyond-LRU) retention rather than estimated reuse. |
+| **[Optimized baseline](../optimized-baseline/README.md)** — routing foundation | Prefix-cache scorer routes a turn to the replica already holding its prefix; load-aware scorers keep bursts off hot replicas. Every option starts here. |
+| **[Tiered KV offloading](../tiered-prefix-cache/README.md)** | Offload KV cache beyond accelerator memory across tiers, so idle sessions restore on resume instead of recomputing prefill. |
+| **[Precise prefix-cache routing](../precise-prefix-cache-routing/README.md)** — advanced | An exact, global view of cache state, enabling session-centric orchestration and non-naive (beyond-LRU) KV-cache offloading & retention. |
 | **[P/D disaggregation](../pd-disaggregation/README.md)** — large models / interactivity | Separate prefill and decode pools so heavy prefill never stalls token generation, stabilizing ITL. |
-| **Tool-aware prefix caching** — cross-cutting | Prefix matching aware of chat/tool message structure, so tool-calling turns keep hitting cache. |
 
 These layers are the available subset of a larger direction. The
 [Agentic Inference SIG northstar](https://docs.google.com/document/d/1DCUVHp9Z8CZUnKiP04nnD_31M3gRishW-cWZ657Cn5U)
 drives toward *program-aware* serving — **session-graph orchestration**, **program-aware
 scheduling**, **zero-recompute state reuse** with typed retention, and **proactive state
-placement** ahead of fan-out; precise routing and storage offloading are the first steps. See the
-[concept page](../../docs/well-lit-paths/agentic-inference.md#direction) for the full direction
-and further reading.
+placement** ahead of fan-out; precise routing and tiered offloading are the first steps. See the
+[well-lit path page](../../docs/well-lit-paths/agentic-inference.md#direction) for the full
+direction and further reading.
 
 ## Deployment Options
 
-The options are reference configurations that select from the stack above, ordered by increasing
-capability and operational cost. Both target the reference workload and are measured against the
-same [benchmark](#benchmarking); pick the lowest rung that meets your SLOs, then layer in the
-advanced optimizations as the workload grows.
-
-| Option | Composes | Requirements & complexity | Best for |
-| :--- | :--- | :--- | :--- |
-| **[Routing + offload](./routing/README.md)** | Optimized-baseline routing + CPU-DRAM KV offload, single-host | Stock EPP scorers, single-host model servers. No disaggregation, no custom builds. **Lowest barrier.** | Prefix reuse and multi-turn memory headroom on a single accelerator pool. |
-| **[Disaggregated + tool-aware](./disaggregated/README.md)** | + P/D disaggregation, NIXL KV transfer, tool-aware prefix caching | Separate prefill/decode pools, a KV-transfer fabric, and a custom router build for tool-aware caching. **Higher operational cost.** | Medium-large models, tight TTFT/ITL targets, heavy tool-calling. |
-| **Advanced layers** *(compose onto either)* | + Precise prefix-cache routing, + storage KV offload | Precise: KV-event publishing/indexing. Storage: an RWX storage backend and I/O tuning. | Session-centric orchestration, beyond-LRU retention, and cross-replica reuse beyond host DRAM. |
-
-### Routing + offload
-
-The entry rung. Single-host replicas serve the full model under the optimized-baseline scorers
-(prefix-cache weighted highest, alongside the queue and KV-utilization scorers), while a
-KV-offload connector spills idle sessions from HBM to CPU DRAM. This captures the two biggest
-wins — prefix reuse and a larger working set — with no disaggregation and no custom images.
-See **[routing/](./routing/README.md)**.
-
-### Disaggregated + tool-aware
-
-The advanced rung, for when prefill interference or strict interactivity SLOs make a single pool
-insufficient. Prefill and decode run as separate pools with KV transferred over NIXL, and the
-router adds disaggregation-aware scheduling plus **tool-aware prefix caching** so tool-structured
-turns still hit cache. Requires a KV-transfer fabric and a router build with tool-aware caching
-enabled. See **[disaggregated/](./disaggregated/README.md)**.
-
-### Advanced layers
-
-Layer onto either option as the working set and the need for program-awareness grow. **Precise
-prefix-cache routing** ([guide](../precise-prefix-cache-routing/README.md)) swaps approximate
-prefix estimation for an exact global KV index, the basis for session-centric orchestration and
-beyond-LRU retention. **Storage KV offloading** ([guide](../tiered-prefix-cache/README.md))
-extends offload past host DRAM for working sets no single host can hold and for cross-replica
-reuse. These map directly to the [northstar direction](../../docs/well-lit-paths/agentic-inference.md#direction).
-
-## Benchmarking
-
-Every option is evaluated against the same agentic workload so results are comparable across
-rungs. The benchmark uses [`inference-perf`](https://github.com/llm-d/llm-d-benchmark) to replay
-a realistic agentic workload — shared and dynamic system prompts, multi-turn sessions, and
-tool-call stalls — rather than a single-turn shared-prefix stream. This exercises the exact
-behaviors the stack is tuned for: cross-turn prefix reuse, session persistence under memory
-pressure, and bursty resumption.
-
-The workload template lives with the routing option at
-[`routing/benchmark-templates/guide.yaml`](./routing/benchmark-templates/guide.yaml). Run it
-against any deployed option by pointing `base_url`/`namespace` at that stack; see the
-[benchmark helper](../../helpers/benchmark.md) for harness mechanics. Replay of real agentic
-traces (program structure and tool-call timing from OpenTelemetry) is the direction for
-program-level evaluation.
+The layers above compose into deployment options spanning a range of capability and operational
+cost — from a routing-and-offloading baseline up to disaggregated serving — added incrementally
+as a workload's scale and latency targets grow. Concrete, benchmarked options are present in this
+directory.
 
 ## Choosing an Option
 
-Start with **routing + offload** if your model fits a single-host pool and the goal is to stop
-re-prefilling shared context — the smallest change with the largest return for most agentic
-deployments. Add **storage offload** once host DRAM can no longer hold the live session set, or
-when newly scaled replicas should read existing cache immediately.
+> 🚧 Under construction — guidance on selecting and combining layers for a given workload and
+> SLO target lands with the deployment options.
 
-Move to **disaggregated + tool-aware** when prefill interference erodes inter-token latency, when
-interactivity SLOs require isolating decode, or when tool-calling structure is splitting your
-cacheable prefix.
+## Benchmarking
 
-Adopt **precise prefix-cache routing** when approximate scoring leaves reuse on the table and you
-want the router to orchestrate placement and retention by session structure rather than recency.
+Deployment options are compared against the same realistic agentic workload — large reused
+contexts, deep multi-turn sessions, and tool-call stalls — replayed with
+[`inference-perf`](https://github.com/llm-d/llm-d-benchmark) rather than a single-turn
+shared-prefix stream, so cross-turn reuse, session persistence, and bursty resumption are
+actually exercised. Replaying real agentic traces (program structure and tool-call timing from
+OpenTelemetry) is the direction for program-level evaluation.
 
-## Prerequisites
-
-Shared across all options (each sub-guide pins versions and option-specific variables):
-
-- Have the [proper client tools installed](../../helpers/client-setup/README.md).
-- Check out the repo:
-
-  ```bash
-  export branch="main" # branch, tag, or commit hash
-  git clone https://github.com/llm-d/llm-d.git && cd llm-d && git checkout ${branch}
-  ```
-
-- A Kubernetes cluster with the accelerators your chosen option targets, and an
-  [`llm-d-hf-token` secret](../../helpers/hf-token.md) in the target namespace.
-
-Follow the install, verification, and cleanup steps in the option's own guide:
-[routing/](./routing/README.md) · [disaggregated/](./disaggregated/README.md).
-
-## Status
-
-This umbrella is new and its rungs are landing incrementally. The routing and disaggregated
-options are under active development ([#1727](https://github.com/llm-d/llm-d/pull/1727),
-[#1740](https://github.com/llm-d/llm-d/pull/1740)); precise routing and storage offload exist as
-capability paths and are being folded in as composable layers; the remaining canonical workload
-shapes are on the roadmap ([#1558](https://github.com/llm-d/llm-d/issues/1558)). Default models,
-hardware, and tuning in each option are starting points, not production guarantees — review and
-adjust them for your environment.

--- a/guides/agentic-inference/README.md
+++ b/guides/agentic-inference/README.md
@@ -1,0 +1,131 @@
+# Agentic Inference
+
+The **agentic-inference well-lit path** is a horizontal, workload-centric umbrella that serves
+agentic *programs* on llm-d by composing the capability paths into a stack and exposing a ladder
+of deployment options that trade complexity for capability. For the workload model, canonical
+shapes, and the direction this path is driving toward, see the
+[Agentic Inference concept page](../../docs/well-lit-paths/agentic-inference.md); this guide is
+the operational counterpart, and the canonical guide of the llm-d Agentic Inference SIG.
+
+The reference workload here is **long-horizon loops** (agentic code generation): deep multi-turn
+sessions over large, repository-scale contexts with tool-call pauses between turns. Three
+behaviors drive every choice below — prefill-heavy/decode-light (a 160K-token context dominates
+TTFT), high reusable locality (cache hit rate, not FLOPs, sets throughput), and bursty/stateful
+arrivals (tool pauses leave sessions idle, then resume in bursts).
+
+## The Optimization Stack
+
+The guide composes llm-d's capability paths into layers that each relieve a specific pressure of
+the agentic workload; the [deployment options](#deployment-options) below select among them.
+
+| Layer | What it does for the workload |
+| :--- | :--- |
+| **[Optimized baseline](../optimized-baseline/README.md)** — routing foundation | Prefix-cache scorer routes a turn to the replica already holding its prefix; load-aware scorers (KV-utilization, queue) keep bursts off hot replicas. Every option starts here. |
+| **[Tiered KV offloading](../tiered-prefix-cache/README.md)** — CPU → storage | Idle sessions spill from HBM to CPU RAM (low overhead) and to storage (RWX PVC; cross-pod sharing, persistence), so resumes restore instead of recomputing prefill. |
+| **[Precise prefix-cache routing](../precise-prefix-cache-routing/README.md)** — advanced | Exact global KV-block index from KV-events, enabling session-centric orchestration and non-naive (beyond-LRU) retention rather than estimated reuse. |
+| **[P/D disaggregation](../pd-disaggregation/README.md)** — large models / interactivity | Separate prefill and decode pools so heavy prefill never stalls token generation, stabilizing ITL. |
+| **Tool-aware prefix caching** — cross-cutting | Prefix matching aware of chat/tool message structure, so tool-calling turns keep hitting cache. |
+
+These layers are the available subset of a larger direction. The
+[Agentic Inference SIG northstar](https://docs.google.com/document/d/1DCUVHp9Z8CZUnKiP04nnD_31M3gRishW-cWZ657Cn5U)
+drives toward *program-aware* serving — **session-graph orchestration**, **program-aware
+scheduling**, **zero-recompute state reuse** with typed retention, and **proactive state
+placement** ahead of fan-out; precise routing and storage offloading are the first steps. See the
+[concept page](../../docs/well-lit-paths/agentic-inference.md#direction) for the full direction
+and further reading.
+
+## Deployment Options
+
+The options are reference configurations that select from the stack above, ordered by increasing
+capability and operational cost. Both target the reference workload and are measured against the
+same [benchmark](#benchmarking); pick the lowest rung that meets your SLOs, then layer in the
+advanced optimizations as the workload grows.
+
+| Option | Composes | Requirements & complexity | Best for |
+| :--- | :--- | :--- | :--- |
+| **[Routing + offload](./routing/README.md)** | Optimized-baseline routing + CPU-DRAM KV offload, single-host | Stock EPP scorers, single-host model servers. No disaggregation, no custom builds. **Lowest barrier.** | Prefix reuse and multi-turn memory headroom on a single accelerator pool. |
+| **[Disaggregated + tool-aware](./disaggregated/README.md)** | + P/D disaggregation, NIXL KV transfer, tool-aware prefix caching | Separate prefill/decode pools, a KV-transfer fabric, and a custom router build for tool-aware caching. **Higher operational cost.** | Medium-large models, tight TTFT/ITL targets, heavy tool-calling. |
+| **Advanced layers** *(compose onto either)* | + Precise prefix-cache routing, + storage KV offload | Precise: KV-event publishing/indexing. Storage: an RWX storage backend and I/O tuning. | Session-centric orchestration, beyond-LRU retention, and cross-replica reuse beyond host DRAM. |
+
+### Routing + offload
+
+The entry rung. Single-host replicas serve the full model under the optimized-baseline scorers
+(prefix-cache weighted highest, alongside the queue and KV-utilization scorers), while a
+KV-offload connector spills idle sessions from HBM to CPU DRAM. This captures the two biggest
+wins — prefix reuse and a larger working set — with no disaggregation and no custom images.
+See **[routing/](./routing/README.md)**.
+
+### Disaggregated + tool-aware
+
+The advanced rung, for when prefill interference or strict interactivity SLOs make a single pool
+insufficient. Prefill and decode run as separate pools with KV transferred over NIXL, and the
+router adds disaggregation-aware scheduling plus **tool-aware prefix caching** so tool-structured
+turns still hit cache. Requires a KV-transfer fabric and a router build with tool-aware caching
+enabled. See **[disaggregated/](./disaggregated/README.md)**.
+
+### Advanced layers
+
+Layer onto either option as the working set and the need for program-awareness grow. **Precise
+prefix-cache routing** ([guide](../precise-prefix-cache-routing/README.md)) swaps approximate
+prefix estimation for an exact global KV index, the basis for session-centric orchestration and
+beyond-LRU retention. **Storage KV offloading** ([guide](../tiered-prefix-cache/README.md))
+extends offload past host DRAM for working sets no single host can hold and for cross-replica
+reuse. These map directly to the [northstar direction](../../docs/well-lit-paths/agentic-inference.md#direction).
+
+## Benchmarking
+
+Every option is evaluated against the same agentic workload so results are comparable across
+rungs. The benchmark uses [`inference-perf`](https://github.com/llm-d/llm-d-benchmark) to replay
+a realistic agentic workload — shared and dynamic system prompts, multi-turn sessions, and
+tool-call stalls — rather than a single-turn shared-prefix stream. This exercises the exact
+behaviors the stack is tuned for: cross-turn prefix reuse, session persistence under memory
+pressure, and bursty resumption.
+
+The workload template lives with the routing option at
+[`routing/benchmark-templates/guide.yaml`](./routing/benchmark-templates/guide.yaml). Run it
+against any deployed option by pointing `base_url`/`namespace` at that stack; see the
+[benchmark helper](../../helpers/benchmark.md) for harness mechanics. Replay of real agentic
+traces (program structure and tool-call timing from OpenTelemetry) is the direction for
+program-level evaluation.
+
+## Choosing an Option
+
+Start with **routing + offload** if your model fits a single-host pool and the goal is to stop
+re-prefilling shared context — the smallest change with the largest return for most agentic
+deployments. Add **storage offload** once host DRAM can no longer hold the live session set, or
+when newly scaled replicas should read existing cache immediately.
+
+Move to **disaggregated + tool-aware** when prefill interference erodes inter-token latency, when
+interactivity SLOs require isolating decode, or when tool-calling structure is splitting your
+cacheable prefix.
+
+Adopt **precise prefix-cache routing** when approximate scoring leaves reuse on the table and you
+want the router to orchestrate placement and retention by session structure rather than recency.
+
+## Prerequisites
+
+Shared across all options (each sub-guide pins versions and option-specific variables):
+
+- Have the [proper client tools installed](../../helpers/client-setup/README.md).
+- Check out the repo:
+
+  ```bash
+  export branch="main" # branch, tag, or commit hash
+  git clone https://github.com/llm-d/llm-d.git && cd llm-d && git checkout ${branch}
+  ```
+
+- A Kubernetes cluster with the accelerators your chosen option targets, and an
+  [`llm-d-hf-token` secret](../../helpers/hf-token.md) in the target namespace.
+
+Follow the install, verification, and cleanup steps in the option's own guide:
+[routing/](./routing/README.md) · [disaggregated/](./disaggregated/README.md).
+
+## Status
+
+This umbrella is new and its rungs are landing incrementally. The routing and disaggregated
+options are under active development ([#1727](https://github.com/llm-d/llm-d/pull/1727),
+[#1740](https://github.com/llm-d/llm-d/pull/1740)); precise routing and storage offload exist as
+capability paths and are being folded in as composable layers; the remaining canonical workload
+shapes are on the roadmap ([#1558](https://github.com/llm-d/llm-d/issues/1558)). Default models,
+hardware, and tuning in each option are starting points, not production guarantees — review and
+adjust them for your environment.

--- a/guides/agentic-inference/README.md
+++ b/guides/agentic-inference/README.md
@@ -24,6 +24,7 @@ the agentic workload; the deployment options below compose them.
 | **[Tiered KV offloading](../tiered-prefix-cache/README.md)** | Offload KV cache beyond accelerator memory across tiers, so idle sessions restore on resume instead of recomputing prefill. |
 | **[Precise prefix-cache routing](../precise-prefix-cache-routing/README.md)** — advanced | An exact, global view of cache state, enabling session-centric orchestration and non-naive (beyond-LRU) KV-cache offloading & retention. |
 | **[P/D disaggregation](../pd-disaggregation/README.md)** — large models / interactivity | Separate prefill and decode pools so heavy prefill never stalls token generation, stabilizing ITL. |
+
 These layers are the available subset of a larger direction. The
 [Agentic Inference SIG northstar](https://docs.google.com/document/d/1DCUVHp9Z8CZUnKiP04nnD_31M3gRishW-cWZ657Cn5U)
 drives toward *program-aware* serving — **session-graph orchestration**, **program-aware
@@ -36,8 +37,8 @@ direction and further reading.
 
 The layers above compose into deployment options spanning a range of capability and operational
 cost — from a routing-and-offloading baseline up to disaggregated serving — added incrementally
-as a workload's scale and latency targets grow. Concrete, benchmarked options are present in this
-directory.
+as a workload's scale and latency targets grow. Concrete, benchmarked options are landing in
+this directory as sub-guides.
 
 ## Choosing an Option
 
@@ -48,8 +49,11 @@ directory.
 
 Deployment options are compared against the same realistic agentic workload — large reused
 contexts, deep multi-turn sessions, and tool-call stalls — replayed with
-[`inference-perf`](https://github.com/llm-d/llm-d-benchmark) rather than a single-turn
+[`inference-perf`](https://github.com/kubernetes-sigs/inference-perf) via the
+[`llm-d-benchmark`](https://github.com/llm-d/llm-d-benchmark) harness rather than a single-turn
 shared-prefix stream, so cross-turn reuse, session persistence, and bursty resumption are
-actually exercised. Replaying real agentic traces (program structure and tool-call timing from
-OpenTelemetry) is the direction for program-level evaluation.
+actually exercised. Options are compared on program-level metrics — whole-session completion
+time and task throughput alongside TTFT and ITL. Replaying real agentic traces (program
+structure and tool-call timing from OpenTelemetry) is the direction for program-level
+evaluation.
 

--- a/guides/agentic-inference/README.md
+++ b/guides/agentic-inference/README.md
@@ -7,7 +7,7 @@ shapes, and the direction this path is driving toward, see the
 [Agentic Inference well-lit path](../../docs/well-lit-paths/agentic-inference.md); this guide is
 the operational counterpart, and the canonical guide of the llm-d Agentic Inference SIG.
 
-The reference workload here is **long-horizon loops** (agentic code generation): deep multi-turn
+The reference workload this guide optimizes for is **long-horizon loops** (agentic code generation): deep multi-turn
 sessions over large, repository-scale contexts with tool-call pauses between turns. Three
 behaviors drive every choice below — prefill-heavy/decode-light (a 160K-token context dominates
 TTFT), high reusable locality (cache hit rate, not FLOPs, sets throughput), and bursty/stateful
@@ -56,4 +56,3 @@ actually exercised. Options are compared on program-level metrics — whole-sess
 time and task throughput alongside TTFT and ITL. Replaying real agentic traces (program
 structure and tool-call timing from OpenTelemetry) is the direction for program-level
 evaluation.
-


### PR DESCRIPTION
Introduce a horizontal, workload-centric umbrella guide for agentic inference at guides/agentic-inference/, anchored on the Agentic Inference SIG northstar. The guide composes the existing capability paths (optimized-baseline routing, tiered KV offloading, precise prefix-cache routing, P/D disaggregation) into a ladder of deployment options and links the two in-flight deployments (#1727 routing, #1740 disaggregated).

Add the matching narrative page at docs/well-lit-paths/agentic-inference.md and register it under a new "Workloads" section in the guide and docs indices.