### PR TITLE
docs: list founders inline instead of logos on getting-started intro

### DIFF
--- a/docs/getting-started/README.mdx
+++ b/docs/getting-started/README.mdx
@@ -14,14 +14,7 @@ Built for agentic pipelines, LLMs, multimodal models, and high-throughput servin
 <div class="intro-founded">
   <div class="intro-cncf">
     <img class="intro-cncf-logo" src="https://llm-d.ai/img/CNCF-logo.svg" alt="CNCF" />
-    <span>llm-d is a CNCF Sandbox project founded by:</span>
-  </div>
-  <div class="intro-founded-logos">
-    <img class="intro-founder-logo" src="https://llm-d.ai/img/logos/IBM.png" alt="IBM" height="18" />
-    <img class="intro-founder-logo" src="https://llm-d.ai/img/logos/Redhat.png" alt="Red Hat" height="18" />
-    <img class="intro-founder-logo" src="https://llm-d.ai/img/logos/Google.png" alt="Google Cloud" height="18" />
-    <img class="intro-founder-logo" src="https://llm-d.ai/img/logos/Nvidia.png" alt="NVIDIA" height="18" />
-    <img class="intro-founder-logo" src="https://llm-d.ai/img/logos/Coreweave.png" alt="CoreWeave" height="18" />
+    <span>llm-d is a CNCF Sandbox project, founded by Red Hat, Google Cloud, IBM Research, CoreWeave, and NVIDIA.</span>
   </div>
 </div>
 


### PR DESCRIPTION
## What

On the getting-started intro page, replace the row of founder company logos under the "founded by" line with an inline sentence that names the founders:

> llm-d is a CNCF Sandbox project, founded by Red Hat, Google Cloud, IBM Research, CoreWeave, and NVIDIA.

The CNCF Sandbox logo is unchanged.

## Why

Cleaner, more readable intro that states the founders in prose rather than as a logo strip.

## Files changed

- `docs/getting-started/README.mdx` — updated the `.intro-cncf` sentence and removed the `.intro-founded-logos` block.

## Testing

- Compiled the updated `.mdx` with the MDX v3 compiler (same major version Docusaurus 3.10 uses) — compiles cleanly, JSX is well-formed.
- No links added or changed; the change only removes the five logo image references. Remaining links (`/getting-started/quickstart`, `https://prism.llm-d.ai/`, `/guides`, the CNCF logo) are untouched.
- Final newline present, no trailing whitespace.

Note: the `.intro-founded-logos` / `.intro-founder-logo` CSS rules live in the `llm-d.github.io` repo and become unused after this change; intentionally left untouched here since they're in a separate repo.
