### PR TITLE
build llm-d image with vllm patch for DP supervisor

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -366,7 +366,7 @@ ${NVSHMEM_DIR}/lib:${NVSHMEM_DIR}/lib64:\
 /opt/vllm/lib/python${PYTHON_VERSION}/site-packages/nvidia/nvshmem/lib:\
 /opt/vllm/lib64/python${PYTHON_VERSION}/site-packages/torch/lib:\
 /usr/local/nvidia/lib:/usr/local/nvidia/lib64:\
-${CUDA_HOME}/lib64:${CUDA_HOME}/compat:\
+${CUDA_HOME}/lib64:\
 ${EFA_PREFIX}/lib:${EFA_PREFIX}/lib64:\
 ${UCX_PREFIX}/lib:${UCX_PREFIX}/lib64:\
 ${UCCL_PREFIX}/lib:\

--- a/docker/common-versions
+++ b/docker/common-versions
@@ -2,8 +2,8 @@
 # vLLM Version Configuration
 # ============================================================================
 # Used by CUDA and CPU platforms
-VLLM_REPO=https://github.com/vllm-project/vllm.git
-VLLM_COMMIT_SHA=0fc695fc6d1d82e9a5ac6835ac8e4e1c83703665 # maps to vLLM official v0.23.0 release
+VLLM_REPO=https://github.com/neuralmagic/vllm.git
+VLLM_COMMIT_SHA=51f799c1a0c8a0476faf7e17eeb6a77983cdd778 # v0.23.0 + fix DP supervisor engine_id collision
 
 # ============================================================================
 # Cuda specific configs


### PR DESCRIPTION
This image pulls in a hotfix for vllm's DP-aware scheduling: https://github.com/neuralmagic/vllm/commit/51f799c1a0c8a0476faf7e17eeb6a77983cdd778 and removes `/compat` from `LD_LIBRARY_PATH`, which was breaking deployments on CKS.