### PR TITLE
Feat/docs autosync

### DIFF
--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -1,3 +1,9 @@
+---
+sidebar_label: Introduction to llm-d
+sidebar_position: 1
+slug: /
+---
+
 import Link from '@docusaurus/Link';
 
 # The fastest path to state-of-the-art LLM inference on any accelerator

--- a/docs/api-reference/README.md
+++ b/docs/api-reference/README.md
@@ -6,9 +6,9 @@ The following Kubernetes APIs are defined in the `inference.networking.k8s.io` (
 
 | Resource | API Group | Version | Description |
 | --- | --- | --- | --- |
-| [InferencePool](inferencepool.md) | `inference.networking.k8s.io` | `v1` | Defines a pool of inference endpoints (model servers) to configure the **Endpoint Picker (EPP)** and Gateways for inference-optimized routing. |
-| [InferenceObjective](inferenceobjective.md) | `llm-d.ai` | `v1alpha2` | Defines performance goals (priority, latency) for specific model workloads within a pool. |
-| [InferenceModelRewrite](inferencemodelrewrite.md) | `llm-d.ai` | `v1alpha2` | Specifies rules for rewriting model names in request bodies, enabling traffic splitting and canary rollouts. |
+| [InferencePool](core-kubernetes/inferencepool.md) | `inference.networking.k8s.io` | `v1` | Defines a pool of inference endpoints (model servers) to configure the **Endpoint Picker (EPP)** and Gateways for inference-optimized routing. |
+| [InferenceObjective](core-kubernetes/inferenceobjective.md) | `llm-d.ai` | `v1alpha2` | Defines performance goals (priority, latency) for specific model workloads within a pool. |
+| [InferenceModelRewrite](core-kubernetes/inferencemodelrewrite.md) | `llm-d.ai` | `v1alpha2` | Specifies rules for rewriting model names in request bodies, enabling traffic splitting and canary rollouts. |
 
 ## Component Configuration
 

--- a/docs/api-reference/_category_.json
+++ b/docs/api-reference/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "References", "position": 7 }

--- a/docs/api-reference/artifacts.md
+++ b/docs/api-reference/artifacts.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 7
+sidebar_label: "Artifacts"
+---
+
 # Artifacts
 
 This page lists the llm-d release artifacts and dependencies:
@@ -19,9 +24,9 @@ llm-d uses the APIs defined in the Gateway API Inference Extension (GAIE) projec
 
 | CRD |  Purpose |
 |-----|----------|
-| [InferencePool](../api-reference/inferencepool.md) | Defines a pool of inference endpoints (model servers) and configures the EPP and proxy for LLM-aware routing. |
-| [InferenceObjective](../api-reference/inferenceobjective.md) | Defines performance goals (priority, latency) for specific model workloads within a pool. |
-| [InferenceModelRewrite](../api-reference/inferencemodelrewrite.md) | Specifies rules for rewriting model names in request bodies, enabling traffic splitting and canary rollouts. |
+| [InferencePool](core-kubernetes/inferencepool.md) | Defines a pool of inference endpoints (model servers) and configures the EPP and proxy for LLM-aware routing. |
+| [InferenceObjective](core-kubernetes/inferenceobjective.md) | Defines performance goals (priority, latency) for specific model workloads within a pool. |
+| [InferenceModelRewrite](core-kubernetes/inferencemodelrewrite.md) | Specifies rules for rewriting model names in request bodies, enabling traffic splitting and canary rollouts. |
 
 Manifests are published at [kubernetes-sigs/gateway-api-inference-extension/config/crd](https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/config/crd) and can be installed like:
 

--- a/docs/api-reference/core-kubernetes/_category_.json
+++ b/docs/api-reference/core-kubernetes/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "Kubernetes APIs", "position": 1 }

--- a/docs/api-reference/core-kubernetes/inferencemodelrewrite.md
+++ b/docs/api-reference/core-kubernetes/inferencemodelrewrite.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 3
+sidebar_label: "InferenceModelRewrite"
+---
+
 # InferenceModelRewrite
 
 `InferenceModelRewrite` defines rules for rewriting inference requests, such as traffic splitting, A/B tests, or canary rollouts across weighted model targets.

--- a/docs/api-reference/core-kubernetes/inferenceobjective.md
+++ b/docs/api-reference/core-kubernetes/inferenceobjective.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 2
+sidebar_label: "InferenceObjective"
+---
+
 # InferenceObjective
 
 `InferenceObjective` represents the desired state of a specific model use case. It allows "Inference Workload Owners" to define performance and latency goals for a model within an `InferencePool`.

--- a/docs/api-reference/core-kubernetes/inferencepool.md
+++ b/docs/api-reference/core-kubernetes/inferencepool.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 1
+sidebar_label: "InferencePool"
+---
+
 # InferencePool
 
 `InferencePool` is the Schema for the `InferencePools` API. It defines a pool of inference endpoints that can be used by a Gateway.

