### PR TITLE
fix: add missing amd-ci kustomize overlay for PD disaggregation

### DIFF
--- a/guides/pd-disaggregation/modelserver/amd/vllm/amd-ci/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/vllm/amd-ci/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base


### PR DESCRIPTION
## Summary

- Adds the missing `guides/pd-disaggregation/modelserver/amd/vllm/amd-ci/kustomization.yaml` overlay directory

The nightly workflow `nightly-e2e-pd-disaggregation-amd-ci-acc-rocm-vllm-x.yaml` sets `infra_provider: amd-ci`, which causes the benchmark tool to look for a kustomize overlay at `guides/pd-disaggregation/modelserver/amd/vllm/amd-ci/`. This directory was never created, causing **every nightly run to fail** (8+ consecutive failures) with:

```
error: must build at directory: not a valid directory:
lstat guides/pd-disaggregation/modelserver/amd/vllm/amd-ci: no such file or directory
```

The fix adds a minimal overlay that references `../base`, following the same pattern as the existing `tensorwave/` overlay.

## Test plan

- [ ] CI Guide Dry Run passes for `pd-disaggregation` AMD ROCM
- [ ] Nightly PD Disaggregation AMD ROCM test progresses past the kustomize overlay step