### PR TITLE
fix: xpu rdma deviceclass name

### DIFF
--- a/docs/getting-started/accelerators.md
+++ b/docs/getting-started/accelerators.md
@@ -70,7 +70,7 @@ For cluster prerequisites, ensure you have the [Intel Resource Drivers for Kuber
 
 For P/D disaggregation with RDMA-accelerated KV-cache transfer on Intel XPU, the following additional prerequisites apply:
 
-- An RDMA DRA driver exposing the `rdma-dranet` device class (e.g., [rdma-dranet](https://github.com/k8snetworkplumbingwg/rdma-dra-driver)).
+- An RDMA DRA driver exposing the `dranet-rdma` device class (e.g., [Intel Network Operator for Kubernetes](https://github.com/intel/network-operator)).
 - GPU-NIC PCIe alignment for optimal transfer performance.
 - UCX transport configured with `ib,rc,ze_copy`.
 

--- a/guides/pd-disaggregation/modelserver/xpu/vllm-rdma/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/xpu/vllm-rdma/kustomization.yaml
@@ -28,7 +28,7 @@ patches:
                   count: 1
               - name: nic
                 exactly:
-                  deviceClassName: rdma-dranet
+                  deviceClassName: dranet-rdma
                   count: 1
                   selectors:
                     - cel:
@@ -54,7 +54,7 @@ patches:
                   count: 1
               - name: nic
                 exactly:
-                  deviceClassName: rdma-dranet
+                  deviceClassName: dranet-rdma
                   count: 1
                   selectors:
                     - cel:


### PR DESCRIPTION
- Add reference to Intel Network Operator instead of deprecated rdma driver repo
- Change DRA DeviceClass name to default set by Intel Network Operator 

Fixes: #1754 