### PR TITLE
[Fix] Add new config required by `actions/checkout@v7`

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -95,6 +95,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref || '' }}
+          allow-unsafe-pr-checkout: true
       - uses: dorny/paths-filter@v4
         if: github.event_name != 'workflow_dispatch' && inputs.force_build != true && inputs.platforms == ''
         id: filter


### PR DESCRIPTION
The `allow-unsafe-pr-checkout: true input is a safety toggle introduced in actions/checkout v7. It allows a workflow to bypass security blocks and check out untrusted pull request code from public forks.

This is required for our CI/CD testing.