### PR TITLE
v0.8.0 release prep: swap to current official images

### DIFF
--- a/docs/api-reference/artifacts.md
+++ b/docs/api-reference/artifacts.md
@@ -51,8 +51,8 @@ llm-d releases the core EPP image as well as additional sidecar images for advan
 
 | Image | Description | Version |
 |-------|-------------|---------|
-| `ghcr.io/llm-d/llm-d-router-endpoint-picker-dev` | Core EPP image | main |
-| `ghcr.io/llm-d/llm-d-routing-sidecar`     | Optional sidecar for model servers, enabling KV cache transfer for P/D | v0.8.0 |
+| `ghcr.io/llm-d/llm-d-router-endpoint-picker` | Core EPP image | main |
+| `ghcr.io/llm-d/llm-d-router-disagg-sidecar`     | Optional sidecar for model servers, enabling KV cache transfer for P/D | v0.8.0 |
 | `registry.k8s.io/gateway-api-inference-extension/latency-training-server` | Optional sidecar for EPP, for predicted-latency model training | v1.5.0 |
 | `registry.k8s.io/gateway-api-inference-extension/latency-prediction-server` | Optional sidecar for EPP, for predicted-latency scheduling | v1.5.0 |
 

--- a/docs/architecture/advanced/disaggregation/operations-sglang.md
+++ b/docs/architecture/advanced/disaggregation/operations-sglang.md
@@ -21,7 +21,7 @@ SGLang coordinates this through a bootstrap server that is started on each prefi
 
 New P and D replicas connect lazily, with no pre-warming step: the first request routed across a given P/D pair triggers a one-time connection setup, and subsequent requests reuse it, so a newly added replica starts serving without restarts.
 
-For each request, the Routing Proxy Sidecar (configured with `--connector=sglang`) generates a unique `bootstrap_room` ID, injects `bootstrap_host`, `bootstrap_port`, and `bootstrap_room` into both the prefill and decode request bodies, and fires the prefill request asynchronously (in a background goroutine) while sending the decode request synchronously. As a result, the decode worker does not wait for prefill to complete before beginning coordination.
+For each request, the Routing Proxy Sidecar (configured with `--kv-connector=sglang`) generates a unique `bootstrap_room` ID, injects `bootstrap_host`, `bootstrap_port`, and `bootstrap_room` into both the prefill and decode request bodies, and fires the prefill request asynchronously (in a background goroutine) while sending the decode request synchronously. As a result, the decode worker does not wait for prefill to complete before beginning coordination.
 
 On the engine side:
 

--- a/docs/architecture/core/router/epp/configuration.md
+++ b/docs/architecture/core/router/epp/configuration.md
@@ -73,7 +73,7 @@ spec:
       ...
       containers:
       - name: epp
-        image: ghcr.io/llm-d/llm-d-router-endpoint-picker-dev:main
+        image: ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0
         imagePullPolicy: IfNotPresent
         args:
         - --pool-name
@@ -99,7 +99,7 @@ spec:
       ...
       containers:
       - name: epp
-        image: ghcr.io/llm-d/llm-d-router-endpoint-picker-dev:main
+        image: ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0
         imagePullPolicy: IfNotPresent
         args:
         - --pool-name

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -6,33 +6,39 @@ For this quickstart, we will use the **Standalone Mode** deployment, which is th
 
 ## Prerequisites
 
