### PR TITLE
Benchmark dynamic model

### DIFF
--- a/guides/optimized-baseline/README.md
+++ b/guides/optimized-baseline/README.md
@@ -253,6 +253,7 @@ export IP=$(kubectl get gateway llm-d-inference-gateway  -n ${NAMESPACE} -o json
 </details>
 
 ```bash
+export MODEL=${MODEL:-Qwen/Qwen3-32B}   # defaults to Qwen/Qwen3-32B; override for other stacks (Intel XPU overlay uses Qwen/Qwen3-0.6B)
 envsubst < guide.yaml > config.yaml
 ./run_only.sh -c config.yaml -o ./results
 ```

--- a/guides/optimized-baseline/benchmark-templates/guide.yaml
+++ b/guides/optimized-baseline/benchmark-templates/guide.yaml
@@ -1,6 +1,6 @@
 endpoint:
   stack_name: &stack_name inf-scheduling-Qwen3-32B  # user defined name for the stack (results prefix)
-  model: &model Qwen/Qwen3-32B        # Exact HuggingFace model name. Must match stack deployed.
+  model: &model ${MODEL}              # HuggingFace model name (set via 'export MODEL=...'). Must match stack deployed.
   namespace: &namespace ${NAMESPACE}  # Namespace where stack is deployed
   base_url: &url http://${IP}  # Base URL of inference endpoint
   hf_token_secret: llm-d-hf-token     # The name of secret that contains the HF token of the stack

--- a/guides/optimized-baseline/benchmark-templates/guidellm.yaml
+++ b/guides/optimized-baseline/benchmark-templates/guidellm.yaml
@@ -1,6 +1,6 @@
 endpoint:
   stack_name: &stack_name optimized-baseline-Qwen3-32B  # user defined name for the stack (results prefix)
-  model: &model Qwen/Qwen3-32B       # Exact HuggingFace model name. Must match stack deployed.
+  model: &model ${MODEL}             # HuggingFace model name (set via 'export MODEL=...'). Must match stack deployed.
   namespace: &namespace ${NAMESPACE}  # Namespace where stack is deployed
   base_url: &url http://${IP}  # Base URL of inference endpoint
   hf_token_secret: llm-d-hf-token     # The name of secret that contains the HF token of the stack

--- a/guides/optimized-baseline/benchmark-templates/sanity.yaml
+++ b/guides/optimized-baseline/benchmark-templates/sanity.yaml
@@ -1,6 +1,6 @@
 endpoint:
   stack_name: &stack_name optimized-baseline-Qwen3-32B  # user defined name for the stack (results prefix)
-  model: &model Qwen/Qwen3-32B       # Exact HuggingFace model name. Must match stack deployed.
+  model: &model ${MODEL}             # HuggingFace model name (set via 'export MODEL=...'). Must match stack deployed.
   namespace: &namespace ${NAMESPACE}  # Namespace where stack is deployed
   base_url: &url http://${IP}  # Base URL of inference endpoint
   hf_token_secret: llm-d-hf-token     # The name of secret that contains the HF token of the stack

--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -217,6 +217,7 @@ curl -LJO "https://raw.githubusercontent.com/llm-d/llm-d/main/guides/pd-disaggre
 ### 3. Execute Benchmark
 
 ```bash
+export MODEL=${MODEL:-openai/gpt-oss-120b}   # defaults to openai/gpt-oss-120b; override for other stacks
 envsubst < 20_1_isl_osl.yaml > config.yaml
 ./run_only.sh -c config.yaml -o ./results
 ```

--- a/guides/pd-disaggregation/README.tpu.md
+++ b/guides/pd-disaggregation/README.tpu.md
@@ -71,6 +71,7 @@ curl -LJO "https://raw.githubusercontent.com/llm-d/llm-d/main/guides/pd-disaggre
 ### 3. Execute Benchmark
 
 ```bash
+export MODEL=${MODEL:-Qwen/Qwen3.5-397B-A17B-FP8}   # defaults to Qwen/Qwen3.5-397B-A17B-FP8; override for other stacks
 envsubst < tpu_v7_qwen3_5.yaml > config.yaml
 ./run_only.sh -c config.yaml -o ./results
 ```

--- a/guides/pd-disaggregation/benchmark-templates/20_1_isl_osl.yaml
+++ b/guides/pd-disaggregation/benchmark-templates/20_1_isl_osl.yaml
@@ -1,6 +1,6 @@
 endpoint:
   stack_name: &stack_name pd-gpt-oss-120b   # user defined name for the stack (results prefix)
-  model: &model openai/gpt-oss-120b         # Exact HuggingFace model name. Must match stack deployed.
+  model: &model ${MODEL}                    # HuggingFace model name (set via 'export MODEL=...'). Must match stack deployed.
   namespace: &namespace ${NAMESPACE}        # Namespace where stack is deployed
   base_url: &url http://${IP}               # Base URL of inference endpoint
   hf_token_secret: llm-d-hf-token           # The name of secret that contains the HF token of the stack

--- a/guides/pd-disaggregation/benchmark-templates/tpu_v7_qwen3_5.yaml
+++ b/guides/pd-disaggregation/benchmark-templates/tpu_v7_qwen3_5.yaml
@@ -1,6 +1,6 @@
 endpoint:
   stack_name: &stack_name tpu-v7-qwen3-5-pd   # user defined name for the stack (results prefix)
-  model: &model Qwen/Qwen3.5-397B-A17B-FP8         # Exact HuggingFace model name. Must match stack deployed.
+  model: &model ${MODEL}                           # HuggingFace model name (set via 'export MODEL=...'). Must match stack deployed.
   namespace: &namespace ${NAMESPACE}        # Namespace where stack is deployed
   base_url: &url http://${IP}               # Base URL of inference endpoint
   hf_token_secret: llm-d-hf-token           # The name of secret that contains the HF token of the stack

--- a/guides/precise-prefix-cache-routing/README.md
+++ b/guides/precise-prefix-cache-routing/README.md
@@ -218,6 +218,7 @@ curl -LJO "https://raw.githubusercontent.com/llm-d/llm-d/main/guides/precise-pre
 
 ```bash
 export IP=$(kubectl get service ${GUIDE_NAME}-epp -n ${NAMESPACE} -o jsonpath='{.spec.clusterIP}')
+export MODEL=${MODEL:-Qwen/Qwen3-32B}   # defaults to Qwen/Qwen3-32B; override for other stacks (Intel XPU overlay uses Qwen/Qwen3-0.6B)
 envsubst < guide.yaml > config.yaml
 ./run_only.sh -c config.yaml -o ./results
 ```

--- a/guides/precise-prefix-cache-routing/benchmark-templates/guide.yaml
+++ b/guides/precise-prefix-cache-routing/benchmark-templates/guide.yaml
@@ -1,6 +1,6 @@
 endpoint:
   stack_name: &stack_name precise-guide-Qwen3-32B  # user defined name for the stack (results prefix)
-  model: &model Qwen/Qwen3-32B        # Exact HuggingFace model name. Must match stack deployed.
+  model: &model ${MODEL}              # HuggingFace model name (set via 'export MODEL=...'). Must match stack deployed.
   namespace: &namespace ${NAMESPACE}  # Namespace where stack is deployed
   base_url: &url http://${IP}  # Base URL of inference endpoint
   hf_token_secret: llm-d-hf-token     # The name of secret that contains the HF token of the stack

--- a/guides/precise-prefix-cache-routing/benchmark-templates/guidellm.yaml
+++ b/guides/precise-prefix-cache-routing/benchmark-templates/guidellm.yaml
@@ -1,6 +1,6 @@
 endpoint:
   stack_name: &stack_name precise-Qwen3-32B  # user defined name for the stack (results prefix)
-  model: &model Qwen/Qwen3-32B       # Exact HuggingFace model name. Must match stack deployed.
+  model: &model ${MODEL}             # HuggingFace model name (set via 'export MODEL=...'). Must match stack deployed.
   namespace: &namespace ${NAMESPACE}  # Namespace where stack is deployed
   base_url: &url http://${IP}  # Base URL of inference endpoint
   hf_token_secret: llm-d-hf-token     # The name of secret that contains the HF token of the stack

--- a/guides/precise-prefix-cache-routing/benchmark-templates/sanity.yaml
+++ b/guides/precise-prefix-cache-routing/benchmark-templates/sanity.yaml
@@ -1,6 +1,6 @@
 endpoint:
   stack_name: &stack_name precise-Qwen3-32B  # user defined name for the stack (results prefix)
-  model: &model Qwen/Qwen3-32B       # Exact HuggingFace model name. Must match stack deployed.
+  model: &model ${MODEL}             # HuggingFace model name (set via 'export MODEL=...'). Must match stack deployed.
   namespace: &namespace ${NAMESPACE}  # Namespace where stack is deployed
   base_url: &url http://${IP}  # Base URL of inference endpoint
   hf_token_secret: llm-d-hf-token     # The name of secret that contains the HF token of the stack

--- a/helpers/benchmark.md
+++ b/helpers/benchmark.md
@@ -49,6 +49,7 @@ This helper describes how to run benchmarks against a deployed llm-d stack.
   ```bash
   export NAMESPACE="<your namespace>"
   export BENCHMARK_PVC="<name of your PVC>"
+  export MODEL=${MODEL:-Qwen/Qwen3-32B}   # defaults to Qwen/Qwen3-32B; set to the model your stack serves
   export LLMD_ROOT_DIR=../..   # where you cloned llm-d/llm-d
   ```
 
@@ -178,7 +179,7 @@ This helper describes how to run benchmarks against a deployed llm-d stack.
 Check your env:
 
   ```bash
-  echo "Using NAMESPACE=${NAMESPACE:?Missing}, GATEWAY_SVC=${GATEWAY_SVC:?Missing}, BENCHMARK_PVC=${BENCHMARK_PVC:?Missing}, BENCHMARK_TEMPLATE=${BENCHMARK_TEMPLATE:?Missing}"
+  echo "Using NAMESPACE=${NAMESPACE:?Missing}, MODEL=${MODEL}, GATEWAY_SVC=${GATEWAY_SVC:?Missing}, BENCHMARK_PVC=${BENCHMARK_PVC:?Missing}, BENCHMARK_TEMPLATE=${BENCHMARK_TEMPLATE:?Missing}"
   ```
 
 ## Run
@@ -856,12 +857,12 @@ The configuration is divided into sections, each with a different scope.
 
 ### Endpoint
 
-These are the properties of the stack (`envsubst` would replace `NAMESPACE` and `GATEWAY_SVC` to match your env). Gated models need a Hugging Face token to access. Your stack should already have a token secret under the name `llm-d-hf-token`. `stack_name` is a user-defined arbitrary name that will be attached to the benchmark results. You can use `stack_name` to help you identify the results of different experiments. The `model` must match your stack. Please note the `yaml` tags -- other section of this `yaml` reference them (e.g., the tokenizer reference the model).
+These are the properties of the stack (`envsubst` would replace `NAMESPACE`, `GATEWAY_SVC`, and `MODEL` to match your env). Gated models need a Hugging Face token to access. Your stack should already have a token secret under the name `llm-d-hf-token`. `stack_name` is a user-defined arbitrary name that will be attached to the benchmark results. You can use `stack_name` to help you identify the results of different experiments. The `model` is taken from the `MODEL` environment variable and must match your stack. Please note the `yaml` tags -- other section of this `yaml` reference them (e.g., the tokenizer reference the model).
 
   ```yaml
   endpoint:
     stack_name: &stack_name optimized-baseline-Qwen3-32B  # user defined name for the stack (results prefix)
-    model: &model Qwen/Qwen3-32B                      # Exact HuggingFace model name. Must match stack deployed.
+    model: &model ${MODEL}                            # HuggingFace model name (set via 'export MODEL=...'). Must match stack deployed.
     namespace: &namespace $NAMESPACE
     base_url: &url http://${GATEWAY_SVC}.${NAMESPACE}.svc.cluster.local:80  # Base URL of inference endpoint
     hf_token_secret: llm-d-hf-token   # The name of secret that contains the HF token of the stack


### PR DESCRIPTION
## Summary

This PR updates benchmark templates to make the served model configurable through the `MODEL` environment variable instead of hard-coding model names in each template.

The change covers benchmark templates for:
- optimized-baseline
- precise-prefix-cache-routing
- pd-disaggregation, including the TPU benchmark template

It also updates the related benchmark documentation to show how to set `MODEL` with guide-specific defaults before running `envsubst`, so the generated benchmark config continues to match the deployed stack while allowing overlays or alternate stacks to use different models.

## Changes

- Replace hard-coded `endpoint.model` values in benchmark templates with `${MODEL}`.
- Add `MODEL` exports with sensible defaults to the affected guide benchmark instructions.
- Document `MODEL` in the shared benchmark helper docs and include it in the environment sanity check output.
- Clarify that `envsubst` now resolves `MODEL` along with the existing namespace and gateway variables.