### PR TITLE
docs: add XPU WideEP guide backend

### DIFF
--- a/guides/wide-ep-lws/README.md
+++ b/guides/wide-ep-lws/README.md
@@ -32,6 +32,14 @@ This guide includes configurations for the following accelerators:
 | NVIDIA GPU (CoreWeave)| `modelserver/coreweave/`   | CoreWeave deployment                     |
 
 > [!NOTE]
+> Experimental Intel XPU validation manifests and follow-up experiments are
+> available in [`experimental-xpu`](./experimental-xpu/). Current evidence
+> validates the DeepSeek-V2-Lite full `wide-ep-lws` path on XPU with NIXL XPU
+> KV buffers (`kv_buffer_device=xpu`) at TP=2+2 when `UCX_TLS` includes
+> `ze_copy` (`tcp,ze_copy` on the tested non-RDMA cluster). The host-buffer
+> fallback (`kv_buffer_device=cpu`) also passed at TP=2+2 and TP=4+4.
+
+> [!NOTE]
 > The pods leveraging inter-node EP must be deployed in a cluster environment with full mesh
 > network connectivity. The DeepEP backend used in WideEP requires All-to-All RDMA
 > connectivity. Every NIC on a host must be able to communicate with every NIC on all other

--- a/guides/wide-ep-lws/experimental-xpu/README.md
+++ b/guides/wide-ep-lws/experimental-xpu/README.md
@@ -1,0 +1,155 @@
+# Experimental: Intel XPU WideEP validation
+
+This experimental guide records how far Intel XPU support currently reaches for `wide-ep-lws`. It includes a Kubernetes expert-parallel smoke manifest, Docker experiments for focused debugging, and the current full-path validation result.
+
+The latest full-path proof target is DeepSeek-V2-Lite with decode + prefill, LWS, router/EPP, XPU expert parallelism, and NIXL KV transfer. That path is validated with XPU KV buffers (`kv_buffer_device=xpu`) when UCX enables the Level Zero copy transport (`UCX_TLS=tcp,ze_copy` on the tested non-RDMA cluster). The host-buffer path (`kv_buffer_device=cpu`) is also validated as a fallback.
+
+## Positioning
+
+The checked-in Kubernetes manifest intentionally stays as a small expert-parallel smoke test. The full `wide-ep-lws` validation was run with temporary LWS/router manifests and is summarized in the experiment matrix. The current PR scope is therefore:
+
+- preserve a reproducible XPU EP Kubernetes smoke test;
+- document the full XPU `wide-ep-lws` validation status;
+- provide experiments that reproduce or debug the XPU runtime layers;
+- document which NVIDIA-specific optimizations are omitted or replaced on XPU.
+
+## Configuration
+
+The checked-in smoke manifest defaults to:
+
+| Parameter | Value |
+| --- | --- |
+| Model | `deepseek-ai/DeepSeek-V2-Lite-Chat` |
+| Accelerator | Intel XPU |
+| Kubernetes allocation | DRA device class `gpu.intel.com` |
+| Smoke manifest XPU count | 4 per pod |
+| Smoke manifest tensor parallelism | 4 |
+| Expert parallelism | enabled |
+| All2All backend | `allgather_reducescatter` |
+| Image | `ghcr.io/llm-d/llm-d-xpu:v0.7.0` |
+
+The separately validated full-path run used:
+
+| Parameter | Value |
+| --- | --- |
+| Full LWS proof shape | decode TP=2 + prefill TP=2 |
+| Full P/D KV transfer | NIXL with `kv_buffer_device=xpu` and `UCX_TLS=tcp,ze_copy` |
+| Full-path manifests | Temporary LWS/router manifests, summarized in the experiment matrix |
+
+## Experiment matrix
+
+The scripts under [`experiments`](./experiments/) are ordered from lowest to highest integration risk:
+
+| Experiment | What it proves | Expected XPU count |
+| --- | --- | --- |
+| DeepSeek-V2-Lite TP+EP | vLLM MoE expert parallelism on XPU | 2 or 4 |
+| PowerMoE DP+EP | vLLM data parallel plus expert parallel process layout | 3 |
+| DeepSeek-V2-Lite P/D + EP | vLLM P/D composition with the validated MoE model | 4 or 8 |
+| Full llm-d LWS/router path | End-to-end WideEP request through EPP, decode sidecar, prefill, NIXL, XCCL, and EP | 4 or 8 |
+
+DeepSeek-V2-Lite TP+EP has been validated on 2 and 4 XPUs. Full DeepSeek-V2-Lite `wide-ep-lws` has been validated on 4 XPUs (decode TP=2 + prefill TP=2) with XPU KV buffers and `UCX_TLS=tcp,ze_copy`. The host-buffer fallback has been validated on both 4 XPUs (decode TP=2 + prefill TP=2) and 8 XPUs (decode TP=4 + prefill TP=4). PowerMoE DP+EP initializes DP and EP ranks on XPU but still needs a clean readiness run with sufficient shared memory.
+
+## XPU differences from the NVIDIA WideEP manifests
+
+The NVIDIA WideEP manifests include several optimizations that are intentionally not copied here:
+
+| NVIDIA setting | XPU status | Reason |
+| --- | --- | --- |
+| `--all2all-backend deepep_low_latency` / `deepep_high_throughput` | replaced | XPU uses `allgather_reducescatter`; DeepEP is NVIDIA/CUDA-specific. |
+| `--moe-backend deep_gemm` | omitted | DeepGEMM is not available for XPU; vLLM uses the XPU/Triton MoE path. |
+| `--enable-dbo` | omitted | DBO support has not been validated on XPU for this guide. |
+| `--enable-eplb` | omitted | EPLB support has not been validated on XPU for this guide. |
+| `--kv_transfer_config` | NIXL with XPU KV buffers | `kv_buffer_device=xpu` passes when `UCX_TLS` includes `ze_copy`; `kv_buffer_device=cpu` remains a validated fallback. |
+| `--data-parallel-*` | omitted from baseline manifest | The Kubernetes manifest uses TP=4 in one model server; DP+EP rank initialization is documented in the experiment matrix but still needs a clean readiness run. |
+
+Performance-only parameters such as `--max-num-batched-tokens`, `--max-num-seqs`, and `--api-server-count` are also left out until there is a repeatable XPU benchmark for this guide.
+
+## Limitations and validation status
+
+- The checked-in manifest below is still a single-pod EP smoke test, not the full LWS deployment.
+- Full LWS/router/P-D validation passed on `xpu-817225` with XPU KV buffers when `UCX_TLS=tcp,ze_copy`.
+- `UCX_TLS=tcp` alone reproduces `nixl_cu12._bindings.nixlBackendError: NIXL_ERR_BACKEND` because UCX does not register XPU VRAM through the Level Zero copy transport.
+- The host-buffer NIXL path (`kv_buffer_device=cpu`) passed at both TP=2+2 and TP=4+4 and is useful as a fallback or debugging control.
+- DP+EP without P/D still needs a clean readiness run; previous runs reached DP/EP initialization but stalled on shared-memory broadcast.
+
+## Prerequisites
+
+- Install the [Intel Resource Drivers for Kubernetes](https://github.com/intel/intel-resource-drivers-for-kubernetes) so the `gpu.intel.com` DRA device class is available.
+- Create the `llm-d-hf-token` secret in the target namespace with the key `HF_TOKEN`.
+
+## Deploy
+
+```bash
+export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
+export NAMESPACE=llm-d-wide-ep-xpu
+
+kubectl create namespace ${NAMESPACE} --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/wide-ep-lws/experimental-xpu/manifests/modelserver/intel
+```
+
+## Verify
+
+Wait for the modelserver pod to become ready, then port-forward it:
+
+```bash
+kubectl get pods -n ${NAMESPACE}
+export MODELSERVER_POD=$(kubectl get pods -n ${NAMESPACE} \
+  -l llm-d.ai/guide=wide-ep-lws-experimental-xpu \
+  -o jsonpath='{.items[0].metadata.name}')
+kubectl port-forward -n ${NAMESPACE} pod/${MODELSERVER_POD} 8000:8000
+```
+
+Send a request:
+
+```bash
+curl -X POST http://localhost:8000/v1/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "deepseek-ai/DeepSeek-V2-Lite-Chat",
+    "prompt": "Hello",
+    "max_tokens": 20
+  }'
+```
+
+Check the vLLM logs for XPU EP initialization:
+
+```bash
+kubectl logs -n ${NAMESPACE} ${MODELSERVER_POD} -c vllm | grep -E "Expert parallelism|EP Rank|backend=xccl|all2all"
+```
+
+## Optional local container smoke test
+
+For quick debugging outside Kubernetes, run the same model with local XPU devices. This path is not a replacement for the Kubernetes manifest because device selection is manual.
+
+> [!WARNING]
+> The local Docker smoke test uses privileged XPU device access and
+> `--trust-remote-code`. Run it only on a dedicated trusted host and only with
+> trusted model code.
+
+```bash
+export HF_TOKEN=your_huggingface_token
+export ZE_AFFINITY_MASK=0,1,2,3
+export TP_SIZE=4
+
+docker run --rm --privileged \
+  --entrypoint vllm \
+  -e HF_TOKEN=${HF_TOKEN} \
+  -e ZE_AFFINITY_MASK=${ZE_AFFINITY_MASK} \
+  -e VLLM_WORKER_MULTIPROC_METHOD=spawn \
+  -e UCX_TLS=tcp,ze_copy \
+  -v /dev/dri:/dev/dri \
+  -p 127.0.0.1:8000:8000 \
+  ghcr.io/llm-d/llm-d-xpu:v0.7.0 \
+  serve deepseek-ai/DeepSeek-V2-Lite-Chat \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --trust-remote-code \
+    --max-model-len 512 \
+    --gpu-memory-utilization 0.8 \
+    --tensor-parallel-size ${TP_SIZE} \
+    --enable-expert-parallel \
+    --all2all-backend allgather_reducescatter \
+    --disable-access-log-for-endpoints=/health,/metrics,/v1/models
+```
+
+For the broader validation matrix, see [`experiments/README.md`](./experiments/README.md).

--- a/guides/wide-ep-lws/experimental-xpu/experiments/README.md
+++ b/guides/wide-ep-lws/experimental-xpu/experiments/README.md
@@ -1,0 +1,117 @@
+# XPU WideEP experiment matrix
+
+These experiments determine which WideEP layers work on Intel XPU and document the full-path validation status.
+
+## Current evidence
+
+| Layer | Status | Evidence |
+| --- | --- | --- |
+| vLLM EP | Validated | On `super-node0`, DeepSeek-V2-Lite completed requests with TP=2 and TP=4 plus `--enable-expert-parallel`; logs showed XCCL, EP ranks, XPU MoE, and KV cache allocation. |
+| vLLM DP+EP | Partially validated | On `super-node0`, PowerMoE DP=3 plus EP initialized DP ranks 0/1/2 and EP ranks 0/1/2 with XCCL and XPU MoE, but did not become healthy before repeated shared-memory broadcast wait messages. Rerun with larger `/dev/shm` or Kubernetes `emptyDir` shared memory. |
+| DeepSeek-V2-Lite P/D+EP with XPU KV buffer | Validated | On `xpu-817225`, full LWS/router e2e passed with decode TP=2 + prefill TP=2, `kv_buffer_device=xpu`, and `UCX_TLS=tcp,ze_copy`. Logs showed `use_mla: True`, `use_host_buffer: False`, XCCL, EP ranks, NIXL Scheduler, and a successful completion through EPP. |
+| DeepSeek-V2-Lite P/D+EP with NIXL host buffer | Validated fallback | On `xpu-817225`, full LWS/router e2e passed with decode TP=2 + prefill TP=2 and decode TP=4 + prefill TP=4. Logs showed XCCL, EP ranks, NIXL Scheduler, NIXL compatibility checks, and transfer plans. |
+| XPU KV buffer with `UCX_TLS=tcp` only | Expected failure | A minimal Qwen TP=1 NIXL control failed with `VRAM memory is detected as host by UCX` followed by `NIXL_ERR_BACKEND`; adding `ze_copy` made the same XPU KV-buffer path start successfully. |
+
+## Resource checks
+
+Before running an experiment on a shared host:
+
+```bash
+xpu-smi discovery
+xpu-smi ps
+docker ps --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}'
+kubectl get pods -A -o wide 2>/dev/null || true
+```
+
+Do not stop unrelated containers or pods just to run these experiments.
+
+> [!WARNING]
+> The Docker experiments use privileged XPU device access and vLLM
+> `--trust-remote-code`; the P/D NIXL script also uses host networking for local
+> prefill/decode communication. Run them only on dedicated trusted hosts and only
+> with trusted model code.
+
+## Experiment 1: DeepSeek-V2-Lite TP+EP
+
+Use Docker Compose for the previously validated DeepSeek-V2-Lite EP cases:
+
+```bash
+cd guides/wide-ep-lws/experimental-xpu/experiments
+export HF_TOKEN=your_huggingface_token
+
+# Requires two free XPUs.
+docker compose --profile v2lite-ep-tp2 up
+
+# Requires four free XPUs.
+docker compose --profile v2lite-ep-tp4 up
+```
+
+Successful logs should include:
+
+```text
+Expert parallelism is enabled
+Using XPU Unquantized MoE backend
+backend=xccl
+allgather_reducescatter
+```
+
+## Experiment 2: MoE DP+EP
+
+This checks whether XPU can run vLLM data parallelism together with expert parallelism:
+
+```bash
+cd guides/wide-ep-lws/experimental-xpu/experiments
+export HF_TOKEN=your_huggingface_token
+
+# Requires three free XPUs.
+docker compose --profile powermoe-ep-dp3 up
+```
+
+This is not full llm-d WideEP, but it helps determine whether DP process layout is viable on XPU before adding router/rank targeting.
+
+On the latest run, this experiment reached DP/EP initialization but not readiness:
+
+```text
+Defaulting api_server_count to data_parallel_size (3)
+world_size=3 ... backend=xccl
+rank 0 ... DP rank 0 ... EP rank 0
+rank 1 ... DP rank 1 ... EP rank 1
+rank 2 ... DP rank 2 ... EP rank 2
+Expert parallelism is enabled
+Using XPU backend for Unquantized MoE
+No available shared memory broadcast block found in 60 seconds
+```
+
+## Experiment 3: DeepSeek-V2-Lite P/D+EP
+
+This checks the WideEP candidate model in a vLLM prefill/decode shape on XPU without the llm-d router. It defaults to the XPU KV-buffer NIXL path that passed full LWS validation:
+
+```bash
+cd guides/wide-ep-lws/experimental-xpu/experiments
+export VLLM_SRC=/path/to/vllm/source
+export HF_TOKEN=your_huggingface_token
+export MODEL_NAME=deepseek-ai/DeepSeek-V2-Lite-Chat
+export MAX_MODEL_LEN=512
+export KV_BUFFER_DEVICE=xpu
+export UCX_TLS=tcp,ze_copy
+
+# Defaults require four free XPUs: two for prefill and two for decode.
+bash run-pd-nixl-docker.sh
+```
+
+The script starts only containers whose names begin with `xpu-pd-nixl-` and removes only those containers on cleanup. `MODEL_NAME` defaults to `deepseek-ai/DeepSeek-V2-Lite-Chat`. If the goal is only to debug NIXL independent of MoE, override it with a known-good dense model such as `facebook/opt-125m`; that does not count as WideEP validation.
+
+To reproduce the UCX transport failure, keep `KV_BUFFER_DEVICE=xpu` and set `UCX_TLS=tcp`. That configuration fails during NIXL KV cache memory registration because UCX cannot register XPU VRAM without the `ze_copy` transport.
+
+## Full LWS/router validation
+
+The full llm-d path was validated on `xpu-817225` with temporary manifests:
+
+| Shape | XPUs | Result | Key evidence |
+| --- | --- | --- | --- |
+| Decode TP=2 + prefill TP=2, `kv_buffer_device=xpu`, `UCX_TLS=tcp,ze_copy` | 4 | Passed | Decode pod `2/2`, prefill pod `1/1`, completion via EPP, `Registering KV_Caches. use_mla: True, kv_buffer_device: xpu, use_host_buffer: False`, and `Application startup complete`. |
+| Decode TP=2 + prefill TP=2, `kv_buffer_device=cpu` | 4 | Passed | Decode pod `2/2`, prefill pod `1/1`, completion via EPP, `TransferTopology(... local_tp=2, remote_tp=2 ...)`. |
+| Decode TP=4 + prefill TP=4, `kv_buffer_device=cpu` | 8 | Passed | 4-XPU DRA claims for each LWS pod, completion via EPP, `world_size=4 backend=xccl`, `[EP Rank 0/4]`, `TransferTopology(... local_tp=4, remote_tp=4 ...)`. |
+| Decode TP=2 + prefill TP=2, `kv_buffer_device=xpu`, `UCX_TLS=tcp` | 4 | Failed as expected | `Registering KV_Caches. use_mla: True, kv_buffer_device: xpu, use_host_buffer: False` followed by `NIXL_ERR_BACKEND`; the minimal Qwen control produced the explicit UCX diagnosis that VRAM was detected as host. |
+
+The table above is the PR-safe summary of the raw validation logs captured during the XPU runs.

--- a/guides/wide-ep-lws/experimental-xpu/experiments/docker-compose.yaml
+++ b/guides/wide-ep-lws/experimental-xpu/experiments/docker-compose.yaml
@@ -1,0 +1,114 @@
+services:
+  v2lite-ep-tp2:
+    image: ${VLLM_XPU_IMAGE:-ghcr.io/llm-d/llm-d-xpu:v0.7.0}
+    entrypoint:
+      - vllm
+      - serve
+    privileged: true
+    shm_size: ${SHM_SIZE:-16gb}
+    environment:
+      HF_TOKEN: ${HF_TOKEN:?set HF_TOKEN}
+      ZE_AFFINITY_MASK: ${ZE_AFFINITY_MASK:-0,1}
+      VLLM_WORKER_MULTIPROC_METHOD: spawn
+      VLLM_ENABLE_V1_MULTIPROCESSING: "1"
+      VLLM_MULTIPROC_EXECUTE_MODEL_TIMEOUT_S: "1200"
+      UCX_TLS: ${UCX_TLS:-tcp,ze_copy}
+      HF_HUB_CACHE: /var/cache/huggingface
+      VLLM_CACHE_ROOT: /var/cache/vllm
+    volumes:
+      - /dev/dri:/dev/dri
+      - ${HF_CACHE_DIR:-./hf-cache}:/var/cache/huggingface
+      - ${VLLM_CACHE_DIR:-./vllm-cache}:/var/cache/vllm
+    ports:
+      - "127.0.0.1:${PORT:-8000}:8000"
+    command:
+      - deepseek-ai/DeepSeek-V2-Lite-Chat
+      - --host=0.0.0.0
+      - --port=8000
+      - --trust-remote-code
+      - --dtype=float16
+      - --block-size=64
+      - --enforce-eager
+      - --max-model-len=512
+      - --gpu-memory-utilization=0.8
+      - --tensor-parallel-size=2
+      - --enable-expert-parallel
+      - --all2all-backend=allgather_reducescatter
+      - --disable-access-log-for-endpoints=/health,/metrics,/v1/models
+    profiles:
+      - v2lite-ep-tp2
+
+  v2lite-ep-tp4:
+    image: ${VLLM_XPU_IMAGE:-ghcr.io/llm-d/llm-d-xpu:v0.7.0}
+    entrypoint:
+      - vllm
+      - serve
+    privileged: true
+    shm_size: ${SHM_SIZE:-16gb}
+    environment:
+      HF_TOKEN: ${HF_TOKEN:?set HF_TOKEN}
+      ZE_AFFINITY_MASK: ${ZE_AFFINITY_MASK:-0,1,2,3}
+      VLLM_WORKER_MULTIPROC_METHOD: spawn
+      VLLM_ENABLE_V1_MULTIPROCESSING: "1"
+      VLLM_MULTIPROC_EXECUTE_MODEL_TIMEOUT_S: "1200"
+      UCX_TLS: ${UCX_TLS:-tcp,ze_copy}
+      HF_HUB_CACHE: /var/cache/huggingface
+      VLLM_CACHE_ROOT: /var/cache/vllm
+    volumes:
+      - /dev/dri:/dev/dri
+      - ${HF_CACHE_DIR:-./hf-cache}:/var/cache/huggingface
+      - ${VLLM_CACHE_DIR:-./vllm-cache}:/var/cache/vllm
+    ports:
+      - "127.0.0.1:${PORT:-8000}:8000"
+    command:
+      - deepseek-ai/DeepSeek-V2-Lite-Chat
+      - --host=0.0.0.0
+      - --port=8000
+      - --trust-remote-code
+      - --dtype=float16
+      - --block-size=64
+      - --enforce-eager
+      - --max-model-len=512
+      - --gpu-memory-utilization=0.8
+      - --tensor-parallel-size=4
+      - --enable-expert-parallel
+      - --all2all-backend=allgather_reducescatter
+      - --disable-access-log-for-endpoints=/health,/metrics,/v1/models
+    profiles:
+      - v2lite-ep-tp4
+
+  powermoe-ep-dp3:
+    image: ${VLLM_XPU_IMAGE:-ghcr.io/llm-d/llm-d-xpu:v0.7.0}
+    entrypoint:
+      - vllm
+      - serve
+    privileged: true
+    shm_size: ${SHM_SIZE:-16gb}
+    environment:
+      HF_TOKEN: ${HF_TOKEN:?set HF_TOKEN}
+      ZE_AFFINITY_MASK: ${ZE_AFFINITY_MASK:-0,1,2}
+      VLLM_WORKER_MULTIPROC_METHOD: spawn
+      VLLM_ENABLE_V1_MULTIPROCESSING: "1"
+      VLLM_MULTIPROC_EXECUTE_MODEL_TIMEOUT_S: "1200"
+      UCX_TLS: ${UCX_TLS:-tcp,ze_copy}
+      HF_HUB_CACHE: /var/cache/huggingface
+      VLLM_CACHE_ROOT: /var/cache/vllm
+    volumes:
+      - /dev/dri:/dev/dri
+      - ${HF_CACHE_DIR:-./hf-cache}:/var/cache/huggingface
+      - ${VLLM_CACHE_DIR:-./vllm-cache}:/var/cache/vllm
+    ports:
+      - "127.0.0.1:${PORT:-8000}:8000"
+    command:
+      - ibm-research/PowerMoE-3b
+      - --host=0.0.0.0
+      - --port=8000
+      - --trust-remote-code
+      - --max-model-len=2048
+      - --tensor-parallel-size=1
+      - --data-parallel-size=3
+      - --enable-expert-parallel
+      - --all2all-backend=allgather_reducescatter
+      - --disable-access-log-for-endpoints=/health,/metrics,/v1/models
+    profiles:
+      - powermoe-ep-dp3

--- a/guides/wide-ep-lws/experimental-xpu/experiments/run-pd-nixl-docker.sh
+++ b/guides/wide-ep-lws/experimental-xpu/experiments/run-pd-nixl-docker.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VLLM_XPU_IMAGE=${VLLM_XPU_IMAGE:-ghcr.io/llm-d/llm-d-xpu:v0.7.0}
+VLLM_SRC=${VLLM_SRC:?set VLLM_SRC to a vLLM source checkout containing tests/v1/kv_connector/nixl_integration}
+
+MODEL_NAME=${MODEL_NAME:-deepseek-ai/DeepSeek-V2-Lite-Chat}
+# DeepSeek-V2-Lite is the WideEP candidate model. For NIXL-only debugging,
+# override MODEL_NAME with a known-good dense model such as facebook/opt-125m.
+MAX_MODEL_LEN=${MAX_MODEL_LEN:-512}
+BLOCK_SIZE=${BLOCK_SIZE:-64}
+GPU_MEMORY_UTILIZATION=${GPU_MEMORY_UTILIZATION:-0.8}
+# XPU device-buffer NIXL requires UCX Level Zero transport. Use tcp,ze_copy for
+# local or non-RDMA P/D debugging; RDMA deployments should include ze_copy in
+# their RDMA transport set as well.
+KV_BUFFER_DEVICE=${KV_BUFFER_DEVICE:-xpu}
+UCX_TLS=${UCX_TLS:-tcp,ze_copy}
+UCX_MEMTYPE_CACHE=${UCX_MEMTYPE_CACHE:-0}
+SHM_SIZE=${SHM_SIZE:-16g}
+
+PREFILL_MASK=${PREFILL_MASK:-0,1}
+DECODE_MASK=${DECODE_MASK:-2,3}
+PREFILL_TP_SIZE=${PREFILL_TP_SIZE:-2}
+DECODE_TP_SIZE=${DECODE_TP_SIZE:-2}
+PREFILL_PORT=${PREFILL_PORT:-8100}
+PREFILL_NIXL_SIDE_PORT=${PREFILL_NIXL_SIDE_PORT:-5577}
+DECODE_PORT=${DECODE_PORT:-8200}
+DECODE_NIXL_SIDE_PORT=${DECODE_NIXL_SIDE_PORT:-5578}
+PROXY_PORT=${PROXY_PORT:-8192}
+
+PREFILL_CONTAINER=${PREFILL_CONTAINER:-xpu-pd-nixl-prefill}
+DECODE_CONTAINER=${DECODE_CONTAINER:-xpu-pd-nixl-decode}
+PROXY_CONTAINER=${PROXY_CONTAINER:-xpu-pd-nixl-proxy}
+
+for container_name in "${PREFILL_CONTAINER}" "${DECODE_CONTAINER}" "${PROXY_CONTAINER}"; do
+  if [[ "${container_name}" != xpu-pd-nixl-* ]]; then
+    echo "Container name ${container_name} must start with xpu-pd-nixl- for safe cleanup" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -f "${VLLM_SRC}/tests/v1/kv_connector/nixl_integration/toy_proxy_server.py" ]]; then
+  echo "toy_proxy_server.py not found under VLLM_SRC=${VLLM_SRC}" >&2
+  exit 1
+fi
+
+docker_env_args=()
+if [[ -n "${HF_TOKEN:-}" ]]; then
+  docker_env_args+=(-e "HF_TOKEN=${HF_TOKEN}")
+fi
+
+cleanup() {
+  docker rm -f "${PROXY_CONTAINER}" "${DECODE_CONTAINER}" "${PREFILL_CONTAINER}" >/dev/null 2>&1 || true
+}
+
+wait_for_server() {
+  local port=$1
+  local name=$2
+  local deadline=$((SECONDS + 1200))
+  until curl -fsS "http://127.0.0.1:${port}/v1/models" >/dev/null 2>&1; do
+    local status
+    status=$(docker inspect -f '{{.State.Status}}' "${name}" 2>/dev/null || true)
+    if [[ "${status}" == "exited" || "${status}" == "dead" ]]; then
+      echo "${name} exited while waiting for port ${port}" >&2
+      docker logs --tail 200 "${name}" >&2 || true
+      return 1
+    fi
+    if (( SECONDS > deadline )); then
+      echo "Timed out waiting for ${name} on port ${port}" >&2
+      docker logs --tail 120 "${name}" >&2 || true
+      return 1
+    fi
+    sleep 2
+  done
+}
+
+trap cleanup EXIT
+cleanup
+
+echo "Warning: this experiment uses privileged XPU containers, host networking, and vLLM --trust-remote-code. Run only on a dedicated trusted host with trusted model code." >&2
+
+docker run -d --name "${PREFILL_CONTAINER}" --network host --privileged \
+  --shm-size "${SHM_SIZE}" \
+  --entrypoint vllm \
+  "${docker_env_args[@]}" \
+  -e "ZE_AFFINITY_MASK=${PREFILL_MASK}" \
+  -e VLLM_WORKER_MULTIPROC_METHOD=spawn \
+  -e VLLM_ENABLE_V1_MULTIPROCESSING=1 \
+  -e VLLM_MULTIPROC_EXECUTE_MODEL_TIMEOUT_S=1200 \
+  -e "UCX_TLS=${UCX_TLS}" \
+  -e "UCX_MEMTYPE_CACHE=${UCX_MEMTYPE_CACHE}" \
+  -e VLLM_NIXL_SIDE_CHANNEL_HOST=127.0.0.1 \
+  -e "VLLM_NIXL_SIDE_CHANNEL_PORT=${PREFILL_NIXL_SIDE_PORT}" \
+  -v /dev/dri:/dev/dri \
+  "${VLLM_XPU_IMAGE}" \
+  serve "${MODEL_NAME}" \
+    --host 127.0.0.1 \
+    --port "${PREFILL_PORT}" \
+    --trust-remote-code \
+    --max-model-len "${MAX_MODEL_LEN}" \
+    --block-size "${BLOCK_SIZE}" \
+    --enforce-eager \
+    --dtype float16 \
+    --tensor-parallel-size "${PREFILL_TP_SIZE}" \
+    --enable-expert-parallel \
+    --all2all-backend allgather_reducescatter \
+    --gpu-memory-utilization "${GPU_MEMORY_UTILIZATION}" \
+    --kv-transfer-config "{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\",\"kv_buffer_device\":\"${KV_BUFFER_DEVICE}\"}"
+
+docker run -d --name "${DECODE_CONTAINER}" --network host --privileged \
+  --shm-size "${SHM_SIZE}" \
+  --entrypoint vllm \
+  "${docker_env_args[@]}" \
+  -e "ZE_AFFINITY_MASK=${DECODE_MASK}" \
+  -e VLLM_WORKER_MULTIPROC_METHOD=spawn \
+  -e VLLM_ENABLE_V1_MULTIPROCESSING=1 \
+  -e VLLM_MULTIPROC_EXECUTE_MODEL_TIMEOUT_S=1200 \
+  -e "UCX_TLS=${UCX_TLS}" \
+  -e "UCX_MEMTYPE_CACHE=${UCX_MEMTYPE_CACHE}" \
+  -e VLLM_NIXL_SIDE_CHANNEL_HOST=127.0.0.1 \
+  -e "VLLM_NIXL_SIDE_CHANNEL_PORT=${DECODE_NIXL_SIDE_PORT}" \
+  -v /dev/dri:/dev/dri \
+  "${VLLM_XPU_IMAGE}" \
+  serve "${MODEL_NAME}" \
+    --host 127.0.0.1 \
+    --port "${DECODE_PORT}" \
+    --trust-remote-code \
+    --max-model-len "${MAX_MODEL_LEN}" \
+    --block-size "${BLOCK_SIZE}" \
+    --enforce-eager \
+    --dtype float16 \
+    --tensor-parallel-size "${DECODE_TP_SIZE}" \
+    --enable-expert-parallel \
+    --all2all-backend allgather_reducescatter \
+    --gpu-memory-utilization "${GPU_MEMORY_UTILIZATION}" \
+    --kv-transfer-config "{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\",\"kv_buffer_device\":\"${KV_BUFFER_DEVICE}\"}"
+
+wait_for_server "${PREFILL_PORT}" "${PREFILL_CONTAINER}"
+wait_for_server "${DECODE_PORT}" "${DECODE_CONTAINER}"
+
+docker run -d --name "${PROXY_CONTAINER}" --network host \
+  --entrypoint python3 \
+  -v "${VLLM_SRC}:/workspace/vllm-src:ro" \
+  "${VLLM_XPU_IMAGE}" \
+  /workspace/vllm-src/tests/v1/kv_connector/nixl_integration/toy_proxy_server.py \
+    --prefiller-host 127.0.0.1 \
+    --prefiller-port "${PREFILL_PORT}" \
+    --decoder-host 127.0.0.1 \
+    --decoder-port "${DECODE_PORT}" \
+    --host 127.0.0.1 \
+    --port "${PROXY_PORT}"
+
+sleep 2
+
+curl -fsS "http://127.0.0.1:${PROXY_PORT}/v1/completions" \
+  -H "Content-Type: application/json" \
+  -d "{\"model\":\"${MODEL_NAME}\",\"prompt\":\"Hello\",\"max_tokens\":16}"
+
+echo
+echo "XPU P/D NIXL request completed through proxy port ${PROXY_PORT}."

