### PR TITLE
Build images from PR

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         default: ''
+      platforms:
+        description: 'Platforms to build (comma-separated: cuda,aws,gb200,xpu,cpu). Overrides change detection when non-empty.'
+        required: false
+        type: string
+        default: ''
     outputs:
       xpu:
         description: 'Whether XPU image was built'
@@ -58,12 +63,12 @@ jobs:
   detect-changes:
     runs-on: ubuntu-latest
     outputs:
-      cuda: ${{ steps.force.outputs.cuda || steps.filter.outputs.cuda || steps.dispatch.outputs.cuda }}
-      aws: ${{ steps.force.outputs.aws || steps.filter.outputs.aws || steps.dispatch.outputs.aws }}
-      gb200: ${{ steps.force.outputs.gb200 || steps.filter.outputs.gb200 || steps.dispatch.outputs.gb200 }}
-      rocm: ${{ steps.force.outputs.rocm || steps.filter.outputs.rocm || steps.dispatch.outputs.rocm }}
-      xpu: ${{ steps.force.outputs.xpu || steps.filter.outputs.xpu || steps.dispatch.outputs.xpu }}
-      cpu: ${{ steps.force.outputs.cpu || steps.filter.outputs.cpu || steps.dispatch.outputs.cpu }}
+      cuda: ${{ steps.force.outputs.cuda || steps.platforms-input.outputs.cuda || steps.filter.outputs.cuda || steps.dispatch.outputs.cuda }}
+      aws: ${{ steps.force.outputs.aws || steps.platforms-input.outputs.aws || steps.filter.outputs.aws || steps.dispatch.outputs.aws }}
+      gb200: ${{ steps.force.outputs.gb200 || steps.platforms-input.outputs.gb200 || steps.filter.outputs.gb200 || steps.dispatch.outputs.gb200 }}
+      rocm: ${{ steps.force.outputs.rocm || steps.platforms-input.outputs.rocm || steps.filter.outputs.rocm || steps.dispatch.outputs.rocm }}
+      xpu: ${{ steps.force.outputs.xpu || steps.platforms-input.outputs.xpu || steps.filter.outputs.xpu || steps.dispatch.outputs.xpu }}
+      cpu: ${{ steps.force.outputs.cpu || steps.platforms-input.outputs.cpu || steps.filter.outputs.cpu || steps.dispatch.outputs.cpu }}
       rdma-tools: ${{ steps.filter.outputs.rdma-tools }}
     steps:
       - name: Force all platforms
@@ -76,11 +81,22 @@ jobs:
           echo "rocm=true" >> $GITHUB_OUTPUT
           echo "xpu=true" >> $GITHUB_OUTPUT
           echo "cpu=true" >> $GITHUB_OUTPUT
