### PR TITLE
Bump api-server-count from 1 to 4 for DeepSeek-V4 NVL72 GB200 guide

### DIFF
--- a/guides/wide-ep-lws/modelserver/gpu/vllm-deepseek-v4/base/decode.yaml
+++ b/guides/wide-ep-lws/modelserver/gpu/vllm-deepseek-v4/base/decode.yaml
@@ -87,7 +87,7 @@ spec:
                   --tokenizer-mode deepseek_v4 \
                   --gpu-memory-utilization 0.85 \
                   --trust-remote-code \
-                  --api-server-count 1 \
+                  --api-server-count 4 \
                   --disable-access-log-for-endpoints=/health,/metrics \
                   --data-parallel-hybrid-lb \
                   --enable-expert-parallel \

--- a/guides/wide-ep-lws/modelserver/gpu/vllm-deepseek-v4/base/prefill.yaml
+++ b/guides/wide-ep-lws/modelserver/gpu/vllm-deepseek-v4/base/prefill.yaml
@@ -60,7 +60,7 @@ spec:
                   --tokenizer-mode deepseek_v4 \
                   --gpu-memory-utilization 0.9 \
                   --trust-remote-code \
-                  --api-server-count 1 \
+                  --api-server-count 4 \
                   --disable-access-log-for-endpoints=/health,/metrics \
                   --data-parallel-hybrid-lb \
                   --enable-expert-parallel \


### PR DESCRIPTION
## Summary

The default is 1 API server per DP rank. We are artificially setting it lower, which can cause performance issues as the API server becomes a bottleneck at high request rates.

- Bumps `--api-server-count` from 1 to 4 in both `decode.yaml` and `prefill.yaml` base manifests for the DeepSeek-V4 wide-EP recipe
- Follow-up to #1737

## Test plan
- [x] Verify kustomize overlays still render correctly with the updated base manifests
- [x] Deploy with one of the OCI deployment variants and confirm vLLM starts with 4 API servers

🤖 Generated with [Claude Code](https://claude.com/claude-code)