### PR TITLE
docs: remove experimental positioning from batch gateway guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Model servers like [vLLM](https://docs.vllm.ai) and [SGLang](https://github.com/
 * **[Advanced KV-Cache Management:](https://llm-d.ai/docs/guides#advanced-kv-cache-management)** Increase the effective "working set size" for multi-turn requests with tiered offloading to CPU or disk and precise global indexing of the KV cache state.
 * **[Serving Large Models:](https://llm-d.ai/docs/guides#serving-large-models)** Optimize massive models (e.g., DeepSeek-R1, GPT-OSS) using prefill/decode disaggregation and wide expert-parallelism over fast accelerator interconnects.
 * **[Operational Excellence:](https://llm-d.ai/docs/guides#operational-excellence)** Ensure production stability with intelligent flow control for multi-tenant serving and proactive, SLO-aware autoscaling based on real-time inference signals.
-* **[Batch Processing:](https://llm-d.ai/docs/guides#experimental)** Efficiently manage large-scale offline inference with OpenAI-compatible Batch APIs and asynchronous processing to maximize hardware utilization.
+* **[Batch Processing:](https://llm-d.ai/docs/guides#workloads)** Efficiently manage large-scale offline inference with OpenAI-compatible Batch APIs and asynchronous processing to maximize hardware utilization.
 
 For a complete list of tested recipes and architectural patterns, see our [well-lit path guides](https://llm-d.ai/docs/guides). These guides provide benchmarked recipes and Helm charts to start serving quickly with best practices common to production deployments. Our intent is to eliminate the heavy lifting common in tuning and deploying generative AI inference on modern accelerators.
 

--- a/guides/README.md
+++ b/guides/README.md
@@ -33,12 +33,12 @@ We currently offer the following:
 Workload-centric guides — each provides the recommended, cohesive deployment for serving a workload, composing the capability guides above. See the [workload narratives](../docs/well-lit-paths/workloads/README.md) for overviews.
 
 * [Agentic Serving](./agentic-serving/README.md) - serve long, multi-turn, tool-using agentic workloads (e.g. coding agents) by composing prefix-aware routing, KV-cache offloading, and P/D disaggregation.
+* [Batch Gateway](./batch-gateway/README.md) - submit, track, and manage large-scale batch inference jobs via an OpenAI-compatible Batch API. Batch Gateway enables efficient processing of batch workloads coexisting with interactive workloads on shared infrastructure.
 * [Multimodal Serving](./multimodal-serving/README.md) - Deploy multimodal model serving (e.g., image/audio/video) using either aggregated routing or dedicated encode disaggregation topologies.
 
 ## Experimental Guides
 
 * [Asynchronous Processing](./asynchronous-processing/README.md) - process inference requests asynchronously using a queue-based architecture. This is ideal for latency-insensitive batch workloads or for filling "slack" capacity in your inference pool.
-* [Batch Gateway](./batch-gateway/README.md) - submit, track, and manage large-scale batch inference jobs via an OpenAI-compatible Batch API. Batch Gateway enables efficient processing of batch workloads coexisting with interactive workloads on shared infrastructure.
 * [Encode Disaggregation](./multimodal-serving/e-disaggregation/README.md) - Offload multimodal encoding (images, video, audio) to dedicated workers via E/PD or E/P/D topologies, freeing prefill/decode resources for text computation.
 
 ## Centralized Configuration

--- a/guides/batch-gateway/README.md
+++ b/guides/batch-gateway/README.md
@@ -1,4 +1,4 @@
-# [Experimental] Batch Gateway
+# Batch Gateway
 
 [Batch Gateway](https://github.com/llm-d/llm-d-batch-gateway) provides an OpenAI-compatible Batch API for submitting, tracking, and managing large-scale batch inference jobs. It is designed to efficiently process batch workloads alongside interactive workloads on shared infrastructure.
 
@@ -77,7 +77,7 @@ export INFERENCE_GW_URL="http://infra-inference-scheduling-inference-gateway-ist
 **From OCI Registry:**
 
 ```bash
-helm install batch-gateway oci://ghcr.io/llm-d-incubation/charts/batch-gateway \
+helm install batch-gateway oci://ghcr.io/llm-d/charts/batch-gateway \
   -n ${NAMESPACE} \
   --set processor.config.globalInferenceGateway.url="${INFERENCE_GW_URL}" \
   --set "apiserver.config.batchAPI.passThroughHeaders={Authorization}" \

--- a/guides/batch-gateway/README.md
+++ b/guides/batch-gateway/README.md
@@ -77,7 +77,7 @@ export INFERENCE_GW_URL="http://infra-inference-scheduling-inference-gateway-ist
 **From OCI Registry:**
 
 ```bash
-helm install batch-gateway oci://ghcr.io/llm-d/charts/batch-gateway \
+helm install batch-gateway oci://ghcr.io/llm-d-incubation/charts/batch-gateway \
   -n ${NAMESPACE} \
   --set processor.config.globalInferenceGateway.url="${INFERENCE_GW_URL}" \
   --set "apiserver.config.batchAPI.passThroughHeaders={Authorization}" \


### PR DESCRIPTION
## Why is this PR needed?
Batch Gateway has graduated, but the umbrella docs still had a few places that positioned it as experimental.
## What does this PR do?
- moves Batch Gateway out of the Experimental Guides section
- removes `[Experimental]` from the Batch Gateway guide title
- updates the root Batch Processing link to the workloads section
- updates the Batch Gateway OCI chart reference to `oci://ghcr.io/llm-d/charts/batch-gateway`
Async-related references are intentionally left unchanged for a later pass.
## How was this tested?
Manually verified the affected markdown files and cross-checked the chart path against the sibling `llm-d-batch-gateway` repo's chart and release metadata.
## Related Issues
Related to llm-d/llm-d-batch-gateway#501


Signed-off-by: Jooyeon Mok <jmok@redhat.com>