-- Ensure you have a Kubernetes cluster and `kubectl` configured.
-- Install [Helm](https://helm.sh/docs/intro/install/).
-- Install [jq](https://jqlang.org/download/).
+- Installed proper client tools (kubectl, helm).
+- Set the following environment variables:
+  ```bash
+  export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
+  source ${REPO_ROOT}/guides/env.sh
+  export GUIDE_NAME="quickstart"
+  export NAMESPACE=llm-d-quickstart
+  ```
 
-### 1. Setup Environment
+- Install the Gateway API Inference Extension CRDs:
 
-Clone the llm-d repository and set up the necessary environment variables:
+  ```bash
+  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
+  ```
 
-```bash
-git clone https://github.com/llm-d/llm-d.git && cd llm-d
+- Create a target namespace for the installation:
 
-export GAIE_VERSION=v1.5.0
-export ROUTER_CHART_VERSION=v0
-export GUIDE_NAME="quickstart"
-export NAMESPACE=llm-d-quickstart
-```
+  ```bash
+  kubectl create namespace ${NAMESPACE} --dry-run=client -o yaml | kubectl apply -f -
+  ```
 
-### 2. Install CRDs and Namespace
+- [Create the `llm-d-hf-token` secret in your target namespace with the key `HF_TOKEN` matching a valid HuggingFace token](../../helpers/hf-token.md) to pull models.
+<!-- llm-d-cicd:skip start -->
+  ```bash
+  export HF_TOKEN=<your HuggingFace token>
+  kubectl create secret generic llm-d-hf-token \
+    --from-literal="HF_TOKEN=${HF_TOKEN}" \
+    --namespace "${NAMESPACE}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+  ```
+<!-- llm-d-cicd:skip end -->
 
-Install the Gateway API Inference Extension CRDs and create the namespace:
-
-```bash
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
-kubectl create namespace ${NAMESPACE}
-```
-
-## Installation
+## Installation Instructions
 
 ### 1. Deploy the llm-d Router (Standalone Mode)
 

--- a/docs/operations/observability/tracing.md
+++ b/docs/operations/observability/tracing.md
@@ -135,7 +135,7 @@ Expected output:
 If you only see generic `GET` spans, check that:
 
 - The vLLM container args include `--collect-detailed-traces all`
-- The EPP image includes tracing instrumentation (`llm-d-router-endpoint-picker-dev`, not upstream `epp`)
+- The EPP image includes tracing instrumentation (`llm-d-router-endpoint-picker`, not upstream `epp`)
 
 ## Production Recommendations
 

--- a/guides/agentic-serving/benchmark-templates/guide.yaml
+++ b/guides/agentic-serving/benchmark-templates/guide.yaml
@@ -40,7 +40,7 @@ harness:
   parallelism: 1                  # Number of parallel workload launcher pods to create.
   wait_timeout: 6000              # Time (in seconds) to wait for workload launcher pod to complete before terminating.
                                   # Set to 0 to disable timeout.
-  image: ghcr.io/llm-d/llm-d-benchmark:v0.6.8.1
+  image: ghcr.io/llm-d/llm-d-benchmark:v0.7.0
 
 env:
   - name: RAYON_NUM_THREADS

--- a/guides/agentic-serving/nemotron-3-ultra-550b-h200.md
+++ b/guides/agentic-serving/nemotron-3-ultra-550b-h200.md
@@ -44,11 +44,10 @@ configuration layers the agentic optimizations onto disaggregated serving:
 - Installed proper client tools (kubectl, helm).
 - Set the following environment variables:
   ```bash
-  export GAIE_VERSION=v1.5.0
-  export ROUTER_CHART_VERSION=v0
+  export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
+  source ${REPO_ROOT}/guides/env.sh
   export GUIDE_NAME="agentic-serving"
   export NAMESPACE=llm-d-agentic-serving
-  export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
   ```
 
 - Install the Gateway API Inference Extension CRDs:

--- a/guides/env.sh
+++ b/guides/env.sh
@@ -5,6 +5,6 @@
 
 export REPO_ROOT=${REPO_ROOT:-$(realpath $(git rev-parse --show-toplevel 2>/dev/null) 2>/dev/null)}
 export GAIE_VERSION=v1.5.0
-export ROUTER_CHART_VERSION=v0
+export ROUTER_CHART_VERSION=v0.9.1
 export ROUTER_STANDALONE_CHART=oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev
 export ROUTER_GATEWAY_CHART=oci://ghcr.io/llm-d/charts/llm-d-router-gateway-dev

--- a/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/common/encode-deployment.yaml
+++ b/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/common/encode-deployment.yaml
@@ -35,6 +35,9 @@ spec:
                 secretKeyRef:
                   name: llm-d-hf-token
                   key: HF_TOKEN
+            # Workaround for https://github.com/vllm-project/vllm/issues/44548, required with vLLM v0.20.0+ due to torch 2.11
+            - name: USER
+              value: llm-d
           ports:
             - name: modelserver
               containerPort: 8000

--- a/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/kustomization.yaml
+++ b/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 namePrefix: e-p-d-disaggregation-nvidia-gpu-vllm-
 
 components:
+  - ../../../../../../../recipes/modelserver/components/images/gpu-vllm-omni
   - ../../../../../../../recipes/modelserver/components/images/routing-sidecar
 
 # TODO(#1891): Remove override once upstream vLLM includes encode-disaggregation support.

--- a/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/kustomization.yaml
+++ b/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
 namePrefix: e-p-d-disaggregation-nvidia-gpu-vllm-
 
 components:
-  - ../../../../../../../recipes/modelserver/components/images/gpu-vllm-omni
   - ../../../../../../../recipes/modelserver/components/images/routing-sidecar
 
 # TODO(#1891): Remove override once upstream vLLM includes encode-disaggregation support.

--- a/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/patch-decode.yaml
+++ b/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/patch-decode.yaml
@@ -8,7 +8,6 @@ spec:
     spec:
       initContainers:
         - name: routing-proxy
-          image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0
           args:
             - --port=8000
             - --vllm-port=8200

--- a/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/patch-decode.yaml
+++ b/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/patch-decode.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       initContainers:
         - name: routing-proxy
-          image: ghcr.io/llm-d/llm-d-router-disagg-sidecar-dev:main 
+          image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0
           args:
             - --port=8000
             - --vllm-port=8200

--- a/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/patch-decode.yaml
+++ b/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/patch-decode.yaml
@@ -38,6 +38,9 @@ spec:
                 secretKeyRef:
                   name: llm-d-hf-token
                   key: HF_TOKEN
+            # Workaround for https://github.com/vllm-project/vllm/issues/44548, required with vLLM v0.20.0+ due to torch 2.11
+            - name: USER
+              value: llm-d
           resources:
             limits:
               cpu: "16"

--- a/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/patch-prefill.yaml
+++ b/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/patch-prefill.yaml
@@ -18,7 +18,6 @@ spec:
             - "--kv-transfer-config"
             - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
             - "--no-disable-hybrid-kv-cache-manager"
-            - "--gpu-memory-utilization=0.9"
             - "--ec-transfer-config"
             - '{"ec_connector": "ECCPUConnector", "ec_role": "ec_consumer"}'
           env:

--- a/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/patch-prefill.yaml
+++ b/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/patch-prefill.yaml
@@ -31,6 +31,9 @@ spec:
                 secretKeyRef:
                   name: llm-d-hf-token
                   key: HF_TOKEN
+            # Workaround for https://github.com/vllm-project/vllm/issues/44548, required with vLLM v0.20.0+ due to torch 2.11
+            - name: USER
+              value: llm-d
           resources:
             limits:
               cpu: "8"

--- a/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-pd/base/kustomization.yaml
+++ b/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-pd/base/kustomization.yaml
@@ -12,6 +12,11 @@ images:
     newName: ghcr.io/revit13/vllm-openai
     newTag: 14d40dc7d
 
+images:
+  - name: REPLACE_ROUTING_SIDECAR_IMAGE
+    newName: ghcr.io/llm-d/llm-d-router-disagg-sidecar
+    newTag: v0.9.0
+
 labels:
   - pairs:
       llm-d.ai/model: Qwen3-VL-32B-Instruct

--- a/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-pd/base/kustomization.yaml
+++ b/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-pd/base/kustomization.yaml
@@ -6,16 +6,16 @@ resources:
 
 namePrefix: e-pd-disaggregation-nvidia-gpu-vllm-
 
-# TODO(#1891): Remove override once upstream vLLM includes encode-disaggregation support.
 images:
-  - name: REPLACE_MODEL_SERVER_IMAGE
-    newName: ghcr.io/revit13/vllm-openai
-    newTag: 14d40dc7d
-
-images:
+  # exception - cannot be in base because generic inference servers have no need for the sidecar.
+  # This is E dissagregation where as PD was previously the only concept of dissag.
   - name: REPLACE_ROUTING_SIDECAR_IMAGE
     newName: ghcr.io/llm-d/llm-d-router-disagg-sidecar
     newTag: v0.9.0
+  # TODO(#1891): Remove override once upstream vLLM includes encode-disaggregation support.
+  - name: REPLACE_MODEL_SERVER_IMAGE
+    newName: ghcr.io/revit13/vllm-openai
+    newTag: 14d40dc7d
 
 labels:
   - pairs:

--- a/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-pd/base/patch-decode.yaml
+++ b/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-pd/base/patch-decode.yaml
@@ -15,7 +15,7 @@ spec:
             - --ec-connector=ec-nixl
             - --zap-log-level=1
             - --secure-proxy=false
-          image: ghcr.io/llm-d/llm-d-router-disagg-sidecar-dev:main 
+          image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0
           imagePullPolicy: Always
           ports:
             - containerPort: 8000

--- a/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-pd/base/patch-decode.yaml
+++ b/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-pd/base/patch-decode.yaml
@@ -8,6 +8,8 @@ spec:
     spec:
       initContainers:
         - name: routing-proxy
+          image: REPLACE_ROUTING_SIDECAR_IMAGE
+          imagePullPolicy: Always
           args:
             - --port=8000
             - --vllm-port=8200
@@ -15,8 +17,6 @@ spec:
             - --ec-connector=ec-nixl
             - --zap-log-level=1
             - --secure-proxy=false
-          image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0
-          imagePullPolicy: Always
           ports:
             - containerPort: 8000
               name: sidecar
@@ -29,6 +29,7 @@ spec:
       containers:
         - name: modelserver
           command: ["vllm", "serve"]
+          imagePullPolicy: Always
           args:
             - "Qwen/Qwen3-VL-32B-Instruct"
             - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"

--- a/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-pd/base/patch-decode.yaml
+++ b/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-pd/base/patch-decode.yaml
@@ -43,6 +43,9 @@ spec:
                 secretKeyRef:
                   name: llm-d-hf-token
                   key: HF_TOKEN
+            # Workaround for https://github.com/vllm-project/vllm/issues/44548, required with vLLM v0.20.0+ due to torch 2.11
+            - name: USER
+              value: llm-d
           ports:
             - name: modelserver
               containerPort: 8200

--- a/guides/multimodal-serving/e-disaggregation/router/e-pd-disaggregation.values.yaml
+++ b/guides/multimodal-serving/e-disaggregation/router/e-pd-disaggregation.values.yaml
@@ -6,12 +6,6 @@ router:
       targetPort: 8081
 
   epp:
-    image:
-      registry: ghcr.io/llm-d
-      repository: llm-d-router-endpoint-picker
-      v0.9.0-rc.2
-      pullPolicy: Always
-
     pluginsConfigFile: "e-pd-config.yaml"
     pluginsCustomConfig:
       e-pd-config.yaml: |

--- a/guides/multimodal-serving/e-disaggregation/router/e-pd-disaggregation.values.yaml
+++ b/guides/multimodal-serving/e-disaggregation/router/e-pd-disaggregation.values.yaml
@@ -8,8 +8,8 @@ router:
   epp:
     image:
       registry: ghcr.io/llm-d
-      repository: llm-d-router-endpoint-picker-dev
-      tag: main
+      repository: llm-d-router-endpoint-picker
+      v0.9.0-rc.2
       pullPolicy: Always
 
     pluginsConfigFile: "e-pd-config.yaml"

--- a/guides/no-kubernetes-deployment/README.md
+++ b/guides/no-kubernetes-deployment/README.md
@@ -106,8 +106,7 @@ docker run -d --name vllm-0 --gpus '"device=0,1"' \
     "${VLLM_IMAGE}" \
     serve "${MODEL}" \
     --disable-access-log-for-endpoints=/health,/metrics,/v1/models \
-    --tensor-parallel-size=2 \
-    --gpu-memory-utilization=0.95
+    --tensor-parallel-size=2
 ```
 
 The optimized-baseline pod also sets resource requests/limits

--- a/guides/no-kubernetes-deployment/README.md
+++ b/guides/no-kubernetes-deployment/README.md
@@ -58,10 +58,10 @@ and `no-hit-lru-scorer` (each weight 2), composed by `max-score-picker`.
   `Qwen/Qwen3-32B` on first start.
 
 The EPP binary is built from [`cmd/epp` of the llm-d-router repo][router-repo]
-or pulled from `ghcr.io/llm-d/llm-d-router-endpoint-picker-dev`.
+or pulled from `ghcr.io/llm-d/llm-d-router-endpoint-picker`.
 
 ```bash
-export EPP_IMAGE=ghcr.io/llm-d/llm-d-router-endpoint-picker-dev:main
+export EPP_IMAGE=ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0
 export ENVOY_IMAGE=docker.io/envoyproxy/envoy:distroless-v1.33.2
 export VLLM_IMAGE=vllm/vllm-openai:v0.19.1
 export MODEL=Qwen/Qwen3-32B

--- a/guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
+++ b/guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
@@ -14,7 +14,6 @@ spec:
             - "Qwen/Qwen3-32B"
             - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
             - "--tensor-parallel-size=2"
-            - "--gpu-memory-utilization=0.95"
             # Uncomment for distributed tracing
             # - "--otlp-traces-endpoint=http://otel-collector:4317"
             # - "--collect-detailed-traces=all"

--- a/guides/optimized-baseline/modelserver/gpu/vllm/gpt-oss/patch-vllm.yaml
+++ b/guides/optimized-baseline/modelserver/gpu/vllm/gpt-oss/patch-vllm.yaml
@@ -14,7 +14,6 @@ spec:
             - "openai/gpt-oss-120b"
             - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
             - "--tensor-parallel-size=1"
-            - "--gpu-memory-utilization=0.95"
             - "--served-model-name=openai/gpt-oss-120b"
             - "--block-size=128"
             - "--enable-auto-tool-choice"

--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -155,7 +155,7 @@ kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/g
 
 SGLang-specific notes:
 
-* **Engine flags**: prefill and decode pods launch with `--disaggregation-mode={prefill,decode}` and `--disaggregation-transfer-backend=nixl`. The decode pod's routing-proxy sidecar is configured with `--connector=sglang`.
+* **Engine flags**: prefill and decode pods launch with `--disaggregation-mode={prefill,decode}` and `--disaggregation-transfer-backend=nixl`. The decode pod's routing-proxy sidecar is configured with `--kv-connector=sglang`.
 * **Bootstrap server**: each prefill instance runs a bootstrap server on port `8998` (the default). To use a different port, set `SGLANG_BOOTSTRAP_PORT` on the sidecar and `--disaggregation-bootstrap-port` on the SGLang engine so the two match. P/D peers discover each other through this server rather than vLLM's peer-to-peer negotiation; the KV transfer itself still runs directly over NIXL/RDMA.
 * **Operations**: scale up/down, request cancellation, fault tolerance, and rollout behavior differ from vLLM. See [Disaggregated Serving: Operations (SGLang)](../../docs/architecture/advanced/disaggregation/operations-sglang.md).
 

--- a/guides/pd-disaggregation/baseline/manifest.yaml
+++ b/guides/pd-disaggregation/baseline/manifest.yaml
@@ -21,7 +21,6 @@ spec:
           command: ["vllm", "serve"]
           args:
             - "openai/gpt-oss-120b"
-            - "--gpu-memory-utilization=0.90"
           ports:
             - name: http
               containerPort: 8000

--- a/guides/pd-disaggregation/benchmark-templates/tpu.yaml
+++ b/guides/pd-disaggregation/benchmark-templates/tpu.yaml
@@ -18,7 +18,7 @@ harness:
   parallelism: 1                  # Number of parallel workload launcher pods to create.
   wait_timeout: 6000              # Time (in seconds) to wait for workload launcher pod to complete before terminating.
                                   # Set to 0 to disable timeout.
-  image: ghcr.io/llm-d/llm-d-benchmark:v0.6.0
+  image: ghcr.io/llm-d/llm-d-benchmark:v0.7.0
   # dataset_url: &dataset_url none
 
 env:

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/aws/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/aws/patch-prefill.yaml
@@ -38,7 +38,6 @@ spec:
             - "--kv-transfer-config"
             - '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
             - "--no-disable-hybrid-kv-cache-manager"
-            - "--gpu-memory-utilization=0.9"
           securityContext:
             capabilities:
               add:

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/base/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/base/patch-prefill.yaml
@@ -17,7 +17,6 @@ spec:
             - "--kv-transfer-config"
             - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
             - "--no-disable-hybrid-kv-cache-manager"
-            - "--gpu-memory-utilization=0.9"
           env:
             - name: HF_TOKEN
               valueFrom:

--- a/guides/precise-prefix-cache-routing/modelserver/gpu/vllm/base/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-routing/modelserver/gpu/vllm/base/patch-vllm.yaml
@@ -14,7 +14,6 @@ spec:
             - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
             - "--tensor-parallel-size=2"
             - "--block-size=64"
-            - "--gpu-memory-utilization=0.95"
             - "--kv-events-config"
             - '{"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"$(KV_EVENTS_ENDPOINT)","topic":"kv@$(POD_IP):$(POD_PORT)@Qwen/Qwen3-32B"}'
             # Uncomment for distributed tracing

--- a/guides/precise-prefix-cache-routing/modelserver/tpu/v7/vllm/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-routing/modelserver/tpu/v7/vllm/patch-vllm.yaml
@@ -19,7 +19,6 @@ spec:
             - "--max-num-seqs=128"
             - "--kv-cache-dtype=fp8"
             - "--async-scheduling"
-            - "--gpu-memory-utilization=0.93"
             - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
             - "--tensor-parallel-size=8"
             - "--block-size=64"

--- a/guides/recipes/modelserver/base/single-host/pd/sglang/patch-sidecar.yaml
+++ b/guides/recipes/modelserver/base/single-host/pd/sglang/patch-sidecar.yaml
@@ -10,7 +10,7 @@ spec:
           args:
             - --port=8000
             - --vllm-port=8200
-            - --connector=sglang
+            - --kv-connector=sglang
             - --zap-log-level=1
             - --secure-proxy=false
           image: REPLACE_ROUTING_SIDECAR_IMAGE

--- a/guides/recipes/modelserver/base/single-host/pd/vllm/patch-sidecar.yaml
+++ b/guides/recipes/modelserver/base/single-host/pd/vllm/patch-sidecar.yaml
@@ -10,7 +10,7 @@ spec:
           args:
             - --port=8000
             - --vllm-port=8200
-            - --connector=nixlv2
+            - --kv-connector=nixlv2
             - --zap-log-level=1
             - --secure-proxy=false
           image: REPLACE_ROUTING_SIDECAR_IMAGE

--- a/guides/recipes/modelserver/components/images/gpu-vllm-omni/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/gpu-vllm-omni/kustomization.yaml
@@ -2,9 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
-    newName: ghcr.io/llm-d/llm-d-cpu
-    newTag: v0.7.0
-    
+    newName: vllm/vllm-omni
+    newTag: v0.22.0
+
+# Workaround for https://github.com/vllm-project/vllm/issues/44548, required with vLLM v0.20.0+ due to torch 2.11
 patches:
   - target:
       kind: Deployment

--- a/guides/recipes/modelserver/components/images/gpu-vllm-omni/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/gpu-vllm-omni/kustomization.yaml
@@ -1,9 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 images:
+  # Requires: https://github.com/vllm-project/vllm/pull/42998 for EC CPU Connector
   - name: REPLACE_MODEL_SERVER_IMAGE
-    newName: vllm/vllm-omni
-    newTag: v0.22.0
+    newName: ghcr.io/revit13/vllm-openai
+    newTag: 14d40dc7d
+  # - name: REPLACE_MODEL_SERVER_IMAGE
+  #   newName: vllm/vllm-omni
+  #   newTag: v0.22.0
 
 # Workaround for https://github.com/vllm-project/vllm/issues/44548, required with vLLM v0.20.0+ due to torch 2.11
 patches:

--- a/guides/recipes/modelserver/components/images/gpu-vllm/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/gpu-vllm/kustomization.yaml
@@ -4,3 +4,22 @@ images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: vllm/vllm-openai
     newTag: v0.23.0
+
+# Workaround for https://github.com/vllm-project/vllm/issues/44548, required with vLLM v0.20.0+ due to torch 2.11
+patches:
+  - target:
+      kind: Deployment
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: USER
+          value: llm-d
+  - target:
+      kind: LeaderWorkerSet
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: USER
+          value: llm-d

--- a/guides/recipes/modelserver/components/images/routing-sidecar/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/routing-sidecar/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 images:
   - name: REPLACE_ROUTING_SIDECAR_IMAGE
-    newName: ghcr.io/llm-d/llm-d-routing-sidecar
+    newName: ghcr.io/llm-d/llm-d-router-disagg-sidecar
     newTag: v0.8.0

--- a/guides/recipes/modelserver/components/images/routing-sidecar/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/routing-sidecar/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Component
 images:
   - name: REPLACE_ROUTING_SIDECAR_IMAGE
     newName: ghcr.io/llm-d/llm-d-router-disagg-sidecar
-    newTag: v0.8.0
+    newTag: v0.9.0

--- a/guides/recipes/modelserver/components/images/routing-sidecar/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/routing-sidecar/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Component
 images:
   - name: REPLACE_ROUTING_SIDECAR_IMAGE
     newName: ghcr.io/llm-d/llm-d-router-disagg-sidecar
-    newTag: v0.9.0
+    newTag: v0.9.1

--- a/guides/recipes/modelserver/components/images/xpu-vllm/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/xpu-vllm/kustomization.yaml
@@ -4,3 +4,23 @@ images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: ghcr.io/llm-d/llm-d-xpu
     newTag: v0.7.0
+
+# Workaround for https://github.com/vllm-project/vllm/issues/44548, required with vLLM v0.20.0+ due to torch 2.11+
+# See: https://github.com/vllm-project/vllm/blob/main/requirements/xpu.txt#L15
+patches:
+  - target:
+      kind: Deployment
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: USER
+          value: llm-d
+  - target:
+      kind: LeaderWorkerSet
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: USER
+          value: llm-d

--- a/guides/recipes/router/base.values.yaml
+++ b/guides/recipes/router/base.values.yaml
@@ -7,7 +7,7 @@ router:
     image:
       registry: ghcr.io/llm-d
       repository: llm-d-router-endpoint-picker  # TODO: drop -dev for release
-      tag: v0.9.0-rc.2  # TODO: pin to a released tag (e.g. v0.9.0)
+      tag: v0.9.1
       pullPolicy: Always  # TODO : change to IfNotPresent once we release a version
     flags:
       v: 2

--- a/guides/recipes/router/base.values.yaml
+++ b/guides/recipes/router/base.values.yaml
@@ -6,8 +6,8 @@ router:
     replicas: 1
     image:
       registry: ghcr.io/llm-d
-      repository: llm-d-router-endpoint-picker-dev  # TODO: drop -dev for release
-      tag: main  # TODO: pin to a released tag (e.g. v0.9.0)
+      repository: llm-d-router-endpoint-picker  # TODO: drop -dev for release
+      tag: v0.9.0-rc.2  # TODO: pin to a released tag (e.g. v0.9.0)
       pullPolicy: Always  # TODO : change to IfNotPresent once we release a version
     flags:
       v: 2

--- a/guides/tiered-prefix-cache/modelserver/gpu/vllm/base/patch-vllm-gpt-oss-120b.yaml
+++ b/guides/tiered-prefix-cache/modelserver/gpu/vllm/base/patch-vllm-gpt-oss-120b.yaml
@@ -13,7 +13,6 @@ spec:
             - "openai/gpt-oss-120b"
             - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
             - "--tensor-parallel-size=1"
-            - "--gpu-memory-utilization=0.95"
             - "--served-model-name=openai/gpt-oss-120b"
             - "--enable-auto-tool-choice"
             - "--tool-call-parser=openai"

--- a/guides/tiered-prefix-cache/modelserver/gpu/vllm/lmcache-connector/cpu/base/kustomization.yaml
+++ b/guides/tiered-prefix-cache/modelserver/gpu/vllm/lmcache-connector/cpu/base/kustomization.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 resources:
   - ../../../base
 
+components:
+  - ../../../../../../../recipes/modelserver/components/images/gpu-vllm
+
 labels:
   - pairs:
       llm-d.ai/guide: tiered-prefix-cache

--- a/guides/tiered-prefix-cache/modelserver/gpu/vllm/lmcache-connector/cpu/base/patch-vllm.yaml
+++ b/guides/tiered-prefix-cache/modelserver/gpu/vllm/lmcache-connector/cpu/base/patch-vllm.yaml
@@ -8,16 +8,12 @@ spec:
       containers:
         - name: modelserver
           # TODO(#1897): Update to centralized gpu-vllm image; avoid hardcoding in patch.
-          image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
           args:
             - "Qwen/Qwen3-32B"
             - "--tensor-parallel-size=2"
             - "--kv-transfer-config"
             - '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'
-            - "--max-num-seq"
-            - "1024"
-            - "--gpu-memory-utilization"
-            - "0.8"
+            - "--max-num-seq=1024"
           env:
             - name: HF_TOKEN
               valueFrom:

--- a/guides/tiered-prefix-cache/modelserver/gpu/vllm/lmcache-connector/fs/base/patch-vllm.yaml
+++ b/guides/tiered-prefix-cache/modelserver/gpu/vllm/lmcache-connector/fs/base/patch-vllm.yaml
@@ -17,8 +17,6 @@ spec:
             - "1024"
             - "--kv-transfer-config"
             - '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'
-            - "--gpu-memory-utilization"
-            - "0.8"
           env:
             - name: HF_TOKEN
               valueFrom:

--- a/guides/tiered-prefix-cache/modelserver/tpu/base/vllm/patch-vllm.yaml
+++ b/guides/tiered-prefix-cache/modelserver/tpu/base/vllm/patch-vllm.yaml
@@ -42,8 +42,7 @@ spec:
                 Qwen/Qwen3-32B \
                 --kv-transfer-config '{"kv_connector":"TPUOffloadConnector","kv_connector_module_path":"tpu_inference.offload.tpu_offload_connector","kv_role":"kv_both"}' \
                 --port 8000 \
-                --tensor-parallel-size 8 \
-                --gpu-memory-utilization 0.9
+                --tensor-parallel-size 8
           env:
             - name: HF_TOKEN
               valueFrom:

--- a/guides/wide-ep-lws/experimental-dp-aware/manifests/inferencepool.values.yaml
+++ b/guides/wide-ep-lws/experimental-dp-aware/manifests/inferencepool.values.yaml
@@ -3,10 +3,6 @@ router:
     replicas: 1
     flags:
       v: 1
-    image:
-      registry: ghcr.io/llm-d
-      repository: llm-d-router-endpoint-picker
-      v0.9.0-rc.2
     extProcPort: 9002
     pluginsConfigFile: "custom-plugins.yaml"
     pluginsCustomConfig:

--- a/guides/wide-ep-lws/experimental-dp-aware/manifests/inferencepool.values.yaml
+++ b/guides/wide-ep-lws/experimental-dp-aware/manifests/inferencepool.values.yaml
@@ -5,8 +5,8 @@ router:
       v: 1
     image:
       registry: ghcr.io/llm-d
-      repository: llm-d-router-endpoint-picker-dev
-      tag: main
+      repository: llm-d-router-endpoint-picker
+      v0.9.0-rc.2
     extProcPort: 9002
     pluginsConfigFile: "custom-plugins.yaml"
     pluginsCustomConfig:

--- a/guides/wide-ep-lws/experimental-dp-aware/manifests/modelserver/base/decode.yaml
+++ b/guides/wide-ep-lws/experimental-dp-aware/manifests/modelserver/base/decode.yaml
@@ -33,7 +33,7 @@ spec:
               - --port=8000
               - --vllm-port=8200
               - --data-parallel-size=8
-              - --connector=nixlv2
+              - --kv-connector=nixlv2
               - --zap-log-level=1
               - --secure-proxy=false
               - --enable-prefiller-sampling

--- a/guides/wide-ep-lws/experimental-dp-aware/manifests/modelserver/base/decode.yaml
+++ b/guides/wide-ep-lws/experimental-dp-aware/manifests/modelserver/base/decode.yaml
@@ -47,7 +47,7 @@ spec:
               #   value: "parentbased_traceidratio"
               # - name: OTEL_TRACES_SAMPLER_ARG
               #   value: "0.1"
-            image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
+            image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0
             imagePullPolicy: Always
             ports:
               - containerPort: 8000

--- a/guides/wide-ep-lws/modelserver/gpu/vllm-deepseek-v4/base/decode.yaml
+++ b/guides/wide-ep-lws/modelserver/gpu/vllm-deepseek-v4/base/decode.yaml
@@ -25,7 +25,7 @@ spec:
             args:
               - --port=8000
               - --vllm-port=8200
-              - --connector=nixlv2
+              - --kv-connector=nixlv2
               - --zap-log-level=1
               - --secure-proxy=false
               - --enable-prefiller-sampling

--- a/guides/wide-ep-lws/modelserver/gpu/vllm-deepseek-v4/base/decode.yaml
+++ b/guides/wide-ep-lws/modelserver/gpu/vllm-deepseek-v4/base/decode.yaml
@@ -29,7 +29,7 @@ spec:
               - --zap-log-level=1
               - --secure-proxy=false
               - --enable-prefiller-sampling
-            image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
+            image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0
             imagePullPolicy: Always
             ports:
               - containerPort: 8000

--- a/guides/wide-ep-lws/modelserver/gpu/vllm-deepseek-v4/base/prefill.yaml
+++ b/guides/wide-ep-lws/modelserver/gpu/vllm-deepseek-v4/base/prefill.yaml
@@ -58,7 +58,6 @@ spec:
                   deepseek-ai/DeepSeek-V4-Pro \
                   --port 8000 \
                   --tokenizer-mode deepseek_v4 \
-                  --gpu-memory-utilization 0.9 \
                   --trust-remote-code \
                   --api-server-count 4 \
                   --disable-access-log-for-endpoints=/health,/metrics \

--- a/guides/wide-ep-lws/modelserver/gpu/vllm/base/decode.yaml
+++ b/guides/wide-ep-lws/modelserver/gpu/vllm/base/decode.yaml
@@ -92,7 +92,6 @@ spec:
                 exec vllm serve \
                   deepseek-ai/DeepSeek-R1-0528 \
                   --port 8200 \
-                  --gpu-memory-utilization 0.9 \
                   --trust-remote-code \
                   --api-server-count 1 \
                   --disable-access-log-for-endpoints=/health,/metrics \

--- a/guides/wide-ep-lws/modelserver/gpu/vllm/base/decode.yaml
+++ b/guides/wide-ep-lws/modelserver/gpu/vllm/base/decode.yaml
@@ -25,7 +25,7 @@ spec:
             args:
               - --port=8000
               - --vllm-port=8200
-              - --connector=nixlv2
+              - --kv-connector=nixlv2
               - --zap-log-level=1
               - --secure-proxy=false
               - --enable-prefiller-sampling

--- a/guides/wide-ep-lws/modelserver/gpu/vllm/base/decode.yaml
+++ b/guides/wide-ep-lws/modelserver/gpu/vllm/base/decode.yaml
@@ -29,7 +29,7 @@ spec:
               - --zap-log-level=1
               - --secure-proxy=false
               - --enable-prefiller-sampling
-            image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
+            image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0
             imagePullPolicy: Always
             # To enable tracing, uncomment:
             # env:

--- a/guides/workload-autoscaling/README.multi-inference-pool.md
+++ b/guides/workload-autoscaling/README.multi-inference-pool.md
@@ -16,7 +16,7 @@ Install an additional Helm release in the same namespace as the optimized-baseli
 ```bash
 export NAMESPACE=llm-d-optimized-baseline
 export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
-export ROUTER_CHART_VERSION=v0
+export ROUTER_CHART_VERSION=v0.9.1
 
 helm install model-b \
     ${ROUTER_STANDALONE_CHART} \

--- a/guides/workload-autoscaling/scripts/nightly-deploy-cks.sh
+++ b/guides/workload-autoscaling/scripts/nightly-deploy-cks.sh
@@ -8,7 +8,7 @@ yq '.spec.template.spec.volumes += {"name": "triton-cache", "emptyDir": {}}' -i 
 yq '.spec.template.spec.containers[0].volumeMounts += {"mountPath": "/.triton", "name": "triton-cache"}' -i guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
 yq '.spec.replicas=2' -i guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
 kubectl apply -k guides/optimized-baseline/modelserver/gpu/vllm/base -n ${NAMESPACE}
-export ROUTER_CHART_VERSION=v0
+export ROUTER_CHART_VERSION=v0.9.1
 helm install workload-variant-autoscaler-inferencepool-standalone \
   oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev \
   -f guides/recipes/router/base.values.yaml \


### PR DESCRIPTION
Changes:
- Consume common image style in multi-modal recipe
- Bump container images to most recent RCs / release images
- Correct outdated --connector refs

cc @llm-d/release-crew 
