### PR TITLE
docs(autoscaling): VA deprecation, migration doc.

### DIFF
--- a/docs/architecture/advanced/autoscaling/README.md
+++ b/docs/architecture/advanced/autoscaling/README.md
@@ -2,17 +2,17 @@
 
 With autoscaling, model servers are added or removed automatically to keep serving capacity aligned with inference demand. llm-d autoscalers consume three categories of scaling signals — supply-side, demand-side, and SLO-driven — surfaced through two complementary systems:
 
-- **HPA/KEDA** - Uses demand-side signals (EPP queue depth and active request counts) to scale model server replicas via Kubernetes HPA or KEDA. Well-suited for homogeneous deployments where each model scales independently.
+- **HPA + EPP Metrics** - Uses demand-side signals (EPP queue depth and active request counts) to scale model server replicas via Kubernetes HPA or KEDA. Well-suited for homogeneous deployments where each model scales independently.
 
-  See [HPA/KEDA](./hpa-keda.md) for complete details on the HPA/KEDA design.
+  See [HPA + EPP Metrics](./hpa-epp.md) for complete details on the HPA/KEDA design.
 
-- **Workload Variant Autoscaler (WVA)** - A global optimizer that, given an inventory of available accelerators, determines how to optimally place model servers — potentially serving different base models — onto those accelerators. WVA consumes supply-side signals (KV cache utilization, model server queue depth) or SLO-driven signals to proactively meet latency targets specified in its configuration. It accounts for heterogeneous hardware, disaggregated serving roles (prefill, decode, or both), and changing traffic patterns. When the accelerator inventory is insufficient to meet all targets, WVA degrades gracefully by prioritizing placement decisions that maximize overall SLO attainment.
+- **HPA + WVA Metrics** - A global optimizer that, given an inventory of available accelerators, determines how to optimally place model servers — potentially serving different base models — onto those accelerators. WVA consumes supply-side signals (KV cache utilization, model server queue depth) or SLO-driven signals to proactively meet latency targets specified in its configuration. It accounts for heterogeneous hardware, disaggregated serving roles (prefill, decode, or both), and changing traffic patterns. When the accelerator inventory is insufficient to meet all targets, WVA degrades gracefully by prioritizing placement decisions that maximize overall SLO attainment.
 
-  See [Workload Variant Autoscaler (WVA)](./wva.md) for complete details on the WVA design.
+  See [HPA + WVA Metrics](./hpa-wva.md) for complete details on the WVA design.
 
 ## Features Matrix
 
-| | [HPA/KEDA](./hpa-keda.md) | [WVA](./wva.md) |
+| | [HPA + EPP Metrics](./hpa-epp.md) | [HPA + WVA Metrics](./hpa-wva.md) |
 |---|---|---|
 | **Scaling Signals** | IGW queue depth and running request count | KV cache utilization, model server queue depth, SLO targets (**Experimental**), IGW queue size (**Experimental**) |
 | **Multiple-Variants** | Unsupported | Supported — optimally places across models and topologies to minimize cost |
@@ -20,12 +20,12 @@ With autoscaling, model servers are added or removed automatically to keep servi
 | **Scale to zero** | Supported | Supported |
 | **Strong Latency SLOs** | Not guaranteed | Supported by learning supply/demand dynamics and scaling proactively to meet targets  (**Experimental**) |
 | **Pending Pods Awareness** | Unsupported — external metrics do not account for pending (unscheduled) pods | Supported — incorporates pending pod state into scaling decisions |
-| **Operational Complexity** | Low - Standard Kubernetes HPA/KEDA only | Medium - Requires WVA controller and `VariantAutoscaling` CRD |
+| **Operational Complexity** | Low - Standard Kubernetes HPA/KEDA only | Medium - Requires WVA controller |
 
 > [!NOTE]
 > Native Kubernetes HPA scale-to-zero requires cluster support for the `HPAScaleToZero` feature. KEDA-based scale-to-zero is an alternative when that HPA feature is not enabled. For WVA-specific requirements, see the linked design documentation.
 
 ## Choosing an Approach
 
