### PR TITLE
guides/precise-prefix-cache-routing: run the renderer as a Service, not an EPP sidecar

### DIFF
--- a/.github/workflows/ci-kustomize-dry-run.yaml
+++ b/.github/workflows/ci-kustomize-dry-run.yaml
@@ -276,13 +276,13 @@ jobs:
         run: .github/scripts/install-gke-crds.sh
 
       - name: Dry-run router (active-active default)
-        # The chart auto-injects the vllm-render sidecar via
-        # `router.tokenizer.enabled: true`.
+        # Tokenization runs as a standalone render Service (../render/), not a
+        # chart-injected sidecar (`router.tokenizer.enabled: false`).
         run: |
           CHART_VERSION=v0
           echo ""
           echo "========================================"
-          echo "precise-prefix-cache-routing: router (vllm-render)"
+          echo "precise-prefix-cache-routing: router (EPP, render via Service)"
           echo "========================================"
           echo "--- helm template ---"
           if ! helm template precise-prefix-cache-routing \
@@ -295,9 +295,29 @@ jobs:
           fi
           echo "--- kubectl apply --dry-run=server ---"
           if kubectl apply --dry-run=server -f /tmp/rendered.yaml; then
-            echo "PASS: precise-prefix-cache-routing / router (vllm-render)"
+            echo "PASS: precise-prefix-cache-routing / router (EPP, render via Service)"
           else
-            echo "FAIL: precise-prefix-cache-routing / router (vllm-render)"
+            echo "FAIL: precise-prefix-cache-routing / router (EPP, render via Service)"
+            exit 1
+          fi
+
+      - name: Dry-run render Service overlay
+        # Standalone `vllm launch render` Service that replaces the EPP sidecar.
+        run: |
+          echo ""
+          echo "========================================"
+          echo "precise-prefix-cache-routing: render (vllm-render Service)"
+          echo "========================================"
+          echo "--- kustomize build ---"
+          if ! kustomize build guides/precise-prefix-cache-routing/render > /tmp/rendered.yaml; then
+            echo "FAIL: kustomize build failed for render"
+            exit 1
+          fi
+          echo "--- kubectl apply --dry-run=server ---"
+          if kubectl apply --dry-run=server -f /tmp/rendered.yaml; then
+            echo "PASS: precise-prefix-cache-routing / render (vllm-render Service)"
+          else
+            echo "FAIL: precise-prefix-cache-routing / render (vllm-render Service)"
             exit 1
           fi
 

--- a/.github/workflows/ci-kustomize-dry-run.yaml
+++ b/.github/workflows/ci-kustomize-dry-run.yaml
@@ -277,7 +277,7 @@ jobs:
 
       - name: Dry-run router (active-active default)
         # Tokenization runs as a standalone render Service (../render/), not a
-        # chart-injected sidecar (`router.tokenizer.enabled: false`).
+        # chart-injected sidecar (the chart's tokenizer sidecar is off by default).
         run: |
           CHART_VERSION=v0
           echo ""

--- a/guides/precise-prefix-cache-routing/README.md
+++ b/guides/precise-prefix-cache-routing/README.md
@@ -100,7 +100,7 @@ kubectl create secret generic llm-d-hf-token \
 
 This deploys the llm-d Router in the simple [Standalone Mode](../../docs/architecture/core/router/proxy.md). The release name `${GUIDE_NAME}` is mandatory — the inference pool selector matches a guide label that pairs with this release.
 
-The chart auto-injects the `vllm-render` sidecar when `router.tokenizer.enabled: true` is set in the values file.
+Tokenization is served by a standalone render Service, not a chart-injected EPP sidecar — the values set `router.tokenizer.enabled: false` and point the `token-producer` plugin at that Service.
 
 ```bash
 helm install ${GUIDE_NAME} \
@@ -111,6 +111,17 @@ helm install ${GUIDE_NAME} \
 ```
 
 The release name `${GUIDE_NAME}` is mandatory for standard deployments — the inference pool selector matches a guide label that pairs with this release.