--- a/docs/api-reference/endpointpickerconfig.md
+++ b/docs/api-reference/endpointpickerconfig.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 2
+sidebar_label: "Component Config: EndpointPickerConfig"
+---
+
 # EndpointPickerConfig (EPP Configuration)
 
 `EndpointPickerConfig` defines the internal configuration for the **Endpoint Picker (EPP)**. Unlike Kubernetes resources (like `InferencePool`), this is a configuration schema used to initialize the EPP binary, typically provided via a ConfigMap or a local file.

--- a/docs/api-reference/epp-grpc-apis.md
+++ b/docs/api-reference/epp-grpc-apis.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 4
+sidebar_label: "RPC APIs"
+---
+
 # EPP gRPC APIs Reference
 
 This document lists the gRPC APIs the [Endpoint Picker (EPP)](../architecture/core/router/epp) supports for inference traffic. gRPC requests flow through the gateway as HTTP/2 (H2C) traffic, and the EPP decodes the gRPC frames and protobuf payloads to do prefix-cache aware routing, plugin decisions, and response usage tracking.

--- a/docs/api-reference/epp-http-apis.md
+++ b/docs/api-reference/epp-http-apis.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 3
+sidebar_label: "HTTP APIs"
+---
+
 # EPP HTTP APIs Reference
 
 This document lists the HTTP APIs the [Endpoint Picker (EPP)](../architecture/core/router/epp) supports for inference traffic. Depending on the API, the EPP may parse fields from the request body to do prefix-cache aware routing, and plugin decisions.

