### PR TITLE
fix: update model server image tag to v0.23.0 in kustomization files

### DIFF
--- a/guides/tiered-prefix-cache/README.md
+++ b/guides/tiered-prefix-cache/README.md
@@ -349,12 +349,12 @@ curl -s http://${IP}/v1/completions \
 ```bash
 # Check the shared PVC for written blocks
 POD=$(kubectl get pod -n ${NAMESPACE} -l llm-d.ai/role=decode -o jsonpath='{.items[0].metadata.name}')
-kubectl exec -n ${NAMESPACE} ${POD} -- du -sh /mnt/files-storage/kv-cache
-kubectl exec -n ${NAMESPACE} ${POD} -- find /mnt/files-storage/kv-cache -maxdepth 5
+kubectl exec -n ${NAMESPACE} ${POD} -- du -sh /mnt/files-storage
+kubectl exec -n ${NAMESPACE} ${POD} -- find /mnt/files-storage -maxdepth 5
 ```
 
 Expected output: `du -sh` shows hundreds of MB to several GB, and `find` lists a path like
-`/mnt/files-storage/kv-cache/<model>/<block-config>/<tp-config>/...` (native fs connector) or `/mnt/files-storage/kv-cache/<model>-xxx.pt` (lmcache connector).
+`/mnt/files-storage/<model>_<hash>_r0/<block-config>/<tp-config>/...` (native fs connector) or `/mnt/files-storage/kv-cache/<model>-xxx.pt` (lmcache connector).
 
 If you have monitoring set up, confirm via `vllm:kv_offload_total_bytes` (native) or `lmcache:local_storage_usage` (lmcache) in the metrics explorer.
 

--- a/guides/tiered-prefix-cache/modelserver/gpu/vllm/base/kustomization-gpt-oss-120b.yaml
+++ b/guides/tiered-prefix-cache/modelserver/gpu/vllm/base/kustomization-gpt-oss-120b.yaml
@@ -9,7 +9,7 @@ namePrefix: optimized-baseline-
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: vllm/vllm-openai
-    newTag: v0.22.0
+    newTag: v0.23.0
 
 labels:
   - pairs:

--- a/guides/tiered-prefix-cache/modelserver/gpu/vllm/base/kustomization.yaml
+++ b/guides/tiered-prefix-cache/modelserver/gpu/vllm/base/kustomization.yaml
@@ -8,7 +8,7 @@ namePrefix: gpu-vllm-
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: vllm/vllm-openai
-    newTag: v0.22.0
+    newTag: v0.23.0
 
 
 labels:


### PR DESCRIPTION
The vllm command for storage offloading assumes vllm v0.23.0 as it calls for a secondary tier names "fs" and not "fs_python", which is the name of the storage tier in v0.22.0.