### PR TITLE
ci: run tiered-prefix-cache nightlies on PRs touching the guide

### DIFF
--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-lmcache.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-lmcache.yaml
@@ -48,9 +48,11 @@ on:
         default: 'true'
         type: string
 
-#  push:
-#    branches:
-#      - main
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-lmcache.yaml
+      - guides/tiered-prefix-cache/**
 
   schedule:
     - cron: '0 12 * * *'
@@ -95,7 +97,8 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    # PR runs execute the e2e test but must not overwrite the dashboard badge.
+    if: always() && github.event_name != 'pull_request'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: tiered-prefix-cache-gke-cpu-llmcache

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-native.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-native.yaml
@@ -48,9 +48,11 @@ on:
         default: 'true'
         type: string
 
-#  push:
-#    branches:
-#      - main
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-native.yaml
+      - guides/tiered-prefix-cache/**
 
   schedule:
     - cron: '0 12 * * *'
@@ -95,7 +97,8 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    # PR runs execute the e2e test but must not overwrite the dashboard badge.
+    if: always() && github.event_name != 'pull_request'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: tiered-prefix-cache-gke-cpu-llmcache

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-tpu-vllm-native.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-tpu-vllm-native.yaml
@@ -58,9 +58,11 @@ on:
         type: 'string'
         default: '2x4'
 
-#  push:
-#    branches:
-#      - main
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-tpu-vllm-native.yaml
+      - guides/tiered-prefix-cache/**
 
   schedule:
     - cron: '0 12 * * *'  # 10:00 UTC daily
@@ -109,7 +111,8 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    # PR runs execute the e2e test but must not overwrite the dashboard badge.
+    if: always() && github.event_name != 'pull_request'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: tiered-prefix-cache-gke-tpu

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-ibm-cpu-gpu-vllm-native.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-ibm-cpu-gpu-vllm-native.yaml
@@ -47,9 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
-#  push:
-#    branches:
-#      - main
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/nightly-e2e-tiered-prefix-cache-ibm-cpu-gpu-vllm-native.yaml
+      - guides/tiered-prefix-cache/**
 
   schedule:
     - cron: '0 12 * * *'  # 10:00 UTC daily
@@ -94,7 +96,8 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    # PR runs execute the e2e test but must not overwrite the dashboard badge.
+    if: always() && github.event_name != 'pull_request'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: tiered-prefix-cache-cpu-offloading-ocp


### PR DESCRIPTION
Add a scoped `pull_request` trigger (branches: main, paths: `guides/tiered-prefix-cache/**` + the workflow file) to the four `nightly-e2e-tiered-prefix-cache-*` workflows so PRs touching the guide get e2e coverage before merge.

The `update-badge` job is guarded with `github.event_name != 'pull_request'` so PR runs execute the test but don't overwrite the status dashboard badge (#1835), which stays driven by scheduled nightly runs.