### PR TITLE
docs: backport founders inline-text intro to release-0.8 (#1960)

### DIFF
--- a/docs/getting-started/README.mdx
+++ b/docs/getting-started/README.mdx
@@ -14,14 +14,7 @@ Built for agentic pipelines, LLMs, multimodal models, and high-throughput servin
 <div class="intro-founded">
   <div class="intro-cncf">
     <img class="intro-cncf-logo" src="https://llm-d.ai/img/CNCF-logo.svg" alt="CNCF" />
-    <span>llm-d is a CNCF Sandbox project founded by:</span>
-  </div>
-  <div class="intro-founded-logos">
-    <img class="intro-founder-logo" src="https://llm-d.ai/img/logos/IBM.png" alt="IBM" height="18" />
-    <img class="intro-founder-logo" src="https://llm-d.ai/img/logos/Redhat.png" alt="Red Hat" height="18" />
-    <img class="intro-founder-logo" src="https://llm-d.ai/img/logos/Google.png" alt="Google Cloud" height="18" />
-    <img class="intro-founder-logo" src="https://llm-d.ai/img/logos/Nvidia.png" alt="NVIDIA" height="18" />
-    <img class="intro-founder-logo" src="https://llm-d.ai/img/logos/Coreweave.png" alt="CoreWeave" height="18" />
+    <span>llm-d is a CNCF Sandbox project, founded by Red Hat, Google Cloud, IBM Research, CoreWeave, and NVIDIA.</span>
   </div>
 </div>
 


### PR DESCRIPTION
## What

Backports #1960 (already merged to `main`) to the **`release-0.8`** branch: replaces the row of founder company logos under "founded by" on the getting-started intro with an inline sentence.

> llm-d is a CNCF Sandbox project, founded by Red Hat, Google Cloud, IBM Research, CoreWeave, and NVIDIA.

## Why

The llm-d.ai docs site builds each version's getting-started intro from its source branch: `dev` ← `main`, `v0.8.0` ← `release-0.8`. Because #1960 landed on `main` but not `release-0.8`, the **v0.8.0** docs render the old logos intro while **dev** shows the new inline-text version. This backport makes them consistent.

After this merges, the website's nightly release-docs sync picks it up and the next site build updates `/docs/0.8.0/` (and the canonical `/docs/`) to the new intro.
