### PR TITLE
docs: add XPU WideEP guide backend

### DIFF
--- a/guides/wide-ep-lws/README.md
+++ b/guides/wide-ep-lws/README.md
@@ -28,22 +28,40 @@ This guide demonstrates how to deploy DeepSeek-R1-0528 using vLLM's P/D disaggre
 | Decode Data Parallelism  | 16                                                      |
 | Total GPUs               | 32                                                      |
 
+### Intel XPU Configuration
+
+The Intel XPU configuration uses the validated DeepSeek-V2-Lite shape:
+
+| Parameter | Value |
+| --- | --- |
+| Model | [DeepSeek-V2-Lite-Chat](https://huggingface.co/deepseek-ai/DeepSeek-V2-Lite-Chat) |
+| Prefill Tensor Parallelism | 2 |
+| Decode Tensor Parallelism | 2 |
+| Total XPUs | 4 |
+| Expert Parallelism | enabled |
+| All2All backend | `allgather_reducescatter` |
+| KV transfer | NIXL with `kv_buffer_device=xpu` |
+| UCX transport | `tcp,ze_copy` for the validated non-RDMA configuration |
+
 ### Tested Hardware Backends
 
 This guide includes configurations for the following accelerators:
 
-| Backend             | Directory                  | Notes                                      |
-| ------------------- | -------------------------- | ------------------------------------------ |
-| NVIDIA GPU (GKE)    | `modelserver/gpu/vllm/gke/`         | GKE deployment                      |
-| NVIDIA GPU (CoreWeave)| `modelserver/gpu/vllm/coreweave/`   | CoreWeave deployment                     |
-| NVIDIA GPU (DGX Cloud GB200)| `modelserver/gpu/vllm/dgx-cloud-gb200/` | DGX Cloud deployment             |
+| Backend               | Directory                                   | Notes                                      |
+| --------------------- | ------------------------------------------- | ------------------------------------------ |
+| NVIDIA GPU (GKE)      | `modelserver/gpu/vllm/gke/`                 | GKE deployment (H200)                      |
+| NVIDIA GPU (GKE A4)   | `modelserver/gpu/vllm/topology-aware/gke-a4/` | GKE deployment (B200)                    |
+| NVIDIA GPU (CoreWeave)| `modelserver/gpu/vllm/coreweave/`           | CoreWeave deployment                       |
+| NVIDIA GPU (GB200)    | `modelserver/gpu/vllm/dgx-cloud-gb200/`     | DGX Cloud GB200 deployment                 |
+| Intel XPU (vLLM)      | `modelserver/xpu/vllm/`                     | DeepSeek-V2-Lite-Chat, DRA `gpu.intel.com`, XCCL, NIXL XPU KV buffers |
 
 > [!NOTE]
-> The pods leveraging inter-node EP must be deployed in a cluster environment with full mesh
-> network connectivity. The DeepEP backend used in WideEP requires All-to-All RDMA
-> connectivity. Every NIC on a host must be able to communicate with every NIC on all other
-> hosts. Networks restricted to communicating only between matching NIC IDs (rail-only
-> connectivity) will fail.
+> NVIDIA GPU backends that use DeepEP for inter-node EP require All-to-All RDMA
+> connectivity. Every NIC on a host must be able to communicate with every NIC
+> on all other hosts. Networks restricted to communicating only between matching
+> NIC IDs (rail-only connectivity) will fail. The Intel XPU backend uses XCCL
+> and `allgather_reducescatter`; it does not use DeepEP, but still requires
+> full-mesh pod network connectivity between decode and prefill workers.
 
 ## Prerequisites
 
@@ -69,6 +87,7 @@ This guide includes configurations for the following accelerators:
   kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
   ```
 * You have deployed the [LeaderWorkerSet controller](https://lws.sigs.k8s.io/docs/installation/)
+* For Intel XPU, install the [Intel Resource Drivers for Kubernetes](https://github.com/intel/intel-resource-drivers-for-kubernetes) and verify that the `gpu.intel.com` DRA DeviceClass is available.
 * Create a target namespace for the installation:
 
   ```bash
@@ -92,6 +111,18 @@ helm install ${GUIDE_NAME} \
     -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
 ```
 
+For Intel XPU, add the XPU router override so EPP targets the single decode
+sidecar port exposed by the XPU manifests:
+
+```bash
+helm install ${GUIDE_NAME} \
+    ${ROUTER_STANDALONE_CHART} \
+    -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
+    -f ${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
+    -f ${REPO_ROOT}/guides/${GUIDE_NAME}/router/xpu.values.yaml \
+    -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
+```
+
 <details>
 <summary><h4>Gateway Mode</h4></summary>
 
@@ -111,6 +142,10 @@ helm install ${GUIDE_NAME} \
     -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
 ```
 
+For Intel XPU, include
+`-f ${REPO_ROOT}/guides/${GUIDE_NAME}/router/xpu.values.yaml` after the
+`${GUIDE_NAME}.values.yaml` file.
+
 </details>
 
 ### 2. Deploy the Model Server
@@ -118,8 +153,13 @@ helm install ${GUIDE_NAME} \
 Apply the Kustomize overlays for your specific backend:
 
 ```bash
+# NVIDIA GPU
 export INFRA_PROVIDER=gke # options: gke, coreweave, dgx-cloud-gb200
 kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}
+
+# Intel XPU
+export MODEL=deepseek-ai/DeepSeek-V2-Lite-Chat
+kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/xpu/vllm
 ```
 
 ### 3. (Optional) Enable Monitoring
@@ -176,6 +216,7 @@ kubectl run curl-debug --rm -it \
     --namespace="$NAMESPACE" \
     --env="IP=$IP" \
     --env="NAMESPACE=$NAMESPACE" \
+    --env="MODEL=$MODEL" \
     -- /bin/bash
 ```
 
@@ -184,10 +225,10 @@ kubectl run curl-debug --rm -it \
 ```bash
 curl -X POST http://${IP}/v1/completions \
     -H 'Content-Type: application/json' \
-    -d '{
-        "model": "deepseek-ai/DeepSeek-R1-0528",
-        "prompt": "How are you today?"
-    }' | jq
+    -d "{
+        \"model\": \"${MODEL}\",
+        \"prompt\": \"How are you today?\"
+    }" | jq
 ```
 
 ## Benchmarking
@@ -208,7 +249,10 @@ To remove the deployed components:
 helm uninstall ${GUIDE_NAME} -n ${NAMESPACE}
 # If you enabled monitoring (Step 3), remove the monitoring overlay first.
 kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/monitoring
+# NVIDIA GPU
 kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}
+# Intel XPU
+kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/xpu/vllm
 ```
 
 ## Benchmarking Results