--- a/docs/api-reference/epp-http-apis.md
+++ b/docs/api-reference/epp-http-apis.md
@@ -22,7 +22,7 @@ This document lists the HTTP APIs the [Endpoint Picker (EPP)](../architecture/co
 
 ## Request Examples
 
-The examples below parameterize the model as `${MODEL_NAME}` and the proxy endpoint as `${IP}`. Set `${MODEL_NAME}` to [`Qwen/Qwen3-VL-32B-Instruct`](https://huggingface.co/Qwen/Qwen3-VL-32B-Instruct) from the [multimodal optimized-baseline guide](../../guides/multimodal-serving/optimized-baseline/README.md), and set `${IP}` to the proxy endpoint IP retrieved per that guide's verification steps.
+The examples below parameterize the model as `${MODEL_NAME}` and the proxy endpoint as `${IP}`. Set `${MODEL_NAME}` to [`Qwen/Qwen3-VL-32B-Instruct`](https://huggingface.co/Qwen/Qwen3-VL-32B-Instruct) from the [multimodal optimized-baseline guide](https://github.com/llm-d/llm-d/tree/main/guides/multimodal-serving), and set `${IP}` to the proxy endpoint IP retrieved per that guide's verification steps.
 
 ```bash
 export MODEL_NAME=Qwen/Qwen3-VL-32B-Instruct

--- a/docs/api-reference/epp-http-headers.md
+++ b/docs/api-reference/epp-http-headers.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 5
+sidebar_label: "HTTP Headers"
+---
+
 # EPP HTTP Headers Reference
 
 This document describes the HTTP headers that the [Endpoint Picker (EPP)](../architecture/core/router/epp) inspects to manage and control inference requests, specifically for flow control, performance management, and request classification.

--- a/docs/api-reference/glossary.md
+++ b/docs/api-reference/glossary.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 6
+sidebar_label: "Glossary"
+---
+
 # Glossary
 
 Quick-reference definitions for terms used throughout the llm-d documentation. For a high-level overview of how these pieces fit together, see the [Architecture Overview](../architecture/README.md).
@@ -36,7 +41,7 @@ Quick-reference definitions for terms used throughout the llm-d documentation. F
 
 **Latency Predictor** — A Consultant that uses XGBoost quantile regression models trained on live traffic to predict per-endpoint TTFT and TPOT, enabling SLO-aware routing. See [Latency Predictor](../architecture/advanced/latency-predictor.md).
 
-**llm-d** — A distributed inference serving stack that adds intelligent routing, KV Cache-aware routing, Disaggregated Serving, and autoscaling on top of existing Model Servers. See [Introduction](../getting-started/README.md).
+**llm-d** — A distributed inference serving stack that adds intelligent routing, KV Cache-aware routing, Disaggregated Serving, and autoscaling on top of existing Model Servers. See [Introduction](../README.mdx).
 
 **llm-d Async Processor** — A lightweight dispatch agent that pulls individual inference requests from message queues (such as Redis and Google Pub/Sub) and sends them to the llm-d Router. It adjusts the dispatch rate based on system metrics to protect interactive traffic. See [Batch Inference](../architecture/advanced/batch/README.md).
 
@@ -46,7 +51,7 @@ Quick-reference definitions for terms used throughout the llm-d documentation. F
 
 **llm-d Router** — The intelligent entry point for inference requests. It provides LLM-aware load balancing (e.g., prefix-cache and load-aware routing) and request queuing, and manages disaggregated serving. It is composed of two functional parts: a data-plane **Proxy** (e.g., Envoy) and the **Endpoint Picker (EPP)**. See [Architecture Overview](../architecture/README.md).
 
-**llm-d Well-Lit Path** — A pre-validated, end-to-end deployment recipe (model + hardware + Helm values + benchmarks) that the llm-d community tests and supports as a first-class configuration. See [Introduction](../getting-started/README.md).
+**llm-d Well-Lit Path** — A pre-validated, end-to-end deployment recipe (model + hardware + Helm values + benchmarks) that the llm-d community tests and supports as a first-class configuration. See [Introduction](../README.mdx).
 
 **MoE (Mixture of Experts)** — A model architecture where only a subset of "expert" sub-networks activate per token, enabling very large models (e.g., DeepSeek-R1) to run efficiently. llm-d supports MoE serving via Wide Expert Parallelism.
 
@@ -76,6 +81,6 @@ Quick-reference definitions for terms used throughout the llm-d documentation. F
 
 **vLLM** — An open-source high-throughput LLM serving engine and the default Model Server in llm-d. Provides PagedAttention, continuous batching, Prefix Caching, and KV-Events for cache-aware routing. See [Model Servers](../architecture/core/model-servers.md).
 
-**Wide Expert Parallelism** — A deployment pattern for large MoE models that combines Data Parallelism and Expert Parallelism across multiple nodes, maximizing KV-cache space for long-context serving. See [Introduction](../getting-started/README.md).
+**Wide Expert Parallelism** — A deployment pattern for large MoE models that combines Data Parallelism and Expert Parallelism across multiple nodes, maximizing KV-cache space for long-context serving. See [Introduction](../README.mdx).
 
 **Workload Variant Autoscaler (WVA)** — A multi-model, SLO-aware autoscaler that optimizes cost on heterogeneous hardware by measuring instance capacity, deriving load functions, and calculating the optimal mix of model variants. See [Architecture Overview](../architecture/README.md).

--- a/docs/architecture/_category_.json
+++ b/docs/architecture/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "Concepts (Architecture)", "position": 4 }

--- a/docs/architecture/advanced/_category_.json
+++ b/docs/architecture/advanced/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "Capabilities", "position": 2 }

--- a/docs/architecture/advanced/autoscaling/_category_.json
+++ b/docs/architecture/advanced/autoscaling/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "Autoscaling", "position": 4 }

--- a/docs/architecture/advanced/autoscaling/hpa-epp.md
+++ b/docs/architecture/advanced/autoscaling/hpa-epp.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 2
+sidebar_label: "EndPoint Picker HPA/KEDA Integration"
+---
+
 # HPA/KEDA with EPP Metrics
 
 The EndPoint Picker (EPP) HPA/KEDA integration enables Kubernetes Horizontal Pod Autoscaler (HPA) to scale model server replicas using demand-side signals sourced from the EPP. Rather than relying on coarse resource utilization metrics, it exposes the EPP's internal queuing state as the authoritative signal for LLM inference load. This approach is well-suited for homogeneous deployments where each model scales independently.

--- a/docs/architecture/advanced/autoscaling/hpa-wva.md
+++ b/docs/architecture/advanced/autoscaling/hpa-wva.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 1
+sidebar_label: "Workload Variant Autoscaling"
+---
+
 # HPA/KEDA with WVA Metrics
 
 > [!WARNING]

--- a/docs/architecture/advanced/batch/_category_.json
+++ b/docs/architecture/advanced/batch/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "Batch Processing", "position": 5 }

--- a/docs/architecture/advanced/batch/async-processor.md
+++ b/docs/architecture/advanced/batch/async-processor.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 2
+---
+
 # Async Processor Architecture
 
 The Async Processor is a lightweight dispatch agent that pulls inference requests from message queues and forwards them to the llm-d Router. It uses dispatch gates to regulate dispatch rate based on system metrics, ensuring that the dispatched workloads don't overflow the inference servers.

--- a/docs/architecture/advanced/batch/batch-gateway.md
+++ b/docs/architecture/advanced/batch/batch-gateway.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # Batch Gateway Architecture
 
 Batch Gateway adds OpenAI-compatible batch inference processing to the llm-d stack. It sits between batch API clients and the llm-d Router, managing the lifecycle of batch jobs — from job creation through request dispatching to result collection.

--- a/docs/architecture/advanced/disaggregation/_category_.json
+++ b/docs/architecture/advanced/disaggregation/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "Disaggregation", "position": 1 }

--- a/docs/architecture/advanced/disaggregation/operations-sglang.md
+++ b/docs/architecture/advanced/disaggregation/operations-sglang.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 2
+---
+
 # Disaggregated Serving: Operations (SGLang)
 
 While disaggregated serving can offer superior performance, it introduces additional operational complexity, including:

--- a/docs/architecture/advanced/disaggregation/operations-vllm.md
+++ b/docs/architecture/advanced/disaggregation/operations-vllm.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # Disaggregated Serving: Operations (vLLM)
 
 While disaggregated serving can offer superior performance, it introduces additional operational complexity, including:

--- a/docs/architecture/advanced/kv-management/_category_.json
+++ b/docs/architecture/advanced/kv-management/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "KV Cache Management", "position": 3 }

--- a/docs/architecture/advanced/kv-management/kv-indexer.md
+++ b/docs/architecture/advanced/kv-management/kv-indexer.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 2
+---
+
 # KV-Cache Indexer
 
 The **KV-Cache Indexer** is a component of the **llm-d Router** (residing within the **EPP**) that enables precise prefix-cache-aware routing functionality.

--- a/docs/architecture/advanced/kv-management/kv-offloader.md
+++ b/docs/architecture/advanced/kv-management/kv-offloader.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 3
+---
+
 # KV-Cache Offloading
 
 KV-Cache offloading extends the effective cache capacity beyond GPU HBM by moving KV blocks to lower-cost tiers like CPU DRAM and shared storage.

--- a/docs/architecture/advanced/kv-management/prefix-cache-aware-routing.md
+++ b/docs/architecture/advanced/kv-management/prefix-cache-aware-routing.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # Prefix-Cache Aware Routing
 
 Prefix-cache aware routing is a core technique managed by the **llm-d Router** (specifically via its **Endpoint Picker (EPP)** component) to reduce tail latency and increase throughput. By routing requests to model server replicas that already contain the relevant Key-Value (KV) cache for a prompt's prefix, the system avoids redundant "prefill" computation, saving both time and accelerator (GPU/TPU) resources. This technique expects the underlying model servers to support KV-caching across requests, such as vLLM's [Automatic Prefix Caching](https://docs.vllm.ai/en/latest/features/automatic_prefix_caching/) feature.

--- a/docs/architecture/advanced/latency-predictor.md
+++ b/docs/architecture/advanced/latency-predictor.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 2
+---
+
 # Latency Predictor
 
 The Latency Predictor is the llm-d component behind predicted latency-based scheduling. Instead of scoring pods by coarse utilization signals alone, the EPP asks an online-trained ML model to predict **Time To First Token (TTFT)** and **Time Per Output Token (TPOT)** for each candidate pod, then routes on those predictions — optionally gated by per-request Service Level Objectives (SLOs).

--- a/docs/architecture/core/_category_.json
+++ b/docs/architecture/core/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "Core", "position": 1 }

--- a/docs/architecture/core/inferencepool.md
+++ b/docs/architecture/core/inferencepool.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # InferencePool
 
 The `InferencePool` is the central resource that bridges the gap between the Gateway, the Endpoint Policy Provider (EPP), and the collection of model server instances. It serves as the source of truth for both endpoint discovery and service mesh/gateway integration.

--- a/docs/architecture/core/model-servers.md
+++ b/docs/architecture/core/model-servers.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 3
+---
+
 # Model Servers
 
 The model server is the component that runs inference on a model. llm-d supports vLLM, SGLang, and TensorRT-LLM (`trtllm-serve`) as model server backends.

--- a/docs/architecture/core/router/_category_.json
+++ b/docs/architecture/core/router/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "Router", "position": 2 }

--- a/docs/architecture/core/router/epp/_category_.json
+++ b/docs/architecture/core/router/epp/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "EPP", "position": 2 }

--- a/docs/architecture/core/router/epp/configuration.md
+++ b/docs/architecture/core/router/epp/configuration.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 5
+---
+
 # Configuration
 
 The `EndpointPickerConfig` is the central configuration for the Endpoint Picker (EPP), defining the graph of plugins and parameters that drive request handling, flow control, and scheduling decisions.

--- a/docs/architecture/core/router/epp/datalayer.md
+++ b/docs/architecture/core/router/epp/datalayer.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 4
+---
+
 # Data Layer
 
 The Data Layer is a pluggable and extensible component within the EPP responsible for gathering, processing, and storing real-time state for model server endpoints. It provides the foundational data—such as queue depths, KV cache utilization, and LoRA adapter states—that [request scheduling](scheduling.md) and [flow control](flow-control.md) plugins use to make informed decisions.

--- a/docs/architecture/core/router/epp/flow-control.md
+++ b/docs/architecture/core/router/epp/flow-control.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 2
+---
+
 # Flow Control
 
 The Flow Control layer within the EPP is a critical mechanism for pool defense and multi-tenancy. It protects the pool of model servers from overload by shifting intelligent queuing to the gateway, enforcing strict priority and tenant-aware fairness.

--- a/docs/architecture/core/router/epp/request-handling.md
+++ b/docs/architecture/core/router/epp/request-handling.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # Request Handler
 
 ## Functionality

--- a/docs/architecture/core/router/epp/scheduling.md
+++ b/docs/architecture/core/router/epp/scheduling.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 3
+---
+
 # Request Scheduler
 
 The Request Scheduler is a highly modular and extensible component within the EPP designed to select the optimal model server (endpoint) for an inference request. It leverages a plugin-based architecture, allowing for sophisticated endpoint picking strategies based on real-time metrics, prefix cache tracking, and model-specific requirements like LoRA adapters.

--- a/docs/architecture/core/router/proxy.md
+++ b/docs/architecture/core/router/proxy.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # Proxy
 
 The proxy is the entry point for inference requests in llm-d Router, receiving client traffic and routing it to the optimal model server via the EPP. Supported implementations range from self-managed application load balancers (e.g., Istio, agentgateway, Envoy AI Gateway) to compliant cloud-managed services, such as Google Cloud's Application Load Balancer. It supports two primary deployment modes: **Standalone Mode**, where a self-managed proxy runs alongside the EPP in the same pod, and **Gateway Mode**, which integrates with L7 load balancers via the Kubernetes Gateway API.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,49 @@
+---
+draft: true
+---
+
+# Contributing to the docs
+
+The docs site builds itself straight from this `docs/` folder. Whatever lives here is what ships: add a page and it shows up, add a folder and it becomes a section in the sidebar. All your work happens right here — you never touch the website repo.
+
+There are only two things to know.
+
+## Folders → `_category_.json`
+
+Any folder that holds more than one page needs a small `_category_.json` that tells the sidebar how the section should look:
+
+```json
+{
+  "label": "Well-Lit Paths",
+  "position": 2,
+  "collapsed": false
+}
+```
+
+- **`label`** (use this) — the name people see in the sidebar, so a folder named `well-lit-paths` can read as "Well-Lit Paths".
+- **`position`** (use this) — where the section sits among its siblings. Lower numbers come first.
+- **`collapsed`** (optional) — whether the section starts open (`false`) or closed (`true`). Leave it out and it starts collapsed.
+
+One file per folder, no matter how many pages are inside.
+
+**A folder with a single page** (just a `README.md`) doesn't need a `_category_.json` — it renders as one page, named after that file, instead of a section.
+
+## Pages → frontmatter (optional)
+
+Each `.md` page can set options in a block at the very top. All of these are optional — add them when you want to override the default:
+
+```yaml
+---
+sidebar_position: 1
+sidebar_label: Tiered Cache
+title: Tiered Prefix Cache
+draft: true
+---
+```
+
+- **`sidebar_position`** — where the page sits within its section. Without it, pages sort alphabetically.
+- **`sidebar_label`** — the name in the sidebar. Defaults to the page's title.
+- **`title`** — the page title. Defaults to the first `#` heading.
+- **`draft`** — `draft: true` keeps the page off the published site while it's still cooking. Delete the line when it's ready to ship.
+
+That's it. Edit the Markdown here, and the sidebar and pages follow.

--- a/docs/getting-started/_category_.json
+++ b/docs/getting-started/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "Getting Started", "position": 2, "collapsed": false }

--- a/docs/getting-started/accelerators.md
+++ b/docs/getting-started/accelerators.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 2
+sidebar_label: "Supported Accelerators"
+---
+
 # llm-d Accelerators
 
 llm-d supports multiple accelerator vendors and we are expanding our coverage.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # Quickstart
 
 This guide provides a simplified, end-to-end walkthrough for deploying an **Optimized Baseline** configuration using llm-d. This setup reduces tail latency and increases throughput through load-aware and prefix-cache aware balancing.

--- a/docs/infrastructure/_category_.json
+++ b/docs/infrastructure/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "Infrastructure & Environments", "position": 6 }

--- a/docs/infrastructure/gateway/_category_.json
+++ b/docs/infrastructure/gateway/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "Kubernetes Gateways", "position": 2 }

