### PR TITLE
Fix: Align GKE overlay patch targets with actual LeaderWorkerSet names

### DIFF
--- a/guides/wide-ep-lws/experimental-dp-aware/manifests/modelserver/gke/kustomization.yaml
+++ b/guides/wide-ep-lws/experimental-dp-aware/manifests/modelserver/gke/kustomization.yaml
@@ -8,7 +8,7 @@ components:
 patches:
   - target:
       kind: LeaderWorkerSet
-      name: prefill
+      name: wide-ep-llm-d-prefill
     patch: |-
       # Prefer the same block and subblock.
       # https://github.com/llm-d/llm-d/tree/main/docs/infrastructure/providers/gke#configuring-support-for-rdma-on-gke-workload-pods
@@ -37,7 +37,7 @@ patches:
                 topologyKey: cloud.google.com/gce-topology-subblock
   - target:
       kind: LeaderWorkerSet
-      name: decode
+      name: wide-ep-llm-d-decode
     patch: |-
       # Prefer the same block and subblock.
       # https://github.com/llm-d/llm-d/tree/main/docs/infrastructure/providers/gke#configuring-support-for-rdma-on-gke-workload-pods

--- a/guides/wide-ep-lws/modelserver/gpu/vllm/gke/kustomization.yaml
+++ b/guides/wide-ep-lws/modelserver/gpu/vllm/gke/kustomization.yaml
@@ -8,7 +8,7 @@ components:
 patches:
   - target:
       kind: LeaderWorkerSet
-      name: prefill
+      name: wide-ep-lws-nvidia-gpu-vllm-prefill
     patch: |-
       # Prefer the same block and subblock.
       # https://github.com/llm-d/llm-d/tree/main/docs/infrastructure/providers/gke#configuring-support-for-rdma-on-gke-workload-pods
@@ -37,7 +37,7 @@ patches:
                 topologyKey: cloud.google.com/gce-topology-subblock
   - target:
       kind: LeaderWorkerSet
-      name: decode
+      name: wide-ep-lws-nvidia-gpu-vllm-decode
     patch: |-
       # Prefer the same block and subblock.
       # https://github.com/llm-d/llm-d/tree/main/docs/infrastructure/providers/gke#configuring-support-for-rdma-on-gke-workload-pods


### PR DESCRIPTION
typo issue. 
Base manifests hardcode full resource names ( wide-ep-llm-d-prefill  and  wide-ep-lws-nvidia-gpu-vllm-prefill ) 

https://github.com/weizhoublue/llm-d/blob/main/guides/wide-ep-lws/experimental-dp-aware/manifests/modelserver/base/decode.yaml#L4

https://github.com/weizhoublue/llm-d/blob/main/guides/wide-ep-lws/experimental-dp-aware/manifests/modelserver/base/prefill.yaml#L4

https://github.com/weizhoublue/llm-d/blob/main/guides/wide-ep-lws/modelserver/gpu/vllm/base/prefill.yaml#L4

https://github.com/weizhoublue/llm-d/blob/main/guides/wide-ep-lws/modelserver/gpu/vllm/base/decode.yaml#L4