### PR TITLE
docs(quickstart): add port to Proxy's IP curl

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -81,7 +81,7 @@ kubectl run curl-debug --rm -it \
 Inside the shell, send a completion request:
 
 ```bash
-curl -X POST http://${IP}/v1/completions \
+curl -X POST http://${IP}:8081/v1/completions \
     -H 'Content-Type: application/json' \
     -d '{
         "model": "Qwen/Qwen3-32B",


### PR DESCRIPTION

The quickstart verification step was using the proxy’s default HTTP port 80, but the standalone chart exposes the user-facing  Envoy listener on [8081 by default](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/release-1.5/config/charts/standalone/values.yaml#L129) (hardcoded).

This PR updates the example request to `http://${IP}:8081/v1/completions` so it matches the exposed port.


 