### PR TITLE
docs: add Deploy section to batch-gateway well-lit path

### DIFF
--- a/docs/well-lit-paths/workloads/batch-serving/batch-gateway.md
+++ b/docs/well-lit-paths/workloads/batch-serving/batch-gateway.md
@@ -18,7 +18,7 @@ Process large-scale batch inference jobs via an OpenAI-compatible API, enabling 
 
 ## Deploy
 
-See the [Batch Gateway guide](../../../../guides/batch-gateway) for manifests and step-by-step deployment.
+- [Batch Gateway Deployment Guide](../../../../guides/batch-gateway) — full deployment instructions, configuration options, and troubleshooting.
 
 ## Related
 

--- a/docs/well-lit-paths/workloads/batch-serving/batch-gateway.md
+++ b/docs/well-lit-paths/workloads/batch-serving/batch-gateway.md
@@ -22,7 +22,6 @@ See the [Batch Gateway guide](../../../../guides/batch-gateway) for manifests an
 
 ## Related
 
-- [Batch Gateway Deployment Guide](../../../../guides/batch-gateway) — full deployment instructions, configuration options, and troubleshooting.
 - [Batch Gateway Architecture](../../../architecture/advanced/batch/batch-gateway.md) — components, data flow, and processing pipeline.
 - [Batch Gateway Repository](https://github.com/llm-d/llm-d-batch-gateway) — source code, Helm chart, platform-specific deployment guides, and demo scripts.
 - [Asynchronous Processing](../../../../guides/asynchronous-processing) — complementary queue-based async inference for individual requests.

--- a/docs/well-lit-paths/workloads/batch-serving/batch-gateway.md
+++ b/docs/well-lit-paths/workloads/batch-serving/batch-gateway.md
@@ -16,6 +16,10 @@ Process large-scale batch inference jobs via an OpenAI-compatible API, enabling 
 - S3-compatible storage or a shared PVC with `ReadWriteMany` (RWX) access mode for batch input/output files.
 - Helm 3.0+.
 
+## Deploy
+
+See the [Batch Gateway guide](../../../../guides/batch-gateway) for manifests and step-by-step deployment.
+
 ## Related
 
 - [Batch Gateway Deployment Guide](../../../../guides/batch-gateway) — full deployment instructions, configuration options, and troubleshooting.

--- a/guides/batch-gateway/README.md
+++ b/guides/batch-gateway/README.md
@@ -1,4 +1,4 @@
-# [Experimental] Batch Gateway
+# Batch Gateway
 
 [Batch Gateway](https://github.com/llm-d/llm-d-batch-gateway) provides an OpenAI-compatible Batch API for submitting, tracking, and managing large-scale batch inference jobs. It is designed to efficiently process batch workloads alongside interactive workloads on shared infrastructure.
 

--- a/guides/batch-gateway/README.md
+++ b/guides/batch-gateway/README.md
@@ -1,4 +1,4 @@
-# Batch Gateway
+# [Experimental] Batch Gateway
 
 [Batch Gateway](https://github.com/llm-d/llm-d-batch-gateway) provides an OpenAI-compatible Batch API for submitting, tracking, and managing large-scale batch inference jobs. It is designed to efficiently process batch workloads alongside interactive workloads on shared infrastructure.
 


### PR DESCRIPTION
## Summary

- Add a `## Deploy` section to the batch-gateway well-lit path page, linking to the deployment guide — matching the pattern used by other well-lit paths (optimized-baseline, flow-control)

The deployment guide link was previously only in the Related section at the bottom of the page.

## Test plan

- [x] Verify the well-lit path page renders correctly on llm-d.ai with the new Deploy section
- [x] Verify the guide link resolves correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)