--- a/docs/infrastructure/gateway/agentgateway.md
+++ b/docs/infrastructure/gateway/agentgateway.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 3
+---
+
 # Agentgateway
 
 This guide shows how to deploy llm-d with

--- a/docs/infrastructure/gateway/envoy-ai-gateway.md
+++ b/docs/infrastructure/gateway/envoy-ai-gateway.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 4
+---
+
 # Envoy AI Gateway
 
 This guide shows how to deploy llm-d with

--- a/docs/infrastructure/gateway/gke.md
+++ b/docs/infrastructure/gateway/gke.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 2
+---
+
 # GKE
 
 This guide shows how to deploy llm-d with

--- a/docs/infrastructure/gateway/install-crds.md
+++ b/docs/infrastructure/gateway/install-crds.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 5
+---
+
 # Installing Gateway API CRDs
 
 Before deploying any Gateway provider, you must install the Gateway API and Gateway API Inference Extension CRDs.

--- a/docs/infrastructure/gateway/istio.md
+++ b/docs/infrastructure/gateway/istio.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # Istio
 
 This guide shows how to deploy llm-d with [Istio](https://istio.io/) as your inference gateway. By the end, inference requests will flow from an Istio-managed `Gateway` to your model servers via the llm-d EPP.

--- a/docs/infrastructure/multi-node.md
+++ b/docs/infrastructure/multi-node.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 3
+sidebar_label: "Kubernetes Multi-Node Orchestration"
+---
+
 # Multi-Node Serving Orchestration
 
 ## (Optional) Install LeaderWorkerSet for multi-host inference

--- a/docs/infrastructure/no-kubernetes-deployment.md
+++ b/docs/infrastructure/no-kubernetes-deployment.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 4
+sidebar_label: "Non-K8s & Bare-Metal Deployments"
+---
+
 # No-Kubernetes Deployment
 
 llm-d's reference deployment runs on Kubernetes — workers are managed by Kubernetes `Deployments`, the EPP discovers them through an `InferencePool`, and the platform handles networking and lifecycle. Many environments don't have a Kubernetes control plane, though: HPC schedulers like Slurm or LSF launch workers dynamically, Ray-based stacks run workers as actors, bare-metal inference farms operate without K8s, and a single workstation with a couple of GPUs is often enough for development.

--- a/docs/infrastructure/providers/_category_.json
+++ b/docs/infrastructure/providers/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "Kubernetes Infrastructure Providers", "position": 1 }

