### PR TITLE
Add failure cat to the nightly workflows

### DIFF
--- a/.github/workflows/nightly-e2e-flow-control-gke-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-flow-control-gke-acc-gpu-vllm-x.yaml
@@ -101,4 +101,5 @@ jobs:
       badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}
 

--- a/.github/workflows/nightly-e2e-optimized-baseline-amd-acc-rocm-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-amd-acc-rocm-vllm-x.yaml
@@ -101,3 +101,4 @@ jobs:
       badge_label: "VLLM ROCm"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-optimized-baseline-cks-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-cks-acc-gpu-vllm-x.yaml
@@ -101,3 +101,4 @@ jobs:
       badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-optimized-baseline-gke-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-gke-acc-gpu-vllm-x.yaml
@@ -101,3 +101,4 @@ jobs:
       badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-optimized-baseline-gke-acc-tpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-gke-acc-tpu-vllm-x.yaml
@@ -112,3 +112,4 @@ jobs:
       badge_label: "VLLM TPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-optimized-baseline-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-ibm-acc-gpu-vllm-x.yaml
@@ -100,3 +100,4 @@ jobs:
       badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-optimized-baseline-intel-acc-xpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-intel-acc-xpu-vllm-x.yaml
@@ -101,3 +101,4 @@ jobs:
       badge_label: "VLLM XPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-pd-disaggregation-amd-ci-acc-rocm-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-amd-ci-acc-rocm-vllm-x.yaml
@@ -101,3 +101,4 @@ jobs:
       badge_label: "VLLM ROCM"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-pd-disaggregation-cks-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-cks-acc-gpu-vllm-x.yaml
@@ -101,3 +101,4 @@ jobs:
       badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-pd-disaggregation-gke-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-gke-acc-gpu-vllm-x.yaml
@@ -101,3 +101,4 @@ jobs:
       badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-pd-disaggregation-gke-acc-tpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-gke-acc-tpu-vllm-x.yaml
@@ -116,3 +116,4 @@ jobs:
       badge_label: "VLLM TPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-pd-disaggregation-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-ibm-acc-gpu-vllm-x.yaml
@@ -100,3 +100,4 @@ jobs:
       badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'true' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-pd-disaggregation-intel-acc-xpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-intel-acc-xpu-vllm-x.yaml
@@ -101,3 +101,4 @@ jobs:
       badge_label: "VLLM XPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-precise-prefix-cache-routing-cks-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-routing-cks-acc-gpu-vllm-x.yaml
@@ -101,3 +101,4 @@ jobs:
       badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-precise-prefix-cache-routing-gke-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-routing-gke-acc-gpu-vllm-x.yaml
@@ -101,3 +101,4 @@ jobs:
       badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-precise-prefix-cache-routing-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-routing-ibm-acc-gpu-vllm-x.yaml
@@ -100,3 +100,4 @@ jobs:
       badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-precise-prefix-cache-routing-intel-acc-xpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-routing-intel-acc-xpu-vllm-x.yaml
@@ -101,3 +101,4 @@ jobs:
       badge_label: "VLLM XPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-predicted-latency-routing-cks-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-routing-cks-acc-gpu-vllm-x.yaml
@@ -101,3 +101,4 @@ jobs:
       badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-predicted-latency-routing-gke-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-routing-gke-acc-gpu-vllm-x.yaml
@@ -101,3 +101,4 @@ jobs:
       badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-predicted-latency-routing-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-routing-ibm-acc-gpu-vllm-x.yaml
@@ -100,3 +100,4 @@ jobs:
       badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-lmcache.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-lmcache.yaml
@@ -102,3 +102,4 @@ jobs:
       badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-native.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-native.yaml
@@ -102,3 +102,4 @@ jobs:
       badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-tpu-vllm-native.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-tpu-vllm-native.yaml
@@ -116,3 +116,4 @@ jobs:
       badge_label: "VLLM TPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-ibm-cpu-gpu-vllm-native.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-ibm-cpu-gpu-vllm-native.yaml
@@ -101,3 +101,4 @@ jobs:
       badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-wide-ep-lws-cks-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-cks-acc-gpu-vllm-x.yaml
@@ -101,3 +101,4 @@ jobs:
       badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'true' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-wide-ep-lws-gke-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-gke-acc-gpu-vllm-x.yaml
@@ -101,3 +101,4 @@ jobs:
       badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'true' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-wide-ep-lws-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-ibm-acc-gpu-vllm-x.yaml
@@ -100,3 +100,4 @@ jobs:
       badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'true' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-workload-autoscaling-cks-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-workload-autoscaling-cks-acc-gpu-vllm-x.yaml
@@ -168,3 +168,4 @@ jobs:
       badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-workload-autoscaling-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-workload-autoscaling-ibm-acc-gpu-vllm-x.yaml
@@ -168,3 +168,4 @@ jobs:
       badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}
       dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}


### PR DESCRIPTION
## Add failure category to nightly badge color classification

Pass `failure_category` from the benchmark workflow output to the badge update workflow across all 29 nightly E2E workflows.

This enables color-coded badges based on which stage of the pipeline failed:

| Category | Color | Message |
|----------|-------|---------|
| success | brightgreen | passing |
| dry-run | blue | dry-run |
| prepare | brown | prepare-error |
| prereqs | black | prereqs-error |
| infra | orange | infra-error |
| guide | red | guide-error |
| benchmark | yellow | benchmark-error |

### Changes

- Added `failure_category: ${{ needs.nightly.outputs.failure_category }}` to the `update-badge` job in all 29 `nightly-e2e-*.yaml` workflows