### PR TITLE
(ci/guide) tiered-prefix-cache: parameterize deploy for multi-variant nightlies

### DIFF
--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-lmcache.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-lmcache.yaml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       decode_pods:
-        description: 'Number of decode (vllm "standalone") pods (default "auto", means what was configured on the scenario)'
+        description: 'Number of decode (vllm "standalone") pods (default "1"; "auto" means what was configured on the scenario)'
         required: false
         type: 'string'
-        default: 'auto'
+        default: '1'
       prefill_pods:
         description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
         required: false

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-lmcache.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-lmcache.yaml
@@ -70,7 +70,7 @@ jobs:
       scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
       standup_method: ${{ inputs.standup_method || 'kustomize' }}
       standup_scenario: ${{ inputs.standup_scenario || 'tiered-prefix-cache' }}
-      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      decode_pods: ${{ inputs.decode_pods || '1' }}
       prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
       accelerator_type: ${{ inputs.accelerator_type || 'gpu' }}
       backend_type: ${{ inputs.backend_type || 'vllm' }}

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-native.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-native.yaml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       decode_pods:
-        description: 'Number of decode (vllm "standalone") pods (default "auto", means what was configured on the scenario)'
+        description: 'Number of decode (vllm "standalone") pods (default "1"; "auto" means what was configured on the scenario)'
         required: false
         type: 'string'
-        default: 'auto'
+        default: '1'
       prefill_pods:
         description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
         required: false

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-native.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-native.yaml
@@ -70,7 +70,7 @@ jobs:
       scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
       standup_method: ${{ inputs.standup_method || 'kustomize' }}
       standup_scenario: ${{ inputs.standup_scenario || 'tiered-prefix-cache' }}
-      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      decode_pods: ${{ inputs.decode_pods || '1' }}
       prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
       accelerator_type: ${{ inputs.accelerator_type || 'gpu' }}
       backend_type: ${{ inputs.backend_type || 'vllm' }}

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-tpu-vllm-native.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-tpu-vllm-native.yaml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       decode_pods:
-        description: 'Number of decode (vllm "standalone") pods (default "auto", means what was configured on the scenario)'
+        description: 'Number of decode (vllm "standalone") pods (default "1"; "auto" means what was configured on the scenario)'
         required: false
         type: 'string'
-        default: 'auto'
+        default: '1'
       prefill_pods:
         description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
         required: false

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-tpu-vllm-native.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-tpu-vllm-native.yaml
@@ -79,7 +79,7 @@ jobs:
       scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
       standup_method: ${{ inputs.standup_method || 'kustomize' }}
       standup_scenario: ${{ inputs.standup_scenario || 'tiered-prefix-cache' }}
-      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      decode_pods: ${{ inputs.decode_pods || '1' }}
       prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
       accelerator_type: ${{ inputs.accelerator_type || 'tpu/v6' }}
       backend_type: ${{ inputs.backend_type || 'vllm' }}

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-ibm-cpu-gpu-vllm-native.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-ibm-cpu-gpu-vllm-native.yaml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       decode_pods:
-        description: 'Number of decode (vllm "standalone") pods (default "auto", means what was configured on the scenario)'
+        description: 'Number of decode (vllm "standalone") pods (default "1"; "auto" means what was configured on the scenario)'
         required: false
         type: 'string'
-        default: 'auto'
+        default: '1'
       prefill_pods:
         description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
         required: false

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-ibm-cpu-gpu-vllm-native.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-ibm-cpu-gpu-vllm-native.yaml
@@ -69,7 +69,7 @@ jobs:
       scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
       standup_method: ${{ inputs.standup_method || 'kustomize' }}
       standup_scenario: ${{ inputs.standup_scenario || 'tiered-prefix-cache' }}
-      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      decode_pods: ${{ inputs.decode_pods || '1' }}
       prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
       accelerator_type: ${{ inputs.accelerator_type || 'gpu' }}
       backend_type: ${{ inputs.backend_type || 'vllm' }}

