### PR TITLE
[TensorRT-LLM] trtllm-serve recipe and optimized baseline guide

### DIFF
--- a/.github/workflows/nightly-e2e-optimized-baseline-gke-acc-gpu-trtllm-x.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-gke-acc-gpu-trtllm-x.yaml
@@ -1,0 +1,98 @@
+name: Nightly - Optimized Baseline E2E (GKE GPU TensorRT-LLM)
+
+on:
+  workflow_dispatch:
+    inputs:
+      decode_pods:
+        description: 'Number of decode (trtllm "standalone") pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      prefill_pods:
+        description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      gateway_class:
+        description: 'Class of gateway used ("istio", "agentgateway", "epponly" (i.e., "standalone"), "none")'
+        required: false
+        default: 'epponly'
+      monitoring_enabled:
+        description: 'Enabled monitoring ("true", "false")'
+        required: true
+        type: 'string'
+        default: 'false'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode ("true", "false")'
+        required: false
+        default: 'false'
+      verbose:
+        description: 'Execute workflow in "verbose" mode ("true", "false")'
+        required: false
+        default: 'false'
+        type: 'string'
+      harness:
+        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
+        required: false
+        default: 'inference-perf'
+        type: 'string'
+      workload:
+        description: 'Workload profile to be used during "run" operation (check list under "workload/profiles")'
+        required: false
+        default: 'sanity_random.yaml'
+        type: 'string'
+      cleanup:
+        description: 'Cleanup the llm-d stack stood up by this workflow'
+        required: false
+        default: 'true'
+        type: string
+
+  schedule:
+    - cron: '0 13 * * *'  # 13:00 UTC daily (staggered from the vLLM nightlies)
+
+permissions:
+  contents: write
+  actions: read
+
+concurrency:
+  group: nightly-e2e-optimized-baseline-gke-gpu-trtllm
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
+    with:
+      scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
+      standup_method: ${{ inputs.standup_method || 'kustomize' }}
+      standup_scenario: ${{ inputs.standup_scenario || 'optimized-baseline' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'gpu' }}
+      backend_type: ${{ inputs.backend_type || 'trtllm' }}
+      infra_provider: ${{ inputs.infra_provider || 'gke' }}
+      connector: ${{ inputs.connector || '' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-optimized-baseline-gke-gpu-trtllm' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-gke-trtllm' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-gke-trtllm' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions/optimized-baseline' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'sanity_random.yaml' }}
+      cleanup: ${{ inputs.cleanup || 'true' }}
+    secrets: inherit
+
+  update-badge:
+    needs: [nightly]
+    if: always()
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
+    with:
+      badge_name: optimized-baseline-gke-trtllm
+      badge_label: "TRTLLM GPU"
+      result: ${{ needs.nightly.result }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/docs/architecture/core/model-servers.md
+++ b/docs/architecture/core/model-servers.md
@@ -1,6 +1,6 @@
 # Model Servers
 
-The model server is the component that runs inference on a model. llm-d supports vLLM and SGLang as model server backends.
+The model server is the component that runs inference on a model. llm-d supports vLLM, SGLang, and TensorRT-LLM (`trtllm-serve`) as model server backends.
 
 ## Functionality
 
@@ -52,6 +52,20 @@ metadata:
 
 ```
 
+> [!NOTE]
+> **TensorRT-LLM (`trtllm-serve`) requirements.** Unlike vLLM/SGLang, `trtllm-serve` exposes
+> the metrics above at **`/prometheus/metrics`**. The plain `/metrics` route returns JSON
+> iteration-stats the EPP cannot parse, so point the EPP's metrics data source at
+> `path: /prometheus/metrics`. The gauges are emitted only when the server is started with
+> **both** `return_perf_metrics: true` **and** `enable_iter_perf_stats: true` (both default
+> `false`, passed via `--extra_llm_api_options`). The first mounts the Prometheus endpoint,
+> and the second starts the iteration-stats loop that populates the dynamic gauges
+> (`trtllm_num_requests_waiting`, `trtllm_num_requests_running`, `trtllm_kv_cache_utilization`).
+> They require **TensorRT-LLM v1.3.0rc12 or newer** (added in [PR #12545](https://github.com/NVIDIA/TensorRT-LLM/pull/12545)). Earlier releases
+> (including 1.2.1 GA) expose only request-lifecycle histograms. See the
+> [optimized-baseline TensorRT-LLM recipe](../../../guides/optimized-baseline/README.md) for a
+> working configuration.
+
 ### LoRA Adapter Serving
 
 Model servers that support dynamic LoRA serving can benefit from the LoRA affinity algorithm. Note
@@ -89,5 +103,6 @@ Model servers are expected to expose health endpoints that Kubernetes uses for l
 
 - [vLLM Documentation](https://docs.vllm.ai/)
 - [SGLang Documentation](https://github.com/sgl-project/sglang)
+- [TensorRT-LLM Documentation](https://nvidia.github.io/TensorRT-LLM/)
 - [InferencePool](inferencepool.md) -- how model servers are discovered and managed
 - [EPP](router/epp) -- how the router routes requests to model servers informed by model servers metrics

--- a/guides/optimized-baseline/README.md
+++ b/guides/optimized-baseline/README.md
@@ -9,7 +9,7 @@
 
 ## Overview
 
-This guide deploys the recommended out of the box [configuration](https://github.com/llm-d/llm-d-router/blob/main/docs/architecture.md) for most vLLM and SGLang deployments, reducing tail latency and increasing throughput through load-aware and prefix-cache aware balancing.
+This guide deploys the recommended out of the box [configuration](https://github.com/llm-d/llm-d-router/blob/main/docs/architecture.md) for most vLLM, SGLang, and TensorRT-LLM deployments, reducing tail latency and increasing throughput through load-aware and prefix-cache aware balancing.
 
 The optimized-baseline defaults to two main routing criteria:
 
@@ -102,6 +102,10 @@ helm install ${GUIDE_NAME} \
     -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
 ```
 
+> [!NOTE]
+> For **TensorRT-LLM** (`trtllm-serve`), replace the last `-f` flag with the TensorRT-LLM
+> values file: `-f ${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}-trtllm.values.yaml`
+
 <details>
 <summary><h4>Gateway Mode</h4></summary>
 
@@ -130,8 +134,7 @@ Apply the Kustomize overlays for your specific backend:
 
 ```bash
 export ACCELERATOR_TYPE=gpu # options: gpu, amd, xpu, hpu, tpu/v6, tpu/v7, cpu
-export INFRA_PROVIDER=base # base | gke
-export MODEL_SERVER=vllm # options: vllm, sglang
+export MODEL_SERVER=vllm # options: vllm, sglang, trtllm
 export INFRA_PROVIDER=base # base | gke (GPU only, omit for other accelerators)
 kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/${ACCELERATOR_TYPE}/${MODEL_SERVER}/${INFRA_PROVIDER}/
 ```

--- a/guides/optimized-baseline/modelserver/gpu/trtllm/base/extra-llm-api-options-configmap.yaml
+++ b/guides/optimized-baseline/modelserver/gpu/trtllm/base/extra-llm-api-options-configmap.yaml
@@ -1,0 +1,17 @@
+# Passed to trtllm-serve via --extra_llm_api_options. Both flags are required
+# (both default false) for the llm-d router to read TensorRT-LLM load metrics:
+#   * return_perf_metrics  -> mounts the Prometheus endpoint at /prometheus/metrics
+#                             (the router's metrics-data-source scrapes this path).
+#   * enable_iter_perf_stats -> starts the background iteration-stats loop that
+#                             populates the dynamic gauges the load-aware scorers
+#                             consume (trtllm_num_requests_waiting / _running,
+#                             trtllm_kv_cache_utilization, trtllm_kv_cache_hit_rate).
+# With only return_perf_metrics the endpoint serves but those gauges stay absent.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: extra-llm-api-options
+data:
+  llm_api_options.yaml: |
+    return_perf_metrics: true
+    enable_iter_perf_stats: true

--- a/guides/optimized-baseline/modelserver/gpu/trtllm/base/kustomization.yaml
+++ b/guides/optimized-baseline/modelserver/gpu/trtllm/base/kustomization.yaml
@@ -6,15 +6,8 @@ resources:
 
 namePrefix: optimized-baseline-nvidia-gpu-trtllm-
 
-images:
-  - name: REPLACE_MODEL_SERVER_IMAGE
-    newName: nvcr.io/nvidia/tensorrt-llm/release
-    # Iteration-state gauges the router's load-aware scorers consume
-    # (trtllm_num_requests_waiting/_running, trtllm_kv_cache_utilization) were
-    # added in PR https://github.com/NVIDIA/TensorRT-LLM/pull/12545, first
-    # available in v1.3.0rc12. Stock 1.2.1 GA lacks
-    # them. There is no v1.3.0 GA yet, so pin a release candidate.
-    newTag: 1.3.0rc18
+components:
+  - ../../../../../recipes/modelserver/components/images/gpu-trtllm
 
 labels:
   - pairs:
@@ -24,36 +17,6 @@ labels:
       llm-d.ai/accelerator-vendor: nvidia
     includeSelectors: true
     includeTemplates: true
-    fields:
-      - version: v1
-        kind: ServiceAccount
-        path: metadata/labels
-        create: true
-      - group: apps
-        version: v1
-        kind: Deployment
-        path: metadata/labels
-        create: true
-      - group: apps
-        version: v1
-        kind: Deployment
-        path: spec/selector/matchLabels
-        create: true
-      - group: apps
-        version: v1
-        kind: Deployment
-        path: spec/template/metadata/labels
-        create: true
-      - group: monitoring.coreos.com
-        version: v1
-        kind: PodMonitor
-        path: metadata/labels
-        create: true
-      - group: monitoring.coreos.com
-        version: v1
-        kind: PodMonitor
-        path: spec/selector/matchLabels
-        create: true
 
 patches:
   - path: patch-trtllm.yaml

--- a/guides/optimized-baseline/modelserver/gpu/trtllm/base/kustomization.yaml
+++ b/guides/optimized-baseline/modelserver/gpu/trtllm/base/kustomization.yaml
@@ -1,0 +1,59 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../../recipes/modelserver/base/single-host/default
+  - extra-llm-api-options-configmap.yaml
+
+namePrefix: optimized-baseline-nvidia-gpu-trtllm-
+
+images:
+  - name: REPLACE_MODEL_SERVER_IMAGE
+    newName: nvcr.io/nvidia/tensorrt-llm/release
+    # Iteration-state gauges the router's load-aware scorers consume
+    # (trtllm_num_requests_waiting/_running, trtllm_kv_cache_utilization) were
+    # added in PR https://github.com/NVIDIA/TensorRT-LLM/pull/12545, first
+    # available in v1.3.0rc12. Stock 1.2.1 GA lacks
+    # them. There is no v1.3.0 GA yet, so pin a release candidate.
+    newTag: 1.3.0rc18
+
+labels:
+  - pairs:
+      llm-d.ai/model: Qwen3-32B
+      llm-d.ai/guide: optimized-baseline
+      llm-d.ai/accelerator-variant: gpu
+      llm-d.ai/accelerator-vendor: nvidia
+    includeSelectors: true
+    includeTemplates: true
+    fields:
+      - version: v1
+        kind: ServiceAccount
+        path: metadata/labels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: metadata/labels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: spec/selector/matchLabels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: spec/template/metadata/labels
+        create: true
+      - group: monitoring.coreos.com
+        version: v1
+        kind: PodMonitor
+        path: metadata/labels
+        create: true
+      - group: monitoring.coreos.com
+        version: v1
+        kind: PodMonitor
+        path: spec/selector/matchLabels
+        create: true
+
+patches:
+  - path: patch-trtllm.yaml

--- a/guides/optimized-baseline/modelserver/gpu/trtllm/base/patch-trtllm.yaml
+++ b/guides/optimized-baseline/modelserver/gpu/trtllm/base/patch-trtllm.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  # Mirrors the vLLM/SGLang variants: 8 replicas × TP=2 = 16 GPUs total.
+  replicas: 8
+  template:
+    spec:
+      containers:
+        - name: modelserver
+          command: ["trtllm-serve", "serve"]
+          # Include all args in overlay patch for consistency.
+          args:
+            - "Qwen/Qwen3-32B"
+            - "--tp_size=2"
+            - "--host=0.0.0.0"
+            - "--port=8000"
+            - "--backend=pytorch"
+            - "--kv_cache_free_gpu_memory_fraction=0.9"
+            # Enables /prometheus/metrics + the iteration-stats loop the router
+            # reads. See extra-llm-api-options-configmap.yaml for the contents.
+            - "--extra_llm_api_options=/etc/trtllm/llm_api_options.yaml"
+          env:
+            - name: HF_HOME
+              value: /hf-cache
+            # Overriding the container command (above) bypasses the image entrypoint
+            # that normally sets up the dynamic linker path, so set it explicitly:
+            #   tensorrt/lib  -> libnvonnxparser.so.10 etc. (tensorrt is imported even
+            #                    on the PyTorch backend)
+            #   nvidia/lib64  -> libcuda.so.1 + NVML (GKE-injected driver)
+            #   cuda/lib64    -> libcudart at runtime
+            - name: LD_LIBRARY_PATH
+              value: "/usr/local/tensorrt/lib:/usr/local/cuda/lib64:/usr/local/nvidia/lib64"
+          resources:
+            limits:
+              cpu: '16'
+              memory: 128Gi
+              nvidia.com/gpu: 2
+            requests:
+              cpu: '8'
+              memory: 96Gi
+              nvidia.com/gpu: 2
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /hf-cache
+              name: hf-cache
+            - mountPath: /etc/trtllm
+              name: extra-llm-api-options
+          startupProbe:
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 120
+          livenessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 20Gi
+        - name: hf-cache
+          emptyDir: {}
+        - name: extra-llm-api-options
+          configMap:
+            name: extra-llm-api-options

--- a/guides/optimized-baseline/modelserver/gpu/trtllm/gke/kustomization.yaml
+++ b/guides/optimized-baseline/modelserver/gpu/trtllm/gke/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+components:
+  - ../../../../../recipes/modelserver/components/disable-gke-nccl-tuner-patch

--- a/guides/optimized-baseline/router/optimized-baseline-trtllm.values.yaml
+++ b/guides/optimized-baseline/router/optimized-baseline-trtllm.values.yaml
@@ -1,0 +1,50 @@
+## optimized-baseline guide overrides for the llm-d router (TensorRT-LLM variant).
+## Layer on top of: recipes/router/base.values.yaml
+##
+## Use this file INSTEAD of optimized-baseline.values.yaml when the model servers
+## are trtllm-serve. It is identical to the vLLM/SGLang variant except for the two
+## TensorRT-LLM-specific knobs below (modelServers.type and the metrics path).
+
+router:
+  extraServicePorts:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8081
+
+  epp:
+    pluginsConfigFile: "optimized-baseline-plugins.yaml"
+    pluginsCustomConfig:
+      optimized-baseline-plugins.yaml: |
+        apiVersion: llm-d.ai/v1alpha1
+        kind: EndpointPickerConfig
+        plugins:
+        - type: queue-scorer
+        - type: kv-cache-utilization-scorer
+        - type: prefix-cache-scorer
+        - type: no-hit-lru-scorer
+        schedulingProfiles:
+        - name: default
+          plugins:
+          - pluginRef: queue-scorer
+            weight: 2
+          - pluginRef: kv-cache-utilization-scorer
+            weight: 2
+          - pluginRef: prefix-cache-scorer
+            weight: 3
+          - pluginRef: no-hit-lru-scorer
+            weight: 2
+
+    # TensorRT-LLM exposes its Prometheus metrics at /prometheus/metrics, not the
+    # default /metrics (which serves JSON iteration-stats the extractor cannot
+    # parse). The model server must be started with return_perf_metrics: true and
+    # enable_iter_perf_stats: true (see the trtllm modelserver overlay).
+    metricsDataSource:
+      path: /prometheus/metrics
+
+  modelServers:
+    # Drives core-metrics-extractor's defaultEngine: trtllm-serve, mapping the
+    # router's load/kv scorers onto the trtllm_* metric names.
+    type: trtllm-serve
+    matchLabels:
+      llm-d.ai/guide: "optimized-baseline"

--- a/guides/recipes/modelserver/components/images/gpu-trtllm/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/gpu-trtllm/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+images:
+  - name: REPLACE_MODEL_SERVER_IMAGE
+    newName: nvcr.io/nvidia/tensorrt-llm/release
+    # Iteration-state gauges the router's load-aware scorers consume
+    # (trtllm_num_requests_waiting/_running, trtllm_kv_cache_utilization) were
+    # added in PR https://github.com/NVIDIA/TensorRT-LLM/pull/12545, first
+    # available in v1.3.0rc12. Stock 1.2.1 GA lacks
+    # them. There is no v1.3.0 GA yet, so pin a release candidate.
+    newTag: 1.3.0rc18


### PR DESCRIPTION
## Summary

Adds a TensorRT-LLM (`trtllm-serve`) variant to the optimized-baseline guide, so the load-aware and prefix-cache-aware router works with TensorRT-LLM model servers (with `trtllm-serve` frontend) alongside the existing vLLM and SGLang paths.

Fixes #1550.

## What this adds
  - **Model server overlay** `modelserver/gpu/trtllm/{base,gke}`: a `trtllm-serve` Deployment, a ConfigMap with the required perf-metrics flags, and kustomize overlays. Mirrors the vLLM/SGLang footprint (Qwen3-32B, 8 replicas at TP=2).
  - **Router values** `router/optimized-baseline-trtllm.values.yaml`: sets `modelServers.type: trtllm-serve` and scrapes `/prometheus/metrics`.
  - **Guide README** section for the trtllm-serve path and its metric requirements.
  - **Nightly E2E workflow** `nightly-e2e-optimized-baseline-gke-trtllm.yaml`, matching the vLLM GKE nightly (same cluster, H100, footprint).
  - **Docs** update in `docs/architecture/core/model-servers.md` describing the trtllm-serve metric requirements.

  ## TensorRT-LLM requirements (encoded in the overlay)

  - Image v1.3.0rc12 or newer. The iteration-state gauges the load scorers read were added in [TensorRT-LLM PR #12545](https://github.com/NVIDIA/TensorRT-LLM/pull/12545).
  - Server started with `return_perf_metrics: true` and `enable_iter_perf_stats: true`.
  - Metrics scraped at `/prometheus/metrics`, not `/metrics`.

  ## Validation

Deployed verbatim on GKE H100 (4 nodes, 8 GPUs each), 8 replicas at TP=2, standalone mode.
  - 240 of 240 shared-prefix requests succeeded with no failures.
  - Prefix-cache-aware routing sent same-prefix traffic to cache-warm pods, with `trtllm_kv_cache_hit_rate` near 0.80 on the serving pods.
  - The router reads the trtllm gauges (they populate after the first request) and routes on them.