### PR TITLE
fix: Add missing `update_badge` parameters to ci workflows

### DIFF
--- a/.github/workflows/nightly-e2e-precise-prefix-cache-gke-acc-tpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-gke-acc-tpu-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
       tpu_chips:
         description: 'Total TPU chips to request (0 for simulated)'
         required: false

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-lmcache.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-lmcache.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 
 #  push:
 #    branches:

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-native.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-native.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 
 #  push:
 #    branches:

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-tpu-vllm-native.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-tpu-vllm-native.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
       tpu_chips:
         description: 'Total TPU chips to request (0 for simulated)'
         required: false

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-ibm-cpu-gpu-vllm-native.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-ibm-cpu-gpu-vllm-native.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 #  push:
 #    branches:
 #      - main


### PR DESCRIPTION
in #1951, A new parameter was added to the /test-nightly default parameters sent to the workflow dispatch. A couple of the workflows did not have that parameter added to them and so running the `/test-nightly` command on them fails. This adds the parameter to the rest of the workflows.