### PR TITLE
docs: fix quickstart to use llm-d router chart instead of upstream GAIE chart

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -18,6 +18,7 @@ Clone the llm-d repository and set up the necessary environment variables:
 git clone https://github.com/llm-d/llm-d.git && cd llm-d
 
 export GAIE_VERSION=v1.5.0
+export ROUTER_CHART_VERSION=v0
 export GUIDE_NAME="quickstart"
 export NAMESPACE=llm-d-quickstart
 ```
@@ -39,10 +40,10 @@ The llm-d Router provides the intelligent load balancing. In Standalone Mode, it
 
 ```bash
 helm install ${GUIDE_NAME} \
-    oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
+    oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev \
     -f guides/recipes/router/base.values.yaml \
     -f guides/optimized-baseline/router/optimized-baseline.values.yaml \
-    -n ${NAMESPACE} --version ${GAIE_VERSION}
+    -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
 ```
 
 ### 2. Deploy the Model Server


### PR DESCRIPTION
## Problem

The quickstart guide (`docs/getting-started/quickstart.md`) references the
upstream GAIE standalone chart:

    oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone --version v1.5.0

This chart expects `inferenceExtension:` and `inferencePool:` as top-level
value keys, but the values files on `main` (`guides/recipes/router/base.values.yaml`,
`guides/optimized-baseline/router/optimized-baseline.values.yaml`) use the
`router:` key structure introduced with the llm-d Router charts. The mismatch
causes `helm install` to fail with:

    .Values.inferencePool.modelServers.matchLabels is required

Every other guide on `main` already points to the correct llm-d chart
(`oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev --version v0`);
the quickstart was the only outlier.

## Fix

- Add `ROUTER_CHART_VERSION=v0` environment variable (consistent with all
  other guides).
- Update the `helm install` command to use the llm-d router standalone chart
  at `oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev`.
- Use `--version ${ROUTER_CHART_VERSION}` instead of `--version ${GAIE_VERSION}`.

`GAIE_VERSION` is retained and still used for CRD installation.