### PR TITLE
guides: add Envoy AI Gateway installation instructions

### DIFF
--- a/docs/api-reference/artifacts.md
+++ b/docs/api-reference/artifacts.md
@@ -37,7 +37,7 @@ llm-d Router is deployed via Helm. We offer a chart both Standalone and Gateway 
 | Chart | Version | OCI Registry | Description |
 |-------|---------|--------------|-------------|
 | **Standalone Mode** | v0 | `oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev` | Deploys an InferencePool and EPP with a standalone Envoy proxy as sidecar in EPP pod  |
-| **Gateway Mode** | v0 | `oci://ghcr.io/llm-d/charts/llm-d-router-gateway-dev` | Deploys an InferencePool and EPP for use with an existing Kubernetes Gateway (e.g. Istio, AgentGateway, GKE) |
+| **Gateway Mode** | v0 | `oci://ghcr.io/llm-d/charts/llm-d-router-gateway-dev` | Deploys an InferencePool and EPP for use with an existing Kubernetes Gateway (e.g. Istio, AgentGateway, Envoy AI Gateway, GKE) |
 
 The charts are currently published by the Gateway API Inference Extension (GAIE) project (see [standalone mode source](https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/config/charts/standalone) and [gateway mode source](https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/config/charts/inferencepool)). Each well-lit path guides provides values files on top of the chart defaults to enable the functionality implemented in EPP.
 

--- a/docs/architecture/core/router/README.md
+++ b/docs/architecture/core/router/README.md
@@ -8,7 +8,7 @@ The llm-d Router is composed of two primary functional parts:
 
 ### Proxy
 
-Any conformant industry-grade L7 proxy. The proxy handles the data plane, including connection management, TLS termination, and request forwarding. Supported implementations range from self-managed application load balancers (e.g., Istio, agentgateway) to compliant cloud-managed services, such as Google Cloud's Application Load Balancer.
+Any conformant industry-grade L7 proxy. The proxy handles the data plane, including connection management, TLS termination, and request forwarding. Supported implementations range from self-managed application load balancers (e.g., Istio, agentgateway, Envoy AI Gateway) to compliant cloud-managed services, such as Google Cloud's Application Load Balancer.
 
 See the [**Proxy deep dive**](proxy.md) to learn about deployment modes (Standalone vs. Gateway Mode), request flow, and Gateway API integration.
 