+
+#### Deploy the Render (Tokenizer) Service
+
+The EPP `token-producer` plugin tokenizes prompts by calling vLLM's `/v1/completions/render` endpoint. This guide serves that endpoint from a dedicated, horizontally-scalable `vllm launch render` Service (3 replicas) instead of a per-EPP-pod sidecar, so render capacity scales independently of the EPP replica count and is shared across all EPP replicas. Deploy it with:
+
+```bash
+kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/render/
+```
+
+> [!NOTE]
+> The render pods deliberately do **not** carry the `llm-d.ai/guide` label — that label is the InferencePool / model-server selector, and the EPP would otherwise treat render pods as routable model servers (and try to subscribe to their nonexistent KV-event socket). Scale the pool with `kubectl scale -n ${NAMESPACE} deploy/${GUIDE_NAME}-render --replicas=<N>`.
 
 <details>
 <summary><b>Gateway Mode</b></summary>
@@ -289,6 +300,8 @@ llmdbenchmark \
 
 ```bash
 helm uninstall ${GUIDE_NAME} -n ${NAMESPACE}
+# Render (tokenizer) Service:
+kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/render/
 # For vLLM (default):
 kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}/
 # For SGLang:

--- a/guides/precise-prefix-cache-routing/README.md
+++ b/guides/precise-prefix-cache-routing/README.md
@@ -100,7 +100,7 @@ kubectl create secret generic llm-d-hf-token \
 
 This deploys the llm-d Router in the simple [Standalone Mode](../../docs/architecture/core/router/proxy.md). The release name `${GUIDE_NAME}` is mandatory — the inference pool selector matches a guide label that pairs with this release.
 
-Tokenization is served by a standalone render Service, not a chart-injected EPP sidecar — the values set `router.tokenizer.enabled: false` and point the `token-producer` plugin at that Service.
+Tokenization is served by a standalone render Service, not a chart-injected EPP sidecar — the chart's `router.tokenizer` sidecar is off by default, and the `token-producer` plugin points at that Service.
 
 ```bash
 helm install ${GUIDE_NAME} \

--- a/guides/precise-prefix-cache-routing/render/deployment.yaml
+++ b/guides/precise-prefix-cache-routing/render/deployment.yaml
@@ -11,16 +11,23 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: vllm-render
+      app.kubernetes.io/part-of: precise-prefix-cache-routing
   template:
     metadata:
       labels:
         app.kubernetes.io/component: vllm-render
+        # Guide-scoped (but NOT `llm-d.ai/guide`, which is the InferencePool /
+        # model-server selector) so the Service below cannot cross-select a
+        # `vllm-render` pod from another guide in a shared namespace.
+        app.kubernetes.io/part-of: precise-prefix-cache-routing
     spec:
+      # The renderer only tokenizes over HTTP; it needs no Kubernetes API access.
+      automountServiceAccountToken: false
       containers:
         - name: vllm-render
           # GPU-less vLLM image — `vllm launch render` only tokenizes, no model
           # weights are loaded. Mirrors the chart's sidecar image/command.
-          image: vllm/vllm-openai-cpu:v0.23.0
+          image: docker.io/vllm/vllm-openai-cpu:v0.23.0
           imagePullPolicy: IfNotPresent
           command: ["vllm", "launch", "render"]
           args:
@@ -30,15 +37,24 @@ spec:
             - name: render-http
               containerPort: 8000
           env:
+            # HF_HOME points at the mounted emptyDir below so tokenizer files
+            # are cached for the pod's lifetime (mountPath == HF_HOME).
             - name: HF_HOME
-              value: /tmp/hf/hub
+              value: /tmp/hf
             - name: HF_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: llm-d-hf-token
                   key: HF_TOKEN
+            # Disable vLLM usage telemetry — its writes to /.config fail under
+            # restricted SecurityContexts (matches the model server patch).
+            - name: DO_NOT_TRACK
+              value: "1"
           resources:
             requests:
+              cpu: "4"
+              memory: 8Gi
+            limits:
               cpu: "4"
               memory: 8Gi
           readinessProbe:
@@ -50,8 +66,8 @@ spec:
             timeoutSeconds: 5
             failureThreshold: 60
           volumeMounts:
-            - mountPath: /root/.cache/huggingface
-              name: model-cache
+            - mountPath: /tmp/hf
+              name: hf-cache
       volumes:
-        - name: model-cache
+        - name: hf-cache
           emptyDir: {}

--- a/guides/precise-prefix-cache-routing/render/deployment.yaml
+++ b/guides/precise-prefix-cache-routing/render/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: render
+spec:
+  # Run the tokenizer renderer as a horizontally-scalable Service instead of an
+  # EPP sidecar (router.tokenizer.enabled: false). EPP replicas share this pool
+  # via the token-producer `vllm.url`, decoupling render capacity from EPP
+  # replica count.
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: vllm-render
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: vllm-render
+    spec:
+      containers:
+        - name: vllm-render
+          # GPU-less vLLM image — `vllm launch render` only tokenizes, no model
+          # weights are loaded. Mirrors the chart's sidecar image/command.
+          image: vllm/vllm-openai-cpu:v0.23.0
+          imagePullPolicy: IfNotPresent
+          command: ["vllm", "launch", "render"]
+          args:
+            - "Qwen/Qwen3-32B" # Must match the token-producer modelName in the router values
+            - "--port=8000"
+          ports:
+            - name: render-http
+              containerPort: 8000
+          env:
+            - name: HF_HOME
+              value: /tmp/hf/hub
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
+          resources:
+            requests:
+              cpu: "4"
+              memory: 8Gi
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: render-http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 60
+          volumeMounts:
+            - mountPath: /root/.cache/huggingface
+              name: model-cache
+      volumes:
+        - name: model-cache
+          emptyDir: {}

--- a/guides/precise-prefix-cache-routing/render/deployment.yaml
+++ b/guides/precise-prefix-cache-routing/render/deployment.yaml
@@ -4,9 +4,9 @@ metadata:
   name: render
 spec:
   # Run the tokenizer renderer as a horizontally-scalable Service instead of an
-  # EPP sidecar (router.tokenizer.enabled: false). EPP replicas share this pool
-  # via the token-producer `vllm.url`, decoupling render capacity from EPP
-  # replica count.
+  # EPP sidecar (the chart's tokenizer sidecar is off by default). EPP replicas
+  # share this pool via the token-producer `vllm.url`, decoupling render
+  # capacity from EPP replica count.
   replicas: 3
   selector:
     matchLabels:
@@ -51,12 +51,14 @@ spec:
             - name: DO_NOT_TRACK
               value: "1"
           resources:
+            # Tokenization is light and bursty; reserve modestly and allow
+            # headroom. 3 replicas request 3 cores / 12Gi total.
             requests:
-              cpu: "4"
-              memory: 8Gi
+              cpu: "1"
+              memory: 4Gi
             limits:
               cpu: "4"
-              memory: 8Gi
+              memory: 12Gi
           readinessProbe:
             httpGet:
               path: /health

--- a/guides/precise-prefix-cache-routing/render/kustomization.yaml
+++ b/guides/precise-prefix-cache-routing/render/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Standalone render (tokenizer) Service for precise-prefix-cache-routing.
+# Replaces the chart-injected `vllm-render` EPP sidecar with a shared,
+# independently-scalable pool. Pairs with `router.tokenizer.enabled: false` and
+# the token-producer `vllm.url` in router/precise-prefix-cache-routing.values.yaml.
+namePrefix: precise-prefix-cache-routing-
+
+resources:
+  - deployment.yaml
+  - service.yaml
+
+# NOTE: the guide label goes on resource metadata ONLY, never on the pod
+# template or selectors. `llm-d.ai/guide: precise-prefix-cache-routing` is the
+# InferencePool / model-server selector (router modelServers.matchLabels); if
+# render pods carried it the EPP would treat them as routable model servers and
+# try to ZMQ-subscribe to their (nonexistent) :5556 KV-event socket.
+labels:
+  - pairs:
+      llm-d.ai/guide: precise-prefix-cache-routing
+    includeSelectors: false
+    includeTemplates: false