--- a/docs/infrastructure/providers/aks/README.md
+++ b/docs/infrastructure/providers/aks/README.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # Deploying llm-d on Azure Kubernetes Service (AKS)
 
 This guide provides instructions for configuring Azure Kubernetes Service (AKS) clusters to run LLM inference workloads using llm-d.

--- a/docs/infrastructure/providers/digitalocean/README.md
+++ b/docs/infrastructure/providers/digitalocean/README.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 2
+---
+
 # llm-d on DigitalOcean Kubernetes Service (DOKS)
 
 This document covers configuring DOKS clusters for running high performance LLM inference with llm-d.

--- a/docs/infrastructure/providers/gke/README.md
+++ b/docs/infrastructure/providers/gke/README.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 3
+---
+
 # llm-d on Google Kubernetes Engine (GKE)
 
 This document covers configuring GKE clusters for running high performance LLM inference with llm-d.

--- a/docs/infrastructure/providers/minikube/README.md
+++ b/docs/infrastructure/providers/minikube/README.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 4
+---
+
 # llm-d on minikube
 
 ## Prerequisites

--- a/docs/infrastructure/providers/openshift-aws/README.md
+++ b/docs/infrastructure/providers/openshift-aws/README.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 6
+---
+
 # llm-d on Red Hat OpenShift on AWS
 
 This document serves as a reference guide, pointing you to the official Red Hat and AWS documentation, as well as NVIDIA documentation, for setting up a Red Hat OpenShift Service on AWS (ROSA) cluster with NVIDIA GPU support.

