### PR TITLE
Converted `pd-disaggregation`, `tiered-prefix-cache` and `wide-ep-lws` CI/CD to nightly benchmark

### DIFF
--- a/.github/workflows/nightly-e2e-pd-disaggregation-cks-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-cks-acc-gpu-vllm-x.yaml
@@ -1,25 +1,59 @@
-name: Nightly - PD Disaggregation E2E (CKS)
-
-# Nightly regression test for the pd-disaggregation guide on CoreWeave (CKS).
-# Deploys the guide and validates with e2e-validate.sh.
+name: Nightly - PD Disaggregation E2E (CKS GPU)
 
 on:
-  schedule:
-    - cron: '30 6 * * *'  # 06:30 UTC daily (staggered from optimized-baseline CKS)
   workflow_dispatch:
     inputs:
-      skip_cleanup:
-        description: 'Skip cleanup after tests (for debugging)'
+      decode_pods:
+        description: 'Number of decode (vllm "standalone") pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      prefill_pods:
+        description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      gateway_class:
+        description: 'Class of gateway used ("istio", "agentgateway", "epponly" (i.e., "standalone"), "none")'
+        required: false
+        default: 'epponly'
+      monitoring_enabled:
+        description: 'Enabled monitoring ("true", "false")'
+        required: true
+        type: 'string'
+        default: 'false'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode ("true", "false")'
         required: false
         default: 'false'
-      pr_number:
-        description: 'PR number for comment-back (set by /test-nightly)'
+      verbose:
+        description: 'Execute workflow in "verbose" mode ("true", "false")'
         required: false
-        default: ''
-      pr_repo:
-        description: 'Repo for PR comment-back'
+        default: 'false'
+        type: 'string'
+      harness:
+        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
         required: false
-        default: 'llm-d/llm-d'
+        default: 'inference-perf'
+        type: 'string'
+      workload:
+        description: 'Workload profile to be used during "run" operation (check list under "workload/profiles")'
+        required: false
+        default: 'sanity_random.yaml'
+#        default: 'guide_pd-disaggregation_1.yaml'
+        type: 'string'
+      cleanup:
+        description: 'Cleanup the llm-d stack stood up by this workflow'
+        required: false
+        default: 'true'
+        type: string
+
+#  push:
+#    branches:
+#      - main
+
+  schedule:
+    - cron: '0 3 * * *'
 
 permissions:
   contents: write
@@ -31,39 +65,31 @@ concurrency:
 
 jobs:
   nightly:
-    if: github.repository == 'llm-d/llm-d'
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-cks.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
-      guide_name: pd-disaggregation
-      namespace: llm-d-nightly-pd-cks
-      gateway_host: 'pd-disaggregation-epp'
-      custom_deploy_script: |
-        export GAIE_VERSION=v1.5.0
-        export ROUTER_CHART_VERSION=v0
-        export GUIDE_NAME="pd-disaggregation"
-        export INFRA_PROVIDER=base
-        kubectl apply -n ${NAMESPACE} -k guides/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}
-        helm install ${GUIDE_NAME} \
-          oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev \
-          -f guides/recipes/router/base.values.yaml \
-          -f guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
-          -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
-      required_gpus: 8
-      recommended_gpus: 8
-      pod_wait_timeout: '30m'
-      pod_readiness_delay: 180
-      # Slim transform: reduce to 8 GPU setup
-      pre_deploy_script: |
-        echo "Applying pd-disaggregation slim transforms..."
-        cd guides/pd-disaggregation/modelserver/gpu/vllm/base
-        yq e '.spec.replicas = 4' -i patch-prefill.yaml
-        yq e '.spec.replicas = 1' -i patch-decode.yaml
-        echo "Slim transform applied: 1x4 TP Decode, 4x1 TP Prefill"
-        cd "$GITHUB_WORKSPACE"
-      allow_gpu_preemption: true
-      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
-      pr_number: ${{ github.event.inputs.pr_number }}
-      pr_repo: ${{ github.event.inputs.pr_repo }}
+      scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
+      standup_method: ${{ inputs.standup_method || 'kustomize' }}
+      standup_scenario: ${{ inputs.standup_scenario || 'pd-disaggregation' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'gpu' }}
+      backend_type: ${{ inputs.backend_type || 'vllm' }}
+      infra_provider: ${{ inputs.infra_provider || 'coreweave' }}
+      connector: ${{ inputs.connector || '' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-pd-disaggregation-cks-gpu' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-cks' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-cks' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions/pd-disaggregation' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'sanity_random.yaml' }}
+#      workload: ${{ inputs.workload || 'guide_pd-disaggregation_1.yaml' }}
+      cleanup: ${{ inputs.cleanup || 'true' }}
     secrets: inherit
 
   update-badge:
@@ -72,5 +98,5 @@ jobs:
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: pd-disaggregation-cks
-      badge_label: "CKS"
+      badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}

--- a/.github/workflows/nightly-e2e-pd-disaggregation-gke-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-gke-acc-gpu-vllm-x.yaml
@@ -1,65 +1,95 @@
 name: Nightly - PD Disaggregation E2E (GKE GPU)
 
-# Nightly regression test for the pd-disaggregation guide on GKE.
-# Deploys the guide and validates with e2e-validate.sh.
-
 on:
-  schedule:
-    - cron: '30 10 * * *'  # 10:30 UTC daily (staggered)
   workflow_dispatch:
     inputs:
-      skip_cleanup:
-        description: 'Skip cleanup after tests (for debugging)'
+      decode_pods:
+        description: 'Number of decode (vllm "standalone") pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      prefill_pods:
+        description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      gateway_class:
+        description: 'Class of gateway used ("istio", "agentgateway", "epponly" (i.e., "standalone"), "none")'
+        required: false
+        default: 'epponly'
+      monitoring_enabled:
+        description: 'Enabled monitoring ("true", "false")'
+        required: true
+        type: 'string'
+        default: 'false'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode ("true", "false")'
         required: false
         default: 'false'
-      pr_number:
-        description: 'PR number for comment-back (set by /test-nightly)'
+      verbose:
+        description: 'Execute workflow in "verbose" mode ("true", "false")'
         required: false
-        default: ''
-      pr_repo:
-        description: 'Repo for PR comment-back'
+        default: 'false'
+        type: 'string'
+      harness:
+        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
         required: false
-        default: 'llm-d/llm-d'
+        default: 'inference-perf'
+        type: 'string'
+      workload:
+        description: 'Workload profile to be used during "run" operation (check list under "workload/profiles")'
+        required: false
+        default: 'sanity_random.yaml'
+#        default: 'guide_pd-disaggregation_1.yaml'
+        type: 'string'
+      cleanup:
+        description: 'Cleanup the llm-d stack stood up by this workflow'
+        required: false
+        default: 'true'
+        type: string
+
+#  push:
+#    branches:
+#      - main
+
+  schedule:
+    - cron: '0 3 * * *'
 
 permissions:
   contents: write
   actions: read
 
 concurrency:
-  group: nightly-e2e-pd-disaggregation-gke
+  group: nightly-e2e-pd-disaggregation-gke-gpu
   cancel-in-progress: true
 
 jobs:
   nightly:
-    if: github.repository == 'llm-d/llm-d'
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
-      guide_name: pd-disaggregation
-      namespace: llm-d-nightly-pd-gke
-      gateway_host: 'pd-disaggregation-epp'
-      custom_deploy_script: |
-        export GAIE_VERSION=v1.5.0
-        export ROUTER_CHART_VERSION=v0
-        export GUIDE_NAME="pd-disaggregation"
-        export INFRA_PROVIDER="gke"
-        kubectl apply -n ${NAMESPACE} -k guides/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}
-        helm install ${GUIDE_NAME} \
-          oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev \
-          -f guides/recipes/router/base.values.yaml \
-          -f guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
-          -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
-      gke_cluster_name: llm-d-e2e-us-south1-2
-      gke_cluster_zone: us-south1
-      required_gpus: 16
-      recommended_gpus: 16
-      accelerator_type: H200
-      pod_wait_timeout: '30m'
-      pod_readiness_delay: 0
-      allow_gpu_preemption: true
-      llm_d_ref: ${{ github.ref }}
-      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
-      pr_number: ${{ github.event.inputs.pr_number }}
-      pr_repo: ${{ github.event.inputs.pr_repo }}
+      scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
+      standup_method: ${{ inputs.standup_method || 'kustomize' }}
+      standup_scenario: ${{ inputs.standup_scenario || 'pd-disaggregation' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'gpu' }}
+      backend_type: ${{ inputs.backend_type || 'vllm' }}
+      infra_provider: ${{ inputs.infra_provider || 'gke' }}
+      connector: ${{ inputs.connector || '' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-pd-disaggregation-gke-gpu' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-gke' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-gke' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions/pd-disaggregation' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'sanity_random.yaml' }}
+#      workload: ${{ inputs.workload || 'guide_pd-disaggregation_1.yaml' }}
+      cleanup: ${{ inputs.cleanup || 'true' }}
     secrets: inherit
 
   update-badge:
