### PR TITLE
feat(monitoring): ship default EPP Prometheus alerting rules

### DIFF
--- a/docs/operations/observability/README.md
+++ b/docs/operations/observability/README.md
@@ -11,7 +11,8 @@ Monitor and debug llm-d deployments with Prometheus metrics, Grafana dashboards,
 * [Metrics](./metrics.md) — Enable and interpret model server and EPP metrics
 * [Distributed Tracing](./tracing.md) — Configure OpenTelemetry across vLLM, the routing proxy, and the EPP
 * [PromQL Reference](./promql.md) — Ready-to-use queries for dashboards and alerting
+* [Alerting](./alerting.md) — Apply the default EPP Prometheus alerting rules
 
 ## Runnable assets
 
-Scripts, Grafana dashboard JSON, and tracing manifests live in [`guides/recipes/observability/`](../../../guides/recipes/observability/) in the llm-d repository (not published as website pages).
+Scripts, Grafana dashboard JSON, alerting rules, and tracing manifests live in [`guides/recipes/observability/`](../../../guides/recipes/observability/) in the llm-d repository (not published as website pages).

--- a/docs/operations/observability/alerting.md
+++ b/docs/operations/observability/alerting.md
@@ -1,0 +1,110 @@
+# Alerting
+
+This page covers a default set of Prometheus alerting rules for the EPP (Endpoint Picker). For Prometheus and Grafana installation, see [Observability Setup](./setup.md) first, and for the metrics these alerts are built on, see [Metrics](./metrics.md).
+
+The rules ship as a [`PrometheusRule`](https://prometheus-operator.dev/docs/getting-started/design/#prometheusrule) custom resource, so they require the Prometheus Operator (bundled with the kube-prometheus-stack installed by the [setup guide](./setup.md)).
+
+> [!NOTE]
+> Commands on this page use `${NAMESPACE}` for the namespace where your llm-d workload runs. Set it before following along:
+> ```bash
+> export NAMESPACE=<your-llm-d-namespace>
+> ```
+
+## Prerequisites
+
+- A running llm-d deployment with an InferencePool — see the [quickstart](../../getting-started/quickstart.md) if needed
+- Prometheus and the Prometheus Operator installed — see [Observability Setup](./setup.md)
+- EPP metrics being scraped — see [Metrics](./metrics.md) (verify the `epp-servicemonitor` ServiceMonitor exists)
+
+## Step 1: Apply the Alerting Rules
+
+Apply the bundled `PrometheusRule`:
+
+```bash
+kubectl apply -n ${NAMESPACE} -f guides/recipes/observability/alerts/epp-alerting-rules.yaml
+```
+
+> [!NOTE]
+> The bundled [`install-prometheus-grafana.sh`](../../../guides/recipes/observability/install-prometheus-grafana.sh) opens Prometheus' `ruleSelector` so any `PrometheusRule` is discovered (central mode). If you run the installer in individual/scoped mode, Prometheus only selects rules carrying the `monitoring-ns: ${NAMESPACE}` label in a namespace with the same label — add that label to the `PrometheusRule` (and its namespace) to match your `ServiceMonitor`. If you bring your own Prometheus, make sure its `ruleSelector` matches the `app: epp-metrics` label on this resource.
+
+## Step 2: Verify
+
+Confirm the rule was created:
+
+```bash
+kubectl get prometheusrules -n ${NAMESPACE}
+```
+
+Expected output:
+
+```text
+NAME                 AGE
+epp-alerting-rules   10s
+```
+
+Then open the Prometheus UI and check that the rules loaded under **Status → Rule Health** (or `http://localhost:9090/rules` after port-forwarding — see [Metrics](./metrics.md#step-5-query-metrics)). You should see the `epp.availability` and `epp.selfhealth` groups.
+
+## Alert Reference
+
+All metric names use the current `llm_d_epp_*` prefix. Thresholds and `for:` windows are conservative defaults — tune them for your traffic profile (see [Customization](#customization)).
+
+### Availability and errors (`epp.availability`)
+
+| Alert | Severity | Fires when | Why it matters |
+|-------|----------|-----------|----------------|
+| `EPPHighErrorRatio` | warning | Error ratio > 5% for 10m | Backend or routing failures are degrading a meaningful share of requests |
+| `EPPCriticalErrorRatio` | critical | Error ratio > 20% for 5m | The inference path is likely broken, not just degraded |
+| `EPPNoReadyEndpoints` | critical | `llm_d_epp_ready_endpoints == 0` for 2m | The pool has no routable endpoints — every request fails |
+| `EPPMetricsAbsent` | critical | `absent(llm_d_epp_ready_endpoints)` for 5m | Coarse cluster-wide signal: no EPP metrics from any pool — every EPP is down or scraping stopped entirely (a silent observability gap) |
+
+The error-ratio alerts are `0/0`-safe: with no traffic the expression yields no value and stays silent. On very low-volume workloads you may see startup flapping — add a request-rate floor with `and sum(rate(llm_d_epp_request_total[5m])) > N`.
+
+> [!NOTE]
+> `EPPMetricsAbsent` uses `absent()`, which only fires when *no* `llm_d_epp_ready_endpoints` series exist at all. In multi-pool deployments, one pool's EPP can die while the others keep reporting — its series vanish rather than report `0`, so neither this alert nor `EPPNoReadyEndpoints` fires for it. For per-pool coverage, alert on series that existed recently but disappeared:
+>
+> ```promql
+> llm_d_epp_ready_endpoints offset 15m unless llm_d_epp_ready_endpoints
+> ```
+>
+> This fires once per vanished pool, at the cost of a fixed lookback window (a pool removed on purpose also fires until the offset ages out).
+
+### EPP self-health (`epp.selfhealth`)
+
+| Alert | Severity | Fires when | Why it matters |
+|-------|----------|-----------|----------------|
+| `EPPDataLayerPollErrors` | warning | `llm_d_epp_datalayer_poll_errors_total` increasing for 10m | A data source failed to poll — scheduling may be running on stale endpoint state |
+| `EPPDataLayerExtractErrors` | warning | `llm_d_epp_datalayer_extract_errors_total` increasing for 10m | A data extractor failed — scheduling may be running on stale state |
+| `EPPExtProcStreamErrors` | warning | `llm_d_epp_extproc_streams_total{code!~"OK\|Canceled"}` increasing for 10m | Envoy↔EPP `ext_proc` streams are terminating abnormally |
+
+> [!NOTE]
+> `EPPExtProcStreamErrors` relies on opt-in metrics enabled by the EPP `--enable-grpc-stream-metrics` flag. When the flag is unset, the series are absent and the alert never fires. The matcher excludes `OK` and `Canceled` (a normal client disconnect) — adjust it for your environment.
+
+## Customization
+
+These rules are a starting point, not a tuned policy. Common adjustments:
+
+- **Thresholds and durations** — edit the `expr` comparison (`> 0.05`) and the `for:` window per alert to match your SLOs and noise tolerance.
+- **Routing** — the `severity: warning|critical` labels are the hook for Alertmanager routing (e.g. page on `critical`, Slack on `warning`). Configure routes in your Alertmanager config.
+- **Scope** — to alert per pool or per model, add a `by (...)` clause to the error-ratio expressions using labels such as `name` or `model_name`.
+
+See the [PromQL Reference](./promql.md) for more queries you can promote into alerts (for example latency SLOs and flow-control saturation).
+
+## Cleanup
+
+```bash
+kubectl delete -n ${NAMESPACE} -f guides/recipes/observability/alerts/epp-alerting-rules.yaml
+```
+
+## Troubleshooting
+
+### Rules don't appear in the Prometheus UI
+
+1. Confirm the resource exists: `kubectl get prometheusrules -n ${NAMESPACE}`.
+2. Confirm Prometheus' `ruleSelector` matches the rule's labels. The bundled installer sets `ruleSelectorNilUsesHelmValues: false` with an open `ruleSelector` in central mode; in scoped mode add the `monitoring-ns` label (see [Step 1](#step-1-apply-the-alerting-rules)).
+3. Check the Prometheus Operator logs for rule-rejection errors: `kubectl logs -n llm-d-monitoring -l app.kubernetes.io/name=prometheus-operator`.
+
+### An alert never fires
+
+- `EPPExtProcStreamErrors` needs the EPP `--enable-grpc-stream-metrics` flag (see the note above).
+- Error-ratio alerts only evaluate once there is traffic — see the `0/0`-safe note above.
+- Self-health counters only produce series after the first error occurs.

--- a/docs/operations/observability/promql.md
+++ b/docs/operations/observability/promql.md
@@ -1,6 +1,6 @@
 # PromQL Query Reference
 
-Ready-to-use PromQL queries for monitoring llm-d deployments. Use these in the Prometheus UI or as the basis for Grafana panels.
+Ready-to-use PromQL queries for monitoring llm-d deployments. Use these in the Prometheus UI or as the basis for Grafana panels. For a default set of ready-to-apply alerts built on these metrics, see [Alerting](./alerting.md).
 
 To generate traffic and populate error metrics for testing, use the [traffic generation script](../../../guides/recipes/observability/generate-traffic-basic.sh).
 

--- a/guides/recipes/observability/alerts/epp-alerting-rules.yaml
+++ b/guides/recipes/observability/alerts/epp-alerting-rules.yaml
@@ -1,0 +1,97 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: epp-alerting-rules
+  labels:
+    app: epp-metrics
+spec:
+  groups:
+  # ---------------------------------------------------------------------------
+  # Availability and errors
+  # ---------------------------------------------------------------------------
+  - name: epp.availability
+    rules:
+    - alert: EPPHighErrorRatio
+      # Fraction of EPP requests returning an error. 0/0 yields no value, so this
+      # stays silent when there is no traffic. If your workload is low-volume and
+      # you see flapping at startup, add a request-rate floor with `and ... > N`.
+      expr: |
+        sum(rate(llm_d_epp_request_error_total[5m]))
+          / sum(rate(llm_d_epp_request_total[5m]))
+          > 0.05
+      for: 10m
+      labels:
+        severity: warning
+      annotations:
+        summary: "EPP error ratio above 5%"
+        description: "EPP request error ratio has been above 5% for 10m (current {{ $value | humanizePercentage }})."
+    - alert: EPPCriticalErrorRatio
+      expr: |
+        sum(rate(llm_d_epp_request_error_total[5m]))
+          / sum(rate(llm_d_epp_request_total[5m]))
+          > 0.20
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: "EPP error ratio above 20%"
+        description: "EPP request error ratio has been above 20% for 5m (current {{ $value | humanizePercentage }}). The inference path is likely degraded."
+    - alert: EPPNoReadyEndpoints
+      # The pool has zero ready endpoints, so the EPP cannot route any request.
+      expr: llm_d_epp_ready_endpoints == 0
+      for: 2m
+      labels:
+        severity: critical
+      annotations:
+        summary: "EPP pool {{ $labels.name }} has no ready endpoints"
+        description: "llm_d_epp_ready_endpoints has been 0 for pool {{ $labels.name }} for 2m. The pool is unroutable."
+    - alert: EPPMetricsAbsent
+      # absent() only fires when NO llm_d_epp_ready_endpoints series exist at all, so
+      # this is a coarse, cluster-wide signal: every EPP is down or the ServiceMonitor
+      # stopped scraping entirely. With multiple pools it will NOT catch a single
+      # pool's EPP dying while others keep reporting - a dead EPP's series vanish
+      # rather than report 0, so EPPNoReadyEndpoints stays silent for it too. For
+      # per-pool coverage, see the "vanished series" pattern in the alerting docs.
+      expr: absent(llm_d_epp_ready_endpoints)
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: "No EPP metrics are being scraped (cluster-wide)"
+        description: "No llm_d_epp_ready_endpoints samples from any pool for 5m. All EPP metric scraping has stopped - every EPP is down or the ServiceMonitor is broken cluster-wide."
+
+  # ---------------------------------------------------------------------------
+  # EPP self-health
+  # ---------------------------------------------------------------------------
+  - name: epp.selfhealth
+    rules:
+    - alert: EPPDataLayerPollErrors
+      # A data source failed to poll, so scheduling may be running on stale
+      # endpoint state. This is otherwise invisible.
+      expr: sum by (source_type) (rate(llm_d_epp_datalayer_poll_errors_total[5m])) > 0
+      for: 10m
+      labels:
+        severity: warning
+      annotations:
+        summary: "EPP data layer poll errors for source {{ $labels.source_type }}"
+        description: "llm_d_epp_datalayer_poll_errors_total is increasing for source {{ $labels.source_type }}. Scheduling may be using stale data."
+    - alert: EPPDataLayerExtractErrors
+      expr: sum by (source_type, extractor_type) (rate(llm_d_epp_datalayer_extract_errors_total[5m])) > 0
+      for: 10m
+      labels:
+        severity: warning
+      annotations:
+        summary: "EPP data layer extract errors ({{ $labels.source_type }}/{{ $labels.extractor_type }})"
+        description: "llm_d_epp_datalayer_extract_errors_total is increasing for {{ $labels.source_type }}/{{ $labels.extractor_type }}. Scheduling may be using stale data."
+    # ext_proc stream metrics are opt-in (EPP flag --enable-grpc-stream-metrics).
+    # When the flag is unset these series are absent and the alert below simply
+    # never fires. "Abnormal" excludes OK and Canceled (the latter is a normal
+    # client disconnect); tune the matcher for your environment.
+    - alert: EPPExtProcStreamErrors
+      expr: sum by (code) (rate(llm_d_epp_extproc_streams_total{code!~"OK|Canceled"}[5m])) > 0
+      for: 10m
+      labels:
+        severity: warning
+      annotations:
+        summary: "EPP ext_proc streams terminating with {{ $labels.code }}"
+        description: "ext_proc gRPC streams are completing with status {{ $labels.code }}. Envoy<->EPP request processing may be failing."

--- a/guides/recipes/observability/install-prometheus-grafana.sh
+++ b/guides/recipes/observability/install-prometheus-grafana.sh
@@ -444,6 +444,9 @@ $(if [[ -n "$WEB_TLS_CONFIG" ]]; then echo -e "$WEB_TLS_CONFIG"; fi)
     podMonitorSelectorNilUsesHelmValues: false
     podMonitorSelector: {}
     podMonitorNamespaceSelector: {}
+    ruleSelectorNilUsesHelmValues: false
+    ruleSelector: {}
+    ruleNamespaceSelector: {}
     maximumStartupDurationSeconds: 300
     resources:
       limits:
@@ -500,6 +503,13 @@ $(if [[ -n "$WEB_TLS_CONFIG" ]]; then echo -e "$WEB_TLS_CONFIG"; fi)
       matchLabels:
         ${MONITORING_LABEL_KEY}: "${MONITORING_LABEL_VALUE}"
     podMonitorNamespaceSelector:
+      matchLabels:
+        ${MONITORING_LABEL_KEY}: "${MONITORING_LABEL_VALUE}"
+    ruleSelectorNilUsesHelmValues: false
+    ruleSelector:
+      matchLabels:
+        ${MONITORING_LABEL_KEY}: "${MONITORING_LABEL_VALUE}"
+    ruleNamespaceSelector:
       matchLabels:
         ${MONITORING_LABEL_KEY}: "${MONITORING_LABEL_VALUE}"
     maximumStartupDurationSeconds: 300


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it

Ships a default set of EPP (Endpoint Picker) Prometheus alerting rules as a `PrometheusRule` under `guides/recipes/observability/alerts/`, plus a docs page at `docs/operations/observability/alerting.md`. The repo exposes a rich `llm_d_epp_*` metric set and documents PromQL for it, but shipped no alerts, so every deployment had to hand-write them.

This relocates the work from llm-d/llm-d-router#1668 into this repo, per @ahg-g  and @gyliu513  request to keep deployable user guides and observability artifacts in `llm-d/llm-d` under `guides/recipes/observability` and `docs/operations/observability`. Metric names are aligned to this repo's current `llm_d_epp_*` prefix (the router used the legacy `llm_d_router_epp_*`).

This is the first slice — availability/errors and EPP self-health — using metric names that are stable today. Latency SLO and flow-control saturation alerts can follow as separate PRs.

### Alerts added

**`epp.availability`**
- `EPPHighErrorRatio` / `EPPCriticalErrorRatio` — error ratio (warning 5%, critical 20%), `0/0`-safe so they stay silent with no traffic
- `EPPNoReadyEndpoints` — `ready_endpoints == 0`, the pool is unroutable
- `EPPMetricsAbsent` — `absent(ready_endpoints)`, catches a dead EPP or broken ServiceMonitor

**`epp.selfhealth`**
- `EPPDataLayerPollErrors` / `EPPDataLayerExtractErrors` — scheduling running on stale data
- `EPPExtProcStreamErrors` — abnormal ext_proc stream terminations (opt-in metric)

### Also included
- `install-prometheus-grafana.sh`: opens Prometheus' `ruleSelector` (mirrors the existing `serviceMonitor`/`podMonitor` treatment) so applied `PrometheusRule`s are actually discovered — the analog of the `kind-dev-env.sh` change in llm-d/llm-d-router#1668.
- Wired the new docs page into the observability `README.md` and cross-linked from `promql.md`.

## Which issue(s) this PR resolves

Relocates and supersedes llm-d/llm-d-router#1668 (originally tracked by llm-d/llm-d-router#1635), per maintainer direction to host observability artifacts and docs in this repo. The router PR will be closed once this merges.