### PR TITLE
[SGLang] Update the well-lit path guide for precise prefix cache aware routing with optimal config and updated benchmark numbers

### DIFF
--- a/guides/precise-prefix-cache-routing/README.md
+++ b/guides/precise-prefix-cache-routing/README.md
@@ -355,9 +355,21 @@ Output tokens/sec — higher is better; TTFT in seconds — lower is better.
 
 ### SGLang
 
+The benchmark runs on 16× H100 GPUs, distributed across 8 model servers (2 H100s per server with TP=2).
+
 #### Comparing llm-d Scheduling to a Simple Kubernetes Service
 
-Benchmark run with the canonical shared-prefix workload from this guide, comparing the precise path against a plain Kubernetes Service (round-robin, no EPP, no scoring) across the same SGLang pods. llm-d Precise shows a large improvement over the k8s baseline — roughly 2× output throughput with TTFT held near constant while the baseline degrades sharply under load.
+Benchmark run with the canonical shared-prefix workload from this guide, comparing the precise path against a plain Kubernetes Service (round-robin, no EPP, no scoring) across the same SGLang pods. llm-d Precise shows a massive improvement over the k8s baseline — delivering nearly 2× overall output throughput with TTFT held completely constant and stable (sub-500ms) under peak load, while the SGLang k8s baseline degrades sharply.
+
+Summary across the full ladder (rates 3 → 60):
+
+| Metric              | k8s service (RR) | llm-d Precise | Δ% vs k8s |
+| :------------------ | :--------------- | :------------ | :-------- |
+| Output tokens/sec   | 4,667            | 9,808         | +110.2%   |
+| Requests/sec        | 4.71             | 9.87          | +109.6%   |
+| TTFT mean (s)       | 69.76            | 0.466         | −99.33%   |
+| TTFT p90 (s)        | 157.64           | 0.672         | −99.57%   |
+| ITL mean (ms)       | 37.9             | 47.4          | +25.1%    |
 
 <details>
 <summary><b><i>Click</i></b> to view the per-rate breakdown across the full ladder</summary>
@@ -366,19 +378,22 @@ Output tokens/sec — higher is better; TTFT in seconds — lower is better.
 
 | Rate | k8s Output | llm-d Output | k8s TTFT mean | llm-d TTFT mean | k8s TTFT p90 | llm-d TTFT p90 |
 | ---: | ---------: | -----------: | ------------: | --------------: | -----------: | -------------: |
-|  3   | 1,752      | 1,690        | 0.629         | 0.213           | 1.014        | 0.243          |
-| 10   | 4,377      | 5,013        | 0.926         | 0.213           | 1.655        | 0.295          |
-| 15   | 4,528      | 6,983        | 3.593         | 0.202           | 5.630        | 0.323          |
-| 20   | 5,799      | 9,439        | 26.500        | 0.529           | 60.170       | 0.511          |
-| 22   | 4,803      | 9,671        | 29.185        | 1.050           | 63.806       | 0.567          |
-| 25   | 5,559      | 9,772        | 29.125        | 0.985           | 63.950       | 0.650          |
-| 30   | 4,967      | 9,976        | 34.295        | 0.759           | 73.831       | 0.573          |
-| 35   | 5,816      | 9,962        | 34.191        | 0.972           | 73.837       | 0.596          |
-| 40   | 5,548      | 11,964       | 84.999        | 15.505          | 152.473      | 44.448         |
-| 43   | 5,374      | 12,049       | 87.271        | 17.201          | 157.532      | 52.145         |
-| 46   | 5,374      | 11,989       | 87.138        | 19.652          | 156.928      | 56.452         |
-| 49   | 5,692      | 11,744       | 85.618        | 18.361          | 157.622      | 52.982         |
-| 52   | 5,326      | 11,933       | 87.259        | 20.287          | 160.448      | 56.957         |
+|  3   | 1,698      | 1,556        | 0.511         | 0.160           | 0.824        | 0.194          |
+| 10   | 4,359      | 5,049        | 0.849         | 0.178           | 1.459        | 0.218          |
+| 15   | 4,608      | 7,188        | 2.734         | 0.179           | 3.696        | 0.245          |
+| 20   | 5,035      | 11,268       | 27.104        | 0.250           | 62.562       | 0.436          |
+| 22   | 4,684      | 11,945       | 31.012        | 0.202           | 68.263       | 0.328          |
+| 25   | 5,056      | 12,797       | 31.411        | 0.195           | 69.237       | 0.255          |
+| 30   | 4,953      | 13,412       | 34.123        | 0.217           | 72.725       | 0.415          |
+| 35   | 5,601      | 13,707       | 33.340        | 0.215           | 74.115       | 0.310          |
+| 40   | 5,773      | 15,914       | 85.332        | 1.171           | 152.247      | 0.754          |
+| 43   | 5,395      | 16,485       | 87.314        | 0.999           | 157.234      | 0.762          |
+| 46   | 5,794      | 16,376       | 88.325        | 0.514           | 160.052      | 0.716          |
+| 49   | 5,622      | 16,576       | 86.050        | 0.320           | 161.950      | 0.631          |
+| 52   | 5,905      | 16,627       | 89.924        | 0.328           | 162.860      | 0.692          |
+| 55   | 5,714      | 16,534       | 88.526        | 0.367           | 162.728      | 0.802          |
+| 57   | 5,744      | 16,459       | 88.682        | 0.374           | 163.161      | 0.781          |
+| 60   | 5,833      | 16,481       | 88.046        | 0.375           | 161.321      | 0.749          |
 
 </details>
 