--- a/guides/wide-ep-lws/experimental-xpu/manifests/modelserver/base/kustomization.yaml
+++ b/guides/wide-ep-lws/experimental-xpu/manifests/modelserver/base/kustomization.yaml
@@ -1,0 +1,35 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - modelserver.yaml
+  - resource-claim-template.yaml
+  - serviceAccount.yaml
+labels:
+  - pairs:
+      llm-d.ai/model: DeepSeek-V2-Lite
+      llm-d.ai/guide: wide-ep-lws-experimental-xpu
+      llm-d.ai/accelerator-variant: xpu
+      llm-d.ai/accelerator-vendor: intel
+      llm-d.ai/engine-type: vllm
+    includeSelectors: true
+    includeTemplates: true
+    fields:
+      - version: v1
+        kind: ServiceAccount
+        path: metadata/labels
+        create: true
+      - group: resource.k8s.io
+        version: v1
+        kind: ResourceClaimTemplate
+        path: metadata/labels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: metadata/labels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: spec/template/metadata/labels
+        create: true

--- a/guides/wide-ep-lws/experimental-xpu/manifests/modelserver/base/modelserver.yaml
+++ b/guides/wide-ep-lws/experimental-xpu/manifests/modelserver/base/modelserver.yaml
@@ -1,0 +1,146 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wide-ep-lws-experimental-xpu-vllm
+  labels:
+    llm-d.ai/inference-serving: "true"
+    llm-d.ai/model: DeepSeek-V2-Lite
+    llm-d.ai/role: modelserver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      llm-d.ai/guide: wide-ep-lws-experimental-xpu
+      llm-d.ai/role: modelserver
+  template:
+    metadata:
+      labels:
+        llm-d.ai/inference-serving: "true"
+        llm-d.ai/guide: wide-ep-lws-experimental-xpu
+        llm-d.ai/accelerator-variant: xpu
+        llm-d.ai/accelerator-vendor: intel
+        llm-d.ai/model: DeepSeek-V2-Lite
+        llm-d.ai/role: modelserver
+    spec:
+      serviceAccountName: deepseek-v2-lite
+      securityContext:
+        fsGroup: 107
+        supplementalGroups:
+          - 107
+      resourceClaims:
+        - name: xpu-claim
+          resourceClaimTemplateName: xpu-claim
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi
+        - name: hf-cache
+          emptyDir: {}
+        - name: vllm-cache
+          emptyDir: {}
+      containers:
+        - name: vllm
+          image: ghcr.io/llm-d/llm-d-xpu:v0.7.0
+          imagePullPolicy: Always
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
+            runAsGroup: 0
+            runAsUser: 0
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - |-
+              find /dev/shm -type f -delete
+
+              exec vllm serve \
+                deepseek-ai/DeepSeek-V2-Lite-Chat \
+                --host 0.0.0.0 \
+                --port 8000 \
+                --trust-remote-code \
+                --dtype float16 \
+                --block-size 64 \
+                --enforce-eager \
+                --gpu-memory-utilization ${GPU_MEMORY_UTILIZATION} \
+                --max-model-len ${MAX_MODEL_LEN} \
+                --tensor-parallel-size ${TP_SIZE} \
+                --enable-expert-parallel \
+                --all2all-backend allgather_reducescatter \
+                --disable-access-log-for-endpoints=/health,/metrics,/v1/models
+          env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
+            - name: VLLM_USE_V1
+              value: "1"
+            - name: VLLM_WORKER_MULTIPROC_METHOD
+              value: spawn
+            - name: VLLM_ENABLE_V1_MULTIPROCESSING
+              value: "1"
+            - name: VLLM_MULTIPROC_EXECUTE_MODEL_TIMEOUT_S
+              value: "1200"
+            - name: TORCH_LLM_ALLREDUCE
+              value: "1"
+            - name: UCX_TLS
+              value: tcp,ze_copy
+            - name: USER
+              value: llm-d
+            - name: TP_SIZE
+              value: "4"
+            - name: MAX_MODEL_LEN
+              value: "512"
+            - name: GPU_MEMORY_UTILIZATION
+              value: "0.8"
+            - name: VLLM_LOGGING_LEVEL
+              value: INFO
+            - name: HF_HUB_CACHE
+              value: /var/cache/huggingface
+            - name: VLLM_CACHE_ROOT
+              value: /var/cache/vllm
+          ports:
+            - containerPort: 8000
+              name: modelserver
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /health
+              port: modelserver
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 120
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: modelserver
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 20
+          readinessProbe:
+            httpGet:
+              path: /v1/models
+              port: modelserver
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            limits:
+              cpu: "16"
+              memory: 128Gi
+            requests:
+              cpu: "16"
+              memory: 128Gi
+            claims:
+              - name: xpu-claim
+          volumeMounts:
+            - name: dshm
+              mountPath: /dev/shm
+            - name: hf-cache
+              mountPath: /var/cache/huggingface
+            - name: vllm-cache
+              mountPath: /var/cache/vllm