--- a/docs/infrastructure/providers/openshift/README.md
+++ b/docs/infrastructure/providers/openshift/README.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 5
+---
+
 # llm-d on OpenShift
 
 This document covers configuring OpenShift clusters for running high performance LLM inference with llm-d.

--- a/docs/infrastructure/rdma/README.md
+++ b/docs/infrastructure/rdma/README.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 5
+sidebar_label: "RDMA & Networking Configuration"
+---
+
 # Remote Direct Memory Access (RDMA) and Networking Configuration
 
 ## Why Networking Matters

--- a/docs/operations/_category_.json
+++ b/docs/operations/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "Operations & Monitoring", "position": 5 }

--- a/docs/operations/observability/_category_.json
+++ b/docs/operations/observability/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "Observability", "position": 2 }

--- a/docs/operations/observability/metrics.md
+++ b/docs/operations/observability/metrics.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 2
+sidebar_label: "Monitoring & Metrics"
+---
+
 # Metrics
 
 This page covers how to enable and interpret metrics from an llm-d deployment. For Prometheus and Grafana installation, see [Observability Setup](./setup.md) first.

--- a/docs/operations/observability/promql.md
+++ b/docs/operations/observability/promql.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 4
+sidebar_label: "PromQL"
+---
+
 # PromQL Query Reference
 
 Ready-to-use PromQL queries for monitoring llm-d deployments. Use these in the Prometheus UI or as the basis for Grafana panels.

--- a/docs/operations/observability/setup.md
+++ b/docs/operations/observability/setup.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # Observability Setup
 
 This page explains how to set up Prometheus, Grafana, and distributed tracing for an llm-d deployment. All guides reference this page — set this up once and it works across every guide.