@@ -68,5 +98,5 @@ jobs:
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: pd-disaggregation-gke
-      badge_label: "GKE GPU"
+      badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}

--- a/.github/workflows/nightly-e2e-pd-disaggregation-gke-acc-tpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-gke-acc-tpu-vllm-x.yaml
@@ -1,28 +1,69 @@
 name: Nightly - PD Disaggregation E2E (GKE TPU)
 
-# Placeholder — real test pending v6e manifests for pd-disaggregation.
-# The existing tpu/vllm kustomization hardcodes tpu7x nodeSelectors; v6e
-# overlays need to land before this can run against the v6e cluster.
-# Tracks issue: https://github.com/llm-d/llm-d/issues/1471
-
 on:
-  schedule:
-    - cron: '30 2 * * *'  # 02:30 UTC daily (staggered from optimized-baseline TPU)
   workflow_dispatch:
     inputs:
-      skip_cleanup:
-        description: 'Skip cleanup after tests (for debugging)'
+      decode_pods:
+        description: 'Number of decode (vllm "standalone") pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      prefill_pods:
+        description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      gateway_class:
+        description: 'Class of gateway used ("istio", "agentgateway", "epponly" (i.e., "standalone"), "none")'
+        required: false
+        default: 'epponly'
+      monitoring_enabled:
+        description: 'Enabled monitoring ("true", "false")'
+        required: true
+        type: 'string'
+        default: 'false'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode ("true", "false")'
         required: false
         default: 'false'
-      pr_number:
-        description: 'PR number for comment-back (set by /test-nightly)'
+      verbose:
+        description: 'Execute workflow in "verbose" mode ("true", "false")'
         required: false
-        default: ''
-      pr_repo:
-        description: 'Repo for PR comment-back'
+        default: 'false'
+        type: 'string'
+      harness:
+        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
         required: false
-        default: 'llm-d/llm-d'
+        default: 'inference-perf'
+        type: 'string'
+      workload:
+        description: 'Workload profile to be used during "run" operation (check list under "workload/profiles")'
+        required: false
+        default: 'sanity_random.yaml'
+#        default: 'guide_pd-disaggregation_1.yaml'
+        type: 'string'
+      cleanup:
+        description: 'Cleanup the llm-d stack stood up by this workflow'
+        required: false
+        default: 'true'
+        type: string
+      tpu_chips:
+        description: 'Total TPU chips to request (0 for simulated)'
+        required: false
+        type: 'string'
+        default: '16'
+      tpu_topology:
+        description: 'GKE TPU topology (e.g. 2x4, 2x2x1)'
+        required: false
+        type: 'string'
+        default: '2x4'
 
+#  push:
+#    branches:
+#      - main
+
+  schedule:
+    - cron: '0 3 * * *'
 permissions:
   contents: write
   actions: read
@@ -33,13 +74,34 @@ concurrency:
 
 jobs:
   nightly:
-    if: github.repository == 'llm-d/llm-d'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Placeholder
-        run: |
-          echo "Skipping PD Disaggregation TPU nightly — v6e manifests not yet available."
-          echo "Unblock: add guides/pd-disaggregation/modelserver/tpu-v6e/ overlay and replace this job."
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
+    with:
+      scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
+      standup_method: ${{ inputs.standup_method || 'kustomize' }}
+      standup_scenario: ${{ inputs.standup_scenario || 'pd-disaggregation' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'tpu-v6' }}
+      backend_type: ${{ inputs.backend_type || 'vllm' }}
+      infra_provider: ${{ inputs.infra_provider || '' }}
+      connector: ${{ inputs.connector || '' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-pd-disaggregation-gke-tpu' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-gke' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-gke-tpu' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions/pd-disaggregation' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'sanity_random.yaml' }}
+#      workload: ${{ inputs.workload || 'guide_pd-disaggregation_1.yaml' }}
+      cleanup: ${{ inputs.cleanup || 'true' }}
+      tpu_chips: ${{ inputs.tpu_chips || '16' }}
+      tpu_topology: ${{ inputs.tpu_topology || '2x4' }}
+    secrets: inherit
 
   update-badge:
     needs: [nightly]
@@ -47,5 +109,5 @@ jobs:
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: pd-disaggregation-gke-tpu
-      badge_label: "GKE TPU"
+      badge_label: "VLLM TPU"
       result: ${{ needs.nightly.result }}

--- a/.github/workflows/nightly-e2e-pd-disaggregation-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-ibm-acc-gpu-vllm-x.yaml
@@ -1,81 +1,94 @@
-name: Nightly - PD Disaggregation E2E (OpenShift)
-
-# Nightly regression test for the pd-disaggregation guide on OpenShift.
-# Deploys via kustomize and validates with e2e-validate.sh.
-# Uses a slim model transformation to reduce GPU requirements.
+name: Nightly - PD Disaggregation E2E (OCP GPU)
 
 on:
-  schedule:
-    - cron: '30 0 * * *'  # 00:30 UTC daily (staggered from optimized-baseline)
   workflow_dispatch:
     inputs:
-      skip_cleanup:
-        description: 'Skip cleanup after tests (for debugging)'
+      decode_pods:
+        description: 'Number of decode (vllm "standalone") pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      prefill_pods:
+        description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      gateway_class:
+        description: 'Class of gateway used ("istio", "agentgateway", "epponly" (i.e., "standalone"), "none")'
+        required: false
+        default: 'epponly'
+      monitoring_enabled:
+        description: 'Enabled monitoring ("true", "false")'
+        required: true
+        type: 'string'
+        default: 'false'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode ("true", "false")'
         required: false
         default: 'false'
-      pr_number:
-        description: 'PR number for comment-back (set by /test-nightly)'
+      verbose:
+        description: 'Execute workflow in "verbose" mode ("true", "false")'
         required: false
-        default: ''
-      pr_repo:
-        description: 'Repo for PR comment-back'
+        default: 'false'
+        type: 'string'
+      harness:
+        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
         required: false
-        default: 'llm-d/llm-d'
+        default: 'inference-perf'
+        type: 'string'
+      workload:
+        description: 'Workload profile to be used during "run" operation (check list under "workload/profiles")'
+        required: false
+        default: 'sanity_random.yaml'
+#        default: 'guide_pd-disaggregation_1.yaml'
+        type: 'string'
+      cleanup:
+        description: 'Cleanup the llm-d stack stood up by this workflow'
+        required: false
+        default: 'true'
+        type: string
+#  push:
+#    branches:
+#      - main
+
+  schedule:
+    - cron: '0 3 * * *'
 
 permissions:
   contents: write
   actions: read
 
 concurrency:
-  group: nightly-e2e-pd-disaggregation
+  group: nightly-e2e-pd-disaggregation-ibm
   cancel-in-progress: true
 
 jobs:
   nightly:
