### PR TITLE
feat: centralize routing sidecar image via Kustomize Component

### DIFF
--- a/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/kustomization.yaml
+++ b/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/kustomization.yaml
@@ -6,6 +6,9 @@ resources:
 
 namePrefix: e-p-d-disaggregation-nvidia-gpu-vllm-
 
+components:
+  - ../../../../../../../recipes/modelserver/components/images/routing-sidecar
+
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: ghcr.io/revit13/vllm-openai

--- a/guides/pd-disaggregation/modelserver/amd/vllm/base/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/vllm/base/kustomization.yaml
@@ -7,6 +7,7 @@ namePrefix: pd-disaggregation-rocm-vllm-
 
 components:
   - ../../../../../recipes/modelserver/components/images/amd-vllm
+  - ../../../../../recipes/modelserver/components/images/routing-sidecar
 
 labels:
   - pairs:

--- a/guides/pd-disaggregation/modelserver/gpu/sglang/base/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/sglang/base/kustomization.yaml
@@ -5,6 +5,9 @@ resources:
 
 namePrefix: pd-disaggregation-nvidia-gpu-sglang-
 
+components:
+  - ../../../../../recipes/modelserver/components/images/routing-sidecar
+
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: docker.io/lmsysorg/sglang

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/base/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/base/kustomization.yaml
@@ -5,6 +5,9 @@ resources:
 
 namePrefix: pd-disaggregation-nvidia-gpu-vllm-
 
+components:
+  - ../../../../../recipes/modelserver/components/images/routing-sidecar
+
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: docker.io/vllm/vllm-openai

--- a/guides/pd-disaggregation/modelserver/hpu/vllm/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/hpu/vllm/kustomization.yaml
@@ -11,6 +11,7 @@ configurations:
 
 components:
   - ../../../../recipes/modelserver/components/images/hpu-vllm
+  - ../../../../recipes/modelserver/components/images/routing-sidecar
 
 labels:
   - pairs:

--- a/guides/pd-disaggregation/modelserver/tpu/base/vllm/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/tpu/base/vllm/kustomization.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 resources:
   - ../../../../../recipes/modelserver/base/single-host/pd/vllm
 
+components:
+  - ../../../../../recipes/modelserver/components/images/routing-sidecar
+
 patches:
   - path: patch-decode.yaml
   - path: patch-prefill.yaml

--- a/guides/pd-disaggregation/modelserver/xpu/vllm/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/xpu/vllm/kustomization.yaml
@@ -11,6 +11,7 @@ configurations:
 
 components:
   - ../../../../recipes/modelserver/components/images/xpu-vllm
+  - ../../../../recipes/modelserver/components/images/routing-sidecar
 
 labels:
   - pairs:

--- a/guides/recipes/modelserver/base/single-host/pd/sglang/patch-sidecar.yaml
+++ b/guides/recipes/modelserver/base/single-host/pd/sglang/patch-sidecar.yaml
@@ -13,7 +13,7 @@ spec:
             - --connector=sglang
             - --zap-log-level=1
             - --secure-proxy=false
-          image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
+          image: REPLACE_ROUTING_SIDECAR_IMAGE
           imagePullPolicy: Always
           ports:
             - containerPort: 8000

--- a/guides/recipes/modelserver/base/single-host/pd/vllm/patch-sidecar.yaml
+++ b/guides/recipes/modelserver/base/single-host/pd/vllm/patch-sidecar.yaml
@@ -13,7 +13,7 @@ spec:
             - --connector=nixlv2
             - --zap-log-level=1
             - --secure-proxy=false
-          image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
+          image: REPLACE_ROUTING_SIDECAR_IMAGE
           imagePullPolicy: Always
           ports:
             - containerPort: 8000

--- a/guides/recipes/modelserver/components/images/routing-sidecar/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/routing-sidecar/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+images:
+  - name: REPLACE_ROUTING_SIDECAR_IMAGE
+    newName: ghcr.io/llm-d/llm-d-routing-sidecar
+    newTag: v0.8.0


### PR DESCRIPTION
## Summary
- Create a new Kustomize Component at `guides/recipes/modelserver/components/images/routing-sidecar/` that provides the image substitution, following the same pattern used for model server images (e.g., `gpu-vllm/`, `amd-vllm/`)

### Not in scope

The `wide-ep-lws` sidecar images use standalone deployment YAMLs (not the recipe base) and need separate handling.

## Dry-run verification

`kubectl kustomize` output was captured before and after the change for all three requested overlays. All produce **identical** output:

```
$ diff /tmp/before-gpu-vllm.yaml /tmp/after-gpu-vllm.yaml
(no diff - IDENTICAL)

$ diff /tmp/before-gpu-sglang.yaml /tmp/after-gpu-sglang.yaml
(no diff - IDENTICAL)

$ diff /tmp/before-amd-vllm.yaml /tmp/after-amd-vllm.yaml
(no diff - IDENTICAL)
```

Additional overlays (xpu, hpu, tpu, multimodal e-p-d) were also verified to render correctly with the routing sidecar image properly resolved to `ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0`.

## Test plan

- [x] `kubectl kustomize` dry-run on `guides/pd-disaggregation/modelserver/gpu/vllm/base/` produces identical output before and after
- [x] `kubectl kustomize` dry-run on `guides/pd-disaggregation/modelserver/gpu/sglang/base/` produces identical output before and after
- [x] `kubectl kustomize` dry-run on `guides/pd-disaggregation/modelserver/amd/vllm/base/` produces identical output before and after
- [x] All other pd-disaggregation overlays (xpu, hpu, tpu) render with correct sidecar image
- [x] Multimodal e-p-d overlay renders correctly (uses its own sidecar override, unaffected)
- [ ] CI nightly kustomize validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)