--- a/docs/operations/observability/tracing.md
+++ b/docs/operations/observability/tracing.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 3
+sidebar_label: "Tracing"
+---
+
 # Distributed Tracing
 
 This guide shows how to enable [OpenTelemetry](https://opentelemetry.io/) distributed tracing across llm-d components.

--- a/docs/operations/readiness-probes.md
+++ b/docs/operations/readiness-probes.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 3
+sidebar_label: "Readiness Probes"
+---
+
 # vLLM Model-Aware Readiness Probes
 
 ## Overview
@@ -303,7 +308,7 @@ kubectl logs -n llm-d $POD --tail=100
 
 - [Kubernetes Probe Configuration](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
 - [vLLM OpenAI-Compatible Server](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html)
-- [llm-d Getting Started](../../README.md)
+- [llm-d Getting Started](../README.mdx)
 - [llm-d Monitoring Guide](observability/README.md)
 
 ## Related Issues

--- a/docs/operations/rollouts/README.md
+++ b/docs/operations/rollouts/README.md
@@ -84,7 +84,7 @@ All rollout guides follow a similar pattern:
 
 Before following these guides, ensure you have:
 
-* A working llm-d deployment (see [getting started guide](../../getting-started/README.md))
+* A working llm-d deployment (see [getting started guide](../../README.mdx))
 * Access to kubectl and the Kubernetes cluster
 * Understanding of Kubernetes Gateway API concepts (for gateway mode)
 * Familiarity with your model serving infrastructure (vLLM, etc.)

--- a/docs/operations/rollouts/_category_.json
+++ b/docs/operations/rollouts/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "Rollouts", "position": 4 }

--- a/docs/operations/rollouts/adapter-rollout.md
+++ b/docs/operations/rollouts/adapter-rollout.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # LoRA Adapter Rollout
 
 The goal of this guide is to show you how to perform incremental roll out operations,
@@ -8,7 +12,7 @@ LoRA adapter rollouts let you deploy new versions of LoRA adapters in phases,
 without altering the underlying base model or infrastructure.
 Use LoRA adapter rollouts to test improvements, bug fixes, or new features in your LoRA adapters.
 
-The [`InferenceModelRewrite`](../../api-reference/inferencemodelrewrite.md) resource allows platform administrators and model owners to control how inference requests are routed to specific models within an InferencePool.
+The [`InferenceModelRewrite`](../../api-reference/core-kubernetes/inferencemodelrewrite.md) resource allows platform administrators and model owners to control how inference requests are routed to specific models within an InferencePool.
 This capability is essential for managing model/adapter lifecycles without disrupting client applications.
 
 > [!IMPORTANT]
@@ -16,7 +20,7 @@ This capability is essential for managing model/adapter lifecycles without disru
 
 ## Prerequisites & Setup
 
-Follow the [getting started guide](../../getting-started/README.md) to set up the llm-d stack.
+Follow the [getting started guide](../../README.mdx) to set up the llm-d stack.
 
 In this guide, we use vLLM's native `lora_filesystem_resolver` to load adapters dynamically from a local directory. To enable this, configure your vLLM deployment with the following environment variables and ensure your adapters are accessible in the cache directory (e.g., mounted via a PVC or synchronized by an initContainer).
 

--- a/docs/operations/rollouts/blue-green-update.md
+++ b/docs/operations/rollouts/blue-green-update.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 2
+---
+
 # Blue-Green Update
 
 The goal of this guide is to show you how to perform incremental roll out operations,

--- a/docs/operations/router.md
+++ b/docs/operations/router.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 1
+sidebar_label: "Router Operations Guide"
+---
+
 # Router Operations Guide
 
 This guide covers operational best practices, high availability deployment architectures, and container sizing recommendations for the llm-d Router components.

--- a/docs/well-lit-paths/_category_.json
+++ b/docs/well-lit-paths/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "Well-Lit Paths", "position": 3, "collapsed": false }

--- a/docs/well-lit-paths/foundations/_category_.json
+++ b/docs/well-lit-paths/foundations/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "Foundations", "position": 1, "collapsed": false }

--- a/docs/well-lit-paths/foundations/flow-control.md
+++ b/docs/well-lit-paths/foundations/flow-control.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 7
+sidebar_label: "Apply Flow Control and Fairness"
+---
+
 # Flow Control
 
 Flow Control feature enables intelligent request queuing. Request queuing is useful for multiple reasons:

--- a/docs/well-lit-paths/foundations/optimized-baseline.md
+++ b/docs/well-lit-paths/foundations/optimized-baseline.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 1
+sidebar_label: "Deploy an Optimized Baseline"
+---
+
 # Optimized Baseline
 
 Traditional HTTP requests are fast, uniform, and cheap. Standard round-robin request scheduling strategies balance this load well.

--- a/docs/well-lit-paths/foundations/pd-disaggregation.md
+++ b/docs/well-lit-paths/foundations/pd-disaggregation.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 5
+sidebar_label: "Deploy Prefill/Decode Disaggregation"
+---
+
 # P/D Disaggregation
 
 LLM inference has two computationally distinct phases:

--- a/docs/well-lit-paths/foundations/precise-prefix-cache-routing.md
+++ b/docs/well-lit-paths/foundations/precise-prefix-cache-routing.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 3
+sidebar_label: "Enable Precise Prefix-Cache Aware Routing"
+---
+
 # Precise Prefix Cache Routing
 
 The model server is the most accurate source of truth for what's cached on its own GPUs and memory tiers. vLLM, SGLang and NVIDIA TensorRT-LLM publish every cache change as an event; llm-d subscribes to that stream, builds a near-real-time view of resident blocks across the fleet, and scores requests against it. The prefix-affinity score is combined with the standard load-aware scorers, similarly to the [Optimized Baseline](optimized-baseline.md) path.

--- a/docs/well-lit-paths/foundations/predicted-latency.md
+++ b/docs/well-lit-paths/foundations/predicted-latency.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 2
+sidebar_label: "Route Requests by Predicted Latency"
+---
+
 # Predicted Latency-Based Scheduling
 
 llm-d's [optimized baseline guide](./optimized-baseline.md) leverages load signals and prefix-cache affinity to schedule requests, combining the signals together with heuristics.