-    if: github.repository == 'llm-d/llm-d'
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
-      guide_name: pd-disaggregation
-      namespace: llm-d-nightly-pd-ocp
-      gateway_host: 'pd-disaggregation-epp'
-      accelerator_type: H100
-      required_gpus: 2
-      recommended_gpus: 4
-      pod_wait_timeout: '30m'
-      pod_readiness_delay: 180
-      image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
-      allow_gpu_preemption: true
-      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
-      pr_number: ${{ github.event.inputs.pr_number }}
-      pr_repo: ${{ github.event.inputs.pr_repo }}
-      pre_deploy_script: |
-        cd guides/pd-disaggregation/modelserver/gpu/vllm/base
-        echo "Applying pd-disaggregation slim transforms..."
-        for f in patch-decode.yaml patch-prefill.yaml; do
-          yq e '.spec.template.spec.containers[0].args[0] = "Qwen/Qwen3-0.6B"' -i "$f"
-          yq e '.spec.replicas = 1' -i "$f"
-          yq e '.spec.template.spec.containers[0].resources.limits["nvidia.com/gpu"] = "1"' -i "$f"
-          yq e '.spec.template.spec.containers[0].resources.requests["nvidia.com/gpu"] = "1"' -i "$f"
-          yq e 'del(.spec.template.spec.containers[0].resources.limits.cpu)' -i "$f"
-          yq e 'del(.spec.template.spec.containers[0].resources.requests.cpu)' -i "$f"
-          yq e 'del(.spec.template.spec.containers[0].resources.limits.memory)' -i "$f"
-          yq e 'del(.spec.template.spec.containers[0].resources.requests.memory)' -i "$f"
-          yq e '.spec.template.spec.volumes[0].emptyDir.sizeLimit = "2Gi"' -i "$f"
-          yq e '.spec.template.spec.priorityClassName = "nightly-gpu-critical"' -i "$f"
-        done
-        yq e '(.spec.template.spec.containers[0].args[] | select(. == "--tensor-parallel-size=4")) = "--tensor-parallel-size=1"' -i patch-decode.yaml
-        echo "Slim transform applied — model: Qwen3-0.6B, 1 GPU decode, 1 prefill replica"
-        cd "$GITHUB_WORKSPACE"
-      custom_deploy_script: |
-        export ROUTER_CHART_VERSION=v0
-        export GUIDE_NAME="pd-disaggregation"
-        export INFRA_PROVIDER="base"
-        kubectl apply -n ${NAMESPACE} -k guides/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}
-        helm install ${GUIDE_NAME} \
-          oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev \
-          -f guides/recipes/router/base.values.yaml \
-          -f guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
-          -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
+      scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
+      standup_method: ${{ inputs.standup_method || 'kustomize' }}
+      standup_scenario: ${{ inputs.standup_scenario || 'pd-disaggregation' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'gpu' }}
+      backend_type: ${{ inputs.backend_type || 'vllm' }}
+      infra_provider: ${{ inputs.infra_provider || 'base' }}
+      connector: ${{ inputs.connector || '' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-pd-disaggregation-ibm-gpu' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-ibm' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-ibm' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions/pd-disaggregation' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'true' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'sanity_random.yaml' }}
+#      workload: ${{ inputs.workload || 'guide_pd-disaggregation_1.yaml' }}
+      cleanup: ${{ inputs.cleanup || 'true' }}
     secrets: inherit
 
   update-badge:
@@ -84,5 +97,5 @@ jobs:
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: pd-disaggregation-ocp
-      badge_label: "OCP"
+      badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}

--- a/.github/workflows/nightly-e2e-pd-disaggregation-intel-acc-xpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-intel-acc-xpu-vllm-x.yaml
@@ -1,39 +1,95 @@
 name: Nightly - PD Disaggregation E2E (XPU)
 
-# Nightly regression test for the pd-disaggregation guide on XPU.
-
 on:
-  schedule:
-    - cron: '30 10 * * *'  # 10:30 UTC daily (staggered)
   workflow_dispatch:
     inputs:
-      skip_cleanup:
-        description: 'Skip cleanup after tests (for debugging)'
+      decode_pods:
+        description: 'Number of decode (vllm "standalone") pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      prefill_pods:
+        description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      gateway_class:
+        description: 'Class of gateway used ("istio", "agentgateway", "epponly" (i.e., "standalone"), "none")'
+        required: false
+        default: 'epponly'
+      monitoring_enabled:
+        description: 'Enabled monitoring ("true", "false")'
+        required: true
+        type: 'string'
+        default: 'false'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode ("true", "false")'
         required: false
         default: 'false'
+      verbose:
+        description: 'Execute workflow in "verbose" mode ("true", "false")'
+        required: false
+        default: 'false'
+        type: 'string'
+      harness:
+        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
+        required: false
+        default: 'inference-perf'
+        type: 'string'
+      workload:
+        description: 'Workload profile to be used during "run" operation (check list under "workload/profiles")'
+        required: false
+        default: 'sanity_random.yaml'
+#        default: 'guide_pd-disaggregation_1.yaml'
+        type: 'string'
+      cleanup:
+        description: 'Cleanup the llm-d stack stood up by this workflow'
+        required: false
+        default: 'true'
+        type: string
+
+#  push:
+#    branches:
+#      - main
+
+  schedule:
+    - cron: '0 3 * * *'
 
 permissions:
   contents: write
   actions: read
 
 concurrency:
-  group: nightly-e2e-pd-disaggregation-xpu
+  group: nightly-e2e-pd-disaggregation-intel-xpu
   cancel-in-progress: true
 
 jobs:
   nightly:
-    if: github.repository == 'llm-d/llm-d'
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-xpu.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
-      guide_name: pd-disaggregation
-      namespace: llm-d-nightly-pd-xpu
-      router_release_name: pd-disaggregation
-      router_values_files: |
-        guides/recipes/router/base.values.yaml
-        guides/pd-disaggregation/router/pd-disaggregation.values.yaml
-      pod_wait_timeout: '10m'
-      llm_d_ref: ${{ github.ref }}
-      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
+      standup_method: ${{ inputs.standup_method || 'kustomize' }}
+      standup_scenario: ${{ inputs.standup_scenario || 'pd-disaggregation' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'xpu' }}
+      backend_type: ${{ inputs.backend_type || 'vllm' }}
+      infra_provider: ${{ inputs.infra_provider || '' }}
+      connector: ${{ inputs.connector || '' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-pd-disaggregation-intel-xpu' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-xpu' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-xpu' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions/pd-disaggregation' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'sanity_random.yaml' }}
+#      workload: ${{ inputs.workload || 'guide_pd-disaggregation_1.yaml' }}
+      cleanup: ${{ inputs.cleanup || 'true' }}
     secrets: inherit
 
   update-badge:
@@ -42,5 +98,5 @@ jobs:
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: pd-disaggregation-xpu
-      badge_label: "XPU"
+      badge_label: "VLLM XPU"
       result: ${{ needs.nightly.result }}

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-lmcache.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-lmcache.yaml
@@ -1,67 +1,96 @@
 name: Nightly - Tiered Prefix Cache CPU Offloading LMCache E2E (GKE GPU)
 
-# Nightly regression test for the tiered-prefix-cache/cpu guide with LMCache connector on GKE.
-# Deploys the LMCache connector and validates with e2e-validate.sh.
-
 on:
-  schedule:
-    - cron: '30 15 * * *'  # 15:30 UTC daily (staggered between other GKE nightlies)
   workflow_dispatch:
     inputs:
-      skip_cleanup:
-        description: 'Skip cleanup after tests (for debugging)'
+      decode_pods:
+        description: 'Number of decode (vllm "standalone") pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      prefill_pods:
+        description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      gateway_class:
+        description: 'Class of gateway used ("istio", "agentgateway", "epponly" (i.e., "standalone"), "none")'
+        required: false
+        default: 'epponly'
+      monitoring_enabled:
+        description: 'Enabled monitoring ("true", "false")'
+        required: true
+        type: 'string'
+        default: 'false'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode ("true", "false")'
         required: false
         default: 'false'
-      pr_number:
-        description: 'PR number for comment-back (set by /test-nightly)'
+      verbose:
+        description: 'Execute workflow in "verbose" mode ("true", "false")'
         required: false
-        default: ''
-      pr_repo:
-        description: 'Repo for PR comment-back'
+        default: 'false'
+        type: 'string'
+      harness:
+        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
         required: false
-        default: 'llm-d/llm-d'
+        default: 'inference-perf'
+        type: 'string'
+      workload:
+        description: 'Workload profile to be used during "run" operation (check list under "workload/profiles")'
+        required: false
+        default: 'sanity_random.yaml'
+#        default: 'guide_tiered-prefix-cache_1.yaml'
+        type: 'string'
+      cleanup:
+        description: 'Cleanup the llm-d stack stood up by this workflow'
+        required: false
+        default: 'true'
+        type: string
+
+#  push:
+#    branches:
+#      - main
+
+  schedule:
+    - cron: '0 12 * * *'
 
 permissions:
   contents: write
   actions: read
 
 concurrency:
-  group: nightly-e2e-tiered-prefix-cache-gke
+  group: nightly-e2e-tiered-prefix-cache-gke-gpu
   cancel-in-progress: true
 
 jobs:
   nightly:
