### PR TITLE
Add v6 recipe for Tiered Prefix Cache.

### DIFF
--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-tpu-vllm-native.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-tpu-vllm-native.yaml
@@ -81,7 +81,7 @@ jobs:
       standup_scenario: ${{ inputs.standup_scenario || 'tiered-prefix-cache' }}
       decode_pods: ${{ inputs.decode_pods || 'auto' }}
       prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
-      accelerator_type: ${{ inputs.accelerator_type || 'tpu-v6' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'tpu/v6' }}
       backend_type: ${{ inputs.backend_type || 'vllm' }}
       infra_provider: ${{ inputs.infra_provider || '' }}
       offloading_target: ${{ inputs.offloading_target || 'cpu' }}
@@ -102,6 +102,9 @@ jobs:
       cleanup: ${{ inputs.cleanup || 'true' }}
       tpu_chips: ${{ inputs.tpu_chips || '16' }}
       tpu_topology: ${{ inputs.tpu_topology || '2x4' }}
+      data_access_timeout: '3600'
+      wait_timeout: '3600'
+      job_timeout: '3600s'
     secrets: inherit
 
   update-badge:

--- a/guides/tiered-prefix-cache/README.md
+++ b/guides/tiered-prefix-cache/README.md
@@ -73,7 +73,7 @@ Generally multiple cache tiers can be applied ordered by their cache read/write 
 | vLLM Native OffloadingConnector | CPU RAM + Filesystem (shared storage) | `modelserver/gpu/vllm/native/fs/` |
 | LMCache Connector | CPU RAM | `modelserver/gpu/vllm/lmcache-connector/cpu/` |
 | LMCache Connector | Filesystem (shared storage) | `modelserver/gpu/vllm/lmcache-connector/fs/` |
-| TPU KVCache Connector | CPU RAM | `modelserver/tpu-v7/vllm/tpu-offloading-connector/` |
+| TPU KVCache Connector | CPU RAM | `modelserver/tpu/v6/vllm/native/tpu-offloading-connector/` and `modelserver/tpu/v7/vllm/native/tpu-offloading-connector/` |
 | SGLang HiCache | CPU RAM | `modelserver/gpu/sglang/native/cpu/` |
 
 <details>
@@ -144,7 +144,7 @@ For advanced configuration options and implementation details, see the [llm-d FS
 | GPU Accelerator           | NVIDIA H100                                             |
 | CPU Cache Offload Size    | 100 GB          
 
-This guide supports both GPU and TPU. The Kustomize overlays are available in `modelserver/gpu/vllm/` and `modelserver/tpu-v7/vllm/`.
+This guide supports both GPU and TPU. The Kustomize overlays are available in `modelserver/gpu/vllm/` and `modelserver/tpu/` (supporting both v6 and v7).
 
 ---
 
@@ -257,15 +257,10 @@ envsubst < ${REPO_ROOT}/guides/tiered-prefix-cache/manifests/pvc.yaml | kubectl 
 
 ```bash
 export CONNECTOR=native  # native | lmcache-connector
-export VARIANT=fs        # fs
+export VARIANT=cpu        # cpu | fs
 export INFRA_PROVIDER=base  # base | gke
-kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/gpu/vllm/${CONNECTOR}/${VARIANT}/${INFRA_PROVIDER}/
-```
-
-**For Google TPU v7:**
-
-```bash
-kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/tpu-v7/vllm/tpu-offloading-connector/
+export ACCELERATOR=gpu # gpu | tpu/v6 | tpu/v7
+kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/${ACCELERATOR}/vllm/${CONNECTOR}/${VARIANT}/${INFRA_PROVIDER}/
 ```
 
 > [!NOTE]

--- a/guides/tiered-prefix-cache/modelserver/tpu/base/vllm/kustomization.yaml
+++ b/guides/tiered-prefix-cache/modelserver/tpu/base/vllm/kustomization.yaml
@@ -3,8 +3,6 @@ kind: Kustomization
 resources:
   - ../../../../../recipes/modelserver/base/single-host/default
 
-namePrefix: tpu-v7-vllm-
-
 labels:
   - pairs:
       llm-d.ai/model: Qwen3-32B

--- a/guides/tiered-prefix-cache/modelserver/tpu/base/vllm/patch-vllm.yaml
+++ b/guides/tiered-prefix-cache/modelserver/tpu/base/vllm/patch-vllm.yaml
@@ -9,9 +9,6 @@ spec:
       labels:
         llm-d.ai/inference-serving: "true"
     spec:
-      nodeSelector:
-        cloud.google.com/gke-tpu-accelerator: tpu7x
-        cloud.google.com/gke-tpu-topology: 2x2x1 # Specify the physical topology for the TPU slice.
       initContainers:
         - name: tpu-node-setup
           image: busybox
@@ -41,7 +38,8 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
-              vllm serve Qwen/Qwen3-32B \
+              exec vllm serve \
+                Qwen/Qwen3-32B \
                 --kv-transfer-config '{"kv_connector":"TPUOffloadConnector","kv_connector_module_path":"tpu_inference.offload.tpu_offload_connector","kv_role":"kv_both"}' \
                 --port 8000 \
                 --tensor-parallel-size 8 \
@@ -60,11 +58,6 @@ spec:
               value: "25000"
             - name: TPU_OFFLOAD_NUM_STAGING_BLOCKS
               value: "1000"
-          resources:
-            requests:
-              google.com/tpu: 4
-            limits:
-              google.com/tpu: 4
           startupProbe:
             initialDelaySeconds: 15
             periodSeconds: 30

--- a/guides/tiered-prefix-cache/modelserver/tpu/v6/vllm/native/cpu/kustomization.yaml
+++ b/guides/tiered-prefix-cache/modelserver/tpu/v6/vllm/native/cpu/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../base/vllm
+
+namePrefix: tpu-v6-vllm-
+
+patches:
+  - path: patch-vllm.yaml

--- a/guides/tiered-prefix-cache/modelserver/tpu/v6/vllm/native/cpu/patch-vllm.yaml
+++ b/guides/tiered-prefix-cache/modelserver/tpu/v6/vllm/native/cpu/patch-vllm.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
+        cloud.google.com/gke-tpu-topology: "2x4"
+      containers:
+        - name: modelserver
+          resources:
+            requests:
+              google.com/tpu: "8"
+            limits:
+              google.com/tpu: "8"

--- a/guides/tiered-prefix-cache/modelserver/tpu/v7/vllm/native/cpu/kustomization.yaml
+++ b/guides/tiered-prefix-cache/modelserver/tpu/v7/vllm/native/cpu/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../base/vllm
+
+namePrefix: tpu-v7-vllm-
+
+patches:
+  - path: patch-vllm.yaml

--- a/guides/tiered-prefix-cache/modelserver/tpu/v7/vllm/native/cpu/patch-vllm.yaml
+++ b/guides/tiered-prefix-cache/modelserver/tpu/v7/vllm/native/cpu/patch-vllm.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x2x1
+      containers:
+        - name: modelserver
+          resources:
+            requests:
+              google.com/tpu: 4
+            limits:
+              google.com/tpu: 4


### PR DESCRIPTION
Currently nightly benchmarks is using v-6, which is not available causing tests to fail.