### PR TITLE
docs: fix broken well-lit-path links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ llm-d is a [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io/) sand
 
 Model servers like [vLLM](https://docs.vllm.ai) and [SGLang](https://github.com/sgl-project/sglang) handle efficiently running large language models on accelerators. llm-d provides state-of-the-art orchestration and optimizations above model servers to serve high-scale real-world traffic efficiently and reliably. Our offerings are organized into four core themes:
 
-* **[Intelligent Routing:](https://llm-d.ai/docs/guides#intelligent-routing)** Maximize performance with prefix-cache and load-aware balancing, including experimental predicted latency-based scheduling to decrease latency and increase throughput.
-* **[Advanced KV-Cache Management:](https://llm-d.ai/docs/guides#advanced-kv-cache-management)** Increase the effective "working set size" for multi-turn requests with tiered offloading to CPU or disk and precise global indexing of the KV cache state.
-* **[Serving Large Models:](https://llm-d.ai/docs/guides#serving-large-models)** Optimize massive models (e.g., DeepSeek-R1, GPT-OSS) using prefill/decode disaggregation and wide expert-parallelism over fast accelerator interconnects.
-* **[Operational Excellence:](https://llm-d.ai/docs/guides#operational-excellence)** Ensure production stability with intelligent flow control for multi-tenant serving and proactive, SLO-aware autoscaling based on real-time inference signals.
-* **[Batch Processing:](https://llm-d.ai/docs/guides#experimental)** Efficiently manage large-scale offline inference with OpenAI-compatible Batch APIs and asynchronous processing to maximize hardware utilization.
+* **[Intelligent Routing:](https://llm-d.ai/docs/well-lit-paths/optimized-baseline)** Maximize performance with prefix-cache and load-aware balancing, including experimental predicted latency-based scheduling to decrease latency and increase throughput.
+* **[Advanced KV-Cache Management:](https://llm-d.ai/docs/well-lit-paths/tiered-prefix-cache)** Increase the effective "working set size" for multi-turn requests with tiered offloading to CPU or disk and precise global indexing of the KV cache state.
+* **[Serving Large Models:](https://llm-d.ai/docs/well-lit-paths/wide-expert-parallelism)** Optimize massive models (e.g., DeepSeek-R1, GPT-OSS) using prefill/decode disaggregation and wide expert-parallelism over fast accelerator interconnects.
+* **[Operational Excellence:](https://github.com/llm-d/llm-d/tree/main/docs/operations)** Ensure production stability with intelligent flow control for multi-tenant serving and proactive, SLO-aware autoscaling based on real-time inference signals.
+* **[Batch Processing:](https://github.com/llm-d/llm-d/tree/main/docs/well-lit-paths/workloads/batch-serving)** Efficiently manage large-scale offline inference with OpenAI-compatible Batch APIs and asynchronous processing to maximize hardware utilization.
 
 For a complete list of tested recipes and architectural patterns, see our [well-lit path guides](https://llm-d.ai/docs/guides). These guides provide benchmarked recipes and Helm charts to start serving quickly with best practices common to production deployments. Our intent is to eliminate the heavy lifting common in tuning and deploying generative AI inference on modern accelerators.
 


### PR DESCRIPTION
## What

Recent docs-site and repo restructuring broke the five "core themes" links in the README. The old `https://llm-d.ai/docs/guides#...` anchors no longer resolve. This PR points each to its current destination:

| Theme | New target |
| --- | --- |
| Intelligent Routing | https://llm-d.ai/docs/well-lit-paths/optimized-baseline |
| Advanced KV-Cache Management | https://llm-d.ai/docs/well-lit-paths/tiered-prefix-cache |
| Serving Large Models | https://llm-d.ai/docs/well-lit-paths/wide-expert-parallelism |
| Operational Excellence | https://github.com/llm-d/llm-d/tree/main/docs/operations |
| Batch Processing | https://github.com/llm-d/llm-d/tree/main/docs/well-lit-paths/workloads/batch-serving |