-    if: github.repository == 'llm-d/llm-d'
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
-      guide_name: tiered-prefix-cache
-      namespace: llm-d-nightly-pfc-cpu-gke
-      gateway_host: 'tiered-prefix-cache-cpu-epp'
-      custom_deploy_script: |
-        export GAIE_VERSION=v1.5.0
-        export ROUTER_CHART_VERSION=v0
-        export GUIDE_NAME="tiered-prefix-cache-cpu"
-        export ACCELERATOR="gpu"
-        export CONNECTOR="lmcache-connector/cpu"
-        export INFRA_PROVIDER="gke"
-        kubectl apply -n ${NAMESPACE} -k guides/tiered-prefix-cache/modelserver/${ACCELERATOR}/vllm/${CONNECTOR}/${INFRA_PROVIDER}
-        helm install ${GUIDE_NAME} \
-          oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev \
-          -f guides/recipes/router/base.values.yaml \
-          -f guides/tiered-prefix-cache/router/${GUIDE_NAME}.values.yaml \
-          -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
-      gke_cluster_name: llm-d-e2e-us-east5
-      gke_cluster_zone: us-east5
-      required_gpus: 8
-      recommended_gpus: 8
-      accelerator_type: H100
-      pod_wait_timeout: '30m'
-      pod_readiness_delay: 0
-      allow_gpu_preemption: true
-      llm_d_ref: ${{ github.ref }}
-      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
-      pr_number: ${{ github.event.inputs.pr_number }}
-      pr_repo: ${{ github.event.inputs.pr_repo }}
+      scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
+      standup_method: ${{ inputs.standup_method || 'kustomize' }}
+      standup_scenario: ${{ inputs.standup_scenario || 'tiered-prefix-cache/cpu' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'gpu' }}
+      backend_type: ${{ inputs.backend_type || 'vllm' }}
+      infra_provider: ${{ inputs.infra_provider || 'gke' }}
+      offloading_target: ${{ inputs.offloading_target || 'cpu' }}
+      connector: ${{ inputs.connector || 'lmcache' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-tiered-prefix-cache-gke-gpu' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-gke' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-gke' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions/tiered-prefix-cache' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'sanity_random.yaml' }}
+#      workload: ${{ inputs.workload || 'guide_tiered-prefix-cache_1.yaml' }}
+      cleanup: ${{ inputs.cleanup || 'true' }}
     secrets: inherit
 
   update-badge:
@@ -69,6 +98,6 @@ jobs:
     if: always()
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
-      badge_name: tiered-prefix-cache-cpu-offloading-lmcache-gke
-      badge_label: "GKE GPU"
+      badge_name: tiered-prefix-cache-gke-cpu-llmcache
+      badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-native.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-native.yaml
@@ -1,67 +1,96 @@
 name: Nightly - Tiered Prefix Cache CPU Offloading E2E (GKE GPU)
 
-# Nightly regression test for the tiered-prefix-cache/cpu guide on GKE.
-# Deploys the CPU offloading connector and validates with e2e-validate.sh.
-
 on:
-  schedule:
-    - cron: '0 12 * * *'  # 12:00 UTC daily (staggered between other GKE nightlies)
   workflow_dispatch:
     inputs:
-      skip_cleanup:
-        description: 'Skip cleanup after tests (for debugging)'
+      decode_pods:
+        description: 'Number of decode (vllm "standalone") pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      prefill_pods:
+        description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      gateway_class:
+        description: 'Class of gateway used ("istio", "agentgateway", "epponly" (i.e., "standalone"), "none")'
+        required: false
+        default: 'epponly'
+      monitoring_enabled:
+        description: 'Enabled monitoring ("true", "false")'
+        required: true
+        type: 'string'
+        default: 'false'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode ("true", "false")'
         required: false
         default: 'false'
-      pr_number:
-        description: 'PR number for comment-back (set by /test-nightly)'
+      verbose:
+        description: 'Execute workflow in "verbose" mode ("true", "false")'
         required: false
-        default: ''
-      pr_repo:
-        description: 'Repo for PR comment-back'
+        default: 'false'
+        type: 'string'
+      harness:
+        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
         required: false
-        default: 'llm-d/llm-d'
+        default: 'inference-perf'
+        type: 'string'
+      workload:
+        description: 'Workload profile to be used during "run" operation (check list under "workload/profiles")'
+        required: false
+        default: 'sanity_random.yaml'
+#        default: 'guide_tiered-prefix-cache_1.yaml'
+        type: 'string'
+      cleanup:
+        description: 'Cleanup the llm-d stack stood up by this workflow'
+        required: false
+        default: 'true'
+        type: string
+
+#  push:
+#    branches:
+#      - main
+
+  schedule:
+    - cron: '0 12 * * *'
 
 permissions:
   contents: write
   actions: read
 
 concurrency:
-  group: nightly-e2e-tiered-prefix-cache-gke
+  group: nightly-e2e-tiered-prefix-cache-gke-gpu
   cancel-in-progress: true
 
 jobs:
   nightly:
-    if: github.repository == 'llm-d/llm-d'
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
-      guide_name: tiered-prefix-cache
-      namespace: llm-d-nightly-pfc-cpu-gke
-      gateway_host: 'tiered-prefix-cache-cpu-epp'
-      custom_deploy_script: |
-        export GAIE_VERSION=v1.5.0
-        export ROUTER_CHART_VERSION=v0
-        export GUIDE_NAME="tiered-prefix-cache-cpu"
-        export ACCELERATOR="gpu"
-        export CONNECTOR="native/cpu"
-        export INFRA_PROVIDER="gke"
-        kubectl apply -n ${NAMESPACE} -k guides/tiered-prefix-cache/modelserver/${ACCELERATOR}/vllm/${CONNECTOR}/${INFRA_PROVIDER}
-        helm install ${GUIDE_NAME} \
-          oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev \
-          -f guides/recipes/router/base.values.yaml \
-          -f guides/tiered-prefix-cache/router/${GUIDE_NAME}.values.yaml \
-          -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
-      gke_cluster_name: llm-d-e2e-us-east5
-      gke_cluster_zone: us-east5
-      required_gpus: 8
-      recommended_gpus: 8
-      accelerator_type: H100
-      pod_wait_timeout: '30m'
-      pod_readiness_delay: 0
-      allow_gpu_preemption: true
-      llm_d_ref: ${{ github.ref }}
-      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
-      pr_number: ${{ github.event.inputs.pr_number }}
-      pr_repo: ${{ github.event.inputs.pr_repo }}
+      scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
+      standup_method: ${{ inputs.standup_method || 'kustomize' }}
+      standup_scenario: ${{ inputs.standup_scenario || 'tiered-prefix-cache/cpu' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'gpu' }}
+      backend_type: ${{ inputs.backend_type || 'vllm' }}
+      infra_provider: ${{ inputs.infra_provider || 'gke' }}
+      offloading_target: ${{ inputs.offloading_target || 'cpu' }}
+      connector: ${{ inputs.connector || 'offloading' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-tiered-prefix-cache-gke-gpu' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-gke' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-gke' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions/tiered-prefix-cache' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'sanity_random.yaml' }}
+#      workload: ${{ inputs.workload || 'guide_tiered-prefix-cache_1.yaml' }}
+      cleanup: ${{ inputs.cleanup || 'true' }}
     secrets: inherit
 
   update-badge:
@@ -69,6 +98,6 @@ jobs:
     if: always()
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
-      badge_name: tiered-prefix-cache-cpu-offloading-gke
-      badge_label: "GKE GPU"
+      badge_name: tiered-prefix-cache-gke-cpu-llmcache
+      badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-tpu-vllm-native.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-tpu-vllm-native.yaml
@@ -1,27 +1,69 @@
 name: Nightly - Tiered Prefix Cache E2E (GKE TPU)
 
-# Placeholder — real test pending v6e compatibility confirmation and manifests.
-# Only tpu-v7 manifests exist; @dannawang0221 to confirm TPUOffloadConnector works on v6e.
-# Tracks issue: https://github.com/llm-d/llm-d/issues/1471
-
 on:
-  schedule:
-    - cron: '30 3 * * *'  # 03:30 UTC daily (staggered from PD TPU nightly; avoids wva-ocp at 03:00)
   workflow_dispatch:
     inputs:
-      skip_cleanup:
-        description: 'Skip cleanup after tests (for debugging)'
+      decode_pods:
+        description: 'Number of decode (vllm "standalone") pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      prefill_pods:
+        description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      gateway_class:
+        description: 'Class of gateway used ("istio", "agentgateway", "epponly" (i.e., "standalone"), "none")'
+        required: false
+        default: 'epponly'
+      monitoring_enabled:
+        description: 'Enabled monitoring ("true", "false")'
+        required: true
+        type: 'string'
+        default: 'false'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode ("true", "false")'
         required: false
         default: 'false'
-      pr_number:
-        description: 'PR number for comment-back (set by /test-nightly)'
+      verbose:
+        description: 'Execute workflow in "verbose" mode ("true", "false")'
         required: false
-        default: ''
-      pr_repo:
-        description: 'Repo for PR comment-back'
+        default: 'false'
+        type: 'string'
+      harness:
+        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
         required: false