--- a/guides/precise-prefix-cache-routing/render/kustomization.yaml
+++ b/guides/precise-prefix-cache-routing/render/kustomization.yaml
@@ -2,22 +2,21 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 # Standalone render (tokenizer) Service for precise-prefix-cache-routing.
-# Replaces the chart-injected `vllm-render` EPP sidecar with a shared,
-# independently-scalable pool. Pairs with `router.tokenizer.enabled: false` and
-# the token-producer `vllm.url` in router/precise-prefix-cache-routing.values.yaml.
+# Replaces the chart-injected `vllm-render` EPP sidecar (off by chart default)
+# with a shared, independently-scalable pool. Pairs with the token-producer
+# `vllm.url` in router/precise-prefix-cache-routing.values.yaml.
 namePrefix: precise-prefix-cache-routing-
 
 resources:
   - deployment.yaml
   - service.yaml
 
-# NOTE: the guide label goes on resource metadata ONLY, never on the pod
-# template or selectors. `llm-d.ai/guide: precise-prefix-cache-routing` is the
+# NOTE: the guide label lands on resource metadata ONLY, never on the pod
+# template or selectors (kustomize `labels` defaults to includeSelectors:false /
+# includeTemplates:false). `llm-d.ai/guide: precise-prefix-cache-routing` is the
 # InferencePool / model-server selector (router modelServers.matchLabels); if
 # render pods carried it the EPP would treat them as routable model servers and
 # try to ZMQ-subscribe to their (nonexistent) :5556 KV-event socket.
 labels:
   - pairs:
       llm-d.ai/guide: precise-prefix-cache-routing
-    includeSelectors: false
-    includeTemplates: false

--- a/guides/precise-prefix-cache-routing/render/service.yaml
+++ b/guides/precise-prefix-cache-routing/render/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: render
+spec:
+  # ClusterIP fronting the render replicas. EPP token-producer dials this name;
+  # kube-proxy load-balances across the pods so any EPP replica can tokenize via
+  # any render pod.
+  selector:
+    app.kubernetes.io/component: vllm-render
+  ports:
+    - name: render-http
+      port: 8000
+      targetPort: render-http
+      protocol: TCP

--- a/guides/precise-prefix-cache-routing/render/service.yaml
+++ b/guides/precise-prefix-cache-routing/render/service.yaml
@@ -8,6 +8,7 @@ spec:
   # any render pod.
   selector:
     app.kubernetes.io/component: vllm-render
+    app.kubernetes.io/part-of: precise-prefix-cache-routing
   ports:
     - name: render-http
       port: 8000

--- a/guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml
+++ b/guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml
@@ -1,9 +1,11 @@
 ## precise-prefix-cache-routing guide overrides for the router.
 ## Layer on top of: recipes/router/base.values.yaml
 ##
-## A `vllm launch render` sidecar exposes /v1/completions/render on
-## localhost:8000; the EPP `token-producer` plugin tokenizes prompts via
-## that HTTP endpoint.
+## Tokenization is served by a standalone `vllm launch render` Service deployed
+## from `../render/` (3 replicas), NOT the chart-injected EPP sidecar. The EPP
+## `token-producer` plugin tokenizes prompts over HTTP against that Service
+## (see its `vllm.url` below). This decouples render capacity from EPP replica
+## count and lets the render pool scale independently.
 ##
 ## Pod-discovery mode with active-active HA (replicas: 2). Each replica dials
 ## every vLLM pod's per-pod ZMQ socket; both indexes converge identically.