+      - name: Parse platforms input (from workflow_call)
+        if: inputs.force_build != true && inputs.platforms != ''
+        id: platforms-input
+        run: |
+          platforms="${{ inputs.platforms }}"
+          echo "cuda=$(echo $platforms | grep -q cuda && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "aws=$(echo $platforms | grep -q aws && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "gb200=$(echo $platforms | grep -q gb200 && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "rocm=$(echo $platforms | grep -q rocm && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "xpu=$(echo $platforms | grep -q xpu && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "cpu=$(echo $platforms | grep -q cpu && echo true || echo false)" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || '' }}
       - uses: dorny/paths-filter@v4
-        if: github.event_name != 'workflow_dispatch' && inputs.force_build != true
+        if: github.event_name != 'workflow_dispatch' && inputs.force_build != true && inputs.platforms == ''
         id: filter
         with:
           filters: |

--- a/.github/workflows/nightly-build-image.yaml
+++ b/.github/workflows/nightly-build-image.yaml
@@ -8,6 +8,20 @@ on:
   schedule:
     - cron: '0 23 * * *'  # 23:00 UTC daily (before all nightly E2Es starting at 00:00)
   workflow_dispatch:
+    inputs:
+      platforms:
+        description: 'Platforms to build (comma-separated: cuda,aws,gb200,xpu,cpu,all)'
+        required: false
+        default: 'cuda'
+        type: string
+      pr_number:
+        description: 'PR number (set automatically by /test-nightly)'
+        required: false
+        type: string
+      pr_repo:
+        description: 'PR repository (set automatically by /test-nightly)'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -15,7 +29,7 @@ permissions:
   security-events: write
 
 concurrency:
-  group: nightly-build-image
+  group: nightly-build-image-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -23,5 +37,6 @@ jobs:
     if: github.repository == 'llm-d/llm-d'
     uses: ./.github/workflows/build-image.yaml
     with:
-      force_build: true
+      force_build: ${{ github.event_name == 'schedule' || inputs.platforms == 'all' }}
+      platforms: ${{ inputs.platforms || '' }}
     secrets: inherit

--- a/.github/workflows/slash-test-nightly.yaml
+++ b/.github/workflows/slash-test-nightly.yaml
@@ -12,12 +12,17 @@ name: /test-nightly Slash Command
 #   prefill_pods=<number> Number of prefill pods (default: 1)
 #   harness=<name>        Benchmark harness (default: inference-perf)
 #
+# Optional parameters (passed to build-image nightly):
+#   platforms=<list>      Platforms to build (comma-separated: cuda,aws,gb200,xpu,cpu,all; default: cuda)
+#
 # Examples:
 #   /test-nightly pd-disaggregation-ocp
 #   /test-nightly *-ocp
 #   /test-nightly optimized-baseline-*
 #   /test-nightly optimized-baseline-cks workload=sanity_random.yaml decode_pods=1
 #   /test-nightly wva-*
+#   /test-nightly build-image
+#   /test-nightly build-image platforms=cuda,aws
 #
 # The command checks out the PR head, pushes a temp branch
 # (test-nightly/pr-<number>) into the main repo, and
@@ -130,6 +135,9 @@ jobs:
                   '- `prefill_pods=<number>` — number of prefill pods (default: `1`)',
                   '- `harness=<name>` — benchmark harness (default: `inference-perf`)',
                   '',
+                  'Optional parameters (applied to `build-image` only):',
+                  '- `platforms=<list>` — platforms to build, comma-separated: cuda,aws,gb200,xpu,cpu,all (default: `cuda`)',
+                  '',
                   'Available nightlies:',
                   all.map(n => '`' + n.name + '`').join(', '),
                 ].join('\n')
@@ -140,12 +148,13 @@ jobs:
             const input = match[1];
 
             // Parse optional key=value parameters (with defaults for quick PR validation)
-            const SUPPORTED_PARAMS = ['workload', 'decode_pods', 'prefill_pods', 'harness'];
+            const SUPPORTED_PARAMS = ['workload', 'decode_pods', 'prefill_pods', 'harness', 'platforms'];
             const DEFAULT_PARAMS = {
               workload: 'sanity_random.yaml',
               decode_pods: '1',
               prefill_pods: '1',
               harness: 'inference-perf',
+              platforms: 'cuda',
             };
             const params = { ...DEFAULT_PARAMS };
             const tokens = comment.split(/\s+/).slice(2);
@@ -331,10 +340,21 @@ jobs:
             for (const m of matches) {
               // Only send benchmark params to E2E benchmark nightlies (not WVA or utility nightlies)
               const isE2eBenchmark = m.workflowFile.startsWith('nightly-e2e-') && !m.workflowFile.includes('-wva-');
-              const benchmarkParams = isE2eBenchmark ? params : {};
+              const isBuildWorkflow = m.workflowFile === 'nightly-build-image.yaml';
+
+              let workflowParams;
+              if (isBuildWorkflow) {
+                workflowParams = { platforms: params.platforms };
+              } else if (isE2eBenchmark) {
+                const { platforms, ...benchmarkOnly } = params;
+                workflowParams = benchmarkOnly;
+              } else {
+                workflowParams = {};
+              }
+              const benchmarkParams = workflowParams;
 
               console.log(`Dispatching ${m.workflowFile} on ref ${ref}` +
-                (isE2eBenchmark ? ` with params: ${JSON.stringify(benchmarkParams)}` : ''));
+                (Object.keys(workflowParams).length > 0 ? ` with params: ${JSON.stringify(workflowParams)}` : ''));
               try {
                 await github.rest.actions.createWorkflowDispatch({
                   owner, repo,
@@ -433,11 +453,18 @@ jobs:
 
             const lines = [];
 
-            // Show overrides only for E2E benchmark nightlies (those that received params)
+            // Show overrides for E2E benchmark nightlies and build workflows
             const hasE2eBenchmark = results.some(r =>
               r.workflowFile.startsWith('nightly-e2e-') && !r.workflowFile.includes('-wva-'));
-            const paramEntries = Object.entries(params);
-            const overridesRow = hasE2eBenchmark && paramEntries.length > 0
+            const hasBuildWorkflow = results.some(r =>
+              r.workflowFile === 'nightly-build-image.yaml');
+            const paramEntries = Object.entries(params)
+              .filter(([k]) => {
+                if (hasBuildWorkflow && k === 'platforms') return true;
+                if (hasE2eBenchmark && k !== 'platforms') return true;
+                return false;
+              });
+            const overridesRow = paramEntries.length > 0
               ? `| Overrides | ${paramEntries.map(([k, v]) => `\`${k}=${v}\``).join(', ')} |`
               : null;
 


### PR DESCRIPTION
## Summary

Enable building container images directly from a PR using `/test-nightly build-image`.

- Add `workflow_dispatch` inputs to `nightly-build-image.yaml` (`platforms`, `pr_number`, `pr_repo`) so it can be triggered by the slash command
- Add `platforms` input to `build-image.yaml`'s `workflow_call` interface with a new `platforms-input` step in `detect-changes` that overrides path-based change detection
- Update `slash-test-nightly.yaml` to recognize `build-image` as a build workflow and route the `platforms` parameter to it

### Usage

```
/test-nightly build-image                       # builds cuda only (default)
/test-nightly build-image platforms=cuda,aws    # builds cuda + aws
/test-nightly build-image platforms=all         # force builds all platforms
```

### Behavior

- Nightly scheduled runs are unchanged (`force_build: true`, all platforms)
- Manual `workflow_dispatch` of `build-image.yaml` continues working as before
- `ci-release.yaml` is unaffected (it has its own inline build steps)
- Concurrency group now includes `github.ref` to allow parallel builds from different PRs