-- **HPA/KEDA** - Homogeneous hardware, independent per-model scaling, demand-side signals only.
-- **WVA** - Heterogeneous hardware, multiple serving variants, supply-constrained environments, and/or SLO-driven scaling.
+- **HPA + EPP Metrics** - Homogeneous hardware, independent per-model scaling, demand-side signals only.
+- **HPA + WVA Metrics** - Heterogeneous hardware, multiple serving variants, supply-constrained environments, and/or SLO-driven scaling.

--- a/docs/architecture/advanced/autoscaling/hpa-epp.md
+++ b/docs/architecture/advanced/autoscaling/hpa-epp.md
@@ -1,6 +1,6 @@
-# EPP HPA/KEDA Integration
+# HPA/KEDA with EPP Metrics
 
-The EPP HPA/KEDA integration enables Kubernetes HPA (Horizontal Pod Autoscaler) to scale model server replicas using demand-side signals sourced from the Endpoint Picker (EPP). Rather than relying on coarse resource utilization metrics, it exposes the EPP's internal queuing state as the authoritative signal for LLM inference load. This approach is well-suited for homogeneous deployments where each model scales independently.
+The EndPoint Picker (EPP) HPA/KEDA integration enables Kubernetes Horizontal Pod Autoscaler (HPA) to scale model server replicas using demand-side signals sourced from the EPP. Rather than relying on coarse resource utilization metrics, it exposes the EPP's internal queuing state as the authoritative signal for LLM inference load. This approach is well-suited for homogeneous deployments where each model scales independently.
 
 ## Functionality
 

