### PR TITLE
fix: correct tracing manifest path for otel collector and jaeger installer

### DIFF
--- a/guides/recipes/observability/install-otel-collector-jaeger.sh
+++ b/guides/recipes/observability/install-otel-collector-jaeger.sh
@@ -69,7 +69,7 @@ install() {
   log_info "Deploying OTel Collector + Jaeger into namespace '${NAMESPACE}'..."
 
   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  TRACING_DIR="${SCRIPT_DIR}/../tracing"
+  TRACING_DIR="${SCRIPT_DIR}/tracing"
   JAEGER_MANIFEST="${TRACING_DIR}/jaeger-all-in-one.yaml"
 
   if [[ ! -f "$JAEGER_MANIFEST" ]]; then
@@ -122,7 +122,7 @@ uninstall() {
   log_info "Removing OTel Collector + Jaeger from namespace '${NAMESPACE}'..."
 
   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  TRACING_DIR="${SCRIPT_DIR}/../tracing"
+  TRACING_DIR="${SCRIPT_DIR}/tracing"
 
   # Remove OTel Collector (try both variants)
   if otel_operator_available; then


### PR DESCRIPTION
I try to deploy OTel Collector and Jaeger for enabling OpenTelemetry distributed tracing like [Docs](https://llm-d.ai/docs/resources/monitoring/tracing#step-1-deploy-otel-collector-and-jaeger)
Then I found that the installer failed to find the Jaeger/OTel manifests due to simple manifest path errors.
## What I changed:
Correct the manifest path used by the installer so it points to the actual Jaeger and OpenTelemetry manifest files.


## bug & fix in install
The bugs I encountered during installation and their resolutions were as follows:

### Before fix
% `./install-otel-collector-jaeger.sh -n llmd`
[INFO]  Deploying OTel Collector + Jaeger into namespace 'llmd'...
[ERROR] Jaeger manifest not found at: /Users/smasuda/llm-d/guides/recipes/observability/../tracing/jaeger-all-in-one.yaml

### after fix
% `./install-otel-collector-jaeger.sh -n llmd`
[INFO]  Deploying OTel Collector + Jaeger into namespace 'llmd'...
[INFO]  Deploying Jaeger all-in-one...
deployment.apps/jaeger created
service/jaeger-collector created
[INFO]  OpenTelemetry Operator not found -- deploying standalone collector...
configmap/otel-collector-config created
deployment.apps/otel-collector created
service/otel-collector created
[OK]    OTel Collector + Jaeger deployed successfully.

[INFO]  Access the Jaeger UI with:
  kubectl port-forward -n llmd svc/jaeger-collector 16686:16686
  Then open http://localhost:16686

[INFO]  Components should export OTLP traces to:
  http://otel-collector.llmd.svc.cluster.local:4317
  (or simply http://otel-collector:4317 from the same namespace)

### traceing pod status after fix 
 % `kubectl get pod -n llmd`
NAME                              READY   STATUS    RESTARTS   AGE
jaeger-84c9bc479-vzt5r            1/1     Running   0          8m10s
otel-collector-5677b5cc89-kxxbx   1/1     Running   0          8m9s