### PR TITLE
fix: remove duplicate hardcoded images from CPU offloading patches

### DIFF
--- a/guides/optimized-baseline/modelserver/cpu/vllm/patch-vllm.yaml
+++ b/guides/optimized-baseline/modelserver/cpu/vllm/patch-vllm.yaml
@@ -9,7 +9,6 @@ spec:
       containers:
         - name: modelserver
           command: ["vllm", "serve"]
-          image: ghcr.io/llm-d/llm-d-cpu:v0.6.0
           args:
             - "meta-llama/Llama-3.2-3B-Instruct"
             - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"

--- a/guides/precise-prefix-cache-routing/modelserver/cpu/vllm/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-routing/modelserver/cpu/vllm/patch-vllm.yaml
@@ -9,7 +9,6 @@ spec:
       containers:
         - name: modelserver
           command: ["vllm", "serve"]
-          image: ghcr.io/llm-d/llm-d-cpu:v0.6.0
           # CI-sized default: smaller model chosen for CPU smoke tests.
           # For precise prefix cache scoring to be meaningful, update
           # `modelName` in router/precise-prefix-cache-routing.values.yaml


### PR DESCRIPTION
## Summary

- Remove hardcoded `image: ghcr.io/llm-d/llm-d-cpu:v0.6.0` from two CPU patch files that duplicated the image already defined by the `cpu-vllm` Kustomize Component

## Dry-run verification

Ran `kubectl kustomize` on both overlays before and after the change. The rendered output is **identical** (the component's images transformer correctly provides the image):

```
$ diff /tmp/optimized-baseline-before.yaml /tmp/optimized-baseline-after.yaml
IDENTICAL

$ diff /tmp/precise-prefix-cache-before.yaml /tmp/precise-prefix-cache-after.yaml
IDENTICAL
```

Both overlays continue to produce `image: ghcr.io/llm-d/llm-d-cpu:v0.6.0` in the rendered Deployment, but now the image is solely controlled by the component -- meaning future version bumps will propagate correctly.
