### PR TITLE
fix(ci): fix dry_run default value for wide-ep-lws update-badge jobs

### DIFF
--- a/.github/workflows/nightly-e2e-wide-ep-lws-cks-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-cks-acc-gpu-vllm-x.yaml
@@ -100,5 +100,5 @@ jobs:
       badge_name: wide-ep-lws-cks
       badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/.github/workflows/nightly-e2e-wide-ep-lws-gke-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-gke-acc-gpu-vllm-x.yaml
@@ -102,5 +102,5 @@ jobs:
       badge_name: wide-ep-lws-gke
       badge_label: "VLLM GPU"
       result: ${{ needs.nightly.result }}
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       failure_category: ${{ needs.nightly.outputs.failure_category }}


### PR DESCRIPTION
In PR #1928 , `inputs.dry_run` default value was modified to 'false', 

```
schedule:
    - cron: '0 1 * * *'

jobs:
  nightly:
    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
    with:
         dry_run: ${{ inputs.dry_run || 'false' }}
          ....
```

but it misses changing it for update-badge job

`dry_run: ${{ inputs.dry_run || 'true' }}`

When the CI is trigger by cron job rather than workflow_dispatch, this led that scheduled nightly job executes real benchmark ('inputs.dry_run =false') without inputs.dry_run, but update-badge job evaluated to 'true' and did not update badge, failing to reflect status.



