### PR TITLE
support ipv6 setting

### DIFF
--- a/guides/pd-disaggregation/README.tpu.md
+++ b/guides/pd-disaggregation/README.tpu.md
@@ -53,6 +53,7 @@ export STACK_NAME="tpu-v7-qwen3-5-pd"
 
 Deploy the router in either Standalone or Gateway mode by following the exact instructions in the **[Deploy the llm-d Router](./README.md#1-deploy-the-llm-d-router)** section of the main guide.
 
+
 ### 2. Deploy the TPU Model Server
 
 Once the router is deployed, apply the Kustomize overlays specifically configured for your TPU architecture:
@@ -68,6 +69,7 @@ kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/t
 ```
 
 *(Note: If you have monitoring enabled, you can optionally apply the monitoring components as described in the [main guide](./README.md#3-enable-monitoring-optional)).*
+
 
 ## Verification
 

--- a/guides/pd-disaggregation/modelserver/tpu/v7/vllm/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/tpu/v7/vllm/patch-decode.yaml
@@ -10,22 +10,33 @@ spec:
         cloud.google.com/gke-tpu-accelerator: "tpu7x"
       containers:
         - name: modelserver
+          command: ["/bin/bash", "-c"]
           args:
-            - "Qwen/Qwen3.5-397B-A17B-FP8"
-            - "--max-model-len=9216"
-            - "--max-num-batched-tokens=8192"
-            - "--max-num-seqs=512"
-            - "--tensor-parallel-size=8"
-            - "--language-model-only"
-            - "--limit-mm-per-prompt"
-            - '{"image": 0, "video": 0}'
-            - "--kv-cache-dtype=fp8"
-            - "--enable-expert-parallel"
-            - "--no-disable-hybrid-kv-cache-manager"
-            - "--kv-transfer-config"
-            - '{"kv_connector":"TPUConnectorHMA","kv_connector_module_path":"tpu_inference.distributed.tpu_connector_hma","kv_role":"kv_consumer"}'
-            - "--port=8200"
-            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+          - |
+            set -euo pipefail
+
+            if [[ "${POD_IP}" == *":"* ]]; then
+              HOST_ADDR="::"
+              export VLLM_HOST_IP="[${POD_IP}]"
+            else
+              HOST_ADDR="0.0.0.0"
+              export VLLM_HOST_IP="${POD_IP}"
+            fi
+
+            exec vllm serve Qwen/Qwen3.5-397B-A17B-FP8 \
+              --host "${HOST_ADDR}" \
+              --max-model-len=9216 \
+              --max-num-batched-tokens=8192 \
+              --max-num-seqs=512 \
+              --tensor-parallel-size=8 \
+              --language-model-only \
+              --limit-mm-per-prompt '{"image": 0, "video": 0}' \
+              --kv-cache-dtype=fp8 \
+              --enable-expert-parallel \
+              --no-disable-hybrid-kv-cache-manager \
+              --kv-transfer-config '{"kv_connector":"TPUConnectorHMA","kv_connector_module_path":"tpu_inference.distributed.tpu_connector_hma","kv_role":"kv_consumer","kv_ip":"$(POD_IP)"}' \
+              --port=8200 \
+              --disable-access-log-for-endpoints=/health,/metrics,/v1/models
           resources:
             limits:
               cpu: "200"

--- a/guides/pd-disaggregation/modelserver/tpu/v7/vllm/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/tpu/v7/vllm/patch-prefill.yaml
@@ -10,22 +10,33 @@ spec:
         cloud.google.com/gke-tpu-accelerator: "tpu7x"
       containers:
         - name: modelserver
+          command: ["/bin/bash", "-c"]
           args:
-            - "Qwen/Qwen3.5-397B-A17B-FP8"
-            - "--max-model-len=9216"
-            - "--max-num-batched-tokens=8192"
-            - "--max-num-seqs=512"
-            - "--tensor-parallel-size=8"
-            - "--language-model-only"
-            - "--limit-mm-per-prompt"
-            - '{"image": 0, "video": 0}'
-            - "--kv-cache-dtype=fp8"
-            - "--enable-expert-parallel"
-            - "--no-disable-hybrid-kv-cache-manager"
-            - "--kv-transfer-config"
-            - '{"kv_connector":"TPUConnectorHMA","kv_connector_module_path":"tpu_inference.distributed.tpu_connector_hma","kv_role":"kv_producer"}'
-            - "--port=8000"
-            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+          - |
+            set -euo pipefail
+
+            if [[ "${POD_IP}" == *":"* ]]; then
+              HOST_ADDR="::"
+              export VLLM_HOST_IP="[${POD_IP}]"
+            else
+              HOST_ADDR="0.0.0.0"
+              export VLLM_HOST_IP="${POD_IP}"
+            fi
+
+            exec vllm serve Qwen/Qwen3.5-397B-A17B-FP8 \
+              --host "${HOST_ADDR}" \
+              --max-model-len=9216 \
+              --max-num-batched-tokens=8192 \
+              --max-num-seqs=512 \
+              --tensor-parallel-size=8 \
+              --language-model-only \
+              --limit-mm-per-prompt '{"image": 0, "video": 0}' \
+              --kv-cache-dtype=fp8 \
+              --enable-expert-parallel \
+              --no-disable-hybrid-kv-cache-manager \
+              --kv-transfer-config '{"kv_connector":"TPUConnectorHMA","kv_connector_module_path":"tpu_inference.distributed.tpu_connector_hma","kv_role":"kv_producer","kv_ip":"$(POD_IP)"}' \
+              --port=8000 \
+              --disable-access-log-for-endpoints=/health,/metrics,/v1/models
           resources:
             limits:
               cpu: "200"


### PR DESCRIPTION
## add IPv6 deployment instructions to TPU guide
- Document steps to configure and install the standalone router for IPv6 setups.
- Add instructions for updating Envoy listener addresses to `::` in values.yaml.
- Document how to enable the `USE_IPV6` environment variable in the TPU v7x model server prefill and decode patches.