### PR TITLE
change tiered-prefix-cache guide to use vllm v0.23.0

### DIFF
--- a/guides/tiered-prefix-cache/modelserver/gpu/vllm/base/kustomization-gpt-oss-120b.yaml
+++ b/guides/tiered-prefix-cache/modelserver/gpu/vllm/base/kustomization-gpt-oss-120b.yaml
@@ -9,7 +9,7 @@ namePrefix: optimized-baseline-
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: vllm/vllm-openai
-    newTag: v0.22.0
+    newTag: v0.23.0
 
 labels:
   - pairs:

--- a/guides/tiered-prefix-cache/modelserver/gpu/vllm/base/kustomization.yaml
+++ b/guides/tiered-prefix-cache/modelserver/gpu/vllm/base/kustomization.yaml
@@ -8,7 +8,7 @@ namePrefix: gpu-vllm-
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: vllm/vllm-openai
-    newTag: v0.22.0
+    newTag: v0.23.0
 
 
 labels:


### PR DESCRIPTION
Moving to 0.23.0 to take advantage of a number of recent vllm multi tier PRs.