--- a/guides/precise-prefix-cache-routing/README.md
+++ b/guides/precise-prefix-cache-routing/README.md
@@ -359,8 +359,6 @@ The benchmark runs on 16× H100 GPUs, distributed across 8 model servers (2 H100
 
 #### Comparing llm-d Scheduling to a Simple Kubernetes Service
 
-Benchmark run with the canonical shared-prefix workload from this guide, comparing the precise path against a plain Kubernetes Service (round-robin, no EPP, no scoring) across the same SGLang pods. llm-d Precise shows a massive improvement over the k8s baseline — delivering nearly 2× overall output throughput with TTFT held completely constant and stable (sub-500ms) under peak load, while the SGLang k8s baseline degrades sharply.
-
 Summary across the full ladder (rates 3 → 60):
 
 | Metric              | k8s service (RR) | llm-d Precise | Δ% vs k8s |

--- a/guides/precise-prefix-cache-routing/modelserver/gpu/sglang/patch-sglang.yaml
+++ b/guides/precise-prefix-cache-routing/modelserver/gpu/sglang/patch-sglang.yaml
@@ -14,6 +14,7 @@ spec:
             - "--host=0.0.0.0"
             - "--port=8000"
             - "--tensor-parallel-size=2"
+            - "--mem-fraction-static=0.9"
             # KV-block granularity. Must match the router scorer's
             # tokenProcessorConfig.blockSize (default 64); SGLang's knob is
             # --page-size, where vLLM uses --block-size.


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                
                                                                                                                                                                                                            
  This PR updates the precise prefix cache routing guide for SGLang with significantly improved benchmark results and includes the configuration tuning that enabled these gains.                           
                                                                                                                                                                                                            
 By tuning SGLang's memory allocation ( --mem-fraction-static=0.9 ), we unlocked drastically better performance under high load, maintaining stable, sub-second TTFT (Time to First Token) even at peak request rates where it previously degraded. Prior to this change, the default usage was coming out to be around 0.82 percent.                                                                                                                                                           
                                                                                                                                                                                                            
  ## Key Changes                                                                                                                                                                                            
                                                                                                                                                                                                            
  ### 1. SGLang Configuration Tune                                                                                           
                                                                                                                                                
  • Added  --mem-fraction-static=0.9  to patch-sglang.yaml. This optimizes GPU memory utilization for the KV cache, which is critical for sustaining high prefix-matching performance under concurrency.      
                                                                                                                                                                                                            
  ### 2. Updated Benchmark Results (README.md)                                                                                                                                                         
                                                                                                                                                                                                            
  • Clarified Setup: Noted that the benchmark runs on 16× H100 GPUs across 8 model servers (TP=2).                                                                                                          
  • Added Summary Table: Introduced a high-level comparison table across the full ladder (rates 3 to 60) highlighting the massive gains of  llm-d Precise  over the standard Kubernetes round-robin         
  baseline:                                                                                                                                                                                                 
      • Output Throughput: +110.2% (~2x increase).                                                                                                                                                          
      • Mean TTFT: -99.33% (reduced from ~70s to 466ms).                                                                                                                                                    
      • p90 TTFT: -99.57% (reduced from ~157s to 672ms).                                                                                                                                                    
  • Updated Detailed Ladder: Refreshed the per-rate breakdown table with the new run data and extended the test ladder up to rate 60 (previously capped at 52).                                             
      • Note on improvement: Previously, at rate 52,  llm-d  mean TTFT had risen to ~20 seconds. With the static memory fraction patch, mean TTFT at rate 52 is now 0.328 seconds, and remains stable at 0. 
      375 seconds even at rate 60.                                                                                                                                                                          
                                                                         

Fixes: #1751 , #1632                                                                        