### PR TITLE
docs(getting-started): reorder landing CTAs and refine founded-by line

### DIFF
--- a/docs/getting-started/README.mdx
+++ b/docs/getting-started/README.mdx
@@ -6,8 +6,16 @@ llm-d is an open-source inference serving stack for Kubernetes. It runs your mod
 
 Built for agentic pipelines, LLMs, multimodal models, and high-throughput serving. Completely engine- and hardware-agnostic.
 
+<div class="intro-ctas">
+  <Link className="button button--primary" to="/getting-started/quickstart">Get started</Link>
+  <Link className="button button--secondary" to="https://prism.llm-d.ai/" target="_blank" rel="noopener noreferrer">Explore the performance data</Link>
+</div>
+
 <div class="intro-founded">
-  <span>llm-d is founded by:</span>
+  <div class="intro-cncf">
+    <img class="intro-cncf-logo" src="https://llm-d.ai/img/CNCF-logo.svg" alt="CNCF" />
+    <span>llm-d is a CNCF Sandbox project founded by:</span>
+  </div>
   <div class="intro-founded-logos">
     <img class="intro-founder-logo" src="https://llm-d.ai/img/logos/IBM.png" alt="IBM" height="18" />
     <img class="intro-founder-logo" src="https://llm-d.ai/img/logos/Redhat.png" alt="Red Hat" height="18" />
@@ -15,16 +23,6 @@ Built for agentic pipelines, LLMs, multimodal models, and high-throughput servin
     <img class="intro-founder-logo" src="https://llm-d.ai/img/logos/Nvidia.png" alt="NVIDIA" height="18" />
     <img class="intro-founder-logo" src="https://llm-d.ai/img/logos/Coreweave.png" alt="CoreWeave" height="18" />
   </div>
-</div>
-
-<div class="intro-cncf">
-  <img class="intro-cncf-logo" src="https://llm-d.ai/img/CNCF-logo.svg" alt="CNCF" />
-  llm-d is a CNCF Sandbox project
-</div>
-
-<div class="intro-ctas">
-  <Link className="button button--primary" to="/getting-started/quickstart">Get started</Link>
-  <Link className="button button--secondary" to="https://prism.llm-d.ai/" target="_blank" rel="noopener noreferrer">View performance analysis</Link>
 </div>
 
 ## Well-Lit Paths


### PR DESCRIPTION
- Move the Get started / performance CTAs above the founders block
- Merge the CNCF line into "llm-d is a CNCF Sandbox project founded by:" above the company logos
- Rename secondary CTA to "Explore the performance data"