--- a/docs/architecture/advanced/autoscaling/hpa-wva.md
+++ b/docs/architecture/advanced/autoscaling/hpa-wva.md
@@ -1,4 +1,7 @@
-# Workload Variant Autoscaling
+# HPA/KEDA with WVA Metrics
+
+> [!WARNING]
+> **Deprecation Notice:** The `VariantAutoscaling` (VA) CRD-based approach described in this document is deprecated. The recommended path is the [HPA + WVA guide](../../../../guides/workload-autoscaling/README.wva.md), which configures HPA directly with WVA-published metrics without requiring the `VariantAutoscaling` CRD. If you are currently using VA objects, see the [Migration from VA to HPA + WVA](#migration-from-va-to-hpa--wva) section below.
 
 ## Functionality
 
@@ -399,3 +402,77 @@ Key controller flags:
 | `--leader-election-lease-duration` | `60s` | Leader election lease duration |
 | `--leader-election-renew-deadline` | `50s` | Leader election renew deadline |
 | `--rest-client-timeout` | `60s` | Kubernetes API client timeout |
+
+## Migration from VA to HPA + WVA
+
+The new [HPA + WVA](../../../../guides/workload-autoscaling/README.wva.md) approach replaces the `VariantAutoscaling` (VA) CRD with standard Kubernetes HPA objects that consume the `wva_desired_replicas` external metric published by WVA. This removes the need to manage VA resources and makes scaling intent visible through the standard `kubectl get hpa` surface.
+
+### Key Differences
+
+| | VA (Deprecated) | HPA + WVA (Recommended) |
+|---|---|---|
+| **Scaling object** | `VariantAutoscaling` CRD | Standard `HorizontalPodAutoscaler` |
+| **Scale target** | Managed by WVA via `scaleTargetRef` in VA spec | Managed by HPA via standard `scaleTargetRef` |
+| **WVA discovery** | WVA watches `VariantAutoscaling` resources | WVA discovers HPA via `llm-d.ai/managed: "true"` annotation |
+| **Scaling metric** | WVA directly sets replica counts | WVA publishes `wva_desired_replicas`; HPA acts on it |
+| **CRD requirement** | Requires `llmd.ai/v1alpha1` `VariantAutoscaling` CRD | No custom CRDs required |
+| **Observability** | `kubectl get va` | `kubectl get hpa` |
+
+### Migration Steps
+
+1. **Delete existing VA objects** for each deployment you are migrating:
+
+   ```bash
+   kubectl delete va <va-name> -n <namespace>
+   ```
+
+   > [!NOTE]
+   > Deleting a VA object stops WVA from managing that deployment's replica count. Scale the deployment to its desired replica count manually before deleting the VA if you need to avoid disruption.
+
+2. **Create HPA objects** with the `llm-d.ai/managed: "true"` annotation. WVA discovers these and publishes `wva_desired_replicas` labeled with `variant_name` and `exported_namespace`:
+
+   ```yaml
+   apiVersion: autoscaling/v2
+   kind: HorizontalPodAutoscaler
+   metadata:
+     name: <deployment-name>
+     namespace: <namespace>
+     annotations:
+       llm-d.ai/managed: "true"
+   spec:
+     scaleTargetRef:
+       apiVersion: apps/v1
+       kind: Deployment
+       name: <deployment-name>
+     minReplicas: 1
+     maxReplicas: <max>
+     metrics:
+       - type: External
+         external:
+           metric:
+             name: wva_desired_replicas
+             selector:
+               matchLabels:
+                 variant_name: <deployment-name>
+                 exported_namespace: <namespace>
+           target:
+             type: AverageValue
+             averageValue: "1"
+   ```
+
+   The `variantCost` previously set on the VA can be carried over as an annotation: `llm-d.ai/variant-cost: "<cost>"`. WVA reads this annotation to preserve cost-aware optimization across variants.
+
+3. **Verify** that WVA is discovering the HPA and publishing the metric:
+
+   ```bash
+   kubectl get hpa <deployment-name> -n <namespace>
+   kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/<namespace>/wva_desired_replicas" | jq .
+   ```
+
+4. **Remove the VA CRD** once all VAs have been migrated and the HPAs are healthy:
+
+   ```bash
+   kubectl delete crd variantautoscalings.llmd.ai
+   ```
+
+See the [HPA + WVA guide](../../../../guides/workload-autoscaling/README.wva.md) for a complete end-to-end setup walkthrough including Prometheus Adapter and WVA controller installation.

--- a/docs/architecture/advanced/autoscaling/scaling-engine-pipeline.svg
+++ b/docs/architecture/advanced/autoscaling/scaling-engine-pipeline.svg
@@ -25,12 +25,12 @@
   <text x="175" y="95" text-anchor="middle" font-weight="600" fill="#000000">Prometheus</text>
   <text x="175" y="110" text-anchor="middle" font-size="11" fill="#666666">vLLM &amp; EPP metrics</text>
 
-  <!-- VA Watch -->
-  <rect x="355" y="72" width="170" height="52" rx="3" fill="#f3f3f3" stroke="#d9d2e9" stroke-width="1"/>
-  <circle r="12" cx="383" cy="98" fill="#ffffff" stroke="#d9d2e9" stroke-width="1"/>
-  <text x="383" y="98" text-anchor="middle" dominant-baseline="central" font-size="15" fill="#000000">&#9670;</text>
-  <text x="452" y="95" text-anchor="middle" font-weight="600" fill="#000000">VA Watch</text>
-  <text x="452" y="110" text-anchor="middle" font-size="11" fill="#666666">Active VA resources</text>
+  <!-- HPA Watch -->
+  <rect x="330" y="72" width="220" height="52" rx="3" fill="#f3f3f3" stroke="#d9d2e9" stroke-width="1"/>
+  <circle r="12" cx="358" cy="98" fill="#ffffff" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="358" y="98" text-anchor="middle" dominant-baseline="central" font-size="15" fill="#000000">&#9670;</text>
+  <text x="460" y="95" text-anchor="middle" font-weight="600" fill="#000000">HPA/KEDA Watch</text>
+  <text x="460" y="110" text-anchor="middle" font-size="11" fill="#666666">Active HPA/KEDA resources</text>
 
   <!-- EPP Metrics -->
   <rect x="630" y="72" width="170" height="52" rx="3" fill="#f3f3f3" stroke="#d9d2e9" stroke-width="1"/>
@@ -58,7 +58,7 @@
   <circle cx="88" cy="236" r="9" fill="#eeeeee" stroke="#d9d2e9" stroke-width="1.2"/>
   <text x="88" y="236" text-anchor="middle" dominant-baseline="central" font-weight="700" font-size="11" fill="#000000">1</text>
   <text x="108" y="233" font-size="12" font-weight="600" fill="#000000">Collect</text>
-  <text x="108" y="248" font-size="11" fill="#666666">Group active VAs by modelID, scrape per-replica metrics</text>
+  <text x="108" y="248" font-size="11" fill="#666666">Group active HPAs by modelID, scrape per-replica metrics</text>
 
   <!-- Arrow 1 → 2 -->
   <line x1="320" y1="256" x2="320" y2="313" stroke="#000000" stroke-width="1.5" marker-end="url(#arr)"/>
@@ -83,9 +83,6 @@
   <text x="478" y="374" text-anchor="middle" font-size="10" fill="#666666">latency-driven</text>
 
   <!-- Experimental badges -->
-  <rect x="240" y="336" width="60" height="14" rx="7" fill="#f59e0b" stroke="#d97706" stroke-width="0.8"/>
-  <text x="270" y="340" text-anchor="middle" dominant-baseline="hanging" font-weight="600" font-size="8" fill="#ffffff">experimental</text>
-
   <rect x="398.5" y="336" width="60" height="14" rx="7" fill="#f59e0b" stroke="#d97706" stroke-width="0.8"/>
   <text x="428.5" y="340" text-anchor="middle" dominant-baseline="hanging" font-weight="600" font-size="8" fill="#ffffff">experimental</text>
 
@@ -140,26 +137,16 @@
   <text x="746" y="694" text-anchor="middle" font-size="11" fill="#666666">100ms polling, EPP queue check</text>
 
   <!-- Arrow from Scale-from-Zero to Cache (dashed) -->
-  <line x1="630" y1="676" x2="452" y2="676" stroke="#000000" stroke-width="1.5" stroke-dasharray="6 4" marker-end="url(#arr)"/>
+  <line x1="630" y1="676" x2="440" y2="676" stroke="#000000" stroke-width="1.5" stroke-dasharray="6 4" marker-end="url(#arr)"/>
 
-  <!-- T-fork: DecisionCache → VA Reconciler (DecisionTrigger) + Actuator -->
-  <line x1="320" y1="698" x2="320" y2="720" stroke="#000000" stroke-width="1.5"/>
-  <line x1="188" y1="720" x2="465" y2="720" stroke="#000000" stroke-width="1.5"/>
-  <line x1="188" y1="720" x2="188" y2="734" stroke="#000000" stroke-width="1.5" marker-end="url(#arr)"/>
-  <line x1="465" y1="720" x2="465" y2="734" stroke="#000000" stroke-width="1.5" marker-end="url(#arr)"/>
-  <text x="245" y="714" text-anchor="middle" font-style="italic" font-size="10" fill="#888888">DecisionTrigger</text>
-
-  <!-- VA Reconciler -->
-  <rect x="55" y="734" width="265" height="60" rx="4" fill="#f3f3f3" stroke="#d9d2e9" stroke-width="1.5"/>
-  <rect x="55" y="734" width="6" height="60" rx="3" fill="#6366f1"/>
-  <text x="188" y="758" text-anchor="middle" font-weight="600" fill="#000000">VA Reconciler</text>
-  <text x="188" y="774" text-anchor="middle" font-size="11" fill="#666666">Update VA status</text>
+  <!-- DecisionCache → Actuator -->
+  <line x1="320" y1="698" x2="320" y2="734" stroke="#000000" stroke-width="1.5" marker-end="url(#arr)"/>
 
   <!-- Actuator -->
-  <rect x="345" y="734" width="240" height="60" rx="4" fill="#f3f3f3" stroke="#d9d2e9" stroke-width="1.5"/>
-  <rect x="345" y="734" width="6" height="60" rx="3" fill="#22c55e"/>
-  <text x="465" y="758" text-anchor="middle" font-weight="600" fill="#000000">Actuator</text>
-  <text x="465" y="772" text-anchor="middle" font-size="10" fill="#666666">emit WVA metrics (wva_desired_replicas, ...)</text>
+  <rect x="200" y="734" width="240" height="60" rx="4" fill="#f3f3f3" stroke="#d9d2e9" stroke-width="1.5"/>
+  <rect x="200" y="734" width="6" height="60" rx="3" fill="#22c55e"/>
+  <text x="320" y="758" text-anchor="middle" font-weight="600" fill="#000000">Actuator</text>
+  <text x="320" y="772" text-anchor="middle" font-size="10" fill="#666666">emit WVA metrics (wva_desired_replicas, ...)</text>
 
   <!-- Legend -->
   <rect x="620" y="744" width="230" height="50" rx="4" fill="#f3f3f3" stroke="#d9d2e9" stroke-width="1"/>

--- a/guides/workload-autoscaling/README.md
+++ b/guides/workload-autoscaling/README.md
@@ -13,13 +13,13 @@ This guide covers the autoscaling strategies available in llm-d. Both use the Ku
 
 The [HPA + EPP Metrics](./README.hpa-epp.md) path integrates the Kubernetes Horizontal Pod Autoscaler (HPA) with signals emitted directly by the Endpoint Picker (EPP). The guide demonstrates autoscaling using queue depth and running request counts from the Endpoint Picker (EPP), but other metrics emitted by the EPP can be used depending on your scaling requirements. These signals reflect the actual state of the inference queue, enabling the HPA to scale out before users experience high latency and scale in when capacity is genuinely idle. This path requires only the standard Kubernetes HPA and the Prometheus Adapter, with no additional controllers. KEDA can be used as an alternative to native HPA for alpha features such as scale-to-zero if your cluster does not support alpha feature gates.
 
-## Workload Variant Autoscaler (WVA)
+## HPA + WVA
 
 The [Workload Variant Autoscaler (WVA)](./README.wva.md) is designed for operators running multiple models or variants on shared GPU hardware. A **variant** is a way of serving a given model with a particular combination of hardware, runtimes, and serving approach — for example, the same model running on A100s, H100s, or L4s, each with different cost and performance characteristics. WVA continuously monitors KV cache utilization, queue depth, and configurable energy and performance budgets to determine optimal replica counts across variants. Rather than scaling all variants equally, WVA preferentially adds capacity on the cheapest available variant and removes it from the most expensive — optimizing infrastructure cost without violating latency SLOs. WVA works alongside the Kubernetes HPA: it emits optimization metrics to Prometheus, and the HPA reads those metrics and performs the actual scaling.
 
 ## Choosing a Path
 
-| | [HPA + EPP Metrics](./README.hpa-epp.md) | [Workload Variant Autoscaler (WVA)](./README.wva.md) |
+| | [HPA + EPP Metrics](./README.hpa-epp.md) | [HPA + WVA](./README.wva.md) |
 |---|---|---|
 | **Best for** | Deployments on homogeneous hardware where each model scales independently | Multi-variant deployments where cost-aware capacity allocation across heterogeneous shared hardware is required |
 | **Scaling signal** | EPP metrics such as queue depth and running request count | KV cache utilization, queue depth, energy and performance budgets |


### PR DESCRIPTION
## Summary

- Renames autoscaling approaches across architecture docs to align with the guide naming: **HPA + EPP Metrics** and **HPA + WVA Metrics** (previously "HPA/KEDA" and "WVA")
- Adds a deprecation warning to `docs/architecture/advanced/autoscaling/wva.md` marking the `VariantAutoscaling` (VA) CRD-based approach as deprecated and pointing users to the HPA + WVA guide
- Adds a **Migration from VA to HPA + WVA** section to `wva.md` with a key-differences table and step-by-step instructions (delete VA objects → create annotated HPAs → verify → remove CRD)
- Fixes `scaling-engine-pipeline.svg`: widened HPA/KEDA Watch box to fit its label, removed the spurious second output arrow from DecisionCache, and removed the experimental badge from the Saturation V2 analyzer