--- a/docs/architecture/core/router/proxy.md
+++ b/docs/architecture/core/router/proxy.md
@@ -167,7 +167,4 @@ llm-d provides [Gateway Mode deployment guides](../../../infrastructure/gateway/
 - [Istio](../../../infrastructure/gateway/istio.md)
 - [GKE Gateway](../../../infrastructure/gateway/gke.md)
 - [agentgateway](../../../infrastructure/gateway/agentgateway.md)
-- [Istio](../../../resources/gateway/istio.md)
-- [GKE Gateway](../../../resources/gateway/gke.md)
-- [agentgateway](../../../resources/gateway/agentgateway.md)
-- [Envoy AI Gateway](../../../resources/gateway/envoy-ai-gateway.md)
+- [Envoy AI Gateway](../../../infrastructure/gateway/envoy-ai-gateway.md)

--- a/docs/architecture/core/router/proxy.md
+++ b/docs/architecture/core/router/proxy.md
@@ -1,6 +1,6 @@
 # Proxy
 
-The proxy is the entry point for inference requests in llm-d Router, receiving client traffic and routing it to the optimal model server via the EPP. Supported implementations range from self-managed application load balancers (e.g., Istio, agentgateway) to compliant cloud-managed services, such as Google Cloud's Application Load Balancer. It supports two primary deployment modes: **Standalone Mode**, where a self-managed proxy runs alongside the EPP in the same pod, and **Gateway Mode**, which integrates with L7 load balancers via the Kubernetes Gateway API.
+The proxy is the entry point for inference requests in llm-d Router, receiving client traffic and routing it to the optimal model server via the EPP. Supported implementations range from self-managed application load balancers (e.g., Istio, agentgateway, Envoy AI Gateway) to compliant cloud-managed services, such as Google Cloud's Application Load Balancer. It supports two primary deployment modes: **Standalone Mode**, where a self-managed proxy runs alongside the EPP in the same pod, and **Gateway Mode**, which integrates with L7 load balancers via the Kubernetes Gateway API.
 
 ## Functionality
 
@@ -65,7 +65,7 @@ Gateway Mode, also known as the **Inference Gateway**, leverages the official Ku
 Gateway Mode is targeted at production environments that require:
 
 - **Shared Infrastructure**: A single, shared Gateway can host multiple HTTP/gRPC routes for both inference workloads (represented as `InferencePool`) and traditional applications (standard Kubernetes `Service` objects).
-- Integration with cloud-native L7 networking solutions (Istio, GKE Gateway, agentgateway).
+- Integration with cloud-native L7 networking solutions (Istio, GKE Gateway, agentgateway, Envoy AI Gateway).
 - Multi-cluster load balancing.
 - Advanced traffic management (weighted splitting, mirroring).
 - Exposure of endpoints to external workloads with robust control.
@@ -167,3 +167,7 @@ llm-d provides [Gateway Mode deployment guides](../../../infrastructure/gateway/
 - [Istio](../../../infrastructure/gateway/istio.md)
 - [GKE Gateway](../../../infrastructure/gateway/gke.md)
 - [agentgateway](../../../infrastructure/gateway/agentgateway.md)
+- [Istio](../../../resources/gateway/istio.md)
+- [GKE Gateway](../../../resources/gateway/gke.md)
+- [agentgateway](../../../resources/gateway/agentgateway.md)
+- [Envoy AI Gateway](../../../resources/gateway/envoy-ai-gateway.md)

--- a/docs/infrastructure/gateway/README.md
+++ b/docs/infrastructure/gateway/README.md
@@ -46,6 +46,7 @@ llm-d requires you select a [Gateway implementation that supports the Gateway AP
 * [GKE Gateway](./gke.md) - GKE's implementation of the Gateway API is through the GKE Gateway controller which provisions Google Cloud Load Balancers for Pods in GKE clusters. The GKE Gateway controller supports weighted traffic splitting, mirroring, advanced routing, multi-cluster load balancing and more. [Official GKE Docs](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/gateway-api).
 * [Istio](./istio.md) - Istio is an open source service mesh and gateway implementation. It provides a fully compliant implementation of the Kubernetes Gateway API for cluster ingress traffic control. [Official Istio docs](https://istio.io/)
 * [Agentgateway](./agentgateway.md) - Agentgateway is a high-performance, Rust-based AI gateway for LLM, MCP, and A2A workloads that can also serve as a Gateway API and Inference Gateway implementation. [Official Agentgateway docs](https://agentgateway.dev/).
+* [Envoy AI Gateway](./envoy-ai-gateway.md) - Envoy AI Gateway is an open source project for using Envoy Gateway to handle request traffic from application clients to GenAI services that can also serve as a Gateway API and Inference Gateway implementation. [Official Envoy AI Gateway docs](https://aigateway.envoyproxy.io/).
 
 ## Other Providers
 

--- a/docs/infrastructure/gateway/envoy-ai-gateway.md
+++ b/docs/infrastructure/gateway/envoy-ai-gateway.md
@@ -173,6 +173,7 @@ curl -X POST http://${IP}/v1/completions \
 ## Cleanup
 
 ```bash
+kubectl delete clienttrafficpolicy client-buffer-limit -n ${NAMESPACE}
 kubectl delete gateway llm-d-inference-gateway -n ${NAMESPACE}
 helm uninstall envoy-ai-gateway -n envoy-ai-gateway-system
 helm uninstall envoy-ai-gateway-crd -n envoy-ai-gateway-system

--- a/docs/infrastructure/gateway/envoy-ai-gateway.md
+++ b/docs/infrastructure/gateway/envoy-ai-gateway.md
@@ -1,0 +1,224 @@
+# Envoy AI Gateway
+
+This guide shows how to deploy llm-d with
+[Envoy AI Gateway](https://aigateway.envoyproxy.io/) as your inference gateway. By the
+end, inference requests will flow from an Envoy-managed `Gateway` to
+your model servers via the llm-d EPP.
+
+> [!NOTE]
+> This guide assumes familiarity with [Gateway API](https://gateway-api.sigs.k8s.io/) and llm-d.
+
+## Prerequisites
+
+1. The environment variables `${GUIDE_NAME}`, `${MODEL_NAME}` and `${NAMESPACE}` should be set as part of deploying one of the well-lit path guides.
+2. A Kubernetes cluster running one of the three most recent [Kubernetes releases](https://kubernetes.io/releases/) (minimum Kubernetes 1.32)
+3. [Helm](https://helm.sh/docs/intro/install/)
+4. [jq](https://jqlang.org/download/)
+
+## Step 1: Install Gateway API Inference Extension CRDs
+
+Envoy Gateway's Helm chart installs Gateway API CRDs automatically. Install only the Gateway API Inference Extension CRDs:
+
+```bash
+GAIE_VERSION=v1.5.0
+
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
+```
+
+Verify the APIs are available:
+
+```bash
+kubectl api-resources --api-group=inference.networking.k8s.io
+```
+
+## Step 2: Install Envoy AI Gateway
+
+Install Envoy Gateway with the AI Gateway integration values, token rate limiting add-on, and InferencePool add-on:
+
+```bash
+ENVOY_GATEWAY_VERSION=v1.8.1
+
+helm upgrade -i eg oci://docker.io/envoyproxy/gateway-helm \
+  --version ${ENVOY_GATEWAY_VERSION} \
+  --namespace envoy-gateway-system \
+  --create-namespace \
+  -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/main/manifests/envoy-gateway-values.yaml \
+  -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/main/examples/inference-pool/envoy-gateway-values-addon.yaml
+
+# Give permissions to Envoy Gateway to watch InferencePool resources
+kubectl apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: envoy-gateway-inference-access
+rules:
+- apiGroups:
+  - inference.networking.k8s.io
+  resources:
+  - inferencepools
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: envoy-gateway-inference-access
+subjects:
+- kind: ServiceAccount
+  name: envoy-gateway
+  namespace: envoy-gateway-system
+roleRef:
+  kind: ClusterRole
+  name: envoy-gateway-inference-access
+  apiGroup: rbac.authorization.k8s.io
+EOF
+
+kubectl wait --timeout=2m -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available
+```
+
+Install the Envoy AI Gateway CRDs and controller:
+
+```bash
+ENVOY_AI_GATEWAY_VERSION=v0.7.0
+
+helm upgrade -i envoy-ai-gateway-crd oci://docker.io/envoyproxy/ai-gateway-crds-helm \
+  --version ${ENVOY_AI_GATEWAY_VERSION} \
+  --namespace envoy-ai-gateway-system \
+  --create-namespace
+
+helm upgrade -i envoy-ai-gateway oci://docker.io/envoyproxy/ai-gateway-helm \
+  --version ${ENVOY_AI_GATEWAY_VERSION} \
+  --namespace envoy-ai-gateway-system \
+  --create-namespace
+
+kubectl wait --timeout=2m -n envoy-ai-gateway-system deployment/ai-gateway-controller --for=condition=Available
+```
+
+Create the GatewayClass
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: envoy-ai-gateway
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+EOF
+```
+
+Verify the installation:
+
+```bash
+kubectl get pods -n envoy-gateway-system
+kubectl get pods -n envoy-ai-gateway-system
+kubectl get gatewayclass envoy-ai-gateway
+```
+
+Expected output:
+
+```text
+NAME   CONTROLLER                                      ACCEPTED   AGE
+envoy-ai-gateway   gateway.envoyproxy.io/gatewayclass-controller   True       30s
+```
+
+## Step 3: Deploy the Gateway
+
+This deploys a gateway using the `envoy-ai-gateway` GatewayClass provided by Envoy Gateway:
+
+```bash
+kubectl apply -k ./guides/recipes/gateway/envoy-ai-gateway -n ${NAMESPACE}
+```
+
+Verify the `Gateway` is programmed:
+
+```bash
+kubectl get gateway llm-d-inference-gateway -n ${NAMESPACE}
+```
+
+Expected output:
+
+```text
+NAME                      CLASS   ADDRESS         PROGRAMMED   AGE
+llm-d-inference-gateway   envoy-ai-gateway    10.xx.xx.xx     True         30s
+```
+
+Wait until `PROGRAMMED` shows `True` before proceeding.
+
+## Step 4: Send a Request
+
+> [!IMPORTANT]
+> Before sending requests, you must deploy a well-lit path guide. This sets up a model server deployment, an `InferencePool`, and an `HTTPRoute` to connect the Gateway to the pool.
+
+Get the `Gateway` external address:
+
+```bash
+export IP=$(kubectl get gateway llm-d-inference-gateway -n ${NAMESPACE} -o jsonpath='{.status.addresses[0].value}')
+```
+
+Send an inference request via the managed `Gateway`:
+
+```bash
+curl -X POST http://${IP}/v1/completions \
+    -H 'Content-Type: application/json' \
+    -H 'X-Gateway-Base-Model-Name: '"$GUIDE_NAME"'' \
+    -d '{
+        "model": '\"${MODEL_NAME}\"',
+        "prompt": "How are you today?"
+    }' | jq
+```
+
+## Cleanup
+
+```bash
+kubectl delete gateway llm-d-inference-gateway -n ${NAMESPACE}
+helm uninstall envoy-ai-gateway -n envoy-ai-gateway-system
+helm uninstall envoy-ai-gateway-crd -n envoy-ai-gateway-system
+kubectl delete namespace envoy-ai-gateway-system
+helm uninstall eg -n envoy-gateway-system
+kubectl delete namespace envoy-gateway-system
+kubectl delete gatewayclass envoy-ai-gateway
+kubectl delete -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
+helm template eg oci://docker.io/envoyproxy/gateway-helm --version ${ENVOY_GATEWAY_VERSION} --include-crds | yq 'select(.kind == "CustomResourceDefinition")' | kubectl delete -f -
+```
+
+## Troubleshooting
+
+### Gateway not showing `PROGRAMMED=True`
+
+```bash
+kubectl describe gateway llm-d-inference-gateway -n ${NAMESPACE}
+kubectl get pods -n envoy-gateway-system
+kubectl logs -n envoy-gateway-system deployment/envoy-gateway --tail=20
+```
+
+Verify the `envoy-ai-gateway` `GatewayClass` is present and accepted:
+
+```bash
+kubectl get gatewayclass envoy-ai-gateway
+```
+
+Also check the Envoy AI Gateway controller is running:
+
+```bash
+kubectl get pods -n envoy-ai-gateway-system
+kubectl logs -n envoy-ai-gateway-system deployment/ai-gateway-controller --tail=20
+```
+
+### HTTPRoute not accepted
+
+```bash
+kubectl describe httproute ${GUIDE_NAME} -n ${NAMESPACE}
+```
+
+Verify that `parentRefs` matches the Gateway name and `backendRefs` matches the InferencePool name.
+
+### No response from Gateway IP
+
+```bash
+kubectl get gateway llm-d-inference-gateway -n ${NAMESPACE} -o jsonpath='{.status.addresses[0].value}'
+```
+
+If the address is empty, your Gateway may still be waiting for a LoadBalancer service. Check that your cluster supports external load balancers.

--- a/docs/infrastructure/gateway/envoy-ai-gateway.md
+++ b/docs/infrastructure/gateway/envoy-ai-gateway.md
@@ -15,21 +15,9 @@ your model servers via the llm-d EPP.
 3. [Helm](https://helm.sh/docs/intro/install/)
 4. [jq](https://jqlang.org/download/)
 
-## Step 1: Install Gateway API Inference Extension CRDs
+## Step 1: Install Gateway API and Gateway API Inference Extension CRDs
 
-Envoy Gateway's Helm chart installs Gateway API CRDs automatically. Install only the Gateway API Inference Extension CRDs:
-
-```bash
-GAIE_VERSION=v1.5.0
-
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
-```
-
-Verify the APIs are available:
-
-```bash
-kubectl api-resources --api-group=inference.networking.k8s.io
-```
+Install the required CRDs by following the [CRD installation guide](./install-crds.md).
 
 ## Step 2: Install Envoy AI Gateway
 
@@ -38,10 +26,23 @@ Install Envoy Gateway with the AI Gateway integration values, token rate limitin
 ```bash
 ENVOY_GATEWAY_VERSION=v1.8.1
 
+# Install the CRDs first, skipping the Gateway API CRDs installed in the previous step.
+# 
+# Note 1: We’re using helm template piped into kubectl apply instead of helm install due to aknown Helm limitation related
+# to large CRDs in the templates/ directory: https://github.com/helm/helm/pull/12277
+# Note 2: We filter the output of the Helm template to remove offending lines until this is fixed: https://github.com/helm/helm/pull/32217
+helm template eg-crds oci://docker.io/envoyproxy/gateway-crds-helm \
+  --version ${ENVOY_GATEWAY_VERSION} \
+  --set crds.gatewayAPI.enabled=false \
+  --set crds.envoyGateway.enabled=true \
+  | grep -v '^Pulled:' | grep -v '^Digest:' | kubectl apply --server-side -f -
+
+# Install Envoy gateway
 helm upgrade -i eg oci://docker.io/envoyproxy/gateway-helm \
   --version ${ENVOY_GATEWAY_VERSION} \
   --namespace envoy-gateway-system \
   --create-namespace \
+  --skip-crds \
   -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/main/manifests/envoy-gateway-values.yaml \
   -f https://raw.githubusercontent.com/envoyproxy/ai-gateway/main/examples/inference-pool/envoy-gateway-values-addon.yaml
 
@@ -126,10 +127,16 @@ envoy-ai-gateway   gateway.envoyproxy.io/gatewayclass-controller   True       30
 
 ## Step 3: Deploy the Gateway
 
-This deploys a gateway using the `envoy-ai-gateway` GatewayClass provided by Envoy Gateway:
+Set the llm-d version to match your deployment:
 
 ```bash
-kubectl apply -k ./guides/recipes/gateway/envoy-ai-gateway -n ${NAMESPACE}
+LLM_D_VERSION=main  # Use 'main' for latest, or a release tag like 'v0.7.0'
+```
+
+This deploys a gateway suitable for `envoy-ai-gateway`, using the `envoy-ai-gateway` gateway class. This is the preferred self-installed inference gateway recipe in llm-d.
+
+```bash
+kubectl apply -k "https://github.com/llm-d/llm-d/guides/recipes/gateway/envoy-ai-gateway?ref=${LLM_D_VERSION}" -n ${NAMESPACE}
 ```
 
 Verify the `Gateway` is programmed:
@@ -180,10 +187,15 @@ helm uninstall envoy-ai-gateway-crd -n envoy-ai-gateway-system
 kubectl delete namespace envoy-ai-gateway-system
 helm uninstall eg -n envoy-gateway-system
 kubectl delete namespace envoy-gateway-system
+helm template eg-crds oci://docker.io/envoyproxy/gateway-crds-helm \
+  --version ${ENVOY_GATEWAY_VERSION} \
+  --set crds.gatewayAPI.enabled=false \
+  --set crds.envoyGateway.enabled=true \
+  | grep -v '^Pulled:' | grep -v '^Digest:' | kubectl delete -f -
 kubectl delete gatewayclass envoy-ai-gateway
-kubectl delete -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
-helm template eg oci://docker.io/envoyproxy/gateway-helm --version ${ENVOY_GATEWAY_VERSION} --include-crds | yq 'select(.kind == "CustomResourceDefinition")' | kubectl delete -f -
 ```
+
+To uninstall the Gateway API and Gateway API Inference Extension CRDs, see the [CRD installation guide](./install-crds.md#uninstalling-gateway-api-crds).
 
 ## Troubleshooting
 

--- a/guides/recipes/gateway/README.md
+++ b/guides/recipes/gateway/README.md
@@ -8,6 +8,8 @@ This directory contains recipes for deploying a `Gateway` called `llm-d-inferenc
 > [!WARNING]
 > The `kgateway` and `kgateway-openshift` recipes are deprecated in llm-d and will be removed in the next release. Prefer `agentgateway` for new self-installed inference deployments. These recipes are retained only to support migrations during the current release.
 
+Available recipes: `agentgateway`, `envoy-ai-gateway`, `istio`, `gke-l7-rilb`, `gke-l7-regional-external-managed`.
+
 A `Gateway` can be deployed with:
 
 ```bash

--- a/guides/recipes/gateway/envoy-ai-gateway/client-traffic-policy.yaml
+++ b/guides/recipes/gateway/envoy-ai-gateway/client-traffic-policy.yaml
@@ -1,0 +1,13 @@
+# By default, Envoy Gateway sets the buffer limit to 32kiB which is not sufficient for AI workloads.
+# This ClientTrafficPolicy sets the buffer limit to 50MiB as an example.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: client-buffer-limit
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: llm-d-inference-gateway
+  connection:
+    bufferLimit: 50Mi

--- a/guides/recipes/gateway/envoy-ai-gateway/gateway.yaml
+++ b/guides/recipes/gateway/envoy-ai-gateway/gateway.yaml
@@ -1,0 +1,6 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: llm-d-inference-gateway
+spec:
+  gatewayClassName: envoy-ai-gateway

--- a/guides/recipes/gateway/envoy-ai-gateway/kustomization.yaml
+++ b/guides/recipes/gateway/envoy-ai-gateway/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - path: gateway.yaml
+    target:
+      kind: Gateway

--- a/guides/recipes/gateway/envoy-ai-gateway/kustomization.yaml
+++ b/guides/recipes/gateway/envoy-ai-gateway/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - client-traffic-policy.yaml
 patches:
   - path: gateway.yaml
     target:

--- a/guides/recipes/router/README.md
+++ b/guides/recipes/router/README.md
@@ -21,7 +21,7 @@ helm install <release-name> \
 
 ## With Kubernetes Gateway API
 
-Use this when you want to route traffic through a proxy managed by the Kubernetes Gateway API (e.g., GKE Gateway, Istio, , Envoy AI Gateway). This requires:
+Use this when you want to route traffic through a proxy managed by the Kubernetes Gateway API (e.g., GKE Gateway, Istio, Agentgateway, Envoy AI Gateway). This requires:
 
 1. A Gateway control plane installed (see [prereq/gateway-provider](../../../docs/infrastructure/gateway/README.md))
 2. Creating a Gateway resource (see [recipes/gateway](../gateway/))

--- a/guides/recipes/router/README.md
+++ b/guides/recipes/router/README.md
@@ -21,7 +21,7 @@ helm install <release-name> \
 
 ## With Kubernetes Gateway API
 
-Use this when you want to route traffic through a proxy managed by the Kubernetes Gateway API (e.g., GKE Gateway, Istio, Agentgateway). This requires:
+Use this when you want to route traffic through a proxy managed by the Kubernetes Gateway API (e.g., GKE Gateway, Istio, , Envoy AI Gateway). This requires:
 
 1. A Gateway control plane installed (see [prereq/gateway-provider](../../../docs/infrastructure/gateway/README.md))
 2. Creating a Gateway resource (see [recipes/gateway](../gateway/))


### PR DESCRIPTION
Adds a guide explaining how to install [Envoy AI Gateway](https://aigateway.envoyproxy.io/)