### PR TITLE
Add async-processor operations guide

### DIFF
--- a/.github/workflows/ci-async-kind-e2e.yaml
+++ b/.github/workflows/ci-async-kind-e2e.yaml
@@ -1,0 +1,49 @@
+name: CI Async Processing E2E (kind)
+
+# Installs the asynchronous-processing guide from zero on a self-contained kind
+# cluster (optimized-baseline backing stack on a CPU model server + Redis +
+# Async Processor) and runs the guide's smoke test: publish a request to the
+# queue and assert a completion lands back on the result queue.
+#
+# This is a GPU-free, single-runner check intended to gate the guide on PRs. The
+# real per-provider/per-accelerator nightly e2e is driven separately via
+# llm-d-benchmark (see llm-d/llm-d#1360).
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/ci-async-kind-e2e.yaml
+      - guides/asynchronous-processing/**
+      - guides/recipes/router/**
+      - guides/optimized-baseline/router/**
+      - guides/optimized-baseline/modelserver/cpu/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  async-kind-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install kind
+        run: |
+          curl -sSLo ./kind https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64
+          sudo install -m 0755 ./kind /usr/local/bin/kind
+          rm -f ./kind
+          kind version
+
+      - name: Run asynchronous-processing guide end-to-end on kind
+        # helm, kubectl and docker are preinstalled on ubuntu-latest. The script
+        # creates and tears down its own isolated kind cluster.
+        run: ./guides/asynchronous-processing/test/kind-e2e.sh

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -15,3 +15,6 @@ Kubernetes HTTP probe configurations using vLLM API endpoints to ensure pods are
 
 ### [llm-d Router Operations Guide](router.md)
 Operational best practices, high availability scaling modes, standalone proxy architectures, and container resource sizing for llm-d Router deployments.
+
+### [Async Processor Operations Guide](async-processor.md)
+Throughput modeling, concurrency sizing (backed by a measured sweep), container resource sizing, and horizontal scaling for the Async Processor batch-dispatch agent.

--- a/docs/operations/async-processor.md
+++ b/docs/operations/async-processor.md
@@ -1,0 +1,188 @@
+# llm-d Async Processor Operations Guide
+
+This guide covers operational best practices, scaling behavior, and container sizing recommendations for the [Async Processor](https://github.com/llm-d/llm-d-async).
+
+The Async Processor is a **lightweight dispatch agent**, not an inference engine. It pulls requests from a message queue (Redis or GCP Pub/Sub), passes them through dispatch gates, and forwards them to the llm-d Router over HTTP. Because the heavy lifting (token generation) happens on the model servers, the processor is almost entirely **I/O-bound**: each worker spends the vast majority of its lifetime blocked on a long-running HTTP call to the Router. This shapes every sizing decision below — the container is small, and the constraint is concurrency and payload buffering, not compute.
+
+> [!NOTE]
+> The **concurrency** guidance in [§2](#2-choosing-concurrency-the-most-important-sizing-decision) is backed by the measured sweep in that section. The **CPU/memory** figures in [§3](#3-container-resource-sizing) are architecture-derived starting points — validate them against your own workload and prefer your own measurements where you have them.
+
+---
+
+## 1. Throughput Model
+
+Understanding how the processor scales is a prerequisite to sizing it.
+
+- **Workers are the unit of in-flight concurrency.** Each worker pulls one request, dispatches it, and blocks until the Router returns a result (or the deadline expires). The total number of requests the processor can have in flight at once is the sum of its worker counts.
+- **The bottleneck is downstream, not the processor.** Dispatch rate is ultimately limited by inference-server capacity and the [dispatch gates](../architecture/advanced/batch/async-processor.md#dispatch-gates), not by the processor's CPU. Adding workers beyond what the inference pool can absorb only grows queue backlog and memory, not throughput.
+- **Scaling is horizontal and stateless.** The processor is a pull-based consumer. Running N replicas against the same queue multiplies effective concurrency: `total in-flight = replicas × workers-per-replica`. Queue backends distribute messages across all consumers, so no leader election or coordination is required.
+
+### Concurrency Configuration
+
+In the helm chart, concurrency is controlled by `ap.concurrency` (default `64`), or per-pool via `ap.workerPools` when you need independent parallelism for different queues/topics:
+
+```yaml
+ap:
+  concurrency: 64       # global worker count (default)
+  # OR, for per-queue control:
+  workerPools:
+    - id: "high-priority"
+      workers: 16
+    - id: "bulk"
+      workers: 8
+```
+
+When `workerPools` is set, the per-pool `workers` value overrides the global `concurrency` for that pool. Total in-flight concurrency for the replica is the sum of all pool worker counts.
+
+---
+
+## 2. Choosing Concurrency (the most important sizing decision)
+
+Concurrency is the single highest-impact knob. The default of `64` is a sane starting point — enough to keep a modest pool busy — but it is **not** automatically right for yours: a single large GPU still has headroom above it, and high-throughput or long-output workloads need considerably more. The sizing rule is Little's Law:
+
+```
+required_workers ≈ target_throughput (req/s) × avg_request_latency (s)
+```
+
+Because LLM requests are slow (seconds to minutes end-to-end), the latency multiplier is large: with a 2 s average request, `concurrency: 64` caps you at `64 / 2 = 32 req/s`, no matter how much GPU sits behind the Router (the old default of `8` capped you at just `4 req/s`).
+
+### Measured sweep
+
+We ran a closed-loop sweep (each worker holds one in-flight request for its full duration — exactly an Async Processor worker) against a live llm-d stack: **Llama-3.1-8B on vLLM (`--max-num-seq 1024`), a single H100-80GB**, ~256-token outputs, dispatched through the inference gateway + EPP. Throughput and vLLM KV-cache utilization vs. concurrency:
+
+| Concurrency | Throughput (req/s) | Mean latency (s) | GPU KV used | Notes |
+| :--- | :--- | :--- | :--- | :--- |
+| 8 | 4.2 | 1.9 | <1% | old default — GPU essentially idle |
+| 32 | 14.7 | 2.2 | 3% | |
+| **64 (default)** | **24.1** | 2.6 | 5% | current default |
+| 128 | 35.8 | 3.6 | 12% | approaching saturation |
+| 192 | 40.4 | 4.7 | 16% | **knee — best throughput/latency** |
+| 256 | 44.3 | 5.8 | 20% | past knee, latency climbing |
+| 512 | 61.4 | 9.7 | 51% | unstable: errors in repeated runs |
+
+Takeaways:
+
+- **The `64` default reaches ~60% of peak throughput.** At `concurrency: 64` this H100 sustains ~24 req/s (KV 5%) — a solid start, but still short of the ~40 req/s at the knee. The old default of `8` managed only ~4 req/s (KV <1%), roughly **10× below** the knee.
+- **The knee for this backend is ~128–192 — about 2–3× the `64` default.** Beyond it, latency rises faster than throughput (256→512 doubled latency for ~40% more throughput).
+- **Little's Law held exactly.** In-flight requests (`throughput × latency`) matched the worker count at every stable point — workers are never idle in the closed loop, so concurrency directly sets the load on the backend.
+- **A single replica destabilized past ~256.** At very high concurrency a lone processor overwhelmed the gateway/EPP connection path (stalls and errors recurred). This is a reason to **scale out** rather than push one replica arbitrarily high (see [§4](#4-horizontal-scaling)).
+
+### Applying it
+
+1. Estimate (or measure) your workload's average end-to-end request latency `W` at the Router.
+2. Set `concurrency ≈ ceil(target_throughput × W × 1.3)` (the 1.3 is headroom).
+3. Cap per-replica concurrency at a level your gateway/EPP handles cleanly (≈128–256 in the test above) and add replicas beyond that.
+4. **With a saturation/budget gate, you can set concurrency above this number and let the gate throttle dispatch** — but remember a gated worker still holds its pulled message in memory, so don't set it absurdly high.
+
+Quick anchor (derived from the sweep, ~256-token outputs):
+
+| Scenario | Target tput | ~Latency | Suggested concurrency | Topology |
+| :--- | :--- | :--- | :--- | :--- |
+| Single small GPU (dev) | ~30 req/s | ~3–5 s | **128** | 1 replica |
+| Saturate 1× H100 (8B) | ~40 req/s | ~5 s | **~192** | 1 replica |
+| Larger fleet | scale linearly | per workload | `tput × W × 1.3` | N replicas × ≤256 |
+
+> [!NOTE]
+> For long-output workloads, `W` grows proportionally (a 5k-token completion is ~10–20× a 256-token one), so the required concurrency grows with it — long-output pipelines often need concurrency in the high hundreds to low thousands, split across replicas.
+
+---
+
+## 3. Container Resource Sizing
+
+The chart's container defaults are deliberately conservative — suitable for the default `concurrency: 64` with small payloads:
+
+```yaml
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+```
+
+Scale these from the two variables that actually drive consumption: **worker concurrency** and **per-request payload size**.
+
+### Memory Allocation
+
+Memory is the dimension most likely to require tuning, and it scales predictably:
+
+- **Per-request buffering dominates.** Each in-flight worker buffers its request body and the result payload in memory. A rough model:
+
+  ```
+  memory ≈ baseline (~128 MiB) + (concurrency × peak payload size × buffering factor ~2)
+  ```
+
+  The buffering factor accounts for serialized request + response held simultaneously, plus marshaling overhead.
+
+- **Payload size, not worker count, is what forces memory up.** With small payloads (a few KiB), even high concurrency is cheap: at `concurrency: 192` and ~16 KiB payloads, payload memory is only `192 × 16 KiB × 2 ≈ 6 MiB` — the default `256Mi` is plenty. Large payloads flip this: a 100k-token prompt with a 5k-token completion is ~1 MiB per request, so `concurrency: 256` needs `128 MiB + 256 × 1 MiB × 2 ≈ 640 MiB`. **Raise memory when payloads are large, not merely when concurrency is high.**
+
+- **Backlog does not accumulate in the processor.** Unlike the Router, undispatched requests stay in the message queue (Redis/Pub/Sub), not in processor memory. Only in-flight requests count toward the footprint, which is why memory tracks concurrency rather than queue depth.
+
+### CPU Allocation
+
+CPU consumption is low because workers are blocked on I/O most of the time. It scales with **dispatch rate**, not concurrency:
+
+- **Per-dispatch cost** comes from JSON (de)serialization of request and result payloads, gate evaluation, and queue read/write. For typical agentic payloads, budget on the order of **0.5–1.0 vCPU per 100 dispatches/second**. Larger payloads raise the serialization cost proportionally.
+- **Gate overhead.** The `prometheus-saturation` and `prometheus-budget` gates poll Prometheus on an interval; the cost is small and independent of dispatch rate. Setting `ap.prometheusCacheTTL` reduces query frequency when many workers share a gate. The `constant` and `redis` gates add negligible CPU.
+- **Redis Sorted Set polling.** With the Redis backend, `pollIntervalMs` (default `1000`) and `batchSize` (default `10`) govern queue-read frequency. Aggressive (low-interval, small-batch) polling raises idle CPU and Redis load; tune `batchSize` up before lowering the interval.
+
+### Sizing Reference (starting points)
+
+Derived guidance for a single replica, by concurrency and payload profile. Treat as initial requests/limits to validate under load, not measured peaks.
+
+| Workload profile | Concurrency | Payload (in/out) | CPU request | Memory request | Memory limit |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| Default / light | 64 | small (≤4k/≤512) | 100m | 256Mi | 512Mi |
+| Saturate 1 small GPU | 128–192 | small (≤4k/≤512) | 500m | 256Mi | 512Mi |
+| Large agentic | 256 | large (100k/1k) | 1 | 1Gi | 2Gi |
+| Long-output | 256 | large (100k/5k+) | 1 | 2Gi | 4Gi |
+
+Note how the second row keeps the default memory despite 2–3× the concurrency — small payloads keep memory flat; only the large-payload rows need more.
+
+Set the **memory limit close to the request** (the footprint is bounded by `concurrency × payload`, so it does not spike with backlog), and keep CPU limits generous relative to requests to absorb dispatch bursts without throttling.
+
+---
+
+## 4. Horizontal Scaling
+
+Prefer horizontal scaling over a single large worker pool once a replica is comfortably sized — it improves availability and spreads queue-read and gate-polling load.
+
+- **Increase replicas to raise total in-flight capacity** up to what the inference pool can absorb: `total in-flight = replicas × concurrency`. Beyond the inference pool's capacity, gates will hold requests closed and extra workers sit idle.
+- **No coordination required.** Replicas independently pull from the shared queue. Redis Sorted Set and GCP Pub/Sub both distribute messages across consumers; Redis Pub/Sub fans out (each replica sees all messages), so use Sorted Set or Pub/Sub-per-consumer semantics when load should be *shared* rather than duplicated.
+- **Gates remain effective across replicas.** Prometheus-based gates observe global inference-server saturation, so independent replicas converge on the same dispatch decisions without sharing state.
+- **Graceful shutdown.** The processor drains in-flight work on termination (`drainTimeout`, default `2m`). Ensure your pod `terminationGracePeriodSeconds` is at least `drainTimeout` so rolling updates and scale-down do not abandon in-flight requests.
+
+### Helm Resource Override Example
+
+Example values overriding concurrency and container resources for a large-agentic profile (100k/1k payloads) at higher concurrency:
+
+```yaml
+ap:
+  concurrency: 256
+  resources:
+    requests:
+      cpu: "1"
+      memory: "1Gi"
+    limits:
+      cpu: "2"
+      memory: "2Gi"
+```
+
+```bash
+helm install async-processor \
+  oci://ghcr.io/llm-d/charts/async-processor \
+  -f guides/asynchronous-processing/${MQ_PROVIDER}/values.yaml \
+  -f resource_overrides.yaml \
+  --set ap.igwBaseURL=http://${IP}:80 \
+  -n ${NAMESPACE} --create-namespace --version ${ASYNC_VERSION}
+```
+
+---
+
+## Related
+
+- [Asynchronous Processing Well-Lit Path](../well-lit-paths/workloads/batch-serving/asynchronous-processing.md) — overview and use cases.
+- [Asynchronous Processing Guide](../../guides/asynchronous-processing/README.md) — deployment instructions for Redis and GCP Pub/Sub.
+- [Async Processor Architecture](../architecture/advanced/batch/async-processor.md) — internal mechanics, gates, and queue integrations.
+- [llm-d Router Operations Guide](router.md) — sizing for the Router/EPP and standalone proxy.

--- a/guides/asynchronous-processing/README.md
+++ b/guides/asynchronous-processing/README.md
@@ -1,6 +1,8 @@
-# [Experimental] Asynchronous Processing with Async Processor
+# Asynchronous Processing with Async Processor
 
 The [Async Processor](https://github.com/llm-d/llm-d-async) provides a way to process inference requests asynchronously using a queue-based architecture. This is ideal for latency-insensitive workloads or for filling "slack" capacity in your inference pool.
+
+> For production sizing, scaling, and container-resource guidance, see the [Async Processor Operations Guide](../../docs/operations/async-processor.md).
 
 ## Overview
 

--- a/guides/asynchronous-processing/test/kind-e2e.sh
+++ b/guides/asynchronous-processing/test/kind-e2e.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+#
+# kind-e2e.sh — install the asynchronous-processing guide from zero in a
+# throwaway kind cluster, run the Redis smoke test, and tear everything down.
+#
+# Fully isolated from any existing setup:
+#   * creates its own kind cluster
+#   * uses a dedicated KUBECONFIG in a temp dir (your current kubecontext is
+#     never read or modified)
+#
+# The optimized-baseline CPU modelserver defaults to a gated 3B model requesting
+# 64 CPU / 64Gi, which will not fit a laptop. This script patches it down to a
+# tiny ungated model (default: facebook/opt-125m) with small resources so the
+# whole chain runs on a developer machine.
+#
+# Usage:
+#   ./kind-e2e.sh                 # create cluster, test, destroy
+#   KEEP=1 ./kind-e2e.sh          # leave the cluster up for inspection on exit
+#   MODEL=Qwen/Qwen2.5-0.5B-Instruct ./kind-e2e.sh
+#
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration (override via environment)
+# ---------------------------------------------------------------------------
+CLUSTER_NAME="${CLUSTER_NAME:-async-e2e}"
+NAMESPACE="${NAMESPACE:-llm-d-async}"
+BASELINE_NAMESPACE="${BASELINE_NAMESPACE:-llm-d-optimized-baseline}"
+BASELINE_GUIDE="${BASELINE_GUIDE:-optimized-baseline}"
+
+MODEL="${MODEL:-facebook/opt-125m}"        # tiny, ungated, CPU-friendly
+ASYNC_VERSION="${ASYNC_VERSION:-0.7.4}"     # chart + image are public under ghcr.io/llm-d
+
+BASELINE_TIMEOUT="${BASELINE_TIMEOUT:-1800}"  # seconds to wait for vLLM ready
+ASYNC_POLL_TRIES="${ASYNC_POLL_TRIES:-120}"   # smoke-test result polls
+ASYNC_POLL_INTERVAL="${ASYNC_POLL_INTERVAL:-5}"
+
+KEEP="${KEEP:-0}"
+
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+
+# Source the shared guide environment so this harness tests the same llm-d Router
+# release as everything else (GAIE_VERSION, ROUTER_STANDALONE_CHART,
+# ROUTER_CHART_VERSION). guides/env.sh is the single source of truth.
+# shellcheck source=/dev/null
+source "${REPO_ROOT}/guides/env.sh"
+
+# Dedicated kubeconfig so we never touch the user's in-use context.
+WORKDIR="$(mktemp -d)"
+export KUBECONFIG="${WORKDIR}/kubeconfig"
+
+# Isolated, empty registry config: pull the public charts/images anonymously and
+# ignore any stale ghcr credentials in the user's ~/.docker/config.json. Set
+# REGISTRY_AUTH=1 to instead use the existing docker credentials (e.g. for
+# private mirrors).
+if [ "${REGISTRY_AUTH:-0}" != "1" ]; then
+  export DOCKER_CONFIG="${WORKDIR}/docker"
+  mkdir -p "${DOCKER_CONFIG}"
+  echo '{}' > "${DOCKER_CONFIG}/config.json"
+fi
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+log()  { printf '\033[1;34m[%s]\033[0m %s\n' "$(date +%H:%M:%S)" "$*"; }
+ok()   { printf '\033[1;32m[ OK ]\033[0m %s\n' "$*"; }
+fail() { printf '\033[1;31m[FAIL]\033[0m %s\n' "$*" >&2; }
+
+cleanup() {
+  local rc=$?
+  if [ "$KEEP" = "1" ]; then
+    log "KEEP=1 set — leaving cluster '${CLUSTER_NAME}' up."
+    log "Inspect with: KUBECONFIG=${KUBECONFIG} kubectl get pods -A"
+    log "Destroy with: kind delete cluster --name ${CLUSTER_NAME}"
+  else
+    log "Tearing down kind cluster '${CLUSTER_NAME}'..."
+    kind delete cluster --name "${CLUSTER_NAME}" >/dev/null 2>&1 || true
+    rm -rf "${WORKDIR}"
+  fi
+  exit $rc
+}
+trap cleanup EXIT
+
+require() { command -v "$1" >/dev/null 2>&1 || { fail "'$1' is required but not installed."; exit 1; }; }
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+log "Preflight: checking tools"
+require kind
+require kubectl
+require helm
+require git
+ok "kind / kubectl / helm / git present"
+
+# ---------------------------------------------------------------------------
+# 1. Throwaway cluster
+# ---------------------------------------------------------------------------
+log "Creating kind cluster '${CLUSTER_NAME}' (isolated kubeconfig: ${KUBECONFIG})"
+kind create cluster --name "${CLUSTER_NAME}" --kubeconfig "${KUBECONFIG}" --wait 120s
+ok "Cluster up"
+
+# ---------------------------------------------------------------------------
+# 2. Prerequisites (GAIE CRDs, namespaces, dummy HF token)
+# ---------------------------------------------------------------------------
+log "Installing Gateway API Inference Extension CRDs (${GAIE_VERSION})"
+kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml"
+
+kubectl create namespace "${BASELINE_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+
+# Ungated model, but the deployment references this secret, so it must exist.
+kubectl create secret generic llm-d-hf-token \
+  --from-literal="HF_TOKEN=hf_dummy" \
+  --namespace "${BASELINE_NAMESPACE}" \
+  --dry-run=client -o yaml | kubectl apply -f -
+ok "Prerequisites applied"
+
+# ---------------------------------------------------------------------------
+# 3. Backing inference stack (optimized-baseline, standalone, CPU)
+# ---------------------------------------------------------------------------
+log "Deploying optimized-baseline router (standalone)"
+# The base values request 4 CPU each for the EPP and Envoy containers (8 CPU for
+# the pod) — production sizing that will not schedule on a small CI runner. Shrink
+# the requests for this smoke test; only requests affect scheduling.
+helm install "${BASELINE_GUIDE}" \
+  "${ROUTER_STANDALONE_CHART}" \
+  -f "${REPO_ROOT}/guides/recipes/router/base.values.yaml" \
+  -f "${REPO_ROOT}/guides/${BASELINE_GUIDE}/router/${BASELINE_GUIDE}.values.yaml" \
+  --set router.epp.resources.requests.cpu=250m \
+  --set router.epp.resources.requests.memory=512Mi \
+  --set router.proxy.resources.requests.cpu=250m \
+  --set router.proxy.resources.requests.memory=512Mi \
+  -n "${BASELINE_NAMESPACE}" --version "${ROUTER_CHART_VERSION}"
+
+log "Deploying CPU modelserver (then patching to '${MODEL}' with small resources)"
+# The optimized-baseline overlays split GPU by ${INFRA_PROVIDER} (gpu/vllm/base,
+# gpu/vllm/gke); the CPU overlay has no such subfolder, so it is just cpu/vllm.
+# This harness is CPU-only by design (no GPU in CI/dev kind).
+kubectl apply -n "${BASELINE_NAMESPACE}" -k "${REPO_ROOT}/guides/${BASELINE_GUIDE}/modelserver/cpu/vllm"
+
+# Shrink the modelserver to a tiny ungated model that fits a developer machine.
+# args is a non-merge-key list (replaced wholesale); env merges by name so the
+# existing HF_TOKEN entry is preserved.
+kubectl patch deployment "${BASELINE_GUIDE}-cpu-vllm-decode" \
+  -n "${BASELINE_NAMESPACE}" --type=strategic --patch "$(cat <<EOF
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: modelserver
+          args:
+            - ${MODEL}
+            - --max_model_len=2048
+            - --disable-access-log-for-endpoints=/health,/metrics,/v1/models
+          env:
+            - name: VLLM_CPU_KVCACHE_SPACE
+              value: "4"
+          resources:
+            requests:
+              cpu: "1"
+              memory: 5Gi
+            limits:
+              cpu: "2"
+              memory: 8Gi
+EOF
+)"
+
+log "Waiting up to ${BASELINE_TIMEOUT}s for the baseline stack to become ready"
+if ! kubectl wait --for=condition=available --timeout="${BASELINE_TIMEOUT}s" \
+      deployment --all -n "${BASELINE_NAMESPACE}"; then
+  fail "Baseline stack did not become ready"
+  kubectl get pods -n "${BASELINE_NAMESPACE}"
+  exit 1
+fi
+ok "Baseline stack ready"
+
+# ---------------------------------------------------------------------------
+# 4. Message queue (Redis)
+# ---------------------------------------------------------------------------
+log "Deploying Redis (no auth)"
+helm repo add bitnami https://charts.bitnami.com/bitnami >/dev/null 2>&1 || true
+helm repo update >/dev/null
+# Standalone (single pod) keeps the CI footprint small; the guide itself uses
+# the chart default (replication). The async-processor connects to the same
+# redis-master service either way.
+helm install redis bitnami/redis -n redis --create-namespace \
+  --set auth.enabled=false --set architecture=standalone --wait
+ok "Redis ready"
+
+# ---------------------------------------------------------------------------
+# 5. Async Processor
+# ---------------------------------------------------------------------------
+IP="$(kubectl get service "${BASELINE_GUIDE}-epp" -n "${BASELINE_NAMESPACE}" -o jsonpath='{.spec.clusterIP}')"
+log "llm-d Router (EPP) endpoint: http://${IP}:80"
+
+log "Deploying Async Processor (${ASYNC_VERSION}, redis backend)"
+helm install async-processor \
+  oci://ghcr.io/llm-d/charts/async-processor \
+  -f "${REPO_ROOT}/guides/asynchronous-processing/redis/values.yaml" \
+  --set ap.igwBaseURL="http://${IP}:80" \
+  -n "${NAMESPACE}" --create-namespace --version "${ASYNC_VERSION}"
+
+if ! kubectl wait --for=condition=available --timeout=300s \
+      deployment --all -n "${NAMESPACE}"; then
+  fail "Async Processor did not become ready"
+  kubectl get pods -n "${NAMESPACE}"
+  exit 1
+fi
+ok "Async Processor ready"
+
+# ---------------------------------------------------------------------------
+# 6. Smoke test: publish a request, poll for a result
+# ---------------------------------------------------------------------------
+REDIS_HOST="redis-master.redis.svc.cluster.local"
+
+log "Publishing a request to the queue (model=${MODEL})"
+kubectl run async-publish --rm -i --restart=Never --image=redis -- \
+  redis-cli -h "${REDIS_HOST}" \
+  ZADD request-sortedset 1999999999 \
+  "{\"request_kind\":\"redis\",\"data\":{\"id\":\"smoketest\",\"deadline\":1999999999,\"payload\":{\"model\":\"${MODEL}\",\"prompt\":\"Hi, good morning \"}}}"
+
+log "Polling result-list (${ASYNC_POLL_TRIES} x ${ASYNC_POLL_INTERVAL}s)"
+if kubectl run async-smoketest --rm -i --restart=Never --image=redis -- \
+    bash -c "for i in \$(seq 1 ${ASYNC_POLL_TRIES}); do R=\$(redis-cli -h ${REDIS_HOST} RPOP result-list); if [ -n \"\$R\" ]; then echo \"RESULT: \$R\"; exit 0; fi; sleep ${ASYNC_POLL_INTERVAL}; done; echo 'TIMEOUT: no async result'; exit 1"; then
+  ok "Smoke test PASSED — async result returned"
+else
+  fail "Smoke test FAILED — no result on result-list"
+  log "Async Processor logs (tail):"
+  kubectl logs -n "${NAMESPACE}" deployment/async-processor --tail=50 2>/dev/null || true
+  exit 1
+fi
+
+ok "End-to-end install from zero succeeded."


### PR DESCRIPTION
## Summary

Adds an operations guide for the **Async Processor** under `docs/operations/`. The focus is **how to size the llm-d async container**, with concurrency as the central decision.

- `docs/operations/async-processor.md` — throughput model, concurrency sizing, container resources, horizontal scaling.
- `docs/operations/README.md` — link entry for the new guide.

## Concurrency sizing is backed by a measured sweep

A closed-loop sweep (each worker holds one in-flight request for its full duration — exactly an Async Processor worker) was run against a live llm-d stack: **Llama-3.1-8B on vLLM (`--max-num-seq 1024`), a single H100-80GB**, ~256-token outputs, dispatched through the inference gateway + EPP.

| Concurrency | Throughput (req/s) | Mean latency (s) | GPU KV used | Notes |
| :--- | :--- | :--- | :--- | :--- |
| **8 (default)** | **4.2** | 1.9 | <1% | GPU essentially idle |
| 64 | 24.1 | 2.6 | 5% | |
| 128 | 35.8 | 3.6 | 12% | approaching saturation |
| 192 | 40.4 | 4.7 | 16% | knee |
| 256 | 44.3 | 5.8 | 20% | past knee |
| 512 | 61.4 | 9.7 | 51% | unstable (errors recurred) |

Results:
- The **default `concurrency: 8` leaves the GPU ~90% idle** (~4 req/s) — ~10× below what the same hardware sustains.
- The **saturation knee is ~128–192** (16–24× the default).
- **Little's Law held exactly**: `in-flight = throughput × latency` matched the worker count at every stable point, validating `concurrency ≈ throughput × latency × 1.3`.
- A single replica destabilized past ~256 → argues for capping per-replica concurrency and scaling out.

## Notes / open items (WIP)

- CPU/memory figures in the Container Resource Sizing section are **architecture-derived** (clearly labeled), not yet measured from a real async-processor deployment.
- Benchmark covers a single 8B/H100 backend at ~256-token outputs; broader profiles (long-output, large agentic payloads) are extrapolated.