-        default: 'llm-d/llm-d'
+        default: 'inference-perf'
+        type: 'string'
+      workload:
+        description: 'Workload profile to be used during "run" operation (check list under "workload/profiles")'
+        required: false
+        default: 'sanity_random.yaml'
+#        default: 'guide_tiered-prefix-cache_1.yaml'
+        type: 'string'
+      cleanup:
+        description: 'Cleanup the llm-d stack stood up by this workflow'
+        required: false
+        default: 'true'
+        type: string
+      tpu_chips:
+        description: 'Total TPU chips to request (0 for simulated)'
+        required: false
+        type: 'string'
+        default: '16'
+      tpu_topology:
+        description: 'GKE TPU topology (e.g. 2x4, 2x2x1)'
+        required: false
+        type: 'string'
+        default: '2x4'
 
+#  push:
+#    branches:
+#      - main
+
+  schedule:
+    - cron: '0 12 * * *'  # 10:00 UTC daily
 permissions:
   contents: write
   actions: read
@@ -32,13 +74,35 @@ concurrency:
 
 jobs:
   nightly:
-    if: github.repository == 'llm-d/llm-d'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Placeholder
-        run: |
-          echo "Skipping Tiered Prefix Cache TPU nightly — v6e manifests not yet available."
-          echo "Unblock: confirm TPUOffloadConnector v6e support, add tpu-v6e manifests, replace this job."
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
+    with:
+      scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
+      standup_method: ${{ inputs.standup_method || 'kustomize' }}
+      standup_scenario: ${{ inputs.standup_scenario || 'tiered-prefix-cache/cpu' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'tpu-v6' }}
+      backend_type: ${{ inputs.backend_type || 'vllm' }}
+      infra_provider: ${{ inputs.infra_provider || '' }}
+      offloading_target: ${{ inputs.offloading_target || 'cpu' }}
+      connector: ${{ inputs.connector || 'offloading' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-tiered-prefix-cache-gke-tpu' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-gke' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-gke-tpu' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions/tiered-prefix-cache' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'sanity_random.yaml' }}
+#      workload: ${{ inputs.workload || 'guide_tiered-prefix-cache_1.yaml' }}
+      cleanup: ${{ inputs.cleanup || 'true' }}
+      tpu_chips: ${{ inputs.tpu_chips || '16' }}
+      tpu_topology: ${{ inputs.tpu_topology || '2x4' }}
+    secrets: inherit
 
   update-badge:
     needs: [nightly]
@@ -46,5 +110,5 @@ jobs:
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: tiered-prefix-cache-gke-tpu
-      badge_label: "GKE TPU"
+      badge_label: "VLLM TPU"
       result: ${{ needs.nightly.result }}

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-ibm-cpu-gpu-vllm-native.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-ibm-cpu-gpu-vllm-native.yaml
@@ -1,86 +1,95 @@
 name: Nightly - Tiered Prefix Cache CPU Offloading E2E (OpenShift)
 
-# Nightly regression test for the tiered-prefix-cache/cpu guide on OpenShift.
-# Uses kustomize for model server + helm for InferencePool + gateway recipe.
-# Slim transform reduces Qwen3-32B to Qwen3-0.6B with 1 GPU.
-
 on:
-  schedule:
-    - cron: '0 2 * * *'  # 02:00 UTC daily (staggered)
   workflow_dispatch:
     inputs:
-      gateway_type:
-        description: 'Gateway provider type'
+      decode_pods:
+        description: 'Number of decode (vllm "standalone") pods (default "auto", means what was configured on the scenario)'
         required: false
-        default: 'istio'
-        type: choice
-        options:
-          - istio
-          - kgateway
-      skip_cleanup:
-        description: 'Skip cleanup after tests (for debugging)'
+        type: 'string'
+        default: 'auto'
+      prefill_pods:
+        description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      gateway_class:
+        description: 'Class of gateway used ("istio", "agentgateway", "epponly" (i.e., "standalone"), "none")'
+        required: false
+        default: 'epponly'
+      monitoring_enabled:
+        description: 'Enabled monitoring ("true", "false")'
+        required: true
+        type: 'string'
+        default: 'false'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode ("true", "false")'
         required: false
         default: 'false'
-      pr_number:
-        description: 'PR number for comment-back (set by /test-nightly)'
+      verbose:
+        description: 'Execute workflow in "verbose" mode ("true", "false")'
         required: false
-        default: ''
-      pr_repo:
-        description: 'Repo for PR comment-back'
+        default: 'false'
+        type: 'string'
+      harness:
+        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
         required: false
-        default: 'llm-d/llm-d'
+        default: 'inference-perf'
+        type: 'string'
+      workload:
+        description: 'Workload profile to be used during "run" operation (check list under "workload/profiles")'
+        required: false
+        default: 'sanity_random.yaml'
+#        default: 'guide_tiered-prefix-cache_1.yaml'
+        type: 'string'
+      cleanup:
+        description: 'Cleanup the llm-d stack stood up by this workflow'
+        required: false
+        default: 'true'
+        type: string
+#  push:
+#    branches:
+#      - main
+
+  schedule:
+    - cron: '0 12 * * *'  # 10:00 UTC daily
 
 permissions:
   contents: write
   actions: read
 
 concurrency:
-  group: nightly-e2e-tiered-prefix-cache
+  group: nightly-e2e-tiered-prefix-cache-ibm
   cancel-in-progress: true
 
 jobs:
   nightly:
-    if: github.repository == 'llm-d/llm-d'
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
-      guide_name: tiered-prefix-cache
-      namespace: llm-d-nightly-pfc-cpu
-      gateway_host: 'tiered-prefix-cache-epp'
-      custom_deploy_script: |
-        NAMESPACE="llm-d-nightly-pfc-cpu"
-        echo "Deploying tiered-prefix-cache/cpu via kustomize + helm..."
-
-        yq '.spec.template.spec.priorityClassName="nightly-gpu-critical"' -i guides/tiered-prefix-cache/modelserver/gpu/vllm/base/patch-vllm.yaml
-        yq '.spec.replicas=2' -i guides/tiered-prefix-cache/modelserver/gpu/vllm/base/patch-vllm.yaml
-
-        # Override image if IMAGE_OVERRIDE is set by the reusable workflow
-        #if [ -n "${IMAGE_OVERRIDE:-}" ]; then
-        #  find guides/tiered-prefix-cache/cpu/modelserver/gpu/vllm -name "*.yaml" -not -name "kustomization.yaml" \
-        #    -exec sed -i "s|ghcr.io/llm-d/llm-d-cuda:[^ \"]*|${IMAGE_OVERRIDE}|g" {} \;
-        #  echo "Image override applied: ${IMAGE_OVERRIDE}"
-        #fi
-
-        kubectl apply -k guides/tiered-prefix-cache/modelserver/gpu/vllm/native/cpu/base -n "$NAMESPACE"
-
-        export ROUTER_CHART_VERSION=v0
-        helm install tiered-prefix-cache \
-        oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev \
-        -f guides/recipes/router/base.values.yaml \
-        -f guides/tiered-prefix-cache/router/tiered-prefix-cache-cpu.values.yaml \
-        -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
-
-        echo "Deployment complete"
-      accelerator_type: H100
-      required_gpus: 1
-      recommended_gpus: 2
-      pod_wait_timeout: '30m'
-      pod_readiness_delay: 180
-      image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
-      allow_gpu_preemption: true
-      install_gateway_provider: false
-      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
-      pr_number: ${{ github.event.inputs.pr_number }}
-      pr_repo: ${{ github.event.inputs.pr_repo }}
+      scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
+      standup_method: ${{ inputs.standup_method || 'kustomize' }}
+      standup_scenario: ${{ inputs.standup_scenario || 'tiered-prefix-cache/cpu' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'gpu' }}
+      backend_type: ${{ inputs.backend_type || 'vllm' }}
+      infra_provider: ${{ inputs.infra_provider || 'base' }}
+      offloading_target: ${{ inputs.offloading_target || 'cpu' }}
+      connector: ${{ inputs.connector || 'offloading' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-tiered-prefix-cache-ibm-gpu' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-ibm' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-ibm' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions/tiered-prefix-cache' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'sanity_random.yaml' }}
+#      workload: ${{ inputs.workload || 'guide_tiered-prefix-cache_1.yaml' }}
+      cleanup: ${{ inputs.cleanup || 'true' }}
     secrets: inherit
 
   update-badge:
@@ -89,5 +98,5 @@ jobs:
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: tiered-prefix-cache-cpu-offloading-ocp
-      badge_label: "OCP"
+      badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}

