### PR TITLE
[Multimodal]: fix path references in optimized baseline guide

### DIFF
--- a/docs/workloads/multimodal-serving.md
+++ b/docs/workloads/multimodal-serving.md
@@ -84,14 +84,6 @@ EPP continuously probes each endpoints' metrics by scraping `/metrics` at a regu
 
 ---
 
-### Multimodal Embedding (vision encoder) cache aware routing
-
-EPP can optimize routing for multimodal requests by considering the state of the multimodal embeddings cache (e.g., vision encoder cache) on serving endpoints. This ensures that requests with large multimodal inputs (like images or videos) are routed to endpoints that likely already have those embeddings cached, significantly reducing latency and computation.
-
-Refer to the [llm-d-router docs](https://github.com/llm-d/llm-d-router/blob/main/pkg/epp/framework/plugins/scheduling/scorer/mmcacheaffinity/README.md) for more details.
-
----
-
 ## Further Reading
 
 * See [Optimized Baseline](../well-lit-paths/optimized-baseline.md) for details on text-based scheduling and general load-balancing.

--- a/docs/workloads/multimodal-serving.md
+++ b/docs/workloads/multimodal-serving.md
@@ -84,6 +84,14 @@ EPP continuously probes each endpoints' metrics by scraping `/metrics` at a regu
 
 ---
 
+### Multimodal Embedding (vision encoder) cache aware routing
+
+EPP can optimize routing for multimodal requests by considering the state of the multimodal embeddings cache (e.g., vision encoder cache) on serving endpoints. This ensures that requests with large multimodal inputs (like images or videos) are routed to endpoints that likely already have those embeddings cached, significantly reducing latency and computation.
+
+Refer to the [llm-d-router docs](https://github.com/llm-d/llm-d-router/blob/main/pkg/epp/framework/plugins/scheduling/scorer/mmcacheaffinity/README.md) for more details.
+
+---
+
 ## Further Reading
 
 * See [Optimized Baseline](../well-lit-paths/optimized-baseline.md) for details on text-based scheduling and general load-balancing.

--- a/guides/multimodal-serving/optimized-baseline/README.md
+++ b/guides/multimodal-serving/optimized-baseline/README.md
@@ -76,7 +76,7 @@ Deploy the llm-d Router in **Standalone Mode** overlaying router custom configur
 helm install ${GUIDE_NAME} \
     oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev \
     -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
-    -f ${REPO_ROOT}/guides/multimodal/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
+    -f ${REPO_ROOT}/guides/multimodal-serving/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
     -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
 ```
 
@@ -93,7 +93,7 @@ export PROVIDER_NAME=gke # options: none, gke, agentgateway, istio
 helm install ${GUIDE_NAME} \
     oci://ghcr.io/llm-d/charts/llm-d-router-gateway-dev  \
     -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
-    -f ${REPO_ROOT}/guides/multimodal/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
+    -f ${REPO_ROOT}/guides/multimodal-serving/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
     --set provider.name=${PROVIDER_NAME} \
     --set httpRoute.create=true \
     --set httpRoute.inferenceGatewayName=llm-d-inference-gateway \
@@ -108,7 +108,7 @@ Apply the Kustomize overlays for your specific backend (defaulting to NVIDIA GPU
 
 ```bash
 export INFRA_PROVIDER=gke # base | gke
-kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/multimodal/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}/
+kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/multimodal-serving/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}/
 ```
 
 ### 3. (Optional) Enable monitoring
@@ -187,7 +187,7 @@ curl -X POST http://${IP}/v1/chat/completions \
 To tear down and clean up all deployed resources:
 ```bash
 helm uninstall ${GUIDE_NAME} -n ${NAMESPACE}
-kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/multimodal/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}/
+kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/multimodal-serving/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}/
 kubectl delete namespace ${NAMESPACE}
 ```
 


### PR DESCRIPTION
### Summary
This PR fixes incorrect file path references in the multimodal serving guide and adds documentation for the new multimodal embedding (vision encoder) cache-aware routing feature in EPP.

### Changes
- **Documentation**: Added a section explaining "Multimodal Embedding (vision encoder) cache-aware routing", detailing how EPP optimizes routing by considering cached embeddings on serving endpoints.
- **Guide Updates**: Corrected path references in the optimized baseline guide, changing `guides/multimodal/` to `guides/multimodal-serving/` to align with the repository structure.

### Fixes
Fixes #1784