--- a/guides/wide-ep-lws/modelserver/xpu/vllm/decode.yaml
+++ b/guides/wide-ep-lws/modelserver/xpu/vllm/decode.yaml
@@ -1,0 +1,177 @@
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  name: wide-ep-lws-xpu-vllm-decode
+  labels:
+    llm-d.ai/model: DeepSeek-V2-Lite-Chat
+    llm-d.ai/role: decode
+spec:
+  replicas: 1
+  leaderWorkerTemplate:
+    size: 1
+    workerTemplate:
+      metadata:
+        labels:
+          llm-d.ai/inference-serving: "true"
+          llm-d.ai/guide: wide-ep-lws
+          llm-d.ai/accelerator-variant: xpu
+          llm-d.ai/accelerator-vendor: intel
+          llm-d.ai/model: DeepSeek-V2-Lite-Chat
+          llm-d.ai/role: decode
+      spec:
+        serviceAccountName: deepseek-v2-lite
+        securityContext:
+          fsGroup: 107
+          supplementalGroups:
+            - 107
+        resourceClaims:
+          - name: xpu-decode-claim
+            resourceClaimTemplateName: xpu-decode-claim
+        initContainers:
+          - name: routing-proxy
+            args:
+              - --port=8000
+              - --vllm-port=8200
+              - --kv-connector=nixlv2
+              - --zap-log-level=1
+              - --secure-proxy=false
+              - --enable-prefiller-sampling
+            image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.1
+            imagePullPolicy: Always
+            ports:
+              - containerPort: 8000
+                name: sidecar
+                protocol: TCP
+            resources: {}
+            restartPolicy: Always
+            securityContext:
+              allowPrivilegeEscalation: false
+              runAsNonRoot: true
+        volumes:
+          - name: dshm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 16Gi
+          - name: hf-cache
+            emptyDir: {}
+          - name: vllm-cache
+            emptyDir: {}
+        containers:
+          - name: vllm
+            image: ghcr.io/llm-d/llm-d-xpu:v0.7.0
+            imagePullPolicy: Always
+            securityContext:
+              capabilities:
+                add:
+                  - IPC_LOCK
+              runAsGroup: 0
+              runAsUser: 0
+            command:
+              - /bin/bash
+              - -c
+            args:
+              - |-
+                find /dev/shm -type f -delete
+
+                exec vllm serve \
+                  deepseek-ai/DeepSeek-V2-Lite-Chat \
+                  --host 0.0.0.0 \
+                  --port 8200 \
+                  --trust-remote-code \
+                  --dtype float16 \
+                  --block-size 64 \
+                  --enforce-eager \
+                  --gpu-memory-utilization ${GPU_MEMORY_UTILIZATION} \
+                  --max-model-len ${MAX_MODEL_LEN} \
+                  --tensor-parallel-size ${TP_SIZE} \
+                  --enable-expert-parallel \
+                  --all2all-backend allgather_reducescatter \
+                  --kv-transfer-config '{"kv_connector":"NixlConnector",
+                                          "kv_role":"kv_both",
+                                          "kv_buffer_device":"xpu"}' \
+                  --disable-access-log-for-endpoints=/health,/metrics,/v1/models
+            env:
+              - name: HF_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: llm-d-hf-token
+                    key: HF_TOKEN
+              - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+                valueFrom:
+                  fieldRef:
+                    fieldPath: status.podIP
+              - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+                value: "5600"
+              - name: VLLM_USE_V1
+                value: "1"
+              - name: VLLM_WORKER_MULTIPROC_METHOD
+                value: spawn
+              - name: VLLM_ENABLE_V1_MULTIPROCESSING
+                value: "1"
+              - name: VLLM_MULTIPROC_EXECUTE_MODEL_TIMEOUT_S
+                value: "1200"
+              - name: TORCH_LLM_ALLREDUCE
+                value: "1"
+              - name: UCX_TLS
+                value: tcp,ze_copy
+              - name: UCX_MEMTYPE_CACHE
+                value: "0"
+              - name: USER
+                value: llm-d
+              - name: TP_SIZE
+                value: "2"
+              - name: MAX_MODEL_LEN
+                value: "512"
+              - name: GPU_MEMORY_UTILIZATION
+                value: "0.8"
+              - name: VLLM_LOGGING_LEVEL
+                value: INFO
+              - name: HF_HUB_CACHE
+                value: /var/cache/huggingface
+              - name: VLLM_CACHE_ROOT
+                value: /var/cache/vllm
+            ports:
+              - containerPort: 8200
+                name: modelserver
+                protocol: TCP
+              - containerPort: 5600
+                name: nixl
+                protocol: TCP
+            startupProbe:
+              httpGet:
+                path: /health
+                port: modelserver
+              initialDelaySeconds: 30
+              periodSeconds: 30
+              timeoutSeconds: 10
+              failureThreshold: 120
+            livenessProbe:
+              httpGet:
+                path: /health
+                port: modelserver
+              periodSeconds: 30
+              timeoutSeconds: 10
+              failureThreshold: 20
+            readinessProbe:
+              httpGet:
+                path: /v1/models
+                port: modelserver
+              periodSeconds: 10
+              timeoutSeconds: 5
+              failureThreshold: 6
+            resources:
+              limits:
+                cpu: "16"
+                memory: 128Gi
+              requests:
+                cpu: "16"
+                memory: 128Gi
+              claims:
+                - name: xpu-decode-claim
+            volumeMounts:
+              - name: dshm
+                mountPath: /dev/shm
+              - name: hf-cache
+                mountPath: /var/cache/huggingface
+              - name: vllm-cache
+                mountPath: /var/cache/vllm

