### PR TITLE
docs(tiered-prefix-cache): refocus guide on deployment, reflect vLLM-native tiering

### DIFF
--- a/docs/well-lit-paths/capabilities/tiered-prefix-cache.md
+++ b/docs/well-lit-paths/capabilities/tiered-prefix-cache.md
@@ -51,6 +51,15 @@ This increases the **KV-working set size**, growing the **receptive-field** (the
 > [!IMPORTANT]
 > CPU KV Cache offloading is low overhead and introduces ~no additional complexity. It can be enabled in almost all deployments. Storage offloading requires additional consideration.
 
+## Storage Tiers
+
+Offloaded KV caches can live on several tiers, ordered by read/write latency: frequently accessed caches stay closest to the accelerator, while larger or colder caches move to slower, higher-capacity tiers. We recommend always enabling the HBM and CPU RAM tiers, and adding a filesystem tier when the working set grows beyond HBM + CPU RAM.
+
+- **CPU RAM** — Low operational overhead and typically far larger than accelerator HBM, making it the default offload target. Loading from CPU RAM is faster than recomputing prefill in most cases, and asynchronous offload adds little overhead.
+- **Local disk** — Increases capacity further, but is slower than CPU RAM. Suitable when the workload tolerates the added latency and local capacity is sufficient.
+- **Shared (remote) storage** — Provides capacity independent of deployment size, KV-cache sharing across replicas, fast scale-up (new replicas reuse existing cache), and persistence across restarts and failures. Latency and throughput depend on the underlying system, so evaluate that the transfer cost does not outweigh the savings. Mature enterprise systems (for example CephFS, GCP Lustre, IBM Storage Scale, AWS EFS) integrate through standard POSIX file access.
+- **P2P sharing** — Inference replicas can share caches in HBM or CPU memory over a peer-to-peer network, extending sharing without additional storage resources. This adds operational overhead and potential contention with model-parallelism traffic; more guidance will follow in future releases.
+
 ## Deploy
 
 See the [KV Cache Management guide](../../../guides/tiered-prefix-cache) for manifests and step-by-step deployment.
@@ -70,13 +79,22 @@ vLLM pods are configured with `OffloadingConnector` and increased CPU memory req
   </picture>
 </p>
 
-### Storage KV Cache Offloading
+### Tiered Offloading to Filesystem
 
-vLLM pods mount a ReadWriteMany PVC backed by shared storage (Lustre, CephFS, or similar) at `/mnt/files-storage`. The `OffloadingConnector` is configured with a custom backend module (`llmd_fs_backend.spec`) that handles async I/O with GPU DMA transfers. This enables cross-pod cache sharing -- newly scaled pods can read existing cache immediately -- persistence across pod restarts, and capacity limited only by storage system size.
+vLLM's `OffloadingConnector` natively supports a multi-tier hierarchy: HBM → CPU RAM → filesystem. Configured with `TieringOffloadingSpec` and a `secondary_tiers` entry of `type: fs`, evicted blocks spill from CPU RAM to a ReadWriteMany PVC mounted at `/mnt/files-storage` (backed by Lustre, CephFS, IBM Storage Scale, AWS EFS, or similar). I/O is asynchronous and uses GPU DMA, parallelized across read/write threads. Because the tier is shared, newly scaled pods read existing cache immediately and the cache persists across pod restarts; capacity is bounded only by the storage system.
+
+The connector does not evict data from the shared tier -- capacity is managed by the storage system or by an external controller (a reference PVC evictor is available in the [llm-d-kv-cache repository](https://github.com/llm-d/llm-d-kv-cache)).
 
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)">
-    <img src="../../assets/fs-offloading.svg" alt="Storage KV Cache Offloading">
+    <img src="../../assets/fs-offloading.svg" alt="Tiered Offloading to Filesystem">
   </picture>
 </p>
+
+## Further Reading
+
+- [Tiered Prefix Cache guide](../../../guides/tiered-prefix-cache) — manifests and step-by-step deployment.
+- [vLLM KV offloading connector](https://vllm-project.github.io/2026/01/08/kv-offloading-connector.html) — design of the native `OffloadingConnector` and its tiering.
+- [Multi-tier KV offloading RFC](https://github.com/vllm-project/vllm/issues/38260) — the upstream tiering design.
+- [LMCache](https://lmcache.ai) and [SGLang HiCache](https://github.com/sgl-project/sglang) — alternative offloading implementations supported by this path.

--- a/docs/well-lit-paths/capabilities/tiered-prefix-cache.md
+++ b/docs/well-lit-paths/capabilities/tiered-prefix-cache.md
@@ -62,7 +62,7 @@ Offloaded KV caches can live on several tiers, ordered by read/write latency: fr
 
 ## Deploy
 
-See the [KV Cache Management guide](../../../guides/tiered-prefix-cache) for manifests and step-by-step deployment.
+See the [Tiered Prefix Cache guide](../../../guides/tiered-prefix-cache) for manifests and step-by-step deployment.
 
 ## Architecture
 
@@ -70,7 +70,7 @@ llm-d leverages the following architectures for offloading.
 
 ### CPU KV Cache Offloading
 
-vLLM pods are configured with `OffloadingConnector` and increased CPU memory requests (e.g., 400 GB). Evicted KV-cache blocks move to host CPU memory instead of being discarded, extending the effective cache size with negligible overhead. The EPP maintains a global index of which blocks exist on which pods and tiers, adding a second `prefix-cache-scorer` plugin for CPU-tier blocks.
+Each model server offloads to host CPU memory through its own native mechanism: vLLM uses the `OffloadingConnector`, and SGLang uses HiCache. Pods are configured with the connector enabled and increased CPU memory requests (e.g., 400 GB). Evicted KV-cache blocks move to host CPU memory instead of being discarded, extending the effective cache size with negligible overhead. The EPP maintains a global index of which blocks exist on which pods and tiers, adding a second `prefix-cache-scorer` plugin for CPU-tier blocks.
 
 <p align="center">
   <picture>

--- a/guides/tiered-prefix-cache/README.md
+++ b/guides/tiered-prefix-cache/README.md
@@ -1,4 +1,4 @@
-# KV Cache Offloading
+# Tiered Prefix Cache
 
 [![E2E (GKE GPU Native)](https://github.com/llm-d/llm-d/actions/workflows/consolidate-status-tiered-prefix-cache-gke-cpu-gpu-vllm-native.yaml/badge.svg)](https://github.com/llm-d/llm-d/actions/workflows/consolidate-status-tiered-prefix-cache-gke-cpu-gpu-vllm-native.yaml)
 [![E2E (GKE GPU LMcache)](https://github.com/llm-d/llm-d/actions/workflows/consolidate-status-tiered-prefix-cache-gke-cpu-gpu-vllm-lmcache.yaml/badge.svg)](https://github.com/llm-d/llm-d/actions/workflows/consolidate-status-tiered-prefix-cache-gke-cpu-gpu-vllm-lmcache.yaml)
@@ -7,144 +7,46 @@
 
 ## Overview
 
-Efficient caching of prefix computation states to avoid recomputation is crucial for boosting Large Language Model (LLM) inference performance such as Time to First Token (TTFT) and overall throughput, as well as reducing the cost.
-For the self-attention mechanism, the generation of the next token leverages the prefix Key & Value (KV) tensors.
-For State Space Model (SSM) models such as mamba models, reusing cache of its SSM states of prefix locations also saves computation for the next token.
-In this guide we use the term "prefix cache" to refer to the cache of computation states in the prefix tokens of a target token which includes the caching of prefix KV tensors and other forms of caches.
-The prefix aware request scheduling optimizations in the [optimized baseline](../optimized-baseline/README.md) also applies here.
+This guide deploys prefix-cache offloading: evicted KV-cache blocks move from accelerator HBM to larger, more cost-effective tiers (CPU RAM, and optionally a shared filesystem) and are pulled back on demand instead of being recomputed. This increases the effective cache size and prefix-cache reuse for multi-turn and long-context workloads.
 
-State of the art inference engines already implement native prefix cache reuse across requests in accelerator High-Bandwidth Memory (HBM), but in most serving environments HBM is already a constrained resource. To increase the amount of available memory beyond HBM requires more cache storage, driving the need for offloading prefix cache from HBM to more cost effective storage options such as CPU RAM.
+For the concepts, tier tradeoffs, and architecture, see the [Tiered Prefix Cache well-lit path](../../docs/well-lit-paths/capabilities/tiered-prefix-cache.md). This guide focuses on deployment. The prefix-aware request scheduling from the [optimized baseline](../optimized-baseline/README.md) also applies here.
 
-This well-lit path offers multiple sub-guides per the cache storage type, either used standalone, or combined with other storage types in a tiered cache hierarchy. It also provides high level guidance on their suitability per workload, and makes recommendations about selecting and configuring a prefix cache offloading implementation.
+## Choosing a Path
 
-## Storage Types
+Each path is a self-contained deployment using a specific offloading implementation. Pick one and follow its deploy block under [Installation Instructions](#2-deploy-the-model-server).
 
-### CPU RAM
+| Path | Implementation | Tiers | Directory |
+| ---- | -------------- | ----- | --------- |
+| **vLLM native** | vLLM `OffloadingConnector` | CPU RAM, CPU RAM + Filesystem | `modelserver/gpu/vllm/native/` |
+| **LMCache** | [LMCache](https://lmcache.ai) connector | CPU RAM, Filesystem | `modelserver/gpu/vllm/lmcache-connector/` |
+| **SGLang HiCache** | SGLang native HiCache | CPU RAM | `modelserver/gpu/sglang/native/cpu/` |
+| **TPU** | vLLM TPU KVCache connector | CPU RAM | `modelserver/tpu/v6/vllm/native/cpu/`, `modelserver/tpu/v7/vllm/native/cpu/` |
 
-Enabling prefix cache offloading to CPU is recommended for the following reasons:
-
-* Little operational overhead.
-* There are usually more CPU RAM storage available than accelerator HBM on the host offering much larger cache capacity.
-* CPU - accelerator transfer is faster than recomputation for most cases.
-* (WIP) Prefix cache storage tier aware optimized baseline makes smart decisions based on cache tier (accelerator HBM vs. CPU RAM).
-
-In low cache size scenario where HBM is primarily used, async CPU offloading should incur little overhead. In high cache size scenario loading cache from CPU RAM offers significantly higher cache hit and thus better performance than HBM only.
-
-### Local Disk
-
-Utilizing local disk storage can significantly increase the cache capacity. However disks are typically significantly slower than CPU RAM.
-
-Consider this when:
-
-* your workload can tolerate the latency overhead.
-* the cache capacity of local disks is sufficient for your use case.
-
-Otherwise we recommend a shared storage because it offers cache sharing between instances, has more options to choose from to get a good tradeoff between cost and performance, and offers significantly larger capacity.
-
-### Shared Storage
-
-Offloading prefix cache to a shared (remote) storage tier provides several important benefits beyond local CPU or disk caching:
-
-* **Extended cache capacity** - Offers massive storage capacity that is independent of the inference engine deployment size.
-* **Shared KV-cache across nodes** - Multiple inference replicas can access and reuse the same prefix cache.
-* **Fast scale-up** - New nodes can immediately reuse existing KV-cache data without warming the cache from scratch.
-* **Persistence across restarts or failures** - KV-cache data survives pod restarts, rescheduling, and node failures.
-* **Enterprise storage integration** - Can leverage mature enterprise storage systems (for example CephFS, GCP Lustre, IBM Storage Scale) with built-in durability, monitoring, and access control.
-
-However, shared storage introduces additional operational and performance considerations. Latency and throughput depend on the characteristics of the underlying storage system, so careful evaluation is required to ensure that cache transfer overhead does not negatively impact inference performance.
-
-Integration between the storage system and llm-d is achieved through vLLM connectors. The specific connector and data path depend on the storage system type and the underlying transport mechanism. Any storage connector that is compatible with vLLM can be used **transparently within the llm-d project**.
-
-### P2P Cache Sharing
-
-A P2P network can be formed between the inference engine instances to share caches in HBMs or CPU memory. It enables more cache sharing without needing additional storage resources. However this strategy adds operational overhead, and potential contention between model parallelism traffic such as tensor parallelism. We will add more recommendations in the following releases.
-
-## Cache Tiering
-
-Generally multiple cache tiers can be applied ordered by their cache read/write latencies, allowing frequently accessed caches to stay as close as possible to the accelerator, and large or less frequently accessed caches to be offloaded to slower tiers. We recommend always setting up HBM and CPU RAM tiers, and consider a third or fourth tier when your cache needs goes beyond HBM + CPU RAM.
-
----
-
-## Supported Connectors
-
-| Connector | Storage Tier | Directory |
-| --------- | ------------ | --------- |
-| vLLM Native OffloadingConnector | CPU RAM | `modelserver/gpu/vllm/native/cpu/` |
-| vLLM Native OffloadingConnector | CPU RAM + Filesystem (shared storage) | `modelserver/gpu/vllm/native/fs/` |
-| LMCache Connector | CPU RAM | `modelserver/gpu/vllm/lmcache-connector/cpu/` |
-| LMCache Connector | Filesystem (shared storage) | `modelserver/gpu/vllm/lmcache-connector/fs/` |
-| TPU KVCache Connector | CPU RAM | `modelserver/tpu/v6/vllm/native/cpu/` and `modelserver/tpu/v7/vllm/native/cpu/` |
-| SGLang HiCache | CPU RAM | `modelserver/gpu/sglang/native/cpu/` |
-
-<details>
-<summary><h4>About vLLM Native OffloadingConnector</h4></summary>
-
-The vLLM native OffloadingConnector offloads KV blocks to CPU RAM and optionally to a POSIX filesystem (for example IBM Storage Scale, CephFS, GCP Lustre, AWS EFS), enabling a multi-tier cache hierarchy: HBM → CPU RAM → shared storage.
-
-**Key advantages:**
-
-* **Fully asynchronous I/O** - Uses vLLM's native offloading pipeline, enabling non-blocking KV cache reads and writes.
-* **File system agnostic** - Works with any storage backend that supports standard POSIX file operations.
-* **KV sharing across instances and nodes** - Multiple vLLM servers can reuse cached prefixes by accessing the same shared storage path.
-* **High throughput via parallelism** - I/O operations are parallelized across multiple threads to increase bandwidth and reduce tail latency.
-* **Minimal GPU compute interference** - Uses GPU DMA for data transfers, reducing interference with GPU compute kernels during load and store operations.
-
-**Note:** The storage connector does not handle cleanup or eviction of data on the shared storage. Storage capacity management must be handled by the underlying storage system or by an external controller. A simple reference implementation of a PVC-based evictor is available in the [kv-cache repository (PVC Evictor)](https://github.com/llm-d/llm-d-kv-cache).
-
-For advanced configuration options and implementation details, see the [llm-d FS backend documentation](https://github.com/llm-d/llm-d-kv-cache/tree/main/kv_connectors/llmd_fs_backend).
-
-</details>
-
-<details>
-<summary><h4>About LMCache Connector</h4></summary>
-
-[LMCache](https://lmcache.ai) is an extension for LLM serving engines that enhances performance by reducing "Time to First Token" (TTFT) and increasing throughput, particularly for long-context scenarios. It provides integration to various storage backends including CPU RAM and shared filesystems. For more information, visit the [LMCache website](https://lmcache.ai).
-
-</details>
-
-<details>
-<summary><h4>About SGLang HiCache</h4></summary>
-
-[HiCache](https://github.com/sgl-project/sglang) is the implementation of CPU prefix cache offloading in SGLang. It enables large-scale prefix caching by offloading KV cache blocks to CPU RAM, significantly increasing the effective cache capacity beyond available GPU HBM.
-
-</details>
-
----
+The **vLLM native** path is the recommended default. Its CPU tier is low-overhead and enabling it is appropriate in almost all deployments; its filesystem tier uses vLLM's native multi-tier offloading (`TieringOffloadingSpec`) to spill from CPU RAM to shared storage (HBM → CPU RAM → filesystem).
 
 ## Default Configuration
 
 ### GPU
 
-| Parameter                 | Value                                                   |
-| ------------------------- | ------------------------------------------------------- |
-| Model                     | [Qwen/Qwen3-32B](https://huggingface.co/Qwen/Qwen3-32B) |
-| GPUs per replica (TP)     | 2                                                       |
-| GPU Accelerator           | NVIDIA H100                                             |
-| CPU Cache Offload Size    | 100 GB                                                  |
+| Parameter              | Value                                                   |
+| ---------------------- | ------------------------------------------------------- |
+| Model                  | [Qwen/Qwen3-32B](https://huggingface.co/Qwen/Qwen3-32B) |
+| GPUs per replica (TP)  | 2                                                       |
+| GPU Accelerator        | NVIDIA H100                                             |
+| CPU Cache Offload Size  | 100 GB                                                 |
 
 ### TPU
 
-| Parameter                 | Value                                                   |
-| ------------------------- | ------------------------------------------------------- |
-| Model                     | [Qwen/Qwen3-32B](https://huggingface.co/Qwen/Qwen3-32B) |
-| TPUs per replica (TP)     | 8                                                       |
-| TPU Accelerator           | TPU v7                                                  |
-| HBM Staging Buffer Size   | 1000 Blocks (~34 GB)                                    |
-| CPU Cache Offload Size    | 25000 Chunks (~780 GB)                                  |
+| Parameter               | Value                                                   |
+| ----------------------- | ------------------------------------------------------- |
+| Model                   | [Qwen/Qwen3-32B](https://huggingface.co/Qwen/Qwen3-32B) |
+| TPUs per replica (TP)   | 8                                                       |
+| TPU Accelerator         | TPU v7                                                  |
+| HBM Staging Buffer Size | 1000 Blocks (~34 GB)                                    |
+| CPU Cache Offload Size  | 25000 Chunks (~780 GB)                                  |
 
-
-## Additional Configuration
-
-### GPU 
-
-| Parameter                 | Value                                                   |
-| ------------------------- | ------------------------------------------------------- |
-| Model                     | [openai/gpt-oss-120b](https://huggingface.co/openai/gpt-oss-120b) |
-| GPUs per replica (TP)     | 1                                                       |
-| GPU Accelerator           | NVIDIA H100                                             |
-| CPU Cache Offload Size    | 100 GB          
-
-This guide supports both GPU and TPU. The Kustomize overlays are available in `modelserver/gpu/vllm/` and `modelserver/tpu/` (supporting both v6 and v7).
+> [!NOTE]
+> A `gpt-oss-120b` variant (TP=1 on NVIDIA H100, 100 GB CPU offload) is also benchmarked — see [gpt-oss-120B benchmarking results](benchmark-results-gpt-oss-120b.md).
 
 ---
 
@@ -226,46 +128,75 @@ helm install tiered-prefix-cache \
 
 </details>
 
+> [!NOTE]
+> To enable tiered prefix caching, the llm-d EPP is configured with two prefix-cache scorers: one for the accelerator (GPU/TPU) cache and one for the CPU cache.
+> LRU capacity for the CPU cache must be configured manually (`lruCapacityPerServer`) because vLLM does not currently emit CPU block metrics.
+
 ---
 
 ### 2. Deploy the Model Server
 
-Select the connector and infrastructure provider matching your environment:
+Deploy **one** of the paths below. Each `kubectl apply -k` targets an overlay directory; the `INFRA_PROVIDER` selects a `base` overlay or a provider-specific one (for example `gke`).
 
-**For NVIDIA GPU — CPU offloading only:**
+#### vLLM native — CPU RAM
 
 ```bash
-export MODEL_SERVER=vllm # vllm | sglang
-export CONNECTOR=native  # native | lmcache-connector
-export VARIANT=cpu       # cpu
 export INFRA_PROVIDER=base  # base | gke
-kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/gpu/${MODEL_SERVER}/${CONNECTOR}/${VARIANT}/${INFRA_PROVIDER}/
+kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/gpu/vllm/native/cpu/${INFRA_PROVIDER}/
 ```
 
-**For NVIDIA GPU — filesystem (shared storage) tier:**
+#### vLLM native — CPU RAM + Filesystem
 
-If using the `native/fs/` or `lmcache-connector/fs/` variants, create a ReadWriteMany PVC.
+This path adds a shared filesystem tier using vLLM's native multi-tier offloading. It requires a ReadWriteMany PVC mounted at `/mnt/files-storage`.
 
-To provision a managed GCP Lustre instance on GKE and configure the corresponding `StorageClass`, follow the [GCP Lustre guide](./manifests/backends/lustre/README.md).
-
-To provision AWS EFS and configure the corresponding `StorageClass`, follow the [EFS guide](./manifests/backends/aws/README.md).
+First, provision the PVC. See [Storage Backends](#storage-backends) to configure a `StorageClass` for your environment.
 
 ```bash
-export STORAGE_CLASS="" # set your preferred storage class or leave empty to use cluster default; or set "lustre" / "efs-sc"
+export STORAGE_CLASS="" # cluster default if empty; or e.g. "lustre" / "efs-sc"
 envsubst < ${REPO_ROOT}/guides/tiered-prefix-cache/manifests/pvc.yaml | kubectl apply -n ${NAMESPACE} -f -
 ```
 
+Then deploy the model server:
+
 ```bash
-export CONNECTOR=native  # native | lmcache-connector
-export VARIANT=cpu        # cpu | fs
 export INFRA_PROVIDER=base  # base | gke
-export ACCELERATOR=gpu # gpu | tpu/v6 | tpu/v7
-kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/${ACCELERATOR}/vllm/${CONNECTOR}/${VARIANT}/${INFRA_PROVIDER}/
+kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/gpu/vllm/native/fs/${INFRA_PROVIDER}/
 ```
 
-> [!NOTE]
-> To enable tiered prefix caching, we customize the llm-d EPP configuration. We configure two prefix cache scorers: one for the GPU/TPU cache and another for the CPU cache.
-> LRU capacity for the CPU cache must be manually configured (`lruCapacityPerServer`) because vLLM currently does not emit CPU block metrics.
+#### LMCache
+
+LMCache supports a CPU RAM tier and a filesystem tier. For the filesystem tier, first provision the PVC as shown in the [vLLM native filesystem path](#vllm-native--cpu-ram--filesystem).
+
+```bash
+export VARIANT=cpu          # cpu | fs
+export INFRA_PROVIDER=base  # base | gke
+kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/gpu/vllm/lmcache-connector/${VARIANT}/${INFRA_PROVIDER}/
+```
+
+#### SGLang HiCache — CPU RAM
+
+```bash
+export INFRA_PROVIDER=base  # base | gke
+kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/gpu/sglang/native/cpu/${INFRA_PROVIDER}/
+```
+
+#### TPU (Google TPU v6 / v7)
+
+```bash
+export TPU_VERSION=v7  # v6 | v7
+kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/tpu/${TPU_VERSION}/vllm/native/cpu/
+```
+
+#### Storage Backends
+
+The filesystem tier works with any storage system that exposes a ReadWriteMany PVC over standard POSIX file access. The following backends have setup guides; others (for example CephFS) work through the same PVC mechanism.
+
+| Backend | StorageClass | Setup |
+| ------- | ------------ | ----- |
+| GCP Lustre (GKE) | `lustre` | [GCP Lustre guide](./manifests/backends/lustre/README.md) |
+| AWS EFS | `efs-sc` | [EFS guide](./manifests/backends/aws/README.md) |
+
+The connector does not evict data from the shared tier. Capacity is managed by the storage system or by an external controller — a reference PVC evictor is available in the [llm-d-kv-cache repository](https://github.com/llm-d/llm-d-kv-cache).
 
 ---
 
@@ -282,7 +213,7 @@ kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/recipes/modelserver/compone
 
 ## Verification
 
-### 1. Check the PVC (filesystem variants only)
+### 1. Check the PVC (filesystem paths only)
 
 ```bash
 kubectl get pvc -n ${NAMESPACE}
@@ -330,7 +261,7 @@ curl -X POST http://${IP}/v1/completions \
     }' | jq
 ```
 
-### 4. Verify KV cache is offloaded to storage (filesystem variants)
+### 4. Verify KV cache is offloaded to storage (filesystem paths)
 
 ```bash
 # Long prompt (~3K tokens) to trigger offload
@@ -349,19 +280,24 @@ kubectl exec -n ${NAMESPACE} ${POD} -- find /mnt/files-storage/kv-cache -maxdept
 ```
 
 Expected output: `du -sh` shows hundreds of MB to several GB, and `find` lists a path like
-`/mnt/files-storage/<model>_<hash>_r0/<block-config>/<tp-config>/...` (native fs connector) or `/mnt/files-storage/kv-cache/<model>-xxx.pt` (lmcache connector).
+`/mnt/files-storage/<model>_<hash>_r0/<block-config>/<tp-config>/...` (vLLM native) or `/mnt/files-storage/kv-cache/<model>-xxx.pt` (LMCache).
 
-If you have monitoring set up, confirm via `vllm:kv_offload_total_bytes` (native) or `lmcache:local_storage_usage` (lmcache) in the metrics explorer.
+If you have monitoring set up, confirm via `vllm:kv_offload_total_bytes` (vLLM native) or `lmcache:local_storage_usage` (LMCache) in the metrics explorer.
 
 ---
 
 ## Cleanup
 
 ```bash
+# Set these to the path you deployed in step 2.
+export MODEL_SERVER=vllm           # vllm | sglang
+export CONNECTOR=native            # native | lmcache-connector
+export VARIANT=cpu                 # cpu | fs
+export INFRA_PROVIDER=base         # base | gke
+
 helm uninstall tiered-prefix-cache -n ${NAMESPACE}
-kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/gpu/vllm/${CONNECTOR}/${VARIANT}/${INFRA_PROVIDER}
-kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/gpu/sglang/${CONNECTOR}/${VARIANT}/${INFRA_PROVIDER} --ignore-not-found
-kubectl delete -f ${REPO_ROOT}/guides/tiered-prefix-cache/manifests/pvc.yaml -n ${NAMESPACE}  # if PVC was created
+kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/gpu/${MODEL_SERVER}/${CONNECTOR}/${VARIANT}/${INFRA_PROVIDER} --ignore-not-found
+kubectl delete -f ${REPO_ROOT}/guides/tiered-prefix-cache/manifests/pvc.yaml -n ${NAMESPACE} --ignore-not-found  # if a PVC was created
 kubectl delete namespace ${NAMESPACE}
 ```
 
@@ -427,7 +363,7 @@ export GATEWAY_CLASS=istio
 
 ### 3. Run the benchmark profile for Tiered Prefix Cache
 
-`guide_tiered-prefix-cache_1.yaml` is a **dedicated workload profile** shipped with `llm-d-benchmark` specifically for this guide — it reproduces the load profile used to generate the [results below](#cpu-offloading-benchmarking-results) (250 prefix groups × 5 prompts each on a 60-second Poisson interval) and is shaped to highlight the strengths of tiered prefix-cache offloading by exercising eviction across HBM and CPU RAM.
+`guide_tiered-prefix-cache_1.yaml` is a **dedicated workload profile** shipped with `llm-d-benchmark` specifically for this guide — it reproduces the load profile used to generate the [results below](#benchmarking-report) (250 prefix groups × 5 prompts each on a 60-second Poisson interval) and is shaped to exercise eviction across HBM and CPU RAM.
 
 Benchmark results are copied to the `workspace` directory that is specified by _you_ (or that is automatically generated when omitted from the cli) on the machine running the CLI. The workspace location is optional — by default the CLI auto-generates a timestamped workspace and prints its full path in the logs during the run. If you'd rather choose where results land, pass `--workspace <YOUR_DIR_HERE>` as a top-level argument of `llmdbenchmark` (before the `run` subcommand):
 
@@ -449,11 +385,11 @@ llmdbenchmark \
 
 ---
 
-### CPU Offloading Benchmarking Results
+## Benchmarking Report
 
-The current weight configuration defaults to `1:1:1:1:1` (Queue Scorer : KV Cache Utilization Scorer : GPU Prefix Cache Scorer : CPU Prefix Cache Scorer : LRU Scorer).
+The results below show the effect of enabling prefix-cache offloading relative to an HBM-only configuration, under a high-cache scenario where the working set exceeds HBM but fits within HBM + CPU RAM. The weight configuration defaults to `1:1:1:1:1` (Queue Scorer : KV Cache Utilization Scorer : GPU Prefix Cache Scorer : CPU Prefix Cache Scorer : LRU Scorer).
 
-#### GPU — High Cache Scenario (HBM < KVCache < HBM + CPU RAM)
+### GPU — CPU RAM Offloading
 
 The benchmark runs on 16 × H100 GPUs, distributed across 8 model servers (2 H100s per server with TP=2) using Qwen3-32B.
 
@@ -464,70 +400,22 @@ The benchmark runs on 16 × H100 GPUs, distributed across 8 model servers (2 H10
 
 | Target Rate | Configuration | Mean TTFT (s) | P90 TTFT (s) | Mean E2E Latency (s) | P90 E2E Latency (s) | Throughput (tok/s) |
 | :---: | :--- | :---: | :---: | :---: | :---: | :---: |
-| **5.0 QPS** | **Optimized Baseline (HBM-only)** | 1.62 | 2.65 | 11.98 | 21.60 | 74,638.5 |
-| | **GPU + CPU tier prefix aware routing** | 1.17 (-27.8%) | 1.79 (-32.5%) | 11.49 (-4.1%) | 20.25 (-6.3%) | 82,880.0 (+11.0%) |
-| **10.0 QPS** | **Optimized Baseline (HBM-only)** | 8.08 | 16.61 | 26.28 | 32.60 | 122,387.7 |
-| | **GPU + CPU tier prefix aware routing** | 0.41 (-94.9%) | 1.31 (-92.1%) | 6.97 (-73.5%) | 9.23 (-71.7%) | 167,027.5 (+36.5%) |
-| **20.0 QPS** | **Optimized Baseline (HBM-only)** | 43.67 | 78.13 | 62.29 | 92.14 | 114,663.2 |
-| | **GPU + CPU tier prefix aware routing** | 0.89 (-98.0%) | 2.66 (-96.6%) | 9.03 (-85.5%) | 11.22 (-87.8%) | 300,749.2 (+162.3%) |
-| **40.0 QPS** | **Optimized Baseline (HBM-only)** | 115.57 | 206.39 | 134.78 | 223.93 | 115,645.0 |
-| | **GPU + CPU tier prefix aware routing** | 25.38 (-78.0%) | 48.14 (-76.7%) | 33.95 (-74.8%) | 56.29 (-74.9%) | 331,212.6 (+186.4%) |
+| **5.0 QPS** | HBM-only | 1.62 | 2.65 | 11.98 | 21.60 | 74,638.5 |
+| | HBM + CPU RAM | 1.17 (-27.8%) | 1.79 (-32.5%) | 11.49 (-4.1%) | 20.25 (-6.3%) | 82,880.0 (+11.0%) |
+| **10.0 QPS** | HBM-only | 8.08 | 16.61 | 26.28 | 32.60 | 122,387.7 |
+| | HBM + CPU RAM | 0.41 (-94.9%) | 1.31 (-92.1%) | 6.97 (-73.5%) | 9.23 (-71.7%) | 167,027.5 (+36.5%) |
+| **20.0 QPS** | HBM-only | 43.67 | 78.13 | 62.29 | 92.14 | 114,663.2 |
+| | HBM + CPU RAM | 0.89 (-98.0%) | 2.66 (-96.6%) | 9.03 (-85.5%) | 11.22 (-87.8%) | 300,749.2 (+162.3%) |
+| **40.0 QPS** | HBM-only | 115.57 | 206.39 | 134.78 | 223.93 | 115,645.0 |
+| | HBM + CPU RAM | 25.38 (-78.0%) | 48.14 (-76.7%) | 33.95 (-74.8%) | 56.29 (-74.9%) | 331,212.6 (+186.4%) |
 
-#### TPU — High Cache Scenario (HBM < KVCache < HBM + CPU RAM)
+### TPU — CPU RAM Offloading
 
-| Medium Configuration | Mean TTFT (s) | P90 TTFT (s) | Mean E2E Latency (s) | P90 E2E Latency (s) | Overall Throughput (tok/s) |
+| Configuration | Mean TTFT (s) | P90 TTFT (s) | Mean E2E Latency (s) | P90 E2E Latency (s) | Overall Throughput (tok/s) |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| **Baseline vLLM** | 0.98 | 2.1 | 22.1 | 26.2 | 67262.3 |
-| **vLLM + CPU offloading 25000 Chunks** | 0.56 (-49%) | 0.5 (-75.7%) | 20.3 (-8.1%) | 23.6 (-9.9%) | 73178.1 (+8.9%) |
+| HBM-only | 0.98 | 2.1 | 22.1 | 26.2 | 67262.3 |
+| HBM + CPU RAM (25000 Chunks) | 0.56 (-49%) | 0.5 (-75.7%) | 20.3 (-8.1%) | 23.6 (-9.9%) | 73178.1 (+8.9%) |
 
----
+### gpt-oss-120B
 
-### Storage Offloading Benchmarking Results
-
-> [!NOTE]
-> The following benchmark results were from a previous release and do not match the deployment of the current release. A follow up benchmark will be conducted and the results will be updated accordingly. See <https://github.com/llm-d/llm-d/issues/680>.
-
-#### LMCache Connector + Lustre
-
-LMCache configuration: `LMCACHE_MAX_LOCAL_CPU_SIZE=20GB`, `LMCACHE_MAX_LOCAL_DISK_SIZE=1120Gi` per GPU (16 GPUs × 1120Gi ≤ 18000Gi Lustre PVC).
-
-##### 50K system prompt length (KVCache size 994 GiB) — KV Cache > (HBM + CPU RAM)
-
-| Configuration | Mean TTFT (s) | P90 TTFT (s) | Mean E2E Latency (s) | P90 E2E Latency (s) | Input (tok/s) | Output (tok/s) | Overall (tok/s) |
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| **Baseline vLLM + CPU offloading** | 25.38 | 37.74 | 56.21 | 69.69 | 18607 | 354 | 18962 |
-| **vLLM + CPU offloading + Lustre** | 20.12 (-21%) | 34.02 (-9.9%) | 45.83 (-18%) | 58.73 (-16%) | 22827 (+23%) | 435 (+23%) | 23262 (+23%) |
-
-##### 70K system prompt length (KVCache size 1.3 TiB) — KV Cache >> (HBM + CPU RAM)
-
-| Configuration | Mean TTFT (s) | P90 TTFT (s) | Mean E2E Latency (s) | P90 E2E Latency (s) | Input (tok/s) | Output (tok/s) | Overall (tok/s) |
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| **Baseline vLLM + CPU offloading** | 58.02 | 74.75 | 87.99 | 105.46 | 16598 | 226.65 | 16825 |
-| **vLLM + CPU offloading + Lustre** | 45 (-22%) | 64.79 (-13%) | 68.28 (-22%) | 87.47 (-17%) | 21364 (+28.71%) | 291 (+28.39%) | 21656 (+28.71%) |
-
-#### LLM-D FS Connector + Lustre
-
-* CPU RAM allocated: `cpu_bytes_to_use=64424509440` (~64 GB per replica, ~356 GB total for 4 replicas).
-* Lustre PVC = 18000 GiB.
-
-##### 30K system prompt length (Qwen3-32B, KVCache size 653 GiB) — KV Cache > (HBM + CPU RAM)
-
-| Configuration | Mean TTFT (s) | P90 TTFT (s) | Mean E2E Latency (s) | P90 E2E Latency (s) | Input (tok/s) | Output (tok/s) | Overall (tok/s) | ITL (s) |
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| **Baseline vLLM + CPU offloading** | 2.24 | 5.14 | 22.21 | 26.6 | 27148 | 836 | 27984 | 0.021 |
-| **vLLM + CPU offloading + Lustre** | 1.38 (-38.4%) | 2.82 (-45.1%) | 20.45 (-7.9%) | 22.77 (-14.4%) | 28832 (+6.2%) | 828 (-1.0%) | 29661 (+6.0%) | 0.02 (-4.8%) |
-
-##### 50K system prompt length (Llama-3.3-70B, KVCache size 994 GiB) — KV Cache > (HBM + CPU RAM)
-
-| Configuration | Mean TTFT (s) | P90 TTFT (s) | Mean E2E Latency (s) | P90 E2E Latency (s) | Input (tok/s) | Output (tok/s) | Overall (tok/s) | ITL (s) |
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| **Baseline vLLM + CPU offloading** | 27.11 | 41.71 | 57.06 | 72.28 | 18333 | 350 | 18682 | 0.029 |
-| **vLLM + CPU offloading + Lustre** | 15.25 (-43.7%) | 24.71 (-40.8%) | 38.55 (-32.4%) | 48.01 (-33.6%) | 27091 (+47.8%) | 517 (+47.7%) | 27609 (+47.8%) | 0.022 (-24.1%) |
-
-
-
-### gpt-oss-120B Benchmarking Results  
-
-The benchmark runs on 16 × H100 GPUs, distributed across 16 model servers (1 H100s per server with TP=1) using gpt-oss-120B and the same workload as in [default configuration benchmark results](#cpu-offloading-benchmarking-results). The benchmark compares to optimized baseline configuration.
-
-For detailed results see [gpt-oss-120B benchmarking results](benchmark-results-gpt-oss-120b.md).
+The benchmark runs on 16 × H100 GPUs, distributed across 16 model servers (1 H100 per server with TP=1) using gpt-oss-120B and the same workload as the GPU results above. For detailed results see [gpt-oss-120B benchmarking results](benchmark-results-gpt-oss-120b.md).

--- a/guides/tiered-prefix-cache/README.md
+++ b/guides/tiered-prefix-cache/README.md
@@ -13,7 +13,7 @@ For the concepts, tier tradeoffs, and architecture, see the [Tiered Prefix Cache
 
 ## Choosing a Path
 
-Each path is a self-contained deployment using a specific offloading implementation. Pick one and follow its deploy block under [Installation Instructions](#2-deploy-the-model-server).
+Each path is a self-contained deployment using a specific offloading implementation. Pick one and follow its deploy block under [Deploy the Model Server](#2-deploy-the-model-server).
 
 | Path | Implementation | Tiers | Directory |
 | ---- | -------------- | ----- | --------- |
@@ -22,7 +22,9 @@ Each path is a self-contained deployment using a specific offloading implementat
 | **SGLang HiCache** | SGLang native HiCache | CPU RAM | `modelserver/gpu/sglang/native/cpu/` |
 | **TPU** | vLLM TPU KVCache connector | CPU RAM | `modelserver/tpu/v6/vllm/native/cpu/`, `modelserver/tpu/v7/vllm/native/cpu/` |
 
-The **vLLM native** path is the recommended default. Its CPU tier is low-overhead and enabling it is appropriate in almost all deployments; its filesystem tier uses vLLM's native multi-tier offloading (`TieringOffloadingSpec`) to spill from CPU RAM to shared storage (HBM → CPU RAM → filesystem).
+We recommend each model server's **native** offloading path: the `OffloadingConnector` on vLLM, and HiCache — its equivalent — on SGLang. Native offloading is low-overhead, requires no extra components, and enabling the CPU tier is appropriate in almost all deployments. Reach for a non-native connector (for example LMCache) only when you need a capability the native path does not yet provide.
+
+The tiers each path supports differ — see the table above. For example, the vLLM native path also extends to a shared filesystem via multi-tier offloading (`TieringOffloadingSpec`), spilling from CPU RAM to shared storage (HBM → CPU RAM → filesystem).
 
 ## Default Configuration
 
@@ -136,7 +138,7 @@ helm install tiered-prefix-cache \
 
 ### 2. Deploy the Model Server
 
-Deploy **one** of the paths below. Each `kubectl apply -k` targets an overlay directory; the `INFRA_PROVIDER` selects a `base` overlay or a provider-specific one (for example `gke`).
+Deploy **one** of the paths below. Each `kubectl apply -k` targets an overlay directory. For the GPU paths, `INFRA_PROVIDER` selects a `base` overlay or a provider-specific one (for example `gke`); the TPU path does not use an infra-provider overlay.
 
 #### vLLM native — CPU RAM
 
@@ -288,15 +290,30 @@ If you have monitoring set up, confirm via `vllm:kv_offload_total_bytes` (vLLM n
 
 ## Cleanup
 
+Uninstall the router, then delete the model server overlay for the path you deployed in step 2.
+
 ```bash
-# Set these to the path you deployed in step 2.
+helm uninstall tiered-prefix-cache -n ${NAMESPACE}
+```
+
+**GPU paths:**
+
+```bash
 export MODEL_SERVER=vllm           # vllm | sglang
 export CONNECTOR=native            # native | lmcache-connector
 export VARIANT=cpu                 # cpu | fs
 export INFRA_PROVIDER=base         # base | gke
-
-helm uninstall tiered-prefix-cache -n ${NAMESPACE}
 kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/gpu/${MODEL_SERVER}/${CONNECTOR}/${VARIANT}/${INFRA_PROVIDER} --ignore-not-found
+```
+
+**TPU path:**
+
+```bash
+export TPU_VERSION=v7  # v6 | v7
+kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/tpu/${TPU_VERSION}/vllm/native/cpu --ignore-not-found
+```
+
+```bash
 kubectl delete -f ${REPO_ROOT}/guides/tiered-prefix-cache/manifests/pvc.yaml -n ${NAMESPACE} --ignore-not-found  # if a PVC was created
 kubectl delete namespace ${NAMESPACE}
 ```
@@ -387,7 +404,13 @@ llmdbenchmark \
 
 ## Benchmarking Report
 
-The results below show the effect of enabling prefix-cache offloading relative to an HBM-only configuration, under a high-cache scenario where the working set exceeds HBM but fits within HBM + CPU RAM. The weight configuration defaults to `1:1:1:1:1` (Queue Scorer : KV Cache Utilization Scorer : GPU Prefix Cache Scorer : CPU Prefix Cache Scorer : LRU Scorer).
+> [!TIP]
+> **Full benchmark reports:**
+> - [gpt-oss-120B — full report](benchmark-results-gpt-oss-120b.md) (TP=1 on 16 × H100): complete throughput, latency, TPOT, and GPU/CPU cache-hit breakdowns across 5–40 QPS.
+>
+> These dedicated reports carry the complete data. The inline summaries below report the headline effect of enabling offloading.
+
+All results show the effect of enabling prefix-cache offloading relative to an HBM-only configuration, under a high-cache scenario where the working set exceeds HBM but fits within HBM + CPU RAM. The weight configuration defaults to `1:1:1:1:1` (Queue Scorer : KV Cache Utilization Scorer : GPU Prefix Cache Scorer : CPU Prefix Cache Scorer : LRU Scorer).
 
 ### GPU — CPU RAM Offloading
 
@@ -416,6 +439,45 @@ The benchmark runs on 16 × H100 GPUs, distributed across 8 model servers (2 H10
 | HBM-only | 0.98 | 2.1 | 22.1 | 26.2 | 67262.3 |
 | HBM + CPU RAM (25000 Chunks) | 0.56 (-49%) | 0.5 (-75.7%) | 20.3 (-8.1%) | 23.6 (-9.9%) | 73178.1 (+8.9%) |
 
-### gpt-oss-120B
+### Storage (Filesystem) Offloading
 
-The benchmark runs on 16 × H100 GPUs, distributed across 16 model servers (1 H100 per server with TP=1) using gpt-oss-120B and the same workload as the GPU results above. For detailed results see [gpt-oss-120B benchmarking results](benchmark-results-gpt-oss-120b.md).
+> [!NOTE]
+> The following benchmark results were from a previous release and do not match the deployment of the current release. A follow up benchmark will be conducted and the results will be updated accordingly. See <https://github.com/llm-d/llm-d/issues/680>.
+
+#### LMCache Connector + Lustre
+
+LMCache configuration: `LMCACHE_MAX_LOCAL_CPU_SIZE=20GB`, `LMCACHE_MAX_LOCAL_DISK_SIZE=1120Gi` per GPU (16 GPUs × 1120Gi ≤ 18000Gi Lustre PVC).
+
+##### 50K system prompt length (KVCache size 994 GiB) — KV Cache > (HBM + CPU RAM)
+
+| Configuration | Mean TTFT (s) | P90 TTFT (s) | Mean E2E Latency (s) | P90 E2E Latency (s) | Input (tok/s) | Output (tok/s) | Overall (tok/s) |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **Baseline vLLM + CPU offloading** | 25.38 | 37.74 | 56.21 | 69.69 | 18607 | 354 | 18962 |
+| **vLLM + CPU offloading + Lustre** | 20.12 (-21%) | 34.02 (-9.9%) | 45.83 (-18%) | 58.73 (-16%) | 22827 (+23%) | 435 (+23%) | 23262 (+23%) |
+
+##### 70K system prompt length (KVCache size 1.3 TiB) — KV Cache >> (HBM + CPU RAM)
+
+| Configuration | Mean TTFT (s) | P90 TTFT (s) | Mean E2E Latency (s) | P90 E2E Latency (s) | Input (tok/s) | Output (tok/s) | Overall (tok/s) |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **Baseline vLLM + CPU offloading** | 58.02 | 74.75 | 87.99 | 105.46 | 16598 | 226.65 | 16825 |
+| **vLLM + CPU offloading + Lustre** | 45 (-22%) | 64.79 (-13%) | 68.28 (-22%) | 87.47 (-17%) | 21364 (+28.71%) | 291 (+28.39%) | 21656 (+28.71%) |
+
+#### LLM-D FS Connector + Lustre
+
+* CPU RAM allocated: `cpu_bytes_to_use=64424509440` (~64 GB per replica, ~356 GB total for 4 replicas).
+* Lustre PVC = 18000 GiB.
+
+##### 30K system prompt length (Qwen3-32B, KVCache size 653 GiB) — KV Cache > (HBM + CPU RAM)
+
+| Configuration | Mean TTFT (s) | P90 TTFT (s) | Mean E2E Latency (s) | P90 E2E Latency (s) | Input (tok/s) | Output (tok/s) | Overall (tok/s) | ITL (s) |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **Baseline vLLM + CPU offloading** | 2.24 | 5.14 | 22.21 | 26.6 | 27148 | 836 | 27984 | 0.021 |
+| **vLLM + CPU offloading + Lustre** | 1.38 (-38.4%) | 2.82 (-45.1%) | 20.45 (-7.9%) | 22.77 (-14.4%) | 28832 (+6.2%) | 828 (-1.0%) | 29661 (+6.0%) | 0.02 (-4.8%) |
+
+##### 50K system prompt length (Llama-3.3-70B, KVCache size 994 GiB) — KV Cache > (HBM + CPU RAM)
+
+| Configuration | Mean TTFT (s) | P90 TTFT (s) | Mean E2E Latency (s) | P90 E2E Latency (s) | Input (tok/s) | Output (tok/s) | Overall (tok/s) | ITL (s) |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **Baseline vLLM + CPU offloading** | 27.11 | 41.71 | 57.06 | 72.28 | 18333 | 350 | 18682 | 0.029 |
+| **vLLM + CPU offloading + Lustre** | 15.25 (-43.7%) | 24.71 (-40.8%) | 38.55 (-32.4%) | 48.01 (-33.6%) | 27091 (+47.8%) | 517 (+47.7%) | 27609 (+47.8%) | 0.022 (-24.1%) |
+

--- a/guides/tiered-prefix-cache/benchmark-results-gpt-oss-120b.md
+++ b/guides/tiered-prefix-cache/benchmark-results-gpt-oss-120b.md
@@ -1,6 +1,6 @@
 ## High Cache Scenario (HBM < KVCache < HBM + CPU RAM)
 
-The benchmark runs on 16 × H100 GPUs, distributed across 16 model servers (1 H100s per server with TP=1) using gpt-oss-120B and the same workload as in [default configuration benchmark results](#README.md/benchmarking-results). The benchmark compares to optimized baseline configuration.
+The benchmark runs on 16 × H100 GPUs, distributed across 16 model servers (1 H100 per server with TP=1) using gpt-oss-120B and the same workload as the [GPU benchmarking report](README.md#gpu--cpu-ram-offloading). The results below show the effect of enabling prefix-cache offloading relative to an HBM-only configuration.
 
 ### Throughput
 


### PR DESCRIPTION
Restructure the tiered-prefix-cache guide around vertical deployment paths (vLLM native / LMCache / SGLang HiCache / TPU) instead of horizontal storage tiers, and move conceptual content into the well-lit-path doc.

Guide:
- Fix H1 (KV Cache Offloading -> Tiered Prefix Cache) to match the canonical name
- Trim concept prose to a short intro + link to the doc
- Add a "Choosing a Path" table; reorganize the model-server step by path, including the previously-missing SGLang deploy command
- Surface storage backends (GCP Lustre, AWS EFS) for collaborator visibility
- Fix the broken gpt-oss config table; generalize Cleanup
- Consolidate benchmarks to neutral baseline-vs-offloading results; drop the stale connector-vs-connector storage comparison

Doc:
- Move tier tradeoffs into a neutral "Storage Tiers" section
- Rewrite FS architecture to describe vLLM-native TieringOffloadingSpec and remove the deprecated llmd_fs_backend framing
- Add a "Further Reading" section

Also fix the broken cross-reference anchor in the gpt-oss benchmark results.