--- a/docs/well-lit-paths/foundations/tiered-prefix-cache.md
+++ b/docs/well-lit-paths/foundations/tiered-prefix-cache.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 4
+sidebar_label: "Configure a Tiered Prefix Cache"
+---
+
 # Tiered Prefix Cache
 
 Given the multi-turn nature of agentic workloads, prefix-cache re-use is a critical factor for high performance inference.

--- a/docs/well-lit-paths/foundations/wide-expert-parallelism.md
+++ b/docs/well-lit-paths/foundations/wide-expert-parallelism.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 6
+sidebar_label: "Scale MoE Models with Wide Expert Parallelism"
+---
+
 # Multi-Node Wide Expert Parallelism
 
 Very large MoE models like DeepSeek-R1 can consume 500GB+ of RAM just to hold the weights of the model, pressuring KV cache space for long context and high throughput serving. This problem is especially magnified for models with MLA attention, which replicates the KV cache when sharded with tensor parallelism.

--- a/docs/well-lit-paths/foundations/workload-autoscaling.md
+++ b/docs/well-lit-paths/foundations/workload-autoscaling.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 8
+sidebar_label: "Autoscale your Inference Pool"
+---
+
 # Workload Autoscaling
 
 Traditional autoscaling indicators like resource utilization metrics (CPU/GPU) are often lagging indicators — they only reflect saturation after it has already occurred, by which point latency has spiked and requests may be failing. For LLM inference, this problem is compounded by the fact that GPU utilization is often pegged near 100% during active batching regardless of actual load, making it an unreliable signal entirely.

--- a/docs/well-lit-paths/workloads/_category_.json
+++ b/docs/well-lit-paths/workloads/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "Workloads", "position": 2, "collapsed": false }

--- a/docs/well-lit-paths/workloads/agentic-serving.md
+++ b/docs/well-lit-paths/workloads/agentic-serving.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 1
+sidebar_label: "Serve Agentic Workloads"
+---
+
 # Agentic Serving
 
 Agents are becoming the dominant shape of production LLM traffic. A single user goal expands into

--- a/docs/well-lit-paths/workloads/batch-serving/_category_.json
+++ b/docs/well-lit-paths/workloads/batch-serving/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "Serve Batch Workloads", "position": 3 }

--- a/docs/well-lit-paths/workloads/batch-serving/asynchronous-processing.md
+++ b/docs/well-lit-paths/workloads/batch-serving/asynchronous-processing.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 1
+sidebar_label: "Asynchronous Processing"
+---
+
 # Asynchronous Processing
 
 The Asynchronous Processing path enables queue-based inference for latency-insensitive workloads or for filling "slack" capacity in your inference pool. It decouples request submission from execution, allowing clients to submit large volumes of work without maintaining a long-lived HTTP connection.

--- a/docs/well-lit-paths/workloads/batch-serving/batch-gateway.md
+++ b/docs/well-lit-paths/workloads/batch-serving/batch-gateway.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 2
+sidebar_label: "Batch Gateway"
+---
+
 # Batch Gateway
 
 Process large-scale batch inference jobs via an OpenAI-compatible API, enabling batch and interactive workloads to coexist efficiently on shared infrastructure.

--- a/docs/well-lit-paths/workloads/multimodal-serving.md
+++ b/docs/well-lit-paths/workloads/multimodal-serving.md
@@ -1,3 +1,8 @@
+---
+sidebar_position: 2
+sidebar_label: "Serve Multimodal Workloads"
+---
+
 # Multimodal Workload Serving
 
 Multimodal inputs are fundamentally changing the shape of production LLM traffic. 


### PR DESCRIPTION
## What this does

Right now the docs site (llm-d.ai) keeps its own idea of how our docs are laid out. Every time it syncs, it runs ~1,000 lines of path and link rewrites to reshape this repo's `docs/` into the site's structure. The downside: whenever we move or rename a page here, something on the site quietly breaks.

This PR closes that gap. From now on, the `docs/` folder *is* the site:

- the folder structure becomes the sidebar
- `_category_.json` files set each section's title, order, and collapse state
- page frontmatter handles labels and ordering within a section

The website then just mirrors this tree as-is: no remapping, no flattening, no slug rewriting.

## What changed

- Added `_category_.json` to every section
- Moved the intro to `docs/README.mdx` (it becomes the docs landing page) and added a short `docs/contributing.md`
- Sorted pages into folders that match the site: API CRDs under
  `api-reference/core-kubernetes/`, EPP docs under
  `architecture/core/router/epp/`, cloud providers under
  `infrastructure/providers/`, and so on
- Fixed a stale multimodal guide link in `epp-http-apis.md` 

## This needs to merge first

This pairs with a PR on llm-d.github.io that rewrites the site sync to read this new structure directly. **Merge this one first.** If the site PR lands before this, the dev docs build breaks, because the structure it expects won't exist yet. So: here first, then there.

See issue: llm-d/llm-d.github.io#377