--- a/guides/wide-ep-lws/modelserver/xpu/vllm/decode.yaml
+++ b/guides/wide-ep-lws/modelserver/xpu/vllm/decode.yaml
@@ -19,7 +19,7 @@ spec:
           llm-d.ai/model: DeepSeek-V2-Lite-Chat
           llm-d.ai/role: decode
       spec:
-        serviceAccountName: deepseek-v2-lite
+        serviceAccountName: sa
         securityContext:
           fsGroup: 107
           supplementalGroups:

--- a/guides/wide-ep-lws/modelserver/xpu/vllm/kustomization.yaml
+++ b/guides/wide-ep-lws/modelserver/xpu/vllm/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ../../../../recipes/modelserver/common
   - decode.yaml
   - prefill.yaml
   - resource-claim-templates.yaml
-  - serviceAccount.yaml
 labels:
   - pairs:
       llm-d.ai/model: DeepSeek-V2-Lite-Chat

--- a/guides/wide-ep-lws/modelserver/xpu/vllm/kustomization.yaml
+++ b/guides/wide-ep-lws/modelserver/xpu/vllm/kustomization.yaml
@@ -1,0 +1,41 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - decode.yaml
+  - prefill.yaml
+  - resource-claim-templates.yaml
+  - serviceAccount.yaml
+labels:
+  - pairs:
+      llm-d.ai/model: DeepSeek-V2-Lite-Chat
+      llm-d.ai/guide: wide-ep-lws
+      llm-d.ai/accelerator-variant: xpu
+      llm-d.ai/accelerator-vendor: intel
+      llm-d.ai/engine-type: vllm
+    includeSelectors: true
+    includeTemplates: true
+    fields:
+      - version: v1
+        kind: ServiceAccount
+        path: metadata/labels
+        create: true
+      - group: leaderworkerset.x-k8s.io
+        version: v1
+        kind: LeaderWorkerSet
+        path: metadata/labels
+        create: true
+      - group: leaderworkerset.x-k8s.io
+        version: v1
+        kind: LeaderWorkerSet
+        path: spec/leaderWorkerTemplate/workerTemplate/metadata/labels
+        create: true
+      - group: monitoring.coreos.com
+        version: v1
+        kind: PodMonitor
+        path: metadata/labels
+        create: true
+      - group: monitoring.coreos.com
+        version: v1
+        kind: PodMonitor
+        path: spec/selector/matchLabels
+        create: true