--- a/.github/workflows/nightly-e2e-wide-ep-lws-cks-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-cks-acc-gpu-vllm-x.yaml
@@ -1,27 +1,59 @@
-name: Nightly - Wide EP LWS E2E (CKS)
-
-# Nightly regression test for the wide-ep-lws guide on CoreWeave (CKS).
-# Uses LeaderWorkerSet for P/D disaggregation with kustomize + helm.
-# Slim transform reduces DeepSeek-R1-0528 to Qwen3-0.6B with 1 GPU per role.
-# Tests: LWS CRD, P/D routing sidecar, InferencePool PD plugins.
+name: Nightly - Wide EP LWS E2E (CKS GPU)
 
 on:
-  schedule:
-    - cron: '0 7 * * *'  # 07:00 UTC daily (staggered from IS/PD CKS)
   workflow_dispatch:
     inputs:
-      skip_cleanup:
-        description: 'Skip cleanup after tests (for debugging)'
+      decode_pods:
+        description: 'Number of decode (vllm "standalone") pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      prefill_pods:
+        description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      gateway_class:
+        description: 'Class of gateway used ("istio", "agentgateway", "epponly" (i.e., "standalone"), "none")'
+        required: false
+        default: 'epponly'
+      monitoring_enabled:
+        description: 'Enabled monitoring ("true", "false")'
+        required: true
+        type: 'string'
+        default: 'false'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode ("true", "false")'
         required: false
         default: 'false'
-      pr_number:
-        description: 'PR number for comment-back (set by /test-nightly)'
+      verbose:
+        description: 'Execute workflow in "verbose" mode ("true", "false")'
         required: false
-        default: ''
-      pr_repo:
-        description: 'Repo for PR comment-back'
+        default: 'false'
+        type: 'string'
+      harness:
+        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
         required: false
-        default: 'llm-d/llm-d'
+        default: 'inference-perf'
+        type: 'string'
+      workload:
+        description: 'Workload profile to be used during "run" operation (check list under "workload/profiles")'
+        required: false
+        default: 'sanity_random.yaml'
+#        default: 'guide_wide-ep-lws_1.yaml'
+        type: 'string'
+      cleanup:
+        description: 'Cleanup the llm-d stack stood up by this workflow'
+        required: false
+        default: 'true'
+        type: string
+
+#  push:
+#    branches:
+#      - main
+
+  schedule:
+    - cron: '0 1 * * *'
 
 permissions:
   contents: write
@@ -33,51 +65,31 @@ concurrency:
 
 jobs:
   nightly:
-    if: github.repository == 'llm-d/llm-d'
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-cks.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
-      guide_name: wide-ep-lws
-      guide_path: guides/wide-ep-lws
-      namespace: llm-d-nightly-wide-ep-cks
-      required_gpus: 32
-      recommended_gpus: 32
-      pod_wait_timeout: '35m'
-      pod_readiness_delay: 0
-      gateway_host: 'wide-ep-lws-epp'
-      pre_deploy_script: |
-        echo "Installing LeaderWorkerSet for wide-ep-lws..."
-        if ! kubectl get crd leaderworkersets.leaderworkerset.x-k8s.io &>/dev/null; then
-          echo "Installing LeaderWorkerSet via helm..."
-          helm install lws oci://registry.k8s.io/lws/charts/lws \
-            --version=0.7.0 \
-            --namespace lws-system \
-            --create-namespace \
-            --wait --timeout 300s
-          kubectl wait deploy/lws-controller-manager -n lws-system \
-            --for=condition=available --timeout=120s || true
-        else
-          echo "LeaderWorkerSet CRD already installed"
-        fi
-      # Custom deploy: kustomize + helm + gateway recipe (not helmfile)
-      custom_deploy_script: |
-        export GAIE_VERSION=v1.5.0
-        export ROUTER_CHART_VERSION=v0
-        export GUIDE_NAME="wide-ep-lws"
-        export INFRA_PROVIDER="coreweave"
-        yq '.spec.leaderWorkerTemplate.workerTemplate.spec.priorityClassName="nightly-gpu-critical"' -i guides/${GUIDE_NAME}/modelserver/gpu/vllm/base/decode.yaml
-        yq '.spec.leaderWorkerTemplate.workerTemplate.spec.priorityClassName="nightly-gpu-critical"' -i guides/${GUIDE_NAME}/modelserver/gpu/vllm/base/prefill.yaml
-        kubectl apply -n ${NAMESPACE} -k guides/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}
-        helm install ${GUIDE_NAME} \
-          oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev \
-          -f guides/recipes/router/base.values.yaml \
-          -f guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
-          -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
-      # Wide-EP-specific validation: check prefill + decode pods
-      e2e_validate_args: '-v'
-      allow_gpu_preemption: true
-      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
-      pr_number: ${{ github.event.inputs.pr_number }}
-      pr_repo: ${{ github.event.inputs.pr_repo }}
+      scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
+      standup_method: ${{ inputs.standup_method || 'kustomize' }}
+      standup_scenario: ${{ inputs.standup_scenario || 'wide-ep-lws' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'gpu' }}
+      backend_type: ${{ inputs.backend_type || 'vllm' }}
+      infra_provider: ${{ inputs.infra_provider || 'coreweave' }}
+      connector: ${{ inputs.connector || '' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-wide-ep-lws-cks-gpu' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-cks' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-cks' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions/wide-ep-lws' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'true' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'sanity_random.yaml' }}
+#      workload: ${{ inputs.workload || 'guide_wide-ep-lws_1.yaml' }}
+      cleanup: ${{ inputs.cleanup || 'true' }}
     secrets: inherit
 
   update-badge:
@@ -86,5 +98,5 @@ jobs:
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: wide-ep-lws-cks
-      badge_label: "CKS"
+      badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}

--- a/.github/workflows/nightly-e2e-wide-ep-lws-gke-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-gke-acc-gpu-vllm-x.yaml
@@ -1,90 +1,95 @@
 name: Nightly - Wide EP LWS E2E (GKE GPU)
 
-# Nightly regression test for the wide-ep-lws guide on GKE.
-# Uses LeaderWorkerSet for P/D disaggregation with kustomize + helm.
-# Uses the existing GKE kustomize overlay (manifests/modelserver/gke).
-# Tests: LWS CRD, P/D routing sidecar, InferencePool PD plugins.
-# Reference: e2e-wide-ep-accelerator-gke.yaml (existing GKE wide-ep CI test)
-
 on:
-  schedule:
-    - cron: '0 11 * * *'  # 11:00 UTC daily (staggered)
   workflow_dispatch:
     inputs:
-      skip_cleanup:
-        description: 'Skip cleanup after tests (for debugging)'
+      decode_pods:
+        description: 'Number of decode (vllm "standalone") pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      prefill_pods:
+        description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      gateway_class:
+        description: 'Class of gateway used ("istio", "agentgateway", "epponly" (i.e., "standalone"), "none")'
+        required: false
+        default: 'epponly'
+      monitoring_enabled:
+        description: 'Enabled monitoring ("true", "false")'
+        required: true
+        type: 'string'
+        default: 'false'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode ("true", "false")'
         required: false
         default: 'false'
-      pr_number:
-        description: 'PR number for comment-back (set by /test-nightly)'
+      verbose:
+        description: 'Execute workflow in "verbose" mode ("true", "false")'
         required: false
-        default: ''
-      pr_repo:
-        description: 'Repo for PR comment-back'
+        default: 'false'
+        type: 'string'
+      harness:
+        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
         required: false
-        default: 'llm-d/llm-d'
+        default: 'inference-perf'
+        type: 'string'
+      workload:
+        description: 'Workload profile to be used during "run" operation (check list under "workload/profiles")'
+        required: false
+        default: 'sanity_random.yaml'
+#        default: 'guide_wide-ep-lws_1.yaml'
+        type: 'string'
+      cleanup:
+        description: 'Cleanup the llm-d stack stood up by this workflow'
+        required: false
+        default: 'true'
+        type: string
+
+#  push:
+#    branches:
+#      - main
+
+  schedule:
+    - cron: '0 1 * * *'
 
 permissions:
   contents: write
   actions: read
 
 concurrency:
-  group: nightly-e2e-wide-ep-lws-gke
+  group: nightly-e2e-wide-ep-lws-gke-gpu
   cancel-in-progress: true
 
 jobs:
   nightly:
-    if: github.repository == 'llm-d/llm-d'
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-gke.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
-      guide_name: wide-ep-lws
-      guide_path: guides/wide-ep-lws
-      namespace: llm-d-nightly-wide-ep-gke
-#      gke_cluster_name: llm-d-e2e-us-east5
-#      gke_cluster_zone: us-east5
-      gke_cluster_name: llm-d-e2e-us-south1-2
-      gke_cluster_zone: us-south1
-      required_gpus: 32
-      recommended_gpus: 32
-      accelerator_type: H200
-      pod_wait_timeout: '35m'
-      pod_readiness_delay: 0
-      gateway_host: 'wide-ep-lws-epp'
-      pre_deploy_script: |
-        echo "Installing LeaderWorkerSet for wide-ep-lws..."
-        if ! kubectl get crd leaderworkersets.leaderworkerset.x-k8s.io &>/dev/null; then
-          echo "Installing LeaderWorkerSet via helm..."
-          helm install lws oci://registry.k8s.io/lws/charts/lws \
-            --version=0.7.0 \
-            --namespace lws-system \
-            --create-namespace \
-            --wait --timeout 300s
-          kubectl wait deploy/lws-controller-manager -n lws-system \
-            --for=condition=available --timeout=120s || true
-        else
-          echo "LeaderWorkerSet CRD already installed"
-        fi
-      # Custom deploy: kustomize (GKE overlay) + helm + gateway recipe
-      # Mirrors the existing e2e-wide-ep-accelerator-gke.yaml deploy pattern
-      custom_deploy_script: |
-        export GAIE_VERSION=v1.5.0
-        export ROUTER_CHART_VERSION=v0
-        export GUIDE_NAME="wide-ep-lws"
-        export INFRA_PROVIDER="gke"
-        yq '.spec.leaderWorkerTemplate.workerTemplate.spec.priorityClassName="nightly-gpu-critical"' -i guides/${GUIDE_NAME}/modelserver/gpu/vllm/base/decode.yaml
-        yq '.spec.leaderWorkerTemplate.workerTemplate.spec.priorityClassName="nightly-gpu-critical"' -i guides/${GUIDE_NAME}/modelserver/gpu/vllm/base/prefill.yaml
-        kubectl apply -n ${NAMESPACE} -k guides/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}
-        helm install ${GUIDE_NAME} \
-          oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev \
-          -f guides/recipes/router/base.values.yaml \
-          -f guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
-          -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
-      # Wide-EP-specific validation: check prefill + decode pods
-      e2e_validate_args: '-v'
-      allow_gpu_preemption: true
-      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
-      pr_number: ${{ github.event.inputs.pr_number }}
-      pr_repo: ${{ github.event.inputs.pr_repo }}
+      scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
+      standup_method: ${{ inputs.standup_method || 'kustomize' }}
+      standup_scenario: ${{ inputs.standup_scenario || 'wide-ep-lws' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'gpu' }}
+      backend_type: ${{ inputs.backend_type || 'vllm' }}
+      infra_provider: ${{ inputs.infra_provider || 'gke' }}
+      connector: ${{ inputs.connector || '' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-wide-ep-lws-gke-gpu' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-gke' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-gke' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions/wide-ep-lws' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'true' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'sanity_random.yaml' }}
+#      workload: ${{ inputs.workload || 'guide_wide-ep-lws_1.yaml' }}
+      cleanup: ${{ inputs.cleanup || 'true' }}
     secrets: inherit
 
   update-badge:
@@ -93,5 +98,5 @@ jobs:
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: wide-ep-lws-gke
-      badge_label: "GKE GPU"
+      badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}

--- a/.github/workflows/nightly-e2e-wide-ep-lws-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-ibm-acc-gpu-vllm-x.yaml
@@ -1,304 +1,94 @@
-name: Nightly - Wide EP LWS E2E (OpenShift)
-
-# Nightly regression test for the wide-ep-lws guide on OpenShift.
-# Uses LeaderWorkerSet for P/D disaggregation with kustomize + helm.
-# Slim transform reduces DeepSeek-R1-0528 to Qwen3-0.6B with 1 GPU per role.
-# Tests: LWS CRD, P/D routing sidecar, InferencePool PD plugins.
+name: Nightly - Wide EP LWS E2E (OCP GPU)
 
 on:
-  schedule:
-    - cron: '30 2 * * *'  # 02:30 UTC daily (staggered)
   workflow_dispatch:
     inputs:
-      gateway_type:
-        description: 'Gateway provider type'
+      decode_pods:
+        description: 'Number of decode (vllm "standalone") pods (default "auto", means what was configured on the scenario)'
         required: false
-        default: 'istio'
-        type: choice
-        options:
-          - istio
-          - kgateway
-      skip_cleanup:
-        description: 'Skip cleanup after tests (for debugging)'
+        type: 'string'
+        default: 'auto'
+      prefill_pods:
+        description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      gateway_class:
+        description: 'Class of gateway used ("istio", "agentgateway", "epponly" (i.e., "standalone"), "none")'
+        required: false
+        default: 'epponly'
+      monitoring_enabled:
+        description: 'Enabled monitoring ("true", "false")'
+        required: true
+        type: 'string'
+        default: 'false'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode ("true", "false")'
         required: false
         default: 'false'
-      pr_number:
-        description: 'PR number for comment-back (set by /test-nightly)'
+      verbose:
+        description: 'Execute workflow in "verbose" mode ("true", "false")'
         required: false
-        default: ''
-      pr_repo:
-        description: 'Repo for PR comment-back'
+        default: 'false'
+        type: 'string'
+      harness:
+        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
         required: false
-        default: 'llm-d/llm-d'
+        default: 'inference-perf'
+        type: 'string'
+      workload:
+        description: 'Workload profile to be used during "run" operation (check list under "workload/profiles")'
+        required: false
+        default: 'sanity_random.yaml'
+#        default: 'guide_wide-ep-lws_1.yaml'
+        type: 'string'
+      cleanup:
+        description: 'Cleanup the llm-d stack stood up by this workflow'
+        required: false
+        default: 'true'
+        type: string
+#  push:
+#    branches:
+#      - main
+
+  schedule:
+    - cron: '0 1 * * *'
 
 permissions:
   contents: write
   actions: read
 
 concurrency:
-  group: nightly-e2e-wide-ep-lws
+  group: nightly-e2e-wide-ep-lws-ibm
   cancel-in-progress: true
 
 jobs:
   nightly:
