### PR TITLE
docs: add llm-d-router monitoring reference to well-lit path paths

### DIFF
--- a/guides/flow-control/README.md
+++ b/guides/flow-control/README.md
@@ -172,6 +172,8 @@ kubectl kustomize ${REPO_ROOT}/guides/optimized-baseline/modelserver/gpu/vllm/${
 kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/recipes/modelserver/components/monitoring
 ```
 
+* To enable monitoring for the `llm-d-router`, refer to the [Router Monitoring & Tracing Configuration](https://github.com/llm-d/llm-d-router/tree/main/config/charts#4-monitoring--tracing-configuration).
+
 ## Verification
 
 ### 1. Get the IP of the Proxy

--- a/guides/multimodal-serving/optimized-baseline/README.md
+++ b/guides/multimodal-serving/optimized-baseline/README.md
@@ -113,6 +113,8 @@ kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/multimodal/${GUIDE_NAME}/mo
 kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/recipes/modelserver/components/monitoring
 ```
 
+- To enable monitoring for the `llm-d-router`, refer to the [Router Monitoring & Tracing Configuration](https://github.com/llm-d/llm-d-router/tree/main/config/charts#4-monitoring--tracing-configuration).
+
 ---
 
 ## Verification

--- a/guides/optimized-baseline/README.md
+++ b/guides/optimized-baseline/README.md
@@ -174,6 +174,8 @@ kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/c
 kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/recipes/modelserver/components/monitoring
 ```
 
+- To enable monitoring for the `llm-d-router`, refer to the [Router Monitoring & Tracing Configuration](https://github.com/llm-d/llm-d-router/tree/main/config/charts#4-monitoring--tracing-configuration).
+
 ## Verification
 
 ### 1. Get the IP of the Proxy

--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -153,6 +153,8 @@ kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/g
 kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/recipes/modelserver/components/monitoring-pd
 ```
 
+* To enable monitoring for the `llm-d-router`, refer to the [Router Monitoring & Tracing Configuration](https://github.com/llm-d/llm-d-router/tree/main/config/charts#4-monitoring--tracing-configuration).
+
 ## Verification
 
 ### 1. Get the IP of the Proxy

--- a/guides/precise-prefix-cache-routing/README.md
+++ b/guides/precise-prefix-cache-routing/README.md
@@ -155,9 +155,8 @@ kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/g
   kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/recipes/modelserver/components/monitoring
   ```
 
-- To enable monitoring for the `llm-d-router`, refer to the [Router Monitoring & Tracing Configuration](https://github.com/llm-d/llm-d-router/tree/main/config/charts#4-monitoring--tracing-configuration).
-
-- Enable Prometheus scrape for the router by layering `-f ${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml` onto the helm command in step 2.
+- Enable Prometheus scrape for the router by layering `-f ${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml` onto the helm command in step 2. For the full set of monitoring & tracing options, see the
+  [Router Monitoring & Tracing Configuration](https://github.com/llm-d/llm-d-router/tree/main/config/charts#4-monitoring--tracing-configuration).
 
 ## Verification
 

--- a/guides/precise-prefix-cache-routing/README.md
+++ b/guides/precise-prefix-cache-routing/README.md
@@ -155,6 +155,8 @@ kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/g
   kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/recipes/modelserver/components/monitoring
   ```
 
+- To enable monitoring for the `llm-d-router`, refer to the [Router Monitoring & Tracing Configuration](https://github.com/llm-d/llm-d-router/tree/main/config/charts#4-monitoring--tracing-configuration).
+
 - Enable Prometheus scrape for the router by layering `-f ${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml` onto the helm command in step 2.
 
 ## Verification

--- a/guides/predicted-latency-routing/README.md
+++ b/guides/predicted-latency-routing/README.md
@@ -134,7 +134,9 @@ kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/optimized-baseline/modelser
 
 ### 3. Enable monitoring (optional)
 
-Follow [optimized-baseline → Enable monitoring](../optimized-baseline/README.md#3-enable-monitoring-optional) — the same steps apply since this guide reuses the same model server manifests.
+Follow [optimized-baseline → Enable monitoring](../optimized-baseline/README.md#3-optional-enable-monitoring) — the same steps apply since this guide reuses the same model server manifests.
+
+To enable monitoring for the `llm-d-router`, refer to the [Router Monitoring & Tracing Configuration](https://github.com/llm-d/llm-d-router/tree/main/config/charts#4-monitoring--tracing-configuration).
 
 ## Send Requests
 

--- a/guides/tiered-prefix-cache/README.md
+++ b/guides/tiered-prefix-cache/README.md
@@ -257,6 +257,8 @@ kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelse
 kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/recipes/modelserver/components/monitoring
 ```
 
+- To enable monitoring for the `llm-d-router`, refer to the [Router Monitoring & Tracing Configuration](https://github.com/llm-d/llm-d-router/tree/main/config/charts#4-monitoring--tracing-configuration).
+
 ---
 
 ## Verification

--- a/guides/wide-ep-lws/README.md
+++ b/guides/wide-ep-lws/README.md
@@ -124,6 +124,8 @@ kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/g
 kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/recipes/modelserver/components/monitoring-pd
 ```
 
+* To enable monitoring for the `llm-d-router`, refer to the [Router Monitoring & Tracing Configuration](https://github.com/llm-d/llm-d-router/tree/main/config/charts#4-monitoring--tracing-configuration).
+
 ### 4. (Optional) Topology Aware Scheduling (TAS)
 
 For information on how to use topology aware scheduling using Kueue, see [LWS + TAS user guide](https://lws.sigs.k8s.io/docs/examples/tas/). To deploy the guide with TAS enabled, use the following command:


### PR DESCRIPTION
 Previously, these guides focused exclusively on monitoring for model servers. This update provides users with a direct path to configure monitoring and tracing for the llm-d-router for metrics like prefix cache hit rate etc

  Changes
   - Added Router Monitoring Link: Integrated a reference to the Router Monitoring & Tracing Configuration (https://github.com/llm-d/llm-d-router/tree/main/config/charts#4-monitoring--tracing-configuration)
     in the following guides:
       - guides/optimized-baseline/README.md
       - guides/flow-control/README.md
       - guides/multimodal-serving/optimized-baseline/README.md
       - guides/pd-disaggregation/README.md
       - guides/precise-prefix-cache-routing/README.md
       - guides/tiered-prefix-cache/README.md
       - guides/wide-ep-lws/README.md
       - guides/predicted-latency-routing/README.md


  Fixes #1777