@@ -11,13 +13,8 @@
 
 router:
   tokenizer:
-    enabled: true
-    # Required by llm-d-router chart v0 when tokenizer is enabled;
-    # must match the deployed model server and the token-producer modelName below
-    modelName: Qwen/Qwen3-32B
-    env:
-      - name: HF_HOME
-        value: /tmp/hf/hub
+    # Sidecar disabled — the renderer runs as a separate Service (../render/).
+    enabled: false
 
   epp:
     replicas: 2
@@ -43,9 +40,11 @@ router:
         plugins:
           - type: token-producer
             parameters:
-              modelName: Qwen/Qwen3-32B # Must match router.tokenizer.modelName above
+              modelName: Qwen/Qwen3-32B # Must match the render Service model (../render/) and the deployed model server
               vllm:
-                url: "http://localhost:8000"
+                # Standalone render Service (../render/), not a loopback sidecar.
+                # `precise-prefix-cache-routing-` namePrefix + Service name `render`.
+                url: "http://precise-prefix-cache-routing-render:8000"
           - type: endpoint-notification-source
           - type: precise-prefix-cache-producer # `precise-prefix-cache-scorer` is deprecated
             parameters:

--- a/guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml
+++ b/guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml
@@ -2,20 +2,17 @@
 ## Layer on top of: recipes/router/base.values.yaml
 ##
 ## Tokenization is served by a standalone `vllm launch render` Service deployed
-## from `../render/` (3 replicas), NOT the chart-injected EPP sidecar. The EPP
-## `token-producer` plugin tokenizes prompts over HTTP against that Service
-## (see its `vllm.url` below). This decouples render capacity from EPP replica
-## count and lets the render pool scale independently.
+## from `../render/` (3 replicas), NOT the chart-injected EPP sidecar. The
+## chart's `router.tokenizer` sidecar is off by default, so no override is
+## needed here; the EPP `token-producer` plugin tokenizes prompts over HTTP
+## against that Service (see its `vllm.url` below). This decouples render
+## capacity from EPP replica count and lets the render pool scale independently.
 ##
 ## Pod-discovery mode with active-active HA (replicas: 2). Each replica dials
 ## every vLLM pod's per-pod ZMQ socket; both indexes converge identically.
 ## Scale to a single replica with --set router.epp.replicas=1.
 
 router:
-  tokenizer:
-    # Sidecar disabled — the renderer runs as a separate Service (../render/).
-    enabled: false
-
   epp:
     replicas: 2
     flags:


### PR DESCRIPTION
The tokenizer renderer was injected as a per-EPP-pod `vllm-render` sidecar by the standalone chart (`router.tokenizer.enabled: true`). That couples render capacity to the EPP replica count and duplicates the tokenizer in every EPP pod.

Replace it with a standalone, horizontally-scalable render Service:
- Add `render/` kustomize overlay: a `vllm launch render` Deployment (3 replicas)
  + ClusterIP Service, mirroring the chart's sidecar container spec.
- Disable the sidecar (`router.tokenizer.enabled: false`) and point the EPP `token-producer` plugin at the Service (`http://precise-prefix-cache-routing-render:8000`).
- Keep the `llm-d.ai/guide` label off render pods — it is the InferencePool / model-server selector, so labeled render pods would be treated as routable model servers (and the EPP would try to ZMQ-subscribe to their nonexistent :5556 KV-event socket).
- README: document deploying/cleaning up the render Service + the label caveat.
- CI: dry-run the new render overlay; correct the stale sidecar comments.

Pin the GPU vLLM model server and the renderer to vllm/vllm-openai{,-cpu}:v0.23.0.

Validated on 16xH100 (8x Qwen3-32B, TP=2) with EPP image ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0-rc.2: the full guide_precise-prefix-cache-routing_1.yaml ladder (rates 3->60) ran with 0 request failures; the 3 render pods served ~17k tokenization requests, evenly load-balanced, with 0 pod restarts.