--- a/guides/tiered-prefix-cache/README.md
+++ b/guides/tiered-prefix-cache/README.md
@@ -138,55 +138,94 @@ helm install tiered-prefix-cache \
 ### 2. Deploy the Model Server
 
 Deploy **one** of the paths below. Each `kubectl apply -k` targets an overlay directory. For the GPU paths, `INFRA_PROVIDER` selects a `base` overlay or a provider-specific one (for example `gke`); the TPU path does not use an infra-provider overlay.
+The general deploy command:
+
+<!--
+CI harvests commands from this README via the llm-d-benchmark kustomize standup step. The `kubectl apply -k` below is the ONLY MODELSERVER-phase command the parser captures.
+
+The `export ...` lines in the same block are harvested as default values for ${ACCELERATOR}, ${BACKEND}, ${CONNECTOR}, ${VARIANT}, and ${INFRA_PROVIDER}. That lets the canonical command resolve out of the box for a non-ci scenario run of llmdbenchmark.
+CI overrides each variable per-variant via the scenario YAML's `kustomize.guideVariableOverrides`, which wins over the harvested defaults (precedence in `variable_resolver.py`: README defaults < overrides).
+
+The per-path example sections further below are wrapped in `llm-d-cicd:skip` markers and exist purely for human reference.
+
+ Note that if you add another un-skipped `kubectl apply -k` block in this section. `_select_modelserver_command` in step_06_kustomize_deploy.py runs only the first match — additional blocks would be silently dropped from CI.
+-->
+```bash
+export ACCELERATOR=gpu  # gpu | tpu/v6 | tpu/v7
+export BACKEND=vllm  # vllm | sglang
+export CONNECTOR=native  # native | lmcache-connector
+export VARIANT=cpu  # cpu | fs
+export INFRA_PROVIDER=base  # base | gke
+
+kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/${ACCELERATOR}/${BACKEND}/${CONNECTOR}/${VARIANT}/${INFRA_PROVIDER}/
+```
+
+> [!NOTE]
+> Not all options work with all other options. Consult the different examples to see what is available at this time.
 
 #### vLLM native — CPU RAM
 
+<!-- llm-d-cicd:skip start -->
 ```bash
 export INFRA_PROVIDER=base  # base | gke
 kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/gpu/vllm/native/cpu/${INFRA_PROVIDER}/
 ```
+<!-- llm-d-cicd:skip end -->
 
 #### vLLM native — CPU RAM + Filesystem
 
 This path adds a shared filesystem tier using vLLM's native multi-tier offloading. It requires a ReadWriteMany PVC mounted at `/mnt/files-storage`.
 
