### PR TITLE
fix: correct argument order for dockerfile env-var linter invocations

### DIFF
--- a/scripts/ENVVARS.md
+++ b/scripts/ENVVARS.md
@@ -70,11 +70,11 @@ declare all environment variables required by scripts they execute.
 
 ```bash
 # check specific dockerfile
-./scripts/lint-dockerfile-envvars.py docker/Dockerfile.cuda docker/scripts
+./scripts/lint-dockerfile-envvars.py docker/scripts docker/Dockerfile.cuda
 
 # check all dockerfiles
 for df in docker/Dockerfile.*; do
-  ./scripts/lint-dockerfile-envvars.py "$df" docker/scripts
+  ./scripts/lint-dockerfile-envvars.py docker/scripts "$df"
 done
 ```
 

--- a/scripts/test-dockerfile-lint.sh
+++ b/scripts/test-dockerfile-lint.sh
@@ -30,7 +30,7 @@ cp /tmp/test-script.sh /tmp/test-scripts/
 
 echo ""
 echo "Test 1: Dockerfile missing required variable (should FAIL)"
-if ./scripts/lint-dockerfile-envvars.py /tmp/test-Dockerfile /tmp/test-scripts 2>&1; then
+if ./scripts/lint-dockerfile-envvars.py /tmp/test-scripts /tmp/test-Dockerfile 2>&1; then
     echo "✗ Test failed: should have detected missing TEST_VAR2"
     exit 1
 else
@@ -49,7 +49,7 @@ EOF
 
 echo ""
 echo "Test 2: Dockerfile with all required variables (should PASS)"
-if ./scripts/lint-dockerfile-envvars.py /tmp/test-Dockerfile-fixed /tmp/test-scripts 2>&1; then
+if ./scripts/lint-dockerfile-envvars.py /tmp/test-scripts /tmp/test-Dockerfile-fixed 2>&1; then
     echo "✓ Test passed: all variables declared"
 else
     echo "✗ Test failed: should have passed with all variables declared"


### PR DESCRIPTION
## Summary

- Corrects the argument order in two callers of `scripts/lint-dockerfile-envvars.py`

`scripts/lint-dockerfile-envvars.py` takes the scripts directory as its first argument and Dockerfiles after it (`scripts_dir = sys.argv[1]`; usage `lint-dockerfile-envvars.py <scripts-dir> <Dockerfile>`). The `lint-dockerfile-envvars` pre-commit hook already calls it that way via `args: [docker/scripts]` + `pass_filenames: true`.

Two callers had the arguments reversed:

- `scripts/test-dockerfile-lint.sh` (the linter's self-test) called it as `<Dockerfile> <scripts-dir>`, so it read the scripts directory as a Dockerfile and crashed with `IsADirectoryError` before linting. Test 1 reported a false pass (the crash's nonzero exit landed in the failure branch) and Test 2 failed, so `bash scripts/test-dockerfile-lint.sh` exited 1 and exercised none of the linter logic.
- `scripts/ENVVARS.md` documented the same reversed order, so the example commands crash when copied.

Swapping the arguments makes both match the linter's contract. The self-test now exits 0, with Test 1 detecting the missing variable and Test 2 passing.

#1302 fixed the same bug in the test but was closed unmerged; this applies that correction and also fixes the matching commands in `scripts/ENVVARS.md`.

## Test plan

- [x] `bash scripts/test-dockerfile-lint.sh` exits 0 (previously exited 1)
- [x] `pre-commit run --files scripts/test-dockerfile-lint.sh scripts/ENVVARS.md` passes