--- a/guides/wide-ep-lws/modelserver/xpu/vllm/prefill.yaml
+++ b/guides/wide-ep-lws/modelserver/xpu/vllm/prefill.yaml
@@ -19,7 +19,7 @@ spec:
           llm-d.ai/model: DeepSeek-V2-Lite-Chat
           llm-d.ai/role: prefill
       spec:
-        serviceAccountName: deepseek-v2-lite
+        serviceAccountName: sa
         securityContext:
           fsGroup: 107
           supplementalGroups:

--- a/guides/wide-ep-lws/modelserver/xpu/vllm/prefill.yaml
+++ b/guides/wide-ep-lws/modelserver/xpu/vllm/prefill.yaml
@@ -1,0 +1,159 @@
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  name: wide-ep-lws-xpu-vllm-prefill
+  labels:
+    llm-d.ai/model: DeepSeek-V2-Lite-Chat
+    llm-d.ai/role: prefill
+spec:
+  replicas: 1
+  leaderWorkerTemplate:
+    size: 1
+    workerTemplate:
+      metadata:
+        labels:
+          llm-d.ai/inference-serving: "true"
+          llm-d.ai/guide: wide-ep-lws
+          llm-d.ai/accelerator-variant: xpu
+          llm-d.ai/accelerator-vendor: intel
+          llm-d.ai/model: DeepSeek-V2-Lite-Chat
+          llm-d.ai/role: prefill
+      spec:
+        serviceAccountName: deepseek-v2-lite
+        securityContext:
+          fsGroup: 107
+          supplementalGroups:
+            - 107
+        resourceClaims:
+          - name: xpu-prefill-claim
+            resourceClaimTemplateName: xpu-prefill-claim
+        volumes:
+          - name: dshm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 16Gi
+          - name: hf-cache
+            emptyDir: {}
+          - name: vllm-cache
+            emptyDir: {}
+        containers:
+          - name: vllm
+            image: ghcr.io/llm-d/llm-d-xpu:v0.7.0
+            imagePullPolicy: Always
+            securityContext:
+              capabilities:
+                add:
+                  - IPC_LOCK
+              runAsGroup: 0
+              runAsUser: 0
+            command:
+              - /bin/bash
+              - -c
+            args:
+              - |-
+                find /dev/shm -type f -delete
+
+                exec vllm serve \
+                  deepseek-ai/DeepSeek-V2-Lite-Chat \
+                  --host 0.0.0.0 \
+                  --port 8000 \
+                  --trust-remote-code \
+                  --dtype float16 \
+                  --block-size 64 \
+                  --enforce-eager \
+                  --gpu-memory-utilization ${GPU_MEMORY_UTILIZATION} \
+                  --max-model-len ${MAX_MODEL_LEN} \
+                  --tensor-parallel-size ${TP_SIZE} \
+                  --enable-expert-parallel \
+                  --all2all-backend allgather_reducescatter \
+                  --kv-transfer-config '{"kv_connector":"NixlConnector",
+                                          "kv_role":"kv_both",
+                                          "kv_buffer_device":"xpu"}' \
+                  --disable-access-log-for-endpoints=/health,/metrics,/v1/models
+            env:
+              - name: HF_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: llm-d-hf-token
+                    key: HF_TOKEN
+              - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+                valueFrom:
+                  fieldRef:
+                    fieldPath: status.podIP
+              - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+                value: "5600"
+              - name: VLLM_USE_V1
+                value: "1"
+              - name: VLLM_WORKER_MULTIPROC_METHOD
+                value: spawn
+              - name: VLLM_ENABLE_V1_MULTIPROCESSING
+                value: "1"
+              - name: VLLM_MULTIPROC_EXECUTE_MODEL_TIMEOUT_S
+                value: "1200"
+              - name: TORCH_LLM_ALLREDUCE
+                value: "1"
+              - name: UCX_TLS
+                value: tcp,ze_copy
+              - name: UCX_MEMTYPE_CACHE
+                value: "0"
+              - name: USER
+                value: llm-d
+              - name: TP_SIZE
+                value: "2"
+              - name: MAX_MODEL_LEN
+                value: "512"
+              - name: GPU_MEMORY_UTILIZATION
+                value: "0.8"
+              - name: VLLM_LOGGING_LEVEL
+                value: INFO
+              - name: VLLM_HTTP_TIMEOUT_KEEP_ALIVE
+                value: "120"
+              - name: HF_HUB_CACHE
+                value: /var/cache/huggingface
+              - name: VLLM_CACHE_ROOT
+                value: /var/cache/vllm
+            ports:
+              - containerPort: 8000
+                name: modelserver
+                protocol: TCP
+              - containerPort: 5600
+                name: nixl
+                protocol: TCP
+            startupProbe:
+              httpGet:
+                path: /health
+                port: modelserver
+              initialDelaySeconds: 30
+              periodSeconds: 30
+              timeoutSeconds: 10
+              failureThreshold: 120
+            livenessProbe:
+              httpGet:
+                path: /health
+                port: modelserver
+              periodSeconds: 30
+              timeoutSeconds: 10
+              failureThreshold: 20
+            readinessProbe:
+              httpGet:
+                path: /v1/models
+                port: modelserver
+              periodSeconds: 10
+              timeoutSeconds: 5
+              failureThreshold: 6
+            resources:
+              limits:
+                cpu: "16"
+                memory: 128Gi
+              requests:
+                cpu: "16"
+                memory: 128Gi
+              claims:
+                - name: xpu-prefill-claim
+            volumeMounts:
+              - name: dshm
+                mountPath: /dev/shm
+              - name: hf-cache
+                mountPath: /var/cache/huggingface
+              - name: vllm-cache
+                mountPath: /var/cache/vllm

