### PR TITLE
guides(autoscaling): Move prometheus adapter installation to main guide

### DIFF
--- a/guides/workload-autoscaling/README.hpa-epp.md
+++ b/guides/workload-autoscaling/README.hpa-epp.md
@@ -28,6 +28,10 @@ Follow the [optimized-baseline](../optimized-baseline/README.md) well-lit path t
 | `inference_extension_flow_control_queue_size` | The number of requests currently buffered in the gateway waiting for an available backend. | Scale-out signal: High queue size indicates that the existing replicas are saturated. |
 | `inference_objective_running_requests` | The number of concurrent requests being processed by the model pool. | Capacity signal: Useful for tracking total throughput. |
 
+## Prerequisites
+
+Make sure to enable monitoring as described in the [autoscaling prerequisites](README.md#prerequisites) section.
+
 ## Configuration Guide
 
 ### 1. Enable Flow Control in EPP
@@ -78,7 +82,7 @@ Apply the rules by upgrading the adapter:
 
 ```bash
 helm upgrade prometheus-adapter prometheus-community/prometheus-adapter \
-  --namespace monitoring \
+  --namespace ${MONITORING_NAMESPACE} \
   --reuse-values \
   --values epp-adapter-values.yaml
 ```

--- a/guides/workload-autoscaling/README.hpa-epp.md
+++ b/guides/workload-autoscaling/README.hpa-epp.md
@@ -63,7 +63,7 @@ rules:
           namespaced: false
       name:
         as: "epp_queue_size"
-      metricsQuery: 'sum(inference_extension_flow_control_queue_size{inference_pool="vllm-llama3-8b-instruct"})'
+      metricsQuery: 'sum(inference_extension_flow_control_queue_size{inference_pool="qwen/qwen3-32b"})'
     - seriesQuery: 'inference_objective_running_requests'
       resources:
         overrides:
@@ -72,11 +72,11 @@ rules:
           namespaced: false
       name:
         as: "epp_running_requests"
-      metricsQuery: 'sum(inference_objective_running_requests{top_level_controller_name="vllm-llama3-8b-instruct-epp"})'
+      metricsQuery: 'sum(inference_objective_running_requests{top_level_controller_name="qwen/qwen3-32b-epp"})'
 ```
 
 > [!NOTE]
-> Replace `vllm-llama3-8b-instruct` and `vllm-llama3-8b-instruct-epp` with your own deployment names.
+> Replace `qwen/qwen3-32b` and `qwen/qwen3-32b-epp` with your own deployment names.
 
 Apply the rules by upgrading the adapter:
 
@@ -106,13 +106,13 @@ Below is a sample HPA configuration `hpa.yaml` that uses the dual-metric setup t
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: vllm-llama3-8b-instruct-hpa
+  name: qwen-qwen3-32b-hpa
   namespace: default
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: vllm-llama3-8b-instruct
+    name: qwen-qwen3-32b
   minReplicas: 1
   maxReplicas: 3
   metrics:
@@ -157,14 +157,14 @@ Apply the manifest and confirm the HPA is reading metrics:
 
 ```bash
 kubectl apply -f hpa.yaml
-kubectl get hpa vllm-llama3-8b-instruct-hpa -n default
+kubectl get hpa qwen-qwen3-32b-hpa -n default
 ```
 
 A successful deployment would look like this:
 
 ```
 NAME                          REFERENCE                            TARGETS              MINPODS   MAXPODS   REPLICAS   AGE
-vllm-llama3-8b-instruct-hpa   Deployment/vllm-llama3-8b-instruct   0/250, 0/250 (avg)   1         3         1          5m
+qwen-qwen3-32b-hpa   Deployment/qwen-qwen3-32b   0/250, 0/250 (avg)   1         3         1          5m
 ```
 
 ## Scale to Zero

--- a/guides/workload-autoscaling/README.hpa-epp.md
+++ b/guides/workload-autoscaling/README.hpa-epp.md
@@ -44,36 +44,7 @@ featureGates:
 
 Follow the [flow control configuration guide](https://gateway-api-inference-extension.sigs.k8s.io/guides/flow-control/#1-enabling-the-layer) to tune the saturation detector in your EPP deployment as needed.
 
-### 2. Install the Prometheus Adapter
-
-> **⚠️ Deprecation Notice:** The Prometheus Adapter project is planned for deprecation ([kubernetes-sigs/prometheus-adapter#701](https://github.com/kubernetes-sigs/prometheus-adapter/issues/701)). **KEDA** is the recommended alternative and is actively maintained. See [Option 2: KEDA](#option-2-keda) below for the recommended approach using KEDA's built-in metrics adapter.
-
-The Prometheus Adapter bridges Prometheus metrics to the Kubernetes External Metrics API,
-which the HPA uses to read EPP signals.
-
-Add the Helm repository and install the adapter into your `monitoring` namespace:
-
-```bash
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo update
-helm install prometheus-adapter prometheus-community/prometheus-adapter \
-  --namespace monitoring \
-  --create-namespace
-```
-
-> **Note:** You must set `prometheus.url` to point to your Prometheus instance. If you are
-using `kube-prometheus-stack`, the default service is `http://prometheus-operated.monitoring.svc:9090`.
-Pass it at install time or in a values file:
-
-```bash
-helm install prometheus-adapter prometheus-community/prometheus-adapter \
-  --namespace monitoring \
-  --create-namespace \
-  --set prometheus.url=http://prometheus-operated.monitoring.svc \
-  --set prometheus.port=9090
-```
-
-### 3. Configure Prometheus Adapter Rules
+### 2. Configure Prometheus Adapter Rules
 
 Create a values file `epp-adapter-values.yaml` with the following rules:
 
@@ -100,8 +71,8 @@ rules:
       metricsQuery: 'sum(inference_objective_running_requests{top_level_controller_name="vllm-llama3-8b-instruct-epp"})'
 ```
 
-> **Note:** Replace `vllm-llama3-8b-instruct` and `vllm-llama3-8b-instruct-epp` with your
-own deployment names.
+> [!NOTE]
+> Replace `vllm-llama3-8b-instruct` and `vllm-llama3-8b-instruct-epp` with your own deployment names.
 
 Apply the rules by upgrading the adapter:
 
@@ -123,7 +94,7 @@ A successful response returns a JSON object with the current metric value. A `40
 the adapter rules are not applied correctly or the Prometheus series does not exist yet —
 re-check the `metricsQuery` label values against your live Prometheus data.
 
-### 4. Create the HPA Resource
+### 3. Create the HPA Resource
 
 Below is a sample HPA configuration `hpa.yaml` that uses the dual-metric setup to scale your model server based on both the queue size and current request load.
 
@@ -170,11 +141,13 @@ spec:
         periodSeconds: 15
 ```
 
-> **Note 1:** The target values (`250`) used here are examples and must be tuned to your model and hardware. A good starting point is to run your model server at a known concurrency level, observe the actual metric values using `kubectl describe hpa`, and set the target below the concurrency at which your model's latency begins to degrade.
+> [!NOTE]
+> The target values (`250`) used here are examples and must be tuned to your model and hardware. A good starting point is to run your model server at a known concurrency level, observe the actual metric values using `kubectl describe hpa`, and set the target below the concurrency at which your model's latency begins to degrade.
 
-> **Note 2:** Although `epp_queue_size` and `epp_running_requests` originate from the EPP pod, we use `type: External` rather than `type: Pods`. This is because `type: Pods` requires metrics to come from the pods being scaled — in this case the model server pods. Since the EPP is a separate deployment acting as a gateway and emitting metrics on behalf of the model server pool, we treat its metrics as external signals.
+> [!NOTE]
+> Although `epp_queue_size` and `epp_running_requests` originate from the EPP pod, we use `type: External` rather than `type: Pods`. This is because `type: Pods` requires metrics to come from the pods being scaled — in this case the model server pods. Since the EPP is a separate deployment acting as a gateway and emitting metrics on behalf of the model server pool, we treat its metrics as external signals.
 
-### 5. Verify the HPA
+### 4. Verify the HPA
 
 Apply the manifest and confirm the HPA is reading metrics:
 

--- a/guides/workload-autoscaling/README.md
+++ b/guides/workload-autoscaling/README.md
@@ -46,7 +46,7 @@ WVA is designed for operators running multiple variants of the same model across
 
 ## Choosing a Path
 
-| | [HPA + EPP Metrics](./README.hpa-epp.md) | [HPA + WVA Metric](./README.wva.md) |
+| | [HPA + EPP Metrics](./README.hpa-epp.md) | [HPA + WVA Metrics](./README.wva.md) |
 |---|---|---|
 | **Best for** | Deployments on homogeneous hardware where each model scales independently | Multi-variant deployments where cost-aware capacity allocation across heterogeneous shared hardware is required |
 | **Scaling signal** | EPP metrics such as queue depth and running request count | KV cache utilization, queue depth, performance budgets |

--- a/guides/workload-autoscaling/README.md
+++ b/guides/workload-autoscaling/README.md
@@ -38,7 +38,7 @@ The [HPA + EPP Metrics](./README.hpa-epp.md) path integrates the Kubernetes Hori
 
 The guide demonstrates autoscaling using queue depth and running request count from EPP, but other metrics emitted by the EPP can be used depending on your scaling requirements. These signals reflect the actual state of the inference queue, enabling the HPA to scale out before users experience high latency and scale in when capacity is genuinely idle. This path requires only the standard Kubernetes HPA and the Prometheus Adapter, with no additional controllers. KEDA can be used in place of the native HPA if scale-to-zero is required and your cluster does not support the HPA scale to zero feature gate (alpha in Kubernetes 1.36).
 
-### HPA + WVA Metric
+### HPA + WVA Metrics
 
 The [Workload Variant Autoscaler (WVA)](./README.wva.md) path integrates the Kubernetes Horizontal Pod Autoscaler (HPA) with the aggregated signal emitted by WVA: `wva_desired_replicas`.
 

--- a/guides/workload-autoscaling/README.md
+++ b/guides/workload-autoscaling/README.md
@@ -3,26 +3,83 @@
 [![E2E (CKS GPU)](https://github.com/llm-d/llm-d/actions/workflows/consolidate-status-workload-autoscaling-cks-acc-gpu-vllm-x.yaml/badge.svg)](https://github.com/llm-d/llm-d/actions/workflows/consolidate-status-workload-autoscaling-cks-acc-gpu-vllm-x.yaml)
 [![E2E (OCP GPU)](https://github.com/llm-d/llm-d/actions/workflows/consolidate-status-workload-autoscaling-ibm-acc-gpu-vllm-x.yaml/badge.svg)](https://github.com/llm-d/llm-d/actions/workflows/consolidate-status-workload-autoscaling-ibm-acc-gpu-vllm-x.yaml)
 
-Traditional autoscaling indicators like resource utilization metrics (CPU/GPU) are often lagging indicators — they only reflect saturation after it has already occurred, by which point latency has spiked and requests may be failing. For LLM inference, this problem is compounded by the fact that GPU utilization is often pegged near 100% during active batching regardless of actual load, making it an unreliable signal entirely.
+Traditional autoscaling indicators like resource utilization metrics (CPU/GPU) are often lagging indicators — they only reflect saturation after it has already occurred, by which point latency has spiked and requests may be failing. For LLM inference, this problem is compounded by the fact that GPU utilization is often pegged near 100% during active batching regardless of actual load, making it an entirely unreliable signal.
 
 Effective LLM autoscaling requires proactive, SLO-aware signals that reflect the true state of the inference system — queue depth, in-flight request counts, and KV cache pressure — so that capacity can be added before end-user latency is impacted.
 
 This guide covers the autoscaling strategies available in llm-d. Both use the Kubernetes HPA or KEDA as the scaling primitive but differ in the use cases they target, the metrics that drive them, and the operational complexity they require.
 
-## HPA + EPP Metrics
+## Prerequisites
 
-The [HPA + EPP Metrics](./README.hpa-epp.md) path integrates the Kubernetes Horizontal Pod Autoscaler (HPA) with signals emitted directly by the Endpoint Picker (EPP). The guide demonstrates autoscaling using queue depth and running request counts from the Endpoint Picker (EPP), but other metrics emitted by the EPP can be used depending on your scaling requirements. These signals reflect the actual state of the inference queue, enabling the HPA to scale out before users experience high latency and scale in when capacity is genuinely idle. This path requires only the standard Kubernetes HPA and the Prometheus Adapter, with no additional controllers. KEDA can be used as an alternative to native HPA for alpha features such as scale-to-zero if your cluster does not support alpha feature gates.
+### Kubernetes Metrics Adapter
 
-## HPA + WVA
+Before choosing an autoscaling path, you must have a metrics adapter configured to expose the necessary signals to the HPA or KEDA.
 
-The [Workload Variant Autoscaler (WVA)](./README.wva.md) is designed for operators running multiple models or variants on shared GPU hardware. A **variant** is a way of serving a given model with a particular combination of hardware, runtimes, and serving approach — for example, the same model running on A100s, H100s, or L4s, each with different cost and performance characteristics. WVA continuously monitors KV cache utilization, queue depth, and configurable energy and performance budgets to determine optimal replica counts across variants. Rather than scaling all variants equally, WVA preferentially adds capacity on the cheapest available variant and removes it from the most expensive — optimizing infrastructure cost without violating latency SLOs. WVA works alongside the Kubernetes HPA: it emits optimization metrics to Prometheus, and the HPA reads those metrics and performs the actual scaling.
+#### Installing KEDA (Recommended)
+
+Follow the [Install KEDA](https://keda.sh/docs/2.20/deploy/) guide. KEDA includes a built-in metrics adapter that exposes custom and external metrics, making it the recommended choice for llm-d autoscaling. KEDA's adapter is actively maintained and supports a wide range of scaling scenarios, including scale-to-zero.
+
+> [!NOTE]
+> On OpenShift, follow the [Custom Metrics Autoscaler Operator documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/nodes/automatically-scaling-pods-with-the-custom-metrics-autoscaler-operator).
+
+#### Installing Prometheus Adapter (Deprecated)
+
+> [!WARNING]
+> The Prometheus Adapter project is planned for deprecation ([kubernetes-sigs/prometheus-adapter#701](https://github.com/kubernetes-sigs/prometheus-adapter/issues/701)).
+
+The Prometheus Adapter bridges Prometheus metrics to the Kubernetes External Metrics API, which the HPA uses to read EPP and WVA signals.
+
+1. Add the Helm repository and install the adapter:
+
+```bash
+export MON_NS=monitoring
+
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+helm install prometheus-adapter prometheus-community/prometheus-adapter \
+  --namespace $MON_NS \
+  --create-namespace
+```
+
+> [!NOTE]
+> You must set `prometheus.url` to point to your Prometheus instance. If you are
+using `kube-prometheus-stack`, the default service is `http://prometheus-operated.monitoring.svc:9090`.
+Pass it at install time or in a values file:
+
+```bash
+helm install prometheus-adapter prometheus-community/prometheus-adapter \
+  --namespace monitoring \
+  --create-namespace \
+  --set prometheus.url=http://prometheus-operated.monitoring.svc \
+  --set prometheus.port=9090
+```
+
+2. Verify the adapter is running and can access Prometheus:
+
+```bash
+kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1"
+```
+
+## Paths
+
+### HPA + EPP Metrics
+
+The [HPA + EPP Metrics](./README.hpa-epp.md) path integrates the Kubernetes Horizontal Pod Autoscaler (HPA) with signals emitted directly by the Endpoint Picker (EPP).
+
+The guide demonstrates autoscaling using queue depth and running request count from EPP, but other metrics emitted by the EPP can be used depending on your scaling requirements. These signals reflect the actual state of the inference queue, enabling the HPA to scale out before users experience high latency and scale in when capacity is genuinely idle. This path requires only the standard Kubernetes HPA and the Prometheus Adapter, with no additional controllers. KEDA can be used in place of the native HPA if scale-to-zero is required and your cluster does not support the HPA scale to zero feature gate (alpha in Kubernetes 1.36).
+
+### HPA + WVA Metric
+
+The [Workload Variant Autoscaler (WVA)](./README.wva.md) path integrates the Kubernetes Horizontal Pod Autoscaler (HPA) with the aggregated signal emitted by WVA: `wva_desired_replicas`.
+
+WVA is designed for operators running multiple variants of the same model across different GPU hardware types (A100s, H100s, L4s), each with different cost and performance characteristics. WVA continuously monitors KV cache utilization, queue depth, and performance budgets to determine optimal replica counts across variants. Rather than scaling all variants equally, WVA preferentially adds capacity on the cheapest available variant and removes it from the most expensive — optimizing infrastructure cost without violating latency SLOs.
 
 ## Choosing a Path
 
-| | [HPA + EPP Metrics](./README.hpa-epp.md) | [HPA + WVA](./README.wva.md) |
+| | [HPA + EPP Metrics](./README.hpa-epp.md) | [HPA + WVA Metric](./README.wva.md) |
 |---|---|---|
 | **Best for** | Deployments on homogeneous hardware where each model scales independently | Multi-variant deployments where cost-aware capacity allocation across heterogeneous shared hardware is required |
-| **Scaling signal** | EPP metrics such as queue depth and running request count | KV cache utilization, queue depth, energy and performance budgets |
+| **Scaling signal** | EPP metrics such as queue depth and running request count | KV cache utilization, queue depth, performance budgets |
 | **Cost optimization** | None — scales based on load signals only | Optimizes across variants by preferring lower-cost hardware |
 | **Additional components** | None — standard Kubernetes HPA only | Requires the WVA controller |
 | **Scale to zero** | Supported | Supported |

--- a/guides/workload-autoscaling/README.md
+++ b/guides/workload-autoscaling/README.md
@@ -11,9 +11,13 @@ This guide covers the autoscaling strategies available in llm-d. Both use the Ku
 
 ## Prerequisites
 
-### Kubernetes Metrics Adapter
+Before choosing an autoscaling path, you must have a monitoring stack with a metrics adapter configured to expose the necessary signals to the HPA or KEDA.
 
-Before choosing an autoscaling path, you must have a metrics adapter configured to expose the necessary signals to the HPA or KEDA.
+### Prometheus
+
+You must have a Prometheus instance running in your cluster. See [Prometheus Setup Guide](../../docs/resources/observability/setup.md) for guidance on setting up Prometheus. Make sure to enable TLS as WVA requires it to securely access the Prometheus API.
+
+### Kubernetes Metrics Adapter
 
 #### Installing KEDA (Recommended)
 
@@ -24,41 +28,7 @@ Follow the [Install KEDA](https://keda.sh/docs/2.20/deploy/) guide. KEDA include
 
 #### Installing Prometheus Adapter (Deprecated)
 
-> [!WARNING]
-> The Prometheus Adapter project is planned for deprecation ([kubernetes-sigs/prometheus-adapter#701](https://github.com/kubernetes-sigs/prometheus-adapter/issues/701)).
-
-The Prometheus Adapter bridges Prometheus metrics to the Kubernetes External Metrics API, which the HPA uses to read EPP and WVA signals.
-
-1. Add the Helm repository and install the adapter:
-
-```bash
-export MON_NS=monitoring
-
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo update
-helm install prometheus-adapter prometheus-community/prometheus-adapter \
-  --namespace $MON_NS \
-  --create-namespace
-```
-
-> [!NOTE]
-> You must set `prometheus.url` to point to your Prometheus instance. If you are
-using `kube-prometheus-stack`, the default service is `http://prometheus-operated.monitoring.svc:9090`.
-Pass it at install time or in a values file:
-
-```bash
-helm install prometheus-adapter prometheus-community/prometheus-adapter \
-  --namespace monitoring \
-  --create-namespace \
-  --set prometheus.url=http://prometheus-operated.monitoring.svc \
-  --set prometheus.port=9090
-```
-
-2. Verify the adapter is running and can access Prometheus:
-
-```bash
-kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1"
-```
+See the [Prometheus Adapter guide](./promadapter.md) for installation instructions. Note that the Prometheus Adapter is planned for deprecation, and it is recommended to use KEDA instead for autoscaling needs.
 
 ## Paths
 

--- a/guides/workload-autoscaling/README.wva.md
+++ b/guides/workload-autoscaling/README.wva.md
@@ -1,6 +1,11 @@
-# Autoscaling Workloads with HPA and WVA Metric
+# Autoscaling Workloads with HPA and WVA Metrics
 
-The [Workload Variant Autoscaler](https://github.com/llm-d-incubation/workload-variant-autoscaler) (WVA) provides dynamic autoscaling capabilities for llm-d inference deployments, automatically adjusting replica counts based on inference server saturation.
+> [!WARNING]
+> The VariantAutoscaling CRD has been deprecated in llm-d 0.8.0 in favor of
+HPA with the `wva_desired_replicas` external metric. This guide covers the new recommended approach using HPA + WVA Metric. The VariantAutoscaling CRD will be removed in 0.9.0.
+
+
+The [Workload Variant Autoscaler](https://github.com/llm-d/workload-variant-autoscaler) (WVA) provides dynamic autoscaling capabilities for llm-d inference deployments, automatically adjusting replica counts based on inference server saturation.
 
 ## Overview
 
@@ -14,53 +19,75 @@ WVA integrates with llm-d to:
 
 Before installing WVA, ensure you have:
 
+1. Enabled monitoring as described in the [autoscaling prerequisites](README.md#prerequisites) section.
+
 1. Installed the [optimized-baseline well-lit path guide](../optimized-baseline/README.md).
 
 > [!NOTE]
-> WVA requires HTTPS connections to Prometheus for metric collection. When installing the [monitoring stack](../../docs/operations/observability/setup.md), ensure to enable HTTPS/TLS support.
-
-> [!NOTE]
-> Make sure to enable monitoring as described in the [optimized-baseline well-lit path guide](../optimized-baseline/README.md#3-optional-enable-monitoring).
-
-2. An external metrics provider installed and configured in your cluster (e.g., Prometheus together with Prometheus Adapter or KEDA). HPA relies on the external metric exposed by WVA, `wva_desired_replicas`, to make scaling decisions. See [Install Prometheus Adapter (Required Dependency)](#install-prometheus-adapter-required-dependency) for installation instructions.
-
-> [!NOTE]
-> This guide relies on prometheus adapter to expose WVA's desired replica count as an external metric for HPA. KEDA is the recommended alternative and this guide will be updated to include KEDA instructions in a future release.
-
-3. [OpenShift User Workload Monitoring](https://docs.redhat.com/en/documentation/openshift_container_platform/4.14/html/monitoring/configuring-user-workload-monitoring) enabled for the namespaces used by this guide.
-
+> Make sure to enable deploy the monitoring resources as described in the [optimized-baseline well-lit path guide](../optimized-baseline/README.md#3-optional-enable-monitoring).
 
 ## Set Namespaces
 
 ```bash
+# Namespace where your inference deployment is running
 export NAMESPACE=llm-d-optimized-baseline
-kubectl create namespace ${NAMESPACE} --dry-run=client -o yaml | kubectl apply -f -
-kubectl create namespace ${WVA_NAMESPACE} --dry-run=client -o yaml | kubectl apply -f -
+
+# Namespace for WVA controller - default to the same namespace as the inference deployment for simplicity, but can be different for cluster-wide autoscaling
+export WVA_NAMESPACE=${NAMESPACE}
+
 export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
 ```
-
-> [!NOTE]
-> **Namespaced-Scoped Installation**: this guide installs WVA to watch resources only in the `llm-d-optimized-baseline` namespace. For cluster-wide autoscaling, set `--watch-namespace=""` in the controller deployment.
-
 
 ## Installation
 
 > [!NOTE]
->  By default, WVA is configured to watch `llm-d-optimized-baseline` (`--watch-namespace=llm-d-optimized-baseline`) only. To enable cluster-wide autoscaling, set `--watch-namespace=""` in the controller deployment and ensure all target HPA/KEDA objects are annotated with `llm-d.ai/managed: "true"`.
+> **Namespaced-Scoped Installation**: this guide installs WVA in namespaced-scoped mode in the `llm-d-optimized-baseline` namespace and configure to watch resources only in that namespace (`--watch-namespace=llm-d-optimized-baseline`). For cluster-wide autoscaling, set `--watch-namespace=""` in the controller deployment.
 
-- Create a secret with the Prometheus CA certificate for secure communication between WVA and Prometheus:
+1. Choose your platform:
 
   ```bash
-  PROMETHEUS_CA_CERT=$(kubectl get secret thanos-querier-tls -n openshift-monitoring -o jsonpath='{.data.tls\.crt}' | base64 -d)
-  kubectl create secret generic prometheus-client-cert \
+  export PLATFORM=k8s # or ocp
+  ```
+
+2.  Extract the Prometheus CA certificate and create a secret for secure communication between WVA and Prometheus:
+
+  ```bash
+  # Extract Prometheus CA cert
+  PROMETHEUS_CA_CERT=$(kubectl get secret prometheus-web-tls -n ${MONITORING_NAMESPACE} -o jsonpath='{.data.tls\.crt}' | base64 -d)
+
+  # Create generic secret with the CA cert for WVA to access Prometheus API securely
+  kubectl create secret generic prometheus-tls-cert \
     --from-literal=ca.crt="${PROMETHEUS_CA_CERT}" \
     --dry-run=client -o yaml | kubectl apply -f - -n ${WVA_NAMESPACE}
   ```
 
-- Install WVA:
+3. Configure Prometheus Adapter Rules (if using Prometheus Adapter as the external metrics provider for WVA):
 
   ```bash
-  kubectl apply -k guides/workload-autoscaling/wva-config/platform/ocp -n ${WVA_NAMESPACE}
+  helm upgrade prometheus-adapter prometheus-community/prometheus-adapter \
+    --namespace ${MONITORING_NAMESPACE} \
+    --reuse-values \
+    --values ${REPO_ROOT}/guides/workload-autoscaling/components/prometheus-adapter/wva-adapter-values.yaml
+  ```
+
+4. Verify the external metrics adapter is registered:
+
+  ```bash
+  kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1"
+
+  {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"external.metrics.k8s.io/v1beta1","resources":[{"name":"wva_desired_replicas","singularName":"","namespaced":true,"kind":"ExternalMetricValueList","verbs":["get"]}]}
+  ```
+
+5. Install WVA CRDs:
+
+  ```bash
+  kubectl apply -k github.com/llm-d/llm-d-workload-variant-autoscaler/config/base/crd?ref=main
+  ```
+
+6. Install WVA controller with Kustomize:
+
+  ```bash
+  kubectl apply -k guides/workload-autoscaling/wva-config/platform/${PLATFORM} -n ${NAMESPACE}
   ```
 
 ## Verify Installation
@@ -125,62 +152,18 @@ kubectl delete -k optimized-baseline-autoscaling/ -n ${NAMESPACE}
 Remove the WVA controller with Kustomize:
 
 ```bash
-kubectl delete -k guides/workload-autoscaling/wva-config/platform/ocp -n ${WVA_NAMESPACE}
+kubectl delete -k guides/workload-autoscaling/wva-config/platform/${PLATFORM} -n ${WVA_NAMESPACE}
 ```
 
 If you installed Prometheus Adapter for WVA, you can uninstall it as well:
 
 ```bash
-helm uninstall prometheus-adapter -n ${MON_NS:-llm-d-monitoring}
+helm uninstall prometheus-adapter -n ${MONITORING_NAMESPACE}
 ```
 
 ## Advanced Configuration, Updates, and Troubleshooting
 
-Please refer to the [Workload Variant Autoscaler documentation](https://github.com/llm-d-incubation/workload-variant-autoscaler) for advanced configuration options, updating WVA versions, and troubleshooting tips.
-
-## Update Prometheus Adapter (Required Dependency)
-
-```bash
-# Download OpenShift-specific values
-curl -o ${TMPDIR:-/tmp}/prometheus-adapter-values.yaml \
-  https://raw.githubusercontent.com/llm-d-incubation/workload-variant-autoscaler/${VERSION}/config/samples/prometheus-adapter-values-ocp.yaml
-
-# Update Prometheus URL
-sed -i.bak "s|url:.*|url: https://thanos-querier.openshift-monitoring.svc.cluster.local|" ${TMPDIR:-/tmp}/prometheus-adapter-values.yaml || \
-  echo "Edit ${TMPDIR:-/tmp}/prometheus-adapter-values.yaml to set prometheus.url"
-
-# Install
-helm upgrade -i prometheus-adapter prometheus-community/prometheus-adapter \
-  --version 5.2.0 -n ${MON_NS} --create-namespace \
-  -f ${TMPDIR:-/tmp}/prometheus-adapter-values.yaml \
-  -f ${REPO_ROOT}/guides/workload-autoscaling/components/prometheus-adapter/values-wva-external-metric.yaml
-
-# Verify that WVA metric is discoverable by external metrics API
-kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1" | jq .
-
-# Verify RBAC permissions
-kubectl auth can-i --list --as=system:serviceaccount:${MON_NS}:prometheus-adapter | grep -E "monitoring.coreos.com|prometheuses|namespaces"
-
-# Create ClusterRole for Prometheus API access if needed
-kubectl apply -f - <<'YAML'
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: allow-thanos-querier-api-access
-rules:
-- nonResourceURLs: [/api/v1/query, /api/v1/query_range, /api/v1/labels, /api/v1/label/*/values, /api/v1/series, /api/v1/metadata, /api/v1/rules, /api/v1/alerts]
-  verbs: [get]
-- apiGroups: [monitoring.coreos.com]
-  resourceNames: [k8s]
-  resources: [prometheuses/api]
-  verbs: [get, create, update]
-- apiGroups: [""]
-  resources: [namespaces]
-  verbs: [get]
-YAML
-```
-
-**Verify installation**: `kubectl get pods -n ${MON_NS} -l app.kubernetes.io/name=prometheus-adapter`
+Please refer to the [Workload Variant Autoscaler documentation](https://github.com/llm-d/workload-variant-autoscaler) for advanced configuration options, updating WVA versions, and troubleshooting tips.
 
 ## Benchmark Results
 

--- a/guides/workload-autoscaling/README.wva.md
+++ b/guides/workload-autoscaling/README.wva.md
@@ -45,50 +45,74 @@ export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
 
 1. Choose your platform:
 
-  ```bash
-  export PLATFORM=k8s # or ocp
-  ```
+    ```bash
+    export PLATFORM=k8s # or ocp
+    ```
 
 2.  Extract the Prometheus CA certificate and create a secret for secure communication between WVA and Prometheus:
 
-  ```bash
-  # Extract Prometheus CA cert
-  PROMETHEUS_CA_CERT=$(kubectl get secret prometheus-web-tls -n ${MONITORING_NAMESPACE} -o jsonpath='{.data.tls\.crt}' | base64 -d)
+    ```bash
+    # Extract Prometheus CA cert
+    PROMETHEUS_CA_CERT=$(kubectl get secret prometheus-web-tls -n ${MONITORING_NAMESPACE} -o jsonpath='{.data.tls\.crt}' | base64 -d)
 
-  # Create generic secret with the CA cert for WVA to access Prometheus API securely
-  kubectl create secret generic prometheus-tls-cert \
-    --from-literal=ca.crt="${PROMETHEUS_CA_CERT}" \
-    --dry-run=client -o yaml | kubectl apply -f - -n ${WVA_NAMESPACE}
-  ```
+    # Create generic secret with the CA cert for WVA to access Prometheus API securely
+    kubectl create secret generic prometheus-tls-cert \
+      --from-literal=ca.crt="${PROMETHEUS_CA_CERT}" \
+      --dry-run=client -o yaml | kubectl apply -f - -n ${WVA_NAMESPACE}
+    ```
 
 3. Configure Prometheus Adapter Rules (if using Prometheus Adapter as the external metrics provider for WVA):
 
-  ```bash
-  helm upgrade prometheus-adapter prometheus-community/prometheus-adapter \
-    --namespace ${MONITORING_NAMESPACE} \
-    --reuse-values \
-    --values ${REPO_ROOT}/guides/workload-autoscaling/components/prometheus-adapter/wva-adapter-values.yaml
-  ```
+    ```bash
+    helm upgrade prometheus-adapter prometheus-community/prometheus-adapter \
+      --namespace ${MONITORING_NAMESPACE} \
+      --reuse-values \
+      --values ${REPO_ROOT}/guides/workload-autoscaling/components/prometheus-adapter/wva-adapter-values.yaml
+    ```
 
 4. Verify the external metrics adapter is registered:
 
-  ```bash
-  kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1"
+    ```bash
+    kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1"
 
-  {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"external.metrics.k8s.io/v1beta1","resources":[{"name":"wva_desired_replicas","singularName":"","namespaced":true,"kind":"ExternalMetricValueList","verbs":["get"]}]}
-  ```
+    {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"external.metrics.k8s.io/v1beta1","resources":[{"name":"wva_desired_replicas","singularName":"","namespaced":true,"kind":"ExternalMetricValueList","verbs":["get"]}]}
+    ```
 
 5. Install WVA CRDs:
 
-  ```bash
-  kubectl apply -k github.com/llm-d/llm-d-workload-variant-autoscaler/config/base/crd?ref=main
-  ```
+    ```bash
+    kubectl apply -k github.com/llm-d/llm-d-workload-variant-autoscaler/config/base/crd?ref=main
+    ```
 
 6. Install WVA controller with Kustomize:
 
-  ```bash
-  kubectl apply -k guides/workload-autoscaling/wva-config/platform/${PLATFORM} -n ${NAMESPACE}
-  ```
+    ```bash
+    kubectl apply -k guides/workload-autoscaling/wva-config/platform/${PLATFORM} -n ${NAMESPACE}
+    ```
+
+7. Enable WVA v2 saturation engine. This will be the default in the next release (0.9.0), but for now it must be enabled manually. The v1 saturation engine will be deprecated in 0.9.0 and removed in 0.10.0.
+
+    > [!CAUTION]
+    > Enabling the v2 saturation engine may change the output of the scaling decisions (i.e. `wva_desired_replicas`) for *all* deployments. This may cause a temporary burst of scaling activity.
+
+    ```bash
+    kubectl edit configmap wva-saturation-scaling-config -n ${WVA_NAMESPACE}
+    ```
+
+    Under the `default:` key, append:
+
+    ```yaml
+    apiVersion: v1
+    data:
+      default: |
+        # Select the V2 token-based saturation analyzer.
+        # Remove this list to fall back to the V1
+        # percentage-based analyzer.
+        analyzers:
+          - name: saturation
+        kvCacheThreshold: 0.80
+        ...
+    ```
 
 ## Verify Installation
 

--- a/guides/workload-autoscaling/README.wva.md
+++ b/guides/workload-autoscaling/README.wva.md
@@ -187,7 +187,7 @@ helm uninstall prometheus-adapter -n ${MONITORING_NAMESPACE}
 
 ## Advanced Configuration, Updates, and Troubleshooting
 
-Please refer to the [Workload Variant Autoscaler documentation](https://github.com/llm-d/workload-variant-autoscaler) for advanced configuration options, updating WVA versions, and troubleshooting tips.
+Please refer to the [Workload Variant Autoscaler documentation](https://github.com/llm-d/llm-d-workload-variant-autoscaler) for advanced configuration options, updating WVA versions, and troubleshooting tips.
 
 ## Benchmark Results
 

--- a/guides/workload-autoscaling/README.wva.md
+++ b/guides/workload-autoscaling/README.wva.md
@@ -43,8 +43,6 @@ export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
 > [!NOTE]
 > **Namespaced-Scoped Installation**: this guide installs WVA in namespaced-scoped mode in the `llm-d-optimized-baseline` namespace and configure to watch resources only in that namespace (`--watch-namespace=llm-d-optimized-baseline`). For cluster-wide autoscaling, set `--watch-namespace=""` in the controller deployment.
 
-### Installation Steps
-
 1. Choose your platform:
 
     ```bash
@@ -92,7 +90,19 @@ export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
     kubectl apply -k guides/workload-autoscaling/wva-config/platform/${PLATFORM} -n ${NAMESPACE}
     ```
 
-### Enabling Saturation Engine V2 (Recommended)
+## Verify Installation
+
+Check that the WVA controller is running:
+
+```bash
+kubectl get deployment -n ${WVA_NAMESPACE}
+NAME                     READY   UP-TO-DATE   AVAILABLE   AGE
+wva-controller-manager   2/2     2            2           10m
+```
+
+This guide configures the controller deployment with `replicas: 2` and leader election enabled for HA (one active leader plus one standby).
+
+## Enabling Saturation Engine V2 (Recommended)
 
 Saturation engine v2 will be the default in the next release (0.9.0), but for now it must be enabled manually. The v1 saturation engine will be deprecated in 0.9.0 and removed in 0.10.0.
 
@@ -120,17 +130,8 @@ Edit the WVA configmap to enable the v2 saturation engine:
       ...
   ```
 
-## Verify Installation
+The WVA controller will automatically pick up the config change and start using the new saturation engine for scaling decisions. You can verify this by checking the controller logs for messages indicating the active saturation engine. Look for a log line like `V2 saturation analysis completed ` to confirm that the v2 engine is active.
 
-Check that the WVA controller is running:
-
-```bash
-kubectl get deployment -n ${WVA_NAMESPACE}
-NAME                     READY   UP-TO-DATE   AVAILABLE   AGE
-wva-controller-manager   2/2     2            2           10m
-```
-
-This guide configures the controller deployment with `replicas: 2` and leader election enabled for HA (one active leader plus one standby).
 
 ## Enabling Autoscaling for an Inference Deployment
 

--- a/guides/workload-autoscaling/README.wva.md
+++ b/guides/workload-autoscaling/README.wva.md
@@ -43,6 +43,8 @@ export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
 > [!NOTE]
 > **Namespaced-Scoped Installation**: this guide installs WVA in namespaced-scoped mode in the `llm-d-optimized-baseline` namespace and configure to watch resources only in that namespace (`--watch-namespace=llm-d-optimized-baseline`). For cluster-wide autoscaling, set `--watch-namespace=""` in the controller deployment.
 
+### Installation Steps
+
 1. Choose your platform:
 
     ```bash
@@ -90,10 +92,12 @@ export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
     kubectl apply -k guides/workload-autoscaling/wva-config/platform/${PLATFORM} -n ${NAMESPACE}
     ```
 
-7. Enable WVA v2 saturation engine. This will be the default in the next release (0.9.0), but for now it must be enabled manually. The v1 saturation engine will be deprecated in 0.9.0 and removed in 0.10.0.
+### Enabling Saturation Engine V2 (Recommended)
 
-    > [!CAUTION]
-    > Enabling the v2 saturation engine may change the output of the scaling decisions (i.e. `wva_desired_replicas`) for *all* deployments. This may cause a temporary burst of scaling activity.
+Saturation engine v2 will be the default in the next release (0.9.0), but for now it must be enabled manually. The v1 saturation engine will be deprecated in 0.9.0 and removed in 0.10.0.
+
+> [!CAUTION]
+> Enabling the v2 saturation engine may change the output of the scaling decisions (i.e. `wva_desired_replicas`) for *all* deployments. This may cause a temporary burst of scaling activity.
 
     ```bash
     kubectl edit configmap wva-saturation-scaling-config -n ${WVA_NAMESPACE}

--- a/guides/workload-autoscaling/README.wva.md
+++ b/guides/workload-autoscaling/README.wva.md
@@ -99,24 +99,26 @@ Saturation engine v2 will be the default in the next release (0.9.0), but for no
 > [!CAUTION]
 > Enabling the v2 saturation engine may change the output of the scaling decisions (i.e. `wva_desired_replicas`) for *all* deployments. This may cause a temporary burst of scaling activity.
 
-    ```bash
-    kubectl edit configmap wva-saturation-scaling-config -n ${WVA_NAMESPACE}
-    ```
+Edit the WVA configmap to enable the v2 saturation engine:
 
-    Under the `default:` key, append:
+  ```bash
+  kubectl edit configmap wva-saturation-scaling-config -n ${WVA_NAMESPACE}
+  ```
 
-    ```yaml
-    apiVersion: v1
-    data:
-      default: |
-        # Select the V2 token-based saturation analyzer.
-        # Remove this list to fall back to the V1
-        # percentage-based analyzer.
-        analyzers:
-          - name: saturation
-        kvCacheThreshold: 0.80
-        ...
-    ```
+  Under the `default:` key, append `analyzers: - name: saturation` to enable the token-based saturation analyzer. The full config should look like this:
+
+  ```yaml
+  apiVersion: v1
+  data:
+    default: |
+      # Select the V2 token-based saturation analyzer.
+      # Remove this list to fall back to the V1
+      # percentage-based analyzer.
+      analyzers:
+        - name: saturation
+      kvCacheThreshold: 0.80
+      ...
+  ```
 
 ## Verify Installation
 

--- a/guides/workload-autoscaling/README.wva.md
+++ b/guides/workload-autoscaling/README.wva.md
@@ -16,16 +16,16 @@ Before installing WVA, ensure you have:
 
 1. Installed the [optimized-baseline well-lit path guide](../optimized-baseline/README.md).
 
-    > [!NOTE]
-    > WVA requires HTTPS connections to Prometheus for metric collection. When installing the [monitoring stack](../../docs/operations/observability/setup.md), ensure to enable HTTPS/TLS support.
+> [!NOTE]
+> WVA requires HTTPS connections to Prometheus for metric collection. When installing the [monitoring stack](../../docs/operations/observability/setup.md), ensure to enable HTTPS/TLS support.
 
-    > [!NOTE]
-    > Make sure to enable monitoring as described in the [optimized-baseline well-lit path guide](../optimized-baseline/README.md#3-optional-enable-monitoring).
+> [!NOTE]
+> Make sure to enable monitoring as described in the [optimized-baseline well-lit path guide](../optimized-baseline/README.md#3-optional-enable-monitoring).
 
 2. An external metrics provider installed and configured in your cluster (e.g., Prometheus together with Prometheus Adapter or KEDA). HPA relies on the external metric exposed by WVA, `wva_desired_replicas`, to make scaling decisions. See [Install Prometheus Adapter (Required Dependency)](#install-prometheus-adapter-required-dependency) for installation instructions.
 
-    > [!NOTE]
-    > This guide relies on prometheus adapter to expose WVA's desired replica count as an external metric for HPA. KEDA is the recommended alternative and this guide will be updated to include KEDA instructions in a future release.
+> [!NOTE]
+> This guide relies on prometheus adapter to expose WVA's desired replica count as an external metric for HPA. KEDA is the recommended alternative and this guide will be updated to include KEDA instructions in a future release.
 
 3. [OpenShift User Workload Monitoring](https://docs.redhat.com/en/documentation/openshift_container_platform/4.14/html/monitoring/configuring-user-workload-monitoring) enabled for the namespaces used by this guide.
 
@@ -138,15 +138,9 @@ helm uninstall prometheus-adapter -n ${MON_NS:-llm-d-monitoring}
 
 Please refer to the [Workload Variant Autoscaler documentation](https://github.com/llm-d-incubation/workload-variant-autoscaler) for advanced configuration options, updating WVA versions, and troubleshooting tips.
 
-## Install Prometheus Adapter (Required Dependency)
+## Update Prometheus Adapter (Required Dependency)
 
 ```bash
-# Setup
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo update
-export VERSION=${VERSION:-v0.7.0}
-export MON_NS=openshift-user-workload-monitoring
-
 # Download OpenShift-specific values
 curl -o ${TMPDIR:-/tmp}/prometheus-adapter-values.yaml \
   https://raw.githubusercontent.com/llm-d-incubation/workload-variant-autoscaler/${VERSION}/config/samples/prometheus-adapter-values-ocp.yaml
@@ -187,7 +181,6 @@ YAML
 ```
 
 **Verify installation**: `kubectl get pods -n ${MON_NS} -l app.kubernetes.io/name=prometheus-adapter`
-
 
 ## Benchmark Results
 

--- a/guides/workload-autoscaling/README.wva.md
+++ b/guides/workload-autoscaling/README.wva.md
@@ -1,4 +1,4 @@
-# Autoscaling with Workload Variant Autoscaler (WVA)
+# Autoscaling Workloads with HPA and WVA Metric
 
 The [Workload Variant Autoscaler](https://github.com/llm-d-incubation/workload-variant-autoscaler) (WVA) provides dynamic autoscaling capabilities for llm-d inference deployments, automatically adjusting replica counts based on inference server saturation.
 

--- a/guides/workload-autoscaling/components/prometheus-adapter/tls-adapter-values.yaml
+++ b/guides/workload-autoscaling/components/prometheus-adapter/tls-adapter-values.yaml
@@ -1,0 +1,19 @@
+# Note: If your Prometheus instance is using a self-signed certificate,
+# you may need to configure the adapter to trust it.
+# You can do this by mounting the CA certificate into the adapter and setting the appropriate flags.
+# Refer to the Prometheus Adapter documentation for details on how to configure TLS settings.
+extraVolumes:
+  - name: prometheus-ca
+    secret:
+      secretName: prometheus-web-tls
+      items:
+        - key: ca.crt
+          path: ca.crt
+
+extraVolumeMounts:
+  - name: prometheus-ca
+    mountPath: /etc/prometheus-ca
+    readOnly: true
+
+extraArguments:
+  - --prometheus-ca-file=/etc/prometheus-ca/ca.crt

--- a/guides/workload-autoscaling/components/prometheus-adapter/wva-adapter-values.yaml
+++ b/guides/workload-autoscaling/components/prometheus-adapter/wva-adapter-values.yaml
@@ -1,4 +1,8 @@
+# Prometheus Adapter Configuration
 rules:
+  # Custom rule to query the desired replicas
+  # from the wva_desired_replicas metric,
+  # which is emitted by WVA and scraped by Prometheus.
   external:
     - seriesQuery: wva_desired_replicas{variant_name!="",exported_namespace!=""}
       resources:

--- a/guides/workload-autoscaling/optimized-baseline-autoscaling/hpa.yaml
+++ b/guides/workload-autoscaling/optimized-baseline-autoscaling/hpa.yaml
@@ -4,11 +4,12 @@ metadata:
   name: optimized-baseline-nvidia-gpu-vllm-decode
   labels:
     inference.optimization/acceleratorName: "H100"
-    llm-d.ai/model: "Qwen3-32B"
     llm-d.ai/inference-serving: "true"
     llm-d.ai/guide: "optimized-baseline"
   annotations:
     llm-d.ai/managed: "true"
+    llm-d.ai/model: "Qwen3-32B"
+    llm-d.ai/variant-cost: "30.0"
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/guides/workload-autoscaling/optimized-baseline-autoscaling/hpa.yaml
+++ b/guides/workload-autoscaling/optimized-baseline-autoscaling/hpa.yaml
@@ -8,7 +8,7 @@ metadata:
     llm-d.ai/guide: "optimized-baseline"
   annotations:
     llm-d.ai/managed: "true"
-    llm-d.ai/model: "Qwen3-32B"
+    llm-d.ai/model-id: "Qwen3-32B"
     llm-d.ai/variant-cost: "30.0"
 spec:
   scaleTargetRef:

--- a/guides/workload-autoscaling/promadapter.md
+++ b/guides/workload-autoscaling/promadapter.md
@@ -1,0 +1,56 @@
+# Prometheus Adapter
+
+> [!WARNING]
+> The Prometheus Adapter project is planned for deprecation ([kubernetes-sigs/prometheus-adapter#701](https://github.com/kubernetes-sigs/prometheus-adapter/issues/701)). It is recommended to use KEDA for autoscaling.
+
+The Prometheus Adapter bridges Prometheus metrics to the Kubernetes External Metrics API, which the HPA uses to read EPP and WVA signals.
+
+## Prerequisites
+
+You must have a Prometheus instance running in your cluster. See [Prometheus Setup Guide](../../docs/resources/observability/setup.md) for guidance on setting up Prometheus. Make sure to enable TLS as WVA requires it to securely access the Prometheus API.
+
+```bash
+export MONITORING_NAMESPACE=llm-d-monitoring
+export PROMETHEUS_URL=https://llmd-kube-prometheus-stack-prometheus.$MONITORING_NAMESPACE.svc.cluster.local
+export PROMETHEUS_PORT=9090
+```
+
+### Platform-specific notes
+
+#### OpenShift
+
+OpenShift User Workload Monitoring operator instal Prometheus in the `openshift-monitoring` namespace.
+
+```bash
+export MONITORING_NAMESPACE=openshift-monitoring
+export PROMETHEUS_URL=https://thanos-querier.$MONITORING_NAMESPACE.svc.cluster.local
+export PROMETHEUS_PORT=9091
+```
+
+## Installation
+
+By default Prometheus is installed in the `llm-d-monitoring` namespace and the adapter is configured to connect to it at `https://prometheus-operated.llm-d-monitoring.svc:9090`. If your Prometheus instance is running elsewhere, update the `prometheus.url` value during installation accordingly.
+
+
+1. Add the Helm repository and install the adapter:
+
+    ```bash
+    helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+    helm repo update
+
+    helm install prometheus-adapter prometheus-community/prometheus-adapter \
+    --namespace $MONITORING_NAMESPACE \
+    --values components/prometheus-adapter/tls-adapter-values.yaml \
+    --set prometheus.url=$PROMETHEUS_URL \
+    --set prometheus.port=$PROMETHEUS_PORT
+
+    ```
+
+2. Wait for the adapter to be running and verify it can access Prometheus:
+
+    ```bash
+    kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1
+
+    {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"custom.metrics.k8s.io/v1beta1","resources":[{"name":"namespaces/node_filesystem_size_bytes","singularName":"","namespaced":false,"kind":"MetricValueList]}
+    ...
+    ```

--- a/guides/workload-autoscaling/wva-config/base/kustomization.yaml
+++ b/guides/workload-autoscaling/wva-config/base/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: llm-d-autoscaler
+
 patches:
   - path: controller-deployment-patch.yaml
     target:

--- a/guides/workload-autoscaling/wva-config/platform/k8s/controller-deployment-patch.yaml
+++ b/guides/workload-autoscaling/wva-config/platform/k8s/controller-deployment-patch.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wva-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          env:
+            - name: PROMETHEUS_BASE_URL
+              value: "https://prometheus-operated.llm-d-monitoring.svc:9090"
+            - name: PROMETHEUS_CA_CERT
+              value: "/etc/prometheus/tls/ca.crt"
+          volumeMounts:
+            - name: prom-ca
+              mountPath: /etc/prometheus/tls
+              readOnly: true
+      volumes:
+        - name: prom-ca
+          secret:
+            secretName: prometheus-tls-cert

--- a/guides/workload-autoscaling/wva-config/platform/k8s/kustomization.yaml
+++ b/guides/workload-autoscaling/wva-config/platform/k8s/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: llm-d-optimized-baseline
+
+resources:
+  - github.com/llm-d/llm-d-workload-variant-autoscaler/config/overlays/namespace-scoped/kubernetes?ref=main
+  - ../../base
+
+patches:
+  - path: controller-deployment-patch.yaml
+    target:
+      kind: Deployment
+      name: wva-controller-manager

--- a/guides/workload-autoscaling/wva-config/platform/ocp/kustomization.yaml
+++ b/guides/workload-autoscaling/wva-config/platform/ocp/kustomization.yaml
@@ -1,9 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: llm-d-autoscaler
+
 resources:
   - github.com/llm-d/llm-d-workload-variant-autoscaler/config/overlays/namespace-scoped/openshift?ref=main
   - ../../base
+
 patches:
   - path: servicemonitor-label-patch.yaml
     target:


### PR DESCRIPTION
## Summary

This PR restructures the workload autoscaling documentation to make it easier to navigate.

- **New top-level guide** (`README.md`): introduces both autoscaling paths (HPA + EPP Metrics and HPA + WVA), explains the prerequisite monitoring stack setup (KEDA recommended, Prometheus Adapter as deprecated fallback), and provides a comparison table to help users choose between the two.
- **Prometheus Adapter installation moved** from WVA-specific sections into the shared main guide (`README.md` → `promadapter.md`), so both autoscaling paths share a single installation reference.
- **Renamed adapter values files** for clarity: `values-wva-external-metric.yaml` → `wva-adapter-values.yaml`, and a new `tls-adapter-values.yaml` added for TLS configuration.
- **WVA kustomization updates**: `wva-config/platform/k8s/kustomization.yaml` adds a namespace override; `wva-config/base/kustomization.yaml` updated accordingly; `wva-config/platform/ocp/kustomization.yaml` adjusted to match.
- **HPA manifest fix** (`optimized-baseline-autoscaling/hpa.yaml`): minor corrections.
 