-    if: github.repository == 'llm-d/llm-d'
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
-      guide_name: wide-ep-lws
-      guide_path: guides/wide-ep-lws
-      namespace: llm-d-nightly-wide-ep
-      helmfile_env: ${{ github.event.inputs.gateway_type || 'istio' }}
-      gateway_type: ${{ github.event.inputs.gateway_type || 'istio' }}
-      accelerator_type: H100
-      required_gpus: 2
-      recommended_gpus: 2
-      pod_wait_timeout: '20m'
-      pod_readiness_delay: 180
-      httproute_file: ''
-      # Slim transform: replace DeepSeek-R1-0528 with Qwen3-0.6B, 1 GPU per role,
-      # remove expert parallelism / RDMA / multi-node, keep LWS + P/D + routing sidecar.
-      # Based on .github/scripts/e2e/wide-ep-transform.sh and e2e-wide-ep-accelerator-gke.yaml.
-      pre_deploy_script: |
-        echo "Applying wide-ep-lws slim transforms..."
-
-        # Install LeaderWorkerSet via helm (matching existing CI approach)
-        if ! kubectl get crd leaderworkersets.leaderworkerset.x-k8s.io &>/dev/null; then
-          echo "Installing LeaderWorkerSet via helm..."
-          helm install lws oci://registry.k8s.io/lws/charts/lws \
-            --version=0.7.0 \
-            --namespace lws-system \
-            --create-namespace \
-            --wait --timeout 300s
-          kubectl wait deploy/lws-controller-manager -n lws-system \
-            --for=condition=available --timeout=120s || true
-        else
-          echo "LeaderWorkerSet CRD already installed"
-        fi
-
-        NIGHTLY_DIR="guides/wide-ep-lws/modelserver/gpu/vllm/nightly"
-        mkdir -p "$NIGHTLY_DIR"
-
-        # --- Slim prefill manifest ---
-        cat > "${NIGHTLY_DIR}/prefill.yaml" <<'PREFILL_EOF'
-        apiVersion: leaderworkerset.x-k8s.io/v1
-        kind: LeaderWorkerSet
-        metadata:
-          name: wide-ep-llm-d-prefill
-          labels:
-            llm-d.ai/inference-serving: "true"
-            llm-d.ai/guide: "wide-ep-lws"
-            llm-d.ai/model: DeepSeek-R1-0528
-            llm-d.ai/role: prefill
-        spec:
-          replicas: 1
-          leaderWorkerTemplate:
-            size: 1
-            workerTemplate:
-              metadata:
-                labels:
-                  llm-d.ai/inference-serving: "true"
-                  llm-d.ai/guide: "wide-ep-lws"
-                  llm-d.ai/model: DeepSeek-R1-0528
-                  llm-d.ai/role: prefill
-              spec:
-                serviceAccountName: deepseek-r1
-                volumes:
-                  - name: dshm
-                    emptyDir:
-                      medium: Memory
-                      sizeLimit: 256Mi
-                containers:
-                  - name: vllm
-                    image: ghcr.io/llm-d/llm-d-cuda-dev:latest
-                    imagePullPolicy: Always
-                    command: ["/bin/bash", "-c"]
-                    args:
-                      - |
-                        exec vllm serve \
-                          Qwen/Qwen3-0.6B \
-                          --port 8000 \
-                          --max-num-seq 64 \
-                          --max-model-len 4096 \
-                          --enforce-eager
-                    env:
-                      - name: VLLM_LOGGING_LEVEL
-                        value: INFO
-                      - name: HF_HUB_CACHE
-                        value: /var/cache/huggingface
-                    ports:
-                      - containerPort: 8000
-                        name: vllm
-                        protocol: TCP
-                    startupProbe:
-                      httpGet:
-                        path: /health
-                        port: vllm
-                      periodSeconds: 1
-                      failureThreshold: 600
-                    readinessProbe:
-                      httpGet:
-                        path: /v1/models
-                        port: vllm
-                      periodSeconds: 10
-                      failureThreshold: 3
-                    resources:
-                      limits:
-                        nvidia.com/gpu: "1"
-                      requests:
-                        nvidia.com/gpu: "1"
-                    volumeMounts:
-                      - name: dshm
-                        mountPath: /dev/shm
-        PREFILL_EOF
-
-        # --- Slim decode manifest (with routing sidecar) ---
-        cat > "${NIGHTLY_DIR}/decode.yaml" <<'DECODE_EOF'
-        apiVersion: leaderworkerset.x-k8s.io/v1
-        kind: LeaderWorkerSet
-        metadata:
-          name: wide-ep-llm-d-decode
-          labels:
-            llm-d.ai/inference-serving: "true"
-            llm-d.ai/guide: "wide-ep-lws"
-            llm-d.ai/model: DeepSeek-R1-0528
-            llm-d.ai/role: decode
-        spec:
-          replicas: 1
-          leaderWorkerTemplate:
-            size: 1
-            workerTemplate:
-              metadata:
-                labels:
-                  llm-d.ai/inference-serving: "true"
-                  llm-d.ai/guide: "wide-ep-lws"
-                  llm-d.ai/model: DeepSeek-R1-0528
-                  llm-d.ai/role: decode
-              spec:
-                serviceAccountName: deepseek-r1
-                initContainers:
-                  - name: routing-proxy
-                    args:
-                      - --port=8000
-                      - --vllm-port=8200
-                      - --connector=nixlv2
-                      - --zap-log-level=1
-                      - --secure-proxy=false
-                      - --enable-prefiller-sampling
-                    image: ghcr.io/llm-d/llm-d-routing-sidecar-dev:latest
-                    imagePullPolicy: Always
-                    ports:
-                      - containerPort: 8000
-                        name: sidecar
-                        protocol: TCP
-                    resources: {}
-                    restartPolicy: Always
-                    securityContext:
-                      allowPrivilegeEscalation: false
-                      runAsNonRoot: true
-                volumes:
-                  - name: dshm
-                    emptyDir:
-                      medium: Memory
-                      sizeLimit: 256Mi
-                containers:
-                  - name: vllm
-                    image: ghcr.io/llm-d/llm-d-cuda-dev:latest
-                    imagePullPolicy: Always
-                    command: ["/bin/bash", "-c"]
-                    args:
-                      - |
-                        exec vllm serve \
-                          Qwen/Qwen3-0.6B \
-                          --port 8200 \
-                          --max-num-seq 64 \
-                          --max-model-len 4096 \
-                          --enforce-eager
-                    env:
-                      - name: VLLM_LOGGING_LEVEL
-                        value: INFO
-                      - name: HF_HUB_CACHE
-                        value: /var/cache/huggingface
-                    ports:
-                      - containerPort: 8200
-                        name: vllm
-                        protocol: TCP
-                    startupProbe:
-                      httpGet:
-                        path: /health
-                        port: vllm
-                      periodSeconds: 1
-                      failureThreshold: 600
-                    readinessProbe:
-                      httpGet:
-                        path: /v1/models
-                        port: vllm
-                      periodSeconds: 10
-                      failureThreshold: 3
-                    resources:
-                      limits:
-                        nvidia.com/gpu: "1"
-                      requests:
-                        nvidia.com/gpu: "1"
-                    volumeMounts:
-                      - name: dshm
-                        mountPath: /dev/shm
-        DECODE_EOF
-
-        # --- ServiceAccount (copy from base) ---
-        cp "guides/wide-ep-lws/modelserver/gpu/vllm/base/serviceAccount.yaml" \
-          "${NIGHTLY_DIR}/serviceAccount.yaml"
-
-        # --- Kustomization for nightly overlay ---
-        cat > "${NIGHTLY_DIR}/kustomization.yaml" <<'KUSTOM_EOF'
-        apiVersion: kustomize.config.k8s.io/v1beta1
-        kind: Kustomization
-        resources:
-          - prefill.yaml
-          - decode.yaml
-          - serviceAccount.yaml
-        KUSTOM_EOF
-
-        # Override image if IMAGE_OVERRIDE is set by the reusable workflow
-        if [ -n "${IMAGE_OVERRIDE:-}" ]; then
-          sed -i "s|ghcr.io/llm-d/llm-d-cuda:[^ \"]*|${IMAGE_OVERRIDE}|g" \
-            "${NIGHTLY_DIR}/prefill.yaml" "${NIGHTLY_DIR}/decode.yaml"
-          echo "Image override applied: ${IMAGE_OVERRIDE}"
-        fi
-
-        echo "Slim transform applied — model: Qwen3-0.6B, 1 GPU per role, LWS size 1"
-      # Custom deploy: kustomize + helm + gateway recipe (not helmfile)
-      custom_deploy_script: |
-        NAMESPACE="llm-d-nightly-wide-ep"
-        GATEWAY_TYPE="${GATEWAY_TYPE:-istio}"
-        echo "Deploying wide-ep-lws via kustomize + helm..."
-
-        # 1. Deploy gateway recipe
-        echo "Deploying gateway recipe ($GATEWAY_TYPE)..."
-        kubectl apply -k "guides/recipes/gateway/${GATEWAY_TYPE}" -n "$NAMESPACE"
-
-        # 2. Deploy model server via kustomize (nightly slim overlay)
-        echo "Deploying model server (LeaderWorkerSets)..."
-        kubectl apply -k guides/wide-ep-lws/modelserver/gpu/vllm/nightly -n "$NAMESPACE"
-
-        # 3. Deploy InferencePool via helm
-        echo "Deploying InferencePool..."
-        export ROUTER_CHART_VERSION=v0
-        helm install llm-d-infpool \
-          -n "$NAMESPACE" \
-          -f guides/recipes/router/base.values.yaml \
-          -f guides/recipes/router/features/httproute-flags.yaml \
-          -f guides/wide-ep-lws/router/wide-ep-lws.values.yaml \
-          --set "provider.name=${GATEWAY_TYPE}" \
-          oci://ghcr.io/llm-d/charts/llm-d-router-gateway-dev \
-          --version ${ROUTER_CHART_VERSION}
-
-        echo "Deployment complete"
-      image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
-      allow_gpu_preemption: true
-      install_gateway_provider: false
-      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
-      pr_number: ${{ github.event.inputs.pr_number }}
-      pr_repo: ${{ github.event.inputs.pr_repo }}
+      scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
+      standup_method: ${{ inputs.standup_method || 'kustomize' }}
+      standup_scenario: ${{ inputs.standup_scenario || 'wide-ep-lws' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'gpu' }}
+      backend_type: ${{ inputs.backend_type || 'vllm' }}
+      infra_provider: ${{ inputs.infra_provider || 'base' }}
+      connector: ${{ inputs.connector || '' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-wide-ep-lws-ibm-gpu' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-ibm' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-ibm' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions/wide-ep-lws' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'true' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'sanity_random.yaml' }}
+#      workload: ${{ inputs.workload || 'guide_wide-ep-lws_1.yaml' }}
+      cleanup: ${{ inputs.cleanup || 'true' }}
     secrets: inherit
 
   update-badge:
@@ -307,5 +97,5 @@ jobs:
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: wide-ep-lws-ocp
-      badge_label: "OCP"
+      badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}


### PR DESCRIPTION

IMPORTANT: at the moment, `wide-ep-lws` is kept in `dry-run` mode, due to lack of hardware to test.