--- a/guides/wide-ep-lws/modelserver/xpu/vllm/resource-claim-templates.yaml
+++ b/guides/wide-ep-lws/modelserver/xpu/vllm/resource-claim-templates.yaml
@@ -1,0 +1,29 @@
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: xpu-decode-claim
+  labels:
+    llm-d.ai/role: decode
+spec:
+  spec:
+    devices:
+      requests:
+        - name: intel
+          exactly:
+            deviceClassName: gpu.intel.com
+            count: 2
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: xpu-prefill-claim
+  labels:
+    llm-d.ai/role: prefill
+spec:
+  spec:
+    devices:
+      requests:
+        - name: intel
+          exactly:
+            deviceClassName: gpu.intel.com
+            count: 2

--- a/guides/wide-ep-lws/modelserver/xpu/vllm/serviceAccount.yaml
+++ b/guides/wide-ep-lws/modelserver/xpu/vllm/serviceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: deepseek-v2-lite
+automountServiceAccountToken: false

--- a/guides/wide-ep-lws/modelserver/xpu/vllm/serviceAccount.yaml
+++ b/guides/wide-ep-lws/modelserver/xpu/vllm/serviceAccount.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: deepseek-v2-lite
-automountServiceAccountToken: false

--- a/guides/wide-ep-lws/router/xpu.values.yaml
+++ b/guides/wide-ep-lws/router/xpu.values.yaml
@@ -1,0 +1,8 @@
+router:
+  modelServers:
+    targetPorts:
+      - number: 8000
+    matchLabels:
+      llm-d.ai/guide: "wide-ep-lws"
+      llm-d.ai/accelerator-variant: "xpu"
+      llm-d.ai/accelerator-vendor: "intel"


