### PR TITLE
docs(ipp): add Inference Payload Processor documentation

### DIFF
--- a/docs/architecture/advanced/inference-payload-processing/README.md
+++ b/docs/architecture/advanced/inference-payload-processing/README.md
@@ -1,0 +1,73 @@
+# Inference Payload Processor (IPP)
+
+## Functionality
+
+The **Inference Payload Processor (IPP)** is a pluggable framework for processing inference request and response payloads before and after routing decisions.
+
+IPP enables:
+
+* **Request Processing** — Inspect and modify request headers, body, or trailers before routing decisions are made.
+* **Response Processing** — Inspect and modify response headers, body, or trailers after the model server responds.
+
+Common use cases include model-aware routing (extracting model names from request bodies), guardrails, content filtering, payload transformation, and observability hooks.
+
+## Integration
+
+IPP integrates with the Proxy via Envoy's [External Processing (ext-proc)](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/ext_proc_filter) protocol.
+
+Both IPP and EPP contribute to routing decisions:
+
+| Component | Routing Scope | Decision |
+|-----------|---------------|----------|
+| **IPP** | Pool-level | Which InferencePool? |
+| **EPP** | Endpoint-level | Which pod within the pool? |
+
+## Request Flow
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)">
+    <img src="../../../assets/ipp-request-flow.svg" alt="IPP Request Flow">
+  </picture>
+</p>
+
+1. **Client** sends an inference request to the Proxy.
+2. **Proxy** invokes IPP via ext-proc.
+3. **IPP** processes the request through its configured plugin pipeline and returns any mutations (headers, body modifications).
+4. **Proxy** applies mutations and routes to the appropriate InferencePool.
+5. **EPP** selects the optimal pod within the pool.
+6. **Model Server** processes the request and returns the response.
+
+## Plugin Architecture
+
+IPP uses a profile-based plugin architecture:
+
+* **Plugins** — Modular units that perform specific processing tasks (e.g., extract fields, set headers, filter models).
+* **Profiles** — Named sets of plugins that define processing pipelines for different request types.
+* **Profile Picker** — Selects which profile to execute based on request properties.
+
+The processing pipeline executes in this order:
+
+```
+PreProcessing → ProfilePicker → Profile Request Plugins → [Model Server] → Profile Response Plugins → PostProcessing
+```
+
+For detailed plugin documentation and configuration, see the [IPP repository](https://github.com/llm-d/llm-d-inference-payload-processor).
+
+## Operations
+
+### Deployment
+
+IPP is deployed as a standalone Kubernetes Deployment. The Helm chart automatically configures the appropriate Proxy integration based on your environment:
+
+* **Istio** — Creates an EnvoyFilter to insert ext_proc into the Gateway
+* **GKE** — Creates a GCPRoutingExtension resource
+
+### Monitoring
+
+IPP exposes Prometheus-compatible metrics on port 9090 at `/metrics`, providing visibility into request processing and plugin execution latency.
+
+## Further Reading
+
+* [IPP Repository](https://github.com/llm-d/llm-d-inference-payload-processor) — Source code, configuration reference, and plugin documentation
+* [Multi-Model Routing](../../../well-lit-paths/foundations/multi-model-routing.md) — Using IPP for model-aware routing

--- a/docs/assets/ipp-request-flow.svg
+++ b/docs/assets/ipp-request-flow.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 750 320" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <marker id="arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#000000"/>
+    </marker>
+    <marker id="arr-back" markerWidth="8" markerHeight="6" refX="0" refY="3" orient="auto">
+      <polygon points="8 0, 0 3, 8 6" fill="#666666"/>
+    </marker>
+  </defs>
+
+  <!-- White Canvas with Purple Border (llm-d branding) -->
+  <rect x="2" y="2" width="746" height="316" rx="0" fill="#ffffff" stroke="#9f659f" stroke-width="3"/>
+
+  <!-- Title -->
+  <text x="375" y="28" text-anchor="middle" font-size="13" font-weight="bold" fill="#000000">IPP Request Flow</text>
+
+  <!-- Client -->
+  <rect x="20" y="100" width="100" height="80" rx="3" fill="#f3f3f3" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="70" y="125" text-anchor="middle" font-size="11" font-weight="bold" fill="#000000">Client</text>
+  <text x="70" y="145" text-anchor="middle" font-size="8" fill="#666666">POST /v1/completions</text>
+  <text x="70" y="160" text-anchor="middle" font-size="8" fill="#444444">{"model": "..."}</text>
+
+  <!-- Client to Gateway -->
+  <line x1="120" y1="140" x2="198" y2="140" stroke="#000000" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="159" y="132" text-anchor="middle" font-size="8" fill="#444444">1</text>
+
+  <!-- Proxy (central hub) -->
+  <rect x="200" y="80" width="180" height="120" rx="3" fill="#e6e6fa" stroke="#9f659f" stroke-width="2"/>
+  <text x="290" y="105" text-anchor="middle" font-size="12" font-weight="bold" fill="#000000">Proxy</text>
+  <text x="290" y="125" text-anchor="middle" font-size="8" fill="#666666">1. Receive request</text>
+  <text x="290" y="140" text-anchor="middle" font-size="8" fill="#666666">2. Call llm-d IPP (ext-proc)</text>
+  <text x="290" y="155" text-anchor="middle" font-size="8" fill="#666666">3. Route by header</text>
+  <text x="290" y="170" text-anchor="middle" font-size="8" fill="#666666">4. Call llm-d EPP (ext-proc)</text>
+  <text x="290" y="185" text-anchor="middle" font-size="8" fill="#666666">5. Forward to endpoint</text>
+
+  <!-- llm-d IPP (ext-proc service) - below proxy -->
+  <rect x="220" y="220" width="140" height="75" rx="3" fill="#e8f4e8" stroke="#82b366" stroke-width="1.5"/>
+  <text x="290" y="242" text-anchor="middle" font-size="10" font-weight="bold" fill="#000000">llm-d IPP</text>
+  <text x="290" y="256" text-anchor="middle" font-size="8" fill="#666666">Process payload</text>
+  <text x="290" y="270" text-anchor="middle" font-size="8" fill="#666666">(pluggable pipeline)</text>
+  <text x="290" y="284" text-anchor="middle" font-size="7" fill="#888888">(ext-proc)</text>
+
+  <!-- Gateway to IPP (bidirectional) -->
+  <line x1="270" y1="200" x2="270" y2="218" stroke="#000000" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="310" y1="218" x2="310" y2="200" stroke="#666666" stroke-width="1" stroke-dasharray="3,2" marker-end="url(#arr)"/>
+  <text x="253" y="212" text-anchor="middle" font-size="7" fill="#444444">2</text>
+
+  <!-- llm-d EPP (ext-proc service) - right of proxy -->
+  <rect x="430" y="110" width="100" height="60" rx="3" fill="#f3f3f3" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="480" y="132" text-anchor="middle" font-size="10" font-weight="bold" fill="#000000">llm-d EPP</text>
+  <text x="480" y="148" text-anchor="middle" font-size="8" fill="#666666">Select endpoint</text>
+  <text x="480" y="161" text-anchor="middle" font-size="7" fill="#888888">(ext-proc)</text>
+
+  <!-- Gateway to EPP (bidirectional) -->
+  <line x1="380" y1="130" x2="428" y2="130" stroke="#000000" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="428" y1="150" x2="380" y2="150" stroke="#666666" stroke-width="1" stroke-dasharray="3,2" marker-end="url(#arr)"/>
+  <text x="404" y="122" text-anchor="middle" font-size="7" fill="#444444">4</text>
+
+  <!-- Model Server -->
+  <rect x="580" y="100" width="140" height="80" rx="3" fill="#f3f3f3" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="650" y="125" text-anchor="middle" font-size="11" font-weight="bold" fill="#000000">Model Server</text>
+  <text x="650" y="145" text-anchor="middle" font-size="8" fill="#666666">vLLM / SGLang</text>
+  <text x="650" y="162" text-anchor="middle" font-size="8" fill="#444444">InferencePool</text>
+
+  <!-- Gateway to Model Server -->
+  <line x1="530" y1="140" x2="578" y2="140" stroke="#000000" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="554" y="132" text-anchor="middle" font-size="7" fill="#444444">5</text>
+
+  <!-- Caption -->
+  <text x="375" y="308" text-anchor="middle" font-size="9" fill="#888888">Proxy consults llm-d IPP and llm-d EPP via ext-proc, then forwards request to selected endpoint</text>
+</svg>

--- a/docs/assets/multi-pool-routing.svg
+++ b/docs/assets/multi-pool-routing.svg
@@ -1,0 +1,108 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 390" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <marker id="arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#000000"/>
+    </marker>
+  </defs>
+
+  <!-- White Canvas with Purple Border (llm-d branding) -->
+  <rect x="2" y="2" width="816" height="386" rx="0" fill="#ffffff" stroke="#9f659f" stroke-width="3"/>
+
+  <!-- Title -->
+  <text x="410" y="28" text-anchor="middle" font-size="13" font-weight="bold" fill="#000000">Multi-Pool Routing Architecture</text>
+
+  <!-- Client -->
+  <rect x="20" y="145" width="85" height="70" rx="3" fill="#f3f3f3" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="62" y="168" text-anchor="middle" font-size="11" font-weight="bold" fill="#000000">Client</text>
+  <text x="62" y="185" text-anchor="middle" font-size="8" fill="#666666">POST /v1/</text>
+  <text x="62" y="197" text-anchor="middle" font-size="8" fill="#666666">completions</text>
+
+  <!-- Client to Proxy -->
+  <line x1="105" y1="180" x2="143" y2="180" stroke="#000000" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Proxy (central hub) -->
+  <rect x="145" y="115" width="120" height="130" rx="3" fill="#e6e6fa" stroke="#9f659f" stroke-width="2"/>
+  <text x="205" y="138" text-anchor="middle" font-size="11" font-weight="bold" fill="#000000">Proxy</text>
+  <text x="205" y="158" text-anchor="middle" font-size="8" fill="#666666">1. Receive request</text>
+  <text x="205" y="173" text-anchor="middle" font-size="8" fill="#666666">2. Call llm-d IPP</text>
+  <text x="205" y="188" text-anchor="middle" font-size="8" fill="#666666">3. Route by header</text>
+  <text x="205" y="203" text-anchor="middle" font-size="8" fill="#666666">4. Call llm-d EPP</text>
+  <text x="205" y="218" text-anchor="middle" font-size="8" fill="#666666">5. Forward request</text>
+  <text x="205" y="238" text-anchor="middle" font-size="7" fill="#888888">(HTTPRoute rules)</text>
+
+  <!-- llm-d IPP (below Proxy) -->
+  <rect x="145" y="270" width="120" height="60" rx="3" fill="#e8f4e8" stroke="#82b366" stroke-width="1.5"/>
+  <text x="205" y="292" text-anchor="middle" font-size="10" font-weight="bold" fill="#000000">llm-d IPP</text>
+  <text x="205" y="308" text-anchor="middle" font-size="8" fill="#666666">Process payload</text>
+  <text x="205" y="320" text-anchor="middle" font-size="7" fill="#888888">(ext-proc)</text>
+
+  <!-- Proxy to IPP (bidirectional) -->
+  <line x1="185" y1="245" x2="185" y2="268" stroke="#000000" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="225" y1="268" x2="225" y2="245" stroke="#666666" stroke-width="1" stroke-dasharray="3,2" marker-end="url(#arr)"/>
+
+  <!-- Routing arrows from Proxy to Pools -->
+  <!-- Proxy to Pool A -->
+  <line x1="265" y1="150" x2="343" y2="100" stroke="#000000" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="305" y="110" text-anchor="middle" font-size="7" fill="#444444">Qwen/...</text>
+
+  <!-- Proxy to Pool B -->
+  <line x1="265" y1="210" x2="343" y2="260" stroke="#000000" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="305" y="250" text-anchor="middle" font-size="7" fill="#444444">deepseek/...</text>
+
+  <!-- InferencePool A -->
+  <rect x="345" y="45" width="455" height="105" rx="5" fill="#e1d5e7" stroke="#9673a6" stroke-width="1.5"/>
+  <text x="572" y="63" text-anchor="middle" font-size="11" font-weight="bold" fill="#000000">InferencePool A (Qwen/Qwen3-32B)</text>
+  
+  <!-- llm-d EPP A inside Pool A -->
+  <rect x="360" y="75" width="85" height="50" rx="3" fill="#f3f3f3" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="402" y="95" text-anchor="middle" font-size="9" font-weight="bold" fill="#000000">llm-d EPP</text>
+  <text x="402" y="110" text-anchor="middle" font-size="7" fill="#666666">Select endpoint</text>
+  <text x="402" y="120" text-anchor="middle" font-size="6" fill="#888888">(ext-proc)</text>
+
+  <!-- EPP A to pods -->
+  <line x1="445" y1="100" x2="483" y2="100" stroke="#000000" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Pods in Pool A -->
+  <rect x="485" y="78" width="50" height="38" rx="2" fill="#ffffff" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="510" y="100" text-anchor="middle" font-size="7" fill="#666666">Model</text>
+  <rect x="545" y="78" width="50" height="38" rx="2" fill="#ffffff" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="570" y="100" text-anchor="middle" font-size="7" fill="#666666">Model</text>
+  <rect x="605" y="78" width="50" height="38" rx="2" fill="#ffffff" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="630" y="100" text-anchor="middle" font-size="7" fill="#666666">Model</text>
+
+  <!-- LoRA label for Pool A -->
+  <text x="720" y="100" text-anchor="middle" font-size="7" fill="#888888">+ LoRA:</text>
+  <text x="720" y="112" text-anchor="middle" font-size="7" fill="#888888">food-review-1</text>
+
+  <!-- InferencePool B -->
+  <rect x="345" y="210" width="455" height="105" rx="5" fill="#f8cecc" stroke="#b85450" stroke-width="1.5"/>
+  <text x="572" y="228" text-anchor="middle" font-size="11" font-weight="bold" fill="#000000">InferencePool B (deepseek/DeepSeek-r1)</text>
+
+  <!-- llm-d EPP B inside Pool B -->
+  <rect x="360" y="240" width="85" height="50" rx="3" fill="#f3f3f3" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="402" y="260" text-anchor="middle" font-size="9" font-weight="bold" fill="#000000">llm-d EPP</text>
+  <text x="402" y="275" text-anchor="middle" font-size="7" fill="#666666">Select endpoint</text>
+  <text x="402" y="285" text-anchor="middle" font-size="6" fill="#888888">(ext-proc)</text>
+
+  <!-- EPP B to pods -->
+  <line x1="445" y1="265" x2="483" y2="265" stroke="#000000" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Pods in Pool B -->
+  <rect x="485" y="243" width="50" height="38" rx="2" fill="#ffffff" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="510" y="265" text-anchor="middle" font-size="7" fill="#666666">Model</text>
+  <rect x="545" y="243" width="50" height="38" rx="2" fill="#ffffff" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="570" y="265" text-anchor="middle" font-size="7" fill="#666666">Model</text>
+  <rect x="605" y="243" width="50" height="38" rx="2" fill="#ffffff" stroke="#d9d2e9" stroke-width="1"/>
+  <text x="630" y="265" text-anchor="middle" font-size="7" fill="#666666">Model</text>
+
+  <!-- LoRA label for Pool B -->
+  <text x="720" y="258" text-anchor="middle" font-size="7" fill="#888888">+ LoRA:</text>
+  <text x="720" y="270" text-anchor="middle" font-size="7" fill="#888888">ski-resorts,</text>
+  <text x="720" y="282" text-anchor="middle" font-size="7" fill="#888888">movie-critique</text>
+
+  <!-- Note -->
+  <text x="572" y="340" text-anchor="middle" font-size="8" fill="#666666" font-style="italic">1 InferencePool : 1 llm-d EPP : 1 base model</text>
+
+  <!-- Caption -->
+  <text x="410" y="375" text-anchor="middle" font-size="9" fill="#888888">Proxy routes to InferencePool based on headers from llm-d IPP; llm-d EPP selects endpoint within pool</text>
+</svg>

--- a/docs/well-lit-paths/foundations/README.md
+++ b/docs/well-lit-paths/foundations/README.md
@@ -8,6 +8,7 @@ These guides teach single architectural capabilities that you can configure inde
 
 - **[Optimized Baseline](optimized-baseline.md)**: Strategies for handling the unique challenges of LLM request scheduling, moving beyond traditional round-robin approaches.
 - **[Predicted Latency-Based Routing](predicted-latency.md)**: Using online-trained machine learning models to predict latency and optimize scheduling.
+- **[Multi-Model Routing](multi-model-routing.md)**: Serving multiple LLMs and LoRA adapters behind a single Gateway endpoint using the Inference Payload Processor (IPP).
 
 ### Advanced KV-Cache Management
 

--- a/docs/well-lit-paths/foundations/multi-model-routing.md
+++ b/docs/well-lit-paths/foundations/multi-model-routing.md
@@ -1,0 +1,42 @@
+# Multi-Model Routing
+
+Organizations often need to serve multiple large language models behind a single API endpoint. A chatbot application might use a Qwen model for conversational tasks, while a recommendation system uses DeepSeek for complex reasoning. Each base model may also have multiple Low-Rank Adaptation (LoRA) fine-tuned variants serving different use cases.
+
+Traditional path-based routing cannot distinguish between these models when they share the same API path (`/v1/chat/completions`). The **Inference Payload Processor (IPP)** solves this by extracting the model name from the request body and routing to the appropriate InferencePool.
+
+> [!NOTE]
+> This capability requires IPP deployment. For simpler deployments serving a single model, see the [Optimized Baseline](optimized-baseline.md) guide instead.
+
+## Deploy
+
+See the [Multi-Model Routing guide](../../../guides/multi-model-routing) for manifests and step-by-step deployment.
+
+## Architecture
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)">
+    <img src="../../assets/multi-pool-routing.svg" alt="Multi-Model Routing Architecture">
+  </picture>
+</p>
+
+The setup creates multiple `InferencePools`, each serving a different base model:
+
+* Each **InferencePool** serves one base model and its LoRA adapters.
+* **IPP** extracts the model name from the request body and maps it to the base model.
+* **HTTPRoutes** match on the `X-Gateway-Base-Model-Name` header to route to the correct pool.
+* **EPP** selects the optimal endpoint within each pool.
+
+During the standard request flow:
+
+* Request arrives at the Proxy with `{"model": "food-review-1"}` in the body
+* Proxy invokes IPP via ext-proc
+* IPP looks up `food-review-1` → base model `Qwen/Qwen3-32B`
+* IPP sets header `X-Gateway-Base-Model-Name: Qwen/Qwen3-32B`
+* Proxy matches HTTPRoute and routes to `qwen-pool`
+* EPP selects endpoint, preserving the original model name
+* Model server loads the `food-review-1` LoRA adapter
+
+## Further Reading
+
+See [IPP Architecture](../../architecture/advanced/inference-payload-processing/README.md) for more details on the Inference Payload Processor.

--- a/guides/multi-model-routing/README.md
+++ b/guides/multi-model-routing/README.md
@@ -1,0 +1,205 @@
+# Multi-Model Routing
+
+## Overview
+
+This guide deploys the **Inference Payload Processor (IPP)** to enable serving multiple LLMs behind a single Gateway endpoint. IPP extracts the model name from the request body and sets routing headers. HTTPRoutes then match these headers to direct traffic to the appropriate InferencePool.
+
+Use this guide when you need to:
+
+* Serve multiple base models (e.g., Qwen for chatbots, DeepSeek for reasoning)
+* Provide a unified API endpoint following the OpenAI specification
+
+For LoRA adapter routing, see [Advanced: LoRA Adapter Routing](#advanced-lora-adapter-routing) after completing the base setup.
+
+For simpler single-model deployments, see the [Optimized Baseline](../optimized-baseline/README.md) guide instead.
+
+## Prerequisites
+
+* Have the [proper client tools installed on your local system](../../helpers/client-setup/README.md) to use this guide.
+* Checkout llm-d repo:
+
+  ```bash
+  export branch="main" # branch, tag, or commit hash
+  git clone https://github.com/llm-d/llm-d.git && cd llm-d && git checkout ${branch}
+  ```
+
+* Set the following environment variables:
+
+  ```bash
+  export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
+  source ${REPO_ROOT}/guides/env.sh
+  export GUIDE_NAME="multi-model-routing"
+  export NAMESPACE="llm-d-multi-model"
+  ```
+
+* Install the Gateway API Inference Extension CRDs:
+
+  ```bash
+  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
+  ```
+
+* Create a target namespace for the installation:
+
+  ```bash
+  kubectl create namespace ${NAMESPACE} --dry-run=client -o yaml | kubectl apply -f -
+  ```
+
+* [Create the `llm-d-hf-token` secret in your target namespace](../../helpers/hf-token.md) with a valid HuggingFace token.
+
+* **Multiple InferencePools deployed**, each serving a different base model. Follow the [Optimized Baseline](../optimized-baseline/README.md) guide for each pool, or [Multi-Inference Pool Setup](../workload-autoscaling/README.multi-inference-pool.md) for adding pools to an existing deployment.
+
+  > [!IMPORTANT]
+  > When deploying InferencePools for this guide, do **not** use `--set httpRoute.create=true`. This guide's HTTPRoutes (Step 3) handle routing based on model name headers. Pool-level catch-all routes would conflict with header-based routing.
+
+* A Kubernetes Gateway (e.g., Istio, GKE, AgentGateway) deployed in your cluster. See [Gateway Infrastructure](../../docs/infrastructure/gateway/README.md).
+
+## Step 1: Deploy IPP
+
+Clone the IPP repository and deploy using Helm:
+
+```bash
+# Clone the IPP repository
+git clone https://github.com/llm-d/llm-d-inference-payload-processor.git /tmp/ipp
+
+# Install IPP (for Istio)
+helm install ipp /tmp/ipp/config/charts/payload-processor \
+    --set provider.name=istio \
+    --set inferenceGateway.name=llm-d-inference-gateway \
+    --set payloadProcessor.image.tag=v0.1.0-rc.4 \
+    -n ${NAMESPACE}
+```
+
+> [!NOTE]
+> For GKE, use `--set provider.name=gke` instead of `istio`.
+> For standalone (no gateway), omit the `provider.name` flag.
+
+Verify IPP is running:
+
+```bash
+kubectl get pods -n ${NAMESPACE} -l app=payload-processor
+```
+
+## Step 2: Create Model Mapping ConfigMaps
+
+Create ConfigMaps that register each base model with IPP. Review and customize [`manifests/configmaps.yaml`](manifests/configmaps.yaml) for your models, then apply:
+
+```bash
+kubectl apply -n ${NAMESPACE} -f ${REPO_ROOT}/guides/multi-model-routing/manifests/configmaps.yaml
+```
+
+Each ConfigMap must have the label `inference.llm-d.ai/ipp-managed: "true"` and specify a `baseModel` value matching the model name in API requests.
+
+> [!IMPORTANT]
+> All model names must be globally unique across all InferencePools.
+
+## Step 3: Configure HTTPRoutes
+
+Create HTTPRoutes that match on the `X-Gateway-Base-Model-Name` header injected by IPP. Review and customize [`manifests/httproutes.yaml`](manifests/httproutes.yaml) for your setup:
+
+- Update `spec.parentRefs[0].name` to match your Gateway name
+- Update `backendRefs[0].name` to match your InferencePool names
+- Ensure the header `value` matches the `baseModel` in the corresponding ConfigMap
+
+```bash
+kubectl apply -n ${NAMESPACE} -f ${REPO_ROOT}/guides/multi-model-routing/manifests/httproutes.yaml
+```
+
+## Step 4: Test the Deployment
+
+Get the Gateway IP and send test requests:
+
+```bash
+export GATEWAY_IP=$(kubectl get gateway llm-d-inference-gateway -n ${NAMESPACE} -o jsonpath='{.status.addresses[0].value}')
+
+# Request to Qwen base model
+curl -X POST "http://${GATEWAY_IP}/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "Qwen/Qwen3-32B", "messages": [{"role": "user", "content": "Hello"}]}'
+
+# Request to DeepSeek base model
+curl -X POST "http://${GATEWAY_IP}/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "deepseek/DeepSeek-r1", "messages": [{"role": "user", "content": "Solve this problem"}]}'
+```
+
+## Troubleshooting
+
+### Check IPP Logs
+
+```bash
+kubectl logs -n ${NAMESPACE} -l app=payload-processor --tail=100
+```
+
+### Verify ConfigMap Discovery
+
+IPP should log discovered model mappings at startup. Check that your ConfigMaps have the required label:
+
+```bash
+kubectl get configmap -l inference.llm-d.ai/ipp-managed=true -n ${NAMESPACE}
+```
+
+### Verify Routing
+
+Check EPP logs to confirm requests reach the correct pool (replace `<pool-name>` with your InferencePool name):
+
+```bash
+kubectl logs -n ${NAMESPACE} -l llm-d-router-gateway=<pool-name>-epp --tail=20
+```
+
+## Cleanup
+
+```bash
+# Remove HTTPRoutes and ConfigMaps
+kubectl delete -n ${NAMESPACE} -f ${REPO_ROOT}/guides/multi-model-routing/manifests/httproutes.yaml
+kubectl delete -n ${NAMESPACE} -f ${REPO_ROOT}/guides/multi-model-routing/manifests/configmaps.yaml
+
+# Remove IPP
+helm uninstall ipp -n ${NAMESPACE}
+
+# Clean up cloned IPP repo
+rm -rf /tmp/ipp
+
+# Remove namespace (if no longer needed)
+kubectl delete namespace ${NAMESPACE}
+```
+
+## Advanced: LoRA Adapter Routing
+
+Once base model routing is working, you can extend ConfigMaps to route LoRA adapter requests to their base model's InferencePool.
+
+Add the `adapters` field to your ConfigMaps listing the LoRA adapter names:
+
+```bash
+kubectl apply -n ${NAMESPACE} -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: qwen-model-mapping
+  labels:
+    inference.llm-d.ai/ipp-managed: "true"
+data:
+  baseModel: "Qwen/Qwen3-32B"
+  adapters: |
+    - food-review-1
+    - travel-assistant
+EOF
+```
+
+When a request comes in with `"model": "food-review-1"`, IPP looks up which base model owns that adapter and sets `X-Gateway-Base-Model-Name: Qwen/Qwen3-32B`. The HTTPRoute then routes the request to the Qwen pool.
+
+**Test LoRA routing:**
+
+```bash
+curl -X POST "http://${GATEWAY_IP}/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "food-review-1", "messages": [{"role": "user", "content": "Review this restaurant"}]}'
+```
+
+> [!IMPORTANT]
+> All adapter names must be globally unique across all ConfigMaps.
+
+## Further Reading
+
+* [Multi-Model Routing Capability](../../docs/well-lit-paths/foundations/multi-model-routing.md) — High-level overview and architecture
+* [IPP Architecture](../../docs/architecture/advanced/inference-payload-processing/README.md) — Technical details of the Inference Payload Processor
+* [IPP Repository](https://github.com/llm-d/llm-d-inference-payload-processor) — Source code, configuration reference, and plugin documentation

--- a/guides/multi-model-routing/manifests/configmaps.yaml
+++ b/guides/multi-model-routing/manifests/configmaps.yaml
@@ -1,0 +1,26 @@
+# ConfigMaps that register base models with IPP.
+# Each ConfigMap must have the label inference.llm-d.ai/ipp-managed: "true"
+#
+# Customize:
+#   - metadata.name: unique name for this mapping
+#   - data.baseModel: the model name as it appears in API requests
+#
+# For LoRA adapter support, see the Advanced section in the guide README.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: qwen-model-mapping
+  labels:
+    inference.llm-d.ai/ipp-managed: "true"
+data:
+  baseModel: "Qwen/Qwen3-32B"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: deepseek-model-mapping
+  labels:
+    inference.llm-d.ai/ipp-managed: "true"
+data:
+  baseModel: "deepseek/DeepSeek-r1"

--- a/guides/multi-model-routing/manifests/httproutes.yaml
+++ b/guides/multi-model-routing/manifests/httproutes.yaml
@@ -1,0 +1,41 @@
+# HTTPRoutes that route requests to InferencePools based on the
+# X-Gateway-Base-Model-Name header set by IPP.
+#
+# Customize:
+#   - spec.parentRefs[0].name: your Gateway name
+#   - rules[0].matches[0].headers[0].value: must match baseModel in ConfigMap
+#   - rules[0].backendRefs[0].name: your InferencePool name
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: qwen-route
+spec:
+  parentRefs:
+  - name: llm-d-inference-gateway
+  rules:
+  - matches:
+    - headers:
+      - name: X-Gateway-Base-Model-Name
+        value: Qwen/Qwen3-32B
+    backendRefs:
+    - group: inference.networking.k8s.io
+      kind: InferencePool
+      name: qwen-pool
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: deepseek-route
+spec:
+  parentRefs:
+  - name: llm-d-inference-gateway
+  rules:
+  - matches:
+    - headers:
+      - name: X-Gateway-Base-Model-Name
+        value: deepseek/DeepSeek-r1
+    backendRefs:
+    - group: inference.networking.k8s.io
+      kind: InferencePool
+      name: deepseek-pool


### PR DESCRIPTION

## Summary

Add comprehensive documentation for the Inference Payload Processor (IPP), enabling multi-pool routing for serving multiple LLMs and LoRA adapters behind a single Gateway endpoint.

## Changes

- **Architecture docs** (`docs/architecture/core/ipp/`): README (overview), configuration.md (Helm/ConfigMap/metrics), plugins.md (11 in-tree plugins reference)
- **Well-lit path** (`docs/well-lit-paths/multi-pool-routing.md`): Conceptual guide for model-aware routing
- **Deployment guide** (`guides/multi-pool-routing/README.md`): Step-by-step setup with Helm commands, ConfigMaps, HTTPRoutes, and troubleshooting
- **Diagrams** (`docs/assets/`): Request flow and multi-pool architecture SVGs
- **Index updates**: Add IPP to architecture README and well-lit paths index



## Related Issues

Resolves https://github.com/llm-d/llm-d-inference-payload-processor/issues/102
#1809 