--- a/guides/wide-ep-lws/experimental-xpu/manifests/modelserver/base/resource-claim-template.yaml
+++ b/guides/wide-ep-lws/experimental-xpu/manifests/modelserver/base/resource-claim-template.yaml
@@ -1,0 +1,12 @@
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: xpu-claim
+spec:
+  spec:
+    devices:
+      requests:
+        - name: intel
+          exactly:
+            deviceClassName: gpu.intel.com
+            count: 4

--- a/guides/wide-ep-lws/experimental-xpu/manifests/modelserver/base/serviceAccount.yaml
+++ b/guides/wide-ep-lws/experimental-xpu/manifests/modelserver/base/serviceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: deepseek-v2-lite
+automountServiceAccountToken: false

--- a/guides/wide-ep-lws/experimental-xpu/manifests/modelserver/intel/kustomization.yaml
+++ b/guides/wide-ep-lws/experimental-xpu/manifests/modelserver/intel/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base


### PR DESCRIPTION
## Summary

Adds a guide-style Intel XPU vLLM backend for `wide-ep-lws` using the validated DeepSeek-V2-Lite configuration.

- adds `modelserver/xpu/vllm/` with LWS decode/prefill manifests;
- uses DRA `gpu.intel.com` ResourceClaimTemplates with two XPUs for decode and two for prefill;
- keeps the standard llm-d router/EPP path with the decode routing sidecar;
- enables XCCL expert parallelism with `allgather_reducescatter`;
- uses NIXL XPU KV buffers (`kv_buffer_device=xpu`) with `UCX_TLS=tcp,ze_copy` for the validated non-RDMA XPU configuration;
- adds `router/xpu.values.yaml` so the router targets the single XPU decode sidecar port instead of the NVIDIA DP=8 port list;
- updates the guide README with the XPU configuration, backend row, DRA prerequisite, deploy, verify, and cleanup instructions.