### PR DESCRIPTION
## Summary
 
 Adds a guide for Intel XPU vLLM backend with `wide-ep-lws` using the validated DeepSeek-V2-Lite configuration.
 
 This adds:
 
 - `modelserver/xpu/vllm/` with LWS decode/prefill manifests
 - DRA `gpu.intel.com` ResourceClaimTemplates with 2 XPUs for decode and 2 XPUs for prefill
 - the standard llm-d router/EPP path with the decode routing sidecar
 - XCCL expert parallelism using `allgather_reducescatter`
 - NIXL XPU KV buffers with `kv_buffer_device=xpu`
 - `UCX_TLS=tcp,ze_copy` for the validated non-RDMA XPU configuration
 - `router/xpu.values.yaml` so EPP targets the XPU decode sidecar port instead of the NVIDIA DP=8 port list
 - README updates for XPU configuration, backend selection, DRA prerequisite, deployment, verification, and cleanup
 
 ## Validation
 
 Local checks:
 
 ```bash
 kubectl kustomize guides/wide-ep-lws/modelserver/xpu/vllm >/tmp/wide-ep-lws-xpu.yaml
 grep -q 'kind: LeaderWorkerSet' /tmp/wide-ep-lws-xpu.yaml
 grep -q 'kv_buffer_device' /tmp/wide-ep-lws-xpu.yaml
 grep -q 'UCX_TLS' /tmp/wide-ep-lws-xpu.yaml
 grep -q 'VLLM_HTTP_TIMEOUT_KEEP_ALIVE' /tmp/wide-ep-lws-xpu.yaml
 grep -q 'automountServiceAccountToken: false' /tmp/wide-ep-lws-xpu.yaml
 git diff --check

Hardware validation:

 - DeepSeek-V2-Lite TP=2 + EP passed on Intel XPU.
 - DeepSeek-V2-Lite TP=4 + EP passed on Intel XPU.
 - Full wide-ep-lws path passed with decode TP=2 + prefill TP=2, LWS, router/EPP, XPU EP, NIXL, kv_buffer_device=xpu, and UCX_TLS=tcp,ze_copy.
 - Host-buffer fallback with kv_buffer_device=cpu also passed at decode TP=2 + prefill TP=2 and decode TP=4 + prefill TP=4.

Scope notes

This adds the validated XPU guide backend. It intentionally does not carry over NVIDIA-only or currently unvalidated options such as DeepEP, DeepGEMM, DBO, EPLB, or the NVIDIA DP=8 router port layout.