### PR TITLE
update-badge parameter

### DIFF
--- a/.github/workflows/nightly-e2e-flow-control-gke-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-flow-control-gke-acc-gpu-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 
 #  push:
 #    branches:
@@ -94,7 +99,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: flow-control-gke

--- a/.github/workflows/nightly-e2e-optimized-baseline-amd-acc-rocm-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-amd-acc-rocm-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 
 #  push:
 #    branches:
@@ -94,7 +99,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: optimized-baseline-rocm

--- a/.github/workflows/nightly-e2e-optimized-baseline-cks-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-cks-acc-gpu-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 
 #  push:
 #    branches:
@@ -94,7 +99,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: optimized-baseline-cks

--- a/.github/workflows/nightly-e2e-optimized-baseline-gke-acc-gpu-trtllm-x.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-gke-acc-gpu-trtllm-x.yaml
@@ -46,6 +46,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 
   schedule:
     - cron: '0 13 * * *'  # 13:00 UTC daily (staggered from the vLLM nightlies)
@@ -88,7 +93,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: optimized-baseline-gke-trtllm

--- a/.github/workflows/nightly-e2e-optimized-baseline-gke-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-gke-acc-gpu-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 
 #  push:
 #    branches:
@@ -94,7 +99,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: optimized-baseline-gke

--- a/.github/workflows/nightly-e2e-optimized-baseline-gke-acc-tpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-gke-acc-tpu-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
       tpu_chips:
         description: 'Total TPU chips to request (0 for simulated)'
         required: false
@@ -105,7 +110,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: optimized-baseline-gke-tpu

--- a/.github/workflows/nightly-e2e-optimized-baseline-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-ibm-acc-gpu-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 #  push:
 #    branches:
 #      - main
@@ -93,7 +98,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: optimized-baseline-ocp

--- a/.github/workflows/nightly-e2e-optimized-baseline-intel-acc-xpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-intel-acc-xpu-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 
 #  push:
 #    branches:
@@ -94,7 +99,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: optimized-baseline-xpu

--- a/.github/workflows/nightly-e2e-pd-disaggregation-amd-ci-acc-rocm-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-amd-ci-acc-rocm-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 
 #  push:
 #    branches:
@@ -94,7 +99,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: pd-disaggregation-amd

--- a/.github/workflows/nightly-e2e-pd-disaggregation-cks-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-cks-acc-gpu-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 
 #  push:
 #    branches:
@@ -94,7 +99,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: pd-disaggregation-cks

--- a/.github/workflows/nightly-e2e-pd-disaggregation-gke-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-gke-acc-gpu-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 
 #  push:
 #    branches:
@@ -96,7 +101,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: pd-disaggregation-gke

--- a/.github/workflows/nightly-e2e-pd-disaggregation-gke-acc-tpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-gke-acc-tpu-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
       tpu_chips:
         description: 'Total TPU chips to request (0 for simulated)'
         required: false
@@ -108,7 +113,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: pd-disaggregation-gke-tpu

--- a/.github/workflows/nightly-e2e-pd-disaggregation-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-ibm-acc-gpu-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 #  push:
 #    branches:
 #      - main
@@ -93,7 +98,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: pd-disaggregation-ocp

--- a/.github/workflows/nightly-e2e-pd-disaggregation-intel-acc-xpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-intel-acc-xpu-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 
 #  push:
 #    branches:
@@ -94,7 +99,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: pd-disaggregation-xpu

--- a/.github/workflows/nightly-e2e-precise-prefix-cache-routing-cks-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-routing-cks-acc-gpu-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 
 #  push:
 #    branches:
@@ -94,7 +99,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: precise-prefix-cache-routing-cks

--- a/.github/workflows/nightly-e2e-precise-prefix-cache-routing-gke-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-routing-gke-acc-gpu-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 
 #  push:
 #    branches:
@@ -94,7 +99,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: precise-prefix-cache-routing-gke

--- a/.github/workflows/nightly-e2e-precise-prefix-cache-routing-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-routing-ibm-acc-gpu-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 #  push:
 #    branches:
 #      - main
@@ -93,7 +98,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: precise-prefix-cache-routing-ocp

--- a/.github/workflows/nightly-e2e-precise-prefix-cache-routing-intel-acc-xpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-routing-intel-acc-xpu-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 
 #  push:
 #    branches:
@@ -94,7 +99,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: precise-prefix-cache-routing-xpu

--- a/.github/workflows/nightly-e2e-predicted-latency-routing-cks-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-routing-cks-acc-gpu-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 
 #  push:
 #    branches:
@@ -94,7 +99,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: predicted-latency-routing-cks

--- a/.github/workflows/nightly-e2e-predicted-latency-routing-gke-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-routing-gke-acc-gpu-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 
 #  push:
 #    branches:
@@ -94,7 +99,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: predicted-latency-routing-gke

--- a/.github/workflows/nightly-e2e-predicted-latency-routing-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-routing-ibm-acc-gpu-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 #  push:
 #    branches:
 #      - main
@@ -93,7 +98,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: predicted-latency-routing-ocp

--- a/.github/workflows/nightly-e2e-wide-ep-lws-cks-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-cks-acc-gpu-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 
 #  push:
 #    branches:
@@ -94,7 +99,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: wide-ep-lws-cks

--- a/.github/workflows/nightly-e2e-wide-ep-lws-gke-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-gke-acc-gpu-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 
 #  push:
 #    branches:
@@ -96,7 +101,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: wide-ep-lws-gke

--- a/.github/workflows/nightly-e2e-wide-ep-lws-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-ibm-acc-gpu-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 #  push:
 #    branches:
 #      - main
@@ -93,7 +98,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: wide-ep-lws-ocp

--- a/.github/workflows/nightly-e2e-workload-autoscaling-cks-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-workload-autoscaling-cks-acc-gpu-vllm-x.yaml
@@ -76,6 +76,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 
 permissions:
   contents: write
@@ -161,7 +166,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: wva-cks

--- a/.github/workflows/nightly-e2e-workload-autoscaling-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-workload-autoscaling-ibm-acc-gpu-vllm-x.yaml
@@ -76,6 +76,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 
 permissions:
   contents: write
@@ -161,7 +166,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: wva-ocp

--- a/.github/workflows/slash-test-nightly.yaml
+++ b/.github/workflows/slash-test-nightly.yaml
@@ -12,6 +12,7 @@ name: /test-nightly Slash Command
 #   prefill_pods=<number> Number of prefill pods (default: 1)
 #   harness=<name>        Benchmark harness (default: inference-perf)
 #   dry_run=<bool>        Run in dry-run mode, no benchmark executed (default: false)
+#   update_badge=<bool>   Update gh-pages badge (default: false for slash command)
 #
 # Optional parameters (passed to build-image nightly):
 #   platforms=<list>      Platforms to build (comma-separated: cuda,aws,gb200,xpu,cpu,all; default: cuda)
@@ -136,6 +137,7 @@ jobs:
                   '- `prefill_pods=<number>` — number of prefill pods (default: `1`)',
                   '- `harness=<name>` — benchmark harness (default: `inference-perf`)',
                   '- `dry_run=true` — validate setup without running the benchmark',
+                  '- `update_badge=true` — update gh-pages badge (default: skipped for slash commands)',
                   '',
                   'Optional parameters (applied to `build-image` only):',
                   '- `platforms=<list>` — platforms to build, comma-separated: cuda,aws,gb200,xpu,cpu,all (default: `cuda`)',
@@ -150,13 +152,14 @@ jobs:
             const input = match[1];
 
             // Parse optional key=value parameters (with defaults for quick PR validation)
-            const SUPPORTED_PARAMS = ['workload', 'decode_pods', 'prefill_pods', 'harness', 'platforms', 'dry_run'];
+            const SUPPORTED_PARAMS = ['workload', 'decode_pods', 'prefill_pods', 'harness', 'platforms', 'dry_run', 'update_badge'];
             const DEFAULT_PARAMS = {
               workload: 'sanity_random.yaml',
               decode_pods: '1',
               prefill_pods: '1',
               harness: 'inference-perf',
               platforms: 'cuda',
+              update_badge: 'false',
             };
             const params = { ...DEFAULT_PARAMS };
             const tokens = comment.split(/\s+/).slice(2);


### PR DESCRIPTION
## Summary
- Add optional parameters to the `/test-nightly` slash command for quick PR validation
- E2E benchmark nightlies automatically use lighter defaults when triggered via slash command: `workload=sanity_random.yaml`, `decode_pods=1`, `prefill_pods=1`, `harness=inference-perf`
- Badge updates are skipped by default when using the slash command (`update_badge=false`), preserving the nightly matrix in `release/README.md` for production health reporting only
- Parameters are only sent to E2E benchmark nightlies (`nightly-e2e-*` excluding WVA) — other nightlies are dispatched without benchmark params to avoid 422 errors
- Users can override any default explicitly (e.g. `workload=guide_optimized-baseline_1.yaml decode_pods=4 update_badge=true`)

## Usage

```
# Force badge update from slash command
/test-nightly optimized-baseline-gke-acc-gpu-vllm-x update_badge=true

# Non-benchmark nightlies still work (no param sent equals update_badge=false)
/test-nightly wva-cks-acc-gpu-vllm-x
```

## Supported parameters

| Parameter | Default (slash cmd) | Description |
|-----------|-------------------|-------------|
| `workload` | `sanity_random.yaml` | Workload profile |
| `decode_pods` | `1` | Number of decode pods |
| `prefill_pods` | `1` | Number of prefill pods |
| `harness` | `inference-perf` | Benchmark harness |
| `dry_run` | `false` | Validate setup without running benchmark |
| `update_badge` | `false` | Update gh-pages badge (skipped to preserve nightly matrix) |

## Badge behavior

| Trigger | Badge updated? |
|---------|----------------|
| Nightly cron (schedule) | Yes (default `update_badge=true`) |
| Manual dispatch (GitHub UI) | Yes (default `update_badge=true`) |   
| `/test-nightly` slash command | **No** (default `update_badge=false`) |
| `/test-nightly ... update_badge=true` | Yes (explicit override) |

> [!CAUTION]
> When running manually from the GitHub UI, badges **will** be updated by default (`update_badge=true`). Be careful about this @maugustosilva.