## Validation

```bash
kubectl kustomize guides/wide-ep-lws/modelserver/xpu/vllm >/tmp/wide-ep-lws-xpu.yaml
grep -q 'kind: LeaderWorkerSet' /tmp/wide-ep-lws-xpu.yaml
grep -q 'kv_buffer_device' /tmp/wide-ep-lws-xpu.yaml
grep -q 'UCX_TLS' /tmp/wide-ep-lws-xpu.yaml
grep -q 'VLLM_HTTP_TIMEOUT_KEEP_ALIVE' /tmp/wide-ep-lws-xpu.yaml
git diff --check
```

Hardware validation:

- DeepSeek-V2-Lite TP=2 + EP passed on Intel XPU.
- DeepSeek-V2-Lite TP=4 + EP passed on Intel XPU.
- Full `wide-ep-lws` path passed with decode TP=2 + prefill TP=2, LWS, router/EPP, XPU EP, NIXL, `kv_buffer_device=xpu`, and `UCX_TLS=tcp,ze_copy`.
- Host-buffer fallback (`kv_buffer_device=cpu`) also passed at decode TP=2 + prefill TP=2 and decode TP=4 + prefill TP=4.

## Scope notes

This adds the validated XPU guide backend. It does not attempt to carry over NVIDIA-only optimizations such as DeepEP, DeepGEMM, DBO, or EPLB.

> Note: this PR was closed before the branch was force-pushed to the guide-style single commit, so GitHub no longer allows reopening this closed PR directly.