-First, provision the PVC. See [Storage Backends](#storage-backends) to configure a `StorageClass` for your environment.
+First, provision the PVC. See [Storage Backends](#storage-backends) to configure a `StorageClass` for your environment - edit [`manifests/pvc.yaml`](./manifests/pvc.yaml) to set your storage class (or leave it blank for the cluster default), then apply:
 
+<!-- llm-d-cicd:skip start -->
 ```bash
-export STORAGE_CLASS="" # cluster default if empty; or e.g. "lustre" / "efs-sc"
-envsubst < ${REPO_ROOT}/guides/tiered-prefix-cache/manifests/pvc.yaml | kubectl apply -n ${NAMESPACE} -f -
+kubectl apply -n ${NAMESPACE} -f ${REPO_ROOT}/guides/tiered-prefix-cache/manifests/pvc.yaml
 ```
+<!-- llm-d-cicd:skip end -->
+
+> [!NOTE]
+> The FS overlay's kustomization.yaml also includes this PVC, so [`manifests/pvc.yaml`](./manifests/pvc.yaml) gets applied anyway with the `kubectl apply` below.
 
 Then deploy the model server:
 
+<!-- llm-d-cicd:skip start -->
 ```bash
 export INFRA_PROVIDER=base  # base | gke
 kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/gpu/vllm/native/fs/${INFRA_PROVIDER}/
 ```
+<!-- llm-d-cicd:skip end -->
 
 #### LMCache
 
-LMCache supports a CPU RAM tier and a filesystem tier. For the filesystem tier, first provision the PVC as shown in the [vLLM native filesystem path](#vllm-native--cpu-ram--filesystem).
+LMCache supports a CPU RAM tier and a filesystem tier. For the filesystem tier, first provision the PVC as shown in the [vLLM native filesystem path](#vllm-native--cpu-ram--filesystem) (Again, the PVC gets applied with the apply command below).
 
+<!-- llm-d-cicd:skip start -->
 ```bash
 export VARIANT=cpu          # cpu | fs
 export INFRA_PROVIDER=base  # base | gke
 kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/gpu/vllm/lmcache-connector/${VARIANT}/${INFRA_PROVIDER}/
 ```
+<!-- llm-d-cicd:skip end -->
 
 #### SGLang HiCache — CPU RAM
 
+<!-- llm-d-cicd:skip start -->
 ```bash
 export INFRA_PROVIDER=base  # base | gke
 kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/gpu/sglang/native/cpu/${INFRA_PROVIDER}/
 ```
+<!-- llm-d-cicd:skip end -->
 
 #### TPU (Google TPU v6 / v7)
 
+<!-- llm-d-cicd:skip start -->
 ```bash
+export INFRA_PROVIDER=""  # Leave empty
 export TPU_VERSION=v7  # v6 | v7
 kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/tpu/${TPU_VERSION}/vllm/native/cpu/
 ```
+<!-- llm-d-cicd:skip end -->
 
 #### Storage Backends
 
@@ -295,25 +334,44 @@ Uninstall the router, then delete the model server overlay for the path you depl
 helm uninstall tiered-prefix-cache -n ${NAMESPACE}
 ```
 
+The general command (see the different paths below):
+```bash
+kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/${ACCELERATOR}/${BACKEND}/${CONNECTOR}/${VARIANT}/${INFRA_PROVIDER} --ignore-not-found
+```
+
+
 **GPU paths:**
 
+<!-- llm-d-cicd:skip start -->
 ```bash
-export MODEL_SERVER=vllm           # vllm | sglang
+export BACKEND=vllm           # vllm | sglang
 export CONNECTOR=native            # native | lmcache-connector
 export VARIANT=cpu                 # cpu | fs
 export INFRA_PROVIDER=base         # base | gke
-kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/gpu/${MODEL_SERVER}/${CONNECTOR}/${VARIANT}/${INFRA_PROVIDER} --ignore-not-found
+kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/gpu/${BACKEND}/${CONNECTOR}/${VARIANT}/${INFRA_PROVIDER} --ignore-not-found
 ```
+<!-- llm-d-cicd:skip end -->
+
 
 **TPU path:**
 
+<!-- llm-d-cicd:skip start -->
 ```bash
 export TPU_VERSION=v7  # v6 | v7
 kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/tpu/${TPU_VERSION}/vllm/native/cpu --ignore-not-found
 ```
+<!-- llm-d-cicd:skip end -->
+
+
+**Storage offloading:**
 
 ```bash
 kubectl delete -f ${REPO_ROOT}/guides/tiered-prefix-cache/manifests/pvc.yaml -n ${NAMESPACE} --ignore-not-found  # if a PVC was created
+```
+
+**For all paths:**
+
+```bash
 kubectl delete namespace ${NAMESPACE}
 ```
 

--- a/guides/tiered-prefix-cache/manifests/pvc.yaml
+++ b/guides/tiered-prefix-cache/manifests/pvc.yaml
@@ -8,4 +8,4 @@ spec:
   resources:
     requests:
       storage: 9000Gi
-  storageClassName: "" # Specify the storage class here, or remove this line to use the default storage class.
+  storageClassName: "" # Specify the storage class here, or leave this empty to use the default storage class.

--- a/guides/tiered-prefix-cache/manifests/pvc.yaml
+++ b/guides/tiered-prefix-cache/manifests/pvc.yaml
@@ -8,4 +8,4 @@ spec:
   resources:
     requests:
       storage: 9000Gi
-  storageClassName: ${STORAGE_CLASS} # Specify the storage class here, or remove this line to use the default storage class.
+  storageClassName: "" # Specify the storage class here, or remove this line to use the default storage class.

--- a/guides/tiered-prefix-cache/modelserver/gpu/vllm/lmcache-connector/fs/base/kustomization.yaml
+++ b/guides/tiered-prefix-cache/modelserver/gpu/vllm/lmcache-connector/fs/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   # Use the CPU offloading base to form a tiered cache structure: HBM - CPU - storage.
   - ../../cpu/base
+  - ../../../../../../manifests/pvc.yaml
 
 labels:
   - pairs:

--- a/guides/tiered-prefix-cache/modelserver/gpu/vllm/native/fs/base/kustomization.yaml
+++ b/guides/tiered-prefix-cache/modelserver/gpu/vllm/native/fs/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - ../../../base
+  - ../../../../../../manifests/pvc.yaml
 
 labels:
   - pairs:

--- a/guides/tiered-prefix-cache/modelserver/gpu/vllm/native/fs/base/patch-vllm.yaml
+++ b/guides/tiered-prefix-cache/modelserver/gpu/vllm/native/fs/base/patch-vllm.yaml
@@ -16,7 +16,7 @@ spec:
               exec vllm serve \
                 Qwen/Qwen3-32B \
                 --tensor-parallel-size=2 \
-                --kv-transfer-config '{"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"spec_name":"TieringOffloadingSpec","cpu_bytes_to_use":107374182400,"block_size":256,"secondary_tiers":[{"type":"fs","root_dir":"/mnt/files-storage","n_read_threads":16,"n_write_threads":16}]}}'
+                --kv-transfer-config '{"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"spec_name":"TieringOffloadingSpec","cpu_bytes_to_use":107374182400,"block_size":256,"secondary_tiers":[{"type":"fs","root_dir":"/mnt/files-storage/kv-cache","n_read_threads":16,"n_write_threads":16}]}}'
           env:
             - name: PYTHONHASHSEED
               value: "42"


### PR DESCRIPTION
## What does this PR do?

Rewrites `guides/tiered-prefix-cache/` so a single README and overlay tree can drive multiple nightly CI flows (vllm/sglang × native/lmcache-connector × cpu/fs × gpu/tpu × base/gke), which is currently not fully supported.

- README emits a single canonical `kubectl apply -k .../modelserver/${ACCELERATOR}/${BACKEND}/${CONNECTOR}/${VARIANT}/${INFRA_PROVIDER}/` command, parsed by the llm-d-benchmark kustomize standup. The previous per-path example blocks are wrapped in `llm-d-cicd:skip` markers, so they stay visible to human readers but no longer compete as MODELSERVER commands.
- `export` block above the canonical command is harvested as default values (`gpu`/`vllm`/`native`/`cpu`/`base`); CI overrides per variant via the scenario YAML's `kustomize.guideVariableOverrides` (overrides win over harvested defaults).
- FS-variant kustomization overlays now include `manifests/pvc.yaml` as a `resources:` entry so the PVC is created atomically with the modelserver.
- Change the amount of decode pods the ci flow runs. For future offloading validation, 1 pod is needed so there will be a deterministic cache hit.

## Required merge order
For the different CI flows to properly work (and to make it possible to add new flows), new `ACCELERATOR` / `BACKEND` yq overrides in the reusable workflow need to be added: https://github.com/llm-d/llm-d-infra/pull/211.
Without those overrides the command's `${ACCELERATOR}` / `${BACKEND}` placeholders will only resolve from the README-harvested defaults, and the existing nightly caller will keep deploying `gpu/vllm/native/cpu/base` regardless of what the workflow inputs say (this is the current flow today anyway)

## Follow-up workflows

New nightly caller workflows for the additional variants will land in a follow-up PR (not in this one).