### PR TITLE
fix(guides): track AWS ECR pd-disaggregation images as components, bump sglang to 0.5.13

### DIFF
--- a/guides/pd-disaggregation/modelserver/gpu/sglang/aws/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/sglang/aws/kustomization.yaml
@@ -3,11 +3,8 @@ kind: Kustomization
 resources:
   - ../base
 
-# TODO(#1894): Align AWS ECR sglang version with centralized gpu-sglang (v0.5.13.post1).
-images:
-  - name: docker.io/lmsysorg/sglang
-    newName: 763104351884.dkr.ecr.us-east-1.amazonaws.com/sglang
-    newTag: 0.5.12-gpu-py312-cu130-ubuntu24.04-ec2
+components:
+  - ../../../../../recipes/modelserver/components/images/aws-gpu-sglang
 
 patches:
   - path: patch-decode.yaml

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/aws/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/aws/kustomization.yaml
@@ -3,11 +3,8 @@ kind: Kustomization
 resources:
   - ../base
 
-# TODO(#1894): Track AWS ECR vllm image version alignment with centralized gpu-vllm.
-images:
-  - name: vllm/vllm-openai
-    newName: 763104351884.dkr.ecr.us-east-1.amazonaws.com/vllm
-    newTag: 0.23.0-gpu-py312-cu130-ubuntu22.04-ec2
+components:
+  - ../../../../../recipes/modelserver/components/images/aws-gpu-vllm
 
 patches:
   - path: patch-decode.yaml

--- a/guides/recipes/modelserver/components/images/README.md
+++ b/guides/recipes/modelserver/components/images/README.md
@@ -8,6 +8,8 @@ This directory contains Kustomize Components that define the **default container
 |-----------|-------|-------------|
 | `gpu-vllm` | `vllm/vllm-openai` | NVIDIA GPU with vLLM |
 | `gpu-sglang` | `docker.io/lmsysorg/sglang` | NVIDIA GPU with SGLang |
+| `aws-gpu-vllm` | `763104351884.dkr.ecr.us-east-1.amazonaws.com/vllm` | NVIDIA GPU with vLLM (AWS ECR mirror) |
+| `aws-gpu-sglang` | `763104351884.dkr.ecr.us-east-1.amazonaws.com/sglang` | NVIDIA GPU with SGLang (AWS ECR mirror) |
 | `amd-vllm` | `ghcr.io/llm-d/llm-d-rocm` | AMD GPU with vLLM |
 | `amd-sglang` | `docker.io/lmsysorg/sglang` | AMD GPU with SGLang (ROCm variant) |
 | `cpu-vllm` | `ghcr.io/llm-d/llm-d-cpu` | CPU with vLLM |

--- a/guides/recipes/modelserver/components/images/aws-gpu-sglang/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/aws-gpu-sglang/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+# AWS ECR mirror of the centralized gpu-sglang image (docker.io/lmsysorg/sglang:v0.5.13.post1).
+# Keep newTag's version aligned with gpu-sglang when that component is bumped.
+images:
+  - name: docker.io/lmsysorg/sglang
+    newName: 763104351884.dkr.ecr.us-east-1.amazonaws.com/sglang
+    newTag: 0.5.13-gpu-py312-cu130-ubuntu24.04-ec2

--- a/guides/recipes/modelserver/components/images/aws-gpu-vllm/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/aws-gpu-vllm/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+# AWS ECR mirror of the centralized gpu-vllm image (vllm/vllm-openai:v0.23.0).
+# Keep newTag's version aligned with gpu-vllm when that component is bumped.
+images:
+  - name: vllm/vllm-openai
+    newName: 763104351884.dkr.ecr.us-east-1.amazonaws.com/vllm
+    newTag: 0.23.0-gpu-py312-cu130-ubuntu22.04-ec2


### PR DESCRIPTION
/kind cleanup

resolves [#1894] (https://github.com/sudoalok/llm-d/issues/1894)

what this does
moves the aws ecr image overrides for the pd-disaggregation guides into tracked components (aws-gpu-vllm / aws-gpu-sglang), same pattern as the existing amd-sglang / tpu-vllm components, instead of leaving them inline in the overlays. also bumps the aws sglang image from 0.5.12 to 0.5.13 to match centralized v0.5.13.post1.

why the aws-specific images (came up on the issue)
these are aws deep learning containers (account 763104351884) published with efa support. the overlay targets p5en.48xlarge and requests vpc.amazonaws.com/efa, so the ecr image is the efa-enabled build (libfabric + aws-ofi-nccl) needed for the multi-node prefill/decode kv transfer over efa. the upstream docker hub images don't bundle the efa stack, so they aren't a drop-in swap for this path. tags are browsable in the public ecr gallery: gallery.ecr.aws/deep-learning-containers/sglang

the 0.5.13 tag is confirmed there (0.5.13-gpu-py312-cu130-ubuntu24.04-ec2). vllm 0.23.0 already matched, so no change there.