### PR TITLE
Bump LWS to 0.9.0

### DIFF
--- a/.github/workflows/ci-kustomize-dry-run.yaml
+++ b/.github/workflows/ci-kustomize-dry-run.yaml
@@ -93,7 +93,7 @@ jobs:
       - name: Install LWS CRDs
         run: |
           kubectl apply --server-side -f \
-            https://raw.githubusercontent.com/kubernetes-sigs/lws/v0.7.0/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml
+            https://raw.githubusercontent.com/kubernetes-sigs/lws/v0.9.0/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml
 
       - name: Install GKE CRDs
         run: .github/scripts/install-gke-crds.sh

--- a/guides/prereq/multi-node-serving/README.md
+++ b/guides/prereq/multi-node-serving/README.md
@@ -4,14 +4,17 @@
 
 The LeaderWorkerSet (LWS) Kubernetes workload controller specializes in deploying serving workloads where each replica is composed of multiple pods spread across hosts, specifically accelerator nodes. llm-d defaults to LWS for deployment of multi-host inference for rank to pod mappings, topology aware placement to ensure optimal accelerator network performance, and all-or-nothing failure and restart semantics to recover in the event of a bad node or accelerator.
 
-Use the [LWS installation guide](https://lws.sigs.k8s.io/docs/installation/) to install 0.7.0 or newer when deploying an llm-d guide using LWS. We provide an [`install-lws.sh`](./install-lws.sh) script:
+Use the [LWS installation guide](https://lws.sigs.k8s.io/docs/installation/) to install the recommended 0.9.0 release when deploying an llm-d guide using LWS. We provide an [`install-lws.sh`](./install-lws.sh) script:
 
     ./install-lws.sh          # install
     ./install-lws.sh delete   # uninstall
 
+> [!WARNING]
+> If you installed LWS 0.7.0 or earlier with Helm, do not upgrade directly to 0.9.0. Helm may delete the LWS CRD and cascade-delete existing `LeaderWorkerSet` resources during upgrade; see [kubernetes-sigs/lws#880](https://github.com/kubernetes-sigs/lws/issues/880).
+
 You may override the version and namespace:
 
-    export LWS_VERSION="0.7.0"
+    export LWS_VERSION="0.9.0"
     export LWS_NAMESPACE="lws-system"
     ./install-lws.sh
 

--- a/guides/prereq/multi-node-serving/install-lws.sh
+++ b/guides/prereq/multi-node-serving/install-lws.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-LWS_VERSION="${LWS_VERSION:-0.7.0}"
+LWS_VERSION="${LWS_VERSION:-0.9.0}"
 LWS_NAMESPACE="${LWS_NAMESPACE:-lws-system}"
 
 if [[ "${1:-}" == "delete" ]]; then


### PR DESCRIPTION
## Summary

- Bump the default/recommended LeaderWorkerSet version to 0.9.0.
- Update the kustomize dry-run LWS CRD URL to v0.9.0.
- Add a note that existing Helm installs of LWS 0.7.0 or earlier should not upgrade directly because of the upstream CRD migration issue.

Refs 
- https://github.com/kubernetes-sigs/lws/issues/880

## Testing

- `bash -n guides/prereq/multi-node-serving/install-lws.sh`
- `rtk git diff --check`
- Verified the 0.9.0 Helm chart and CRD URL
- Installed LWS 0.9.0 on local kind and ran a minimal LeaderWorkerSet smoke test
