### PR TITLE
fix: WVA HPA guide fails to install in non-default namespaces

### DIFF
--- a/guides/workload-autoscaling/README.wva.md
+++ b/guides/workload-autoscaling/README.wva.md
@@ -49,7 +49,7 @@ export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
 ```
 
 > [!NOTE]
-> **Namespaced-Scoped Installation**: this guide installs WVA to watch resources only in the `llm-d-optimized-baseline` namespace. For cluster-wide autoscaling, set `--watch-namespace=""` in the controller deployment.
+> **Namespaced-Scoped Installation**: this guide installs WVA to watch resources only in the `${WVA_NAMESPACE}` namespace. For cluster-wide autoscaling, set `--watch-namespace=""` in the controller deployment.
 
 ## Installation
 
@@ -87,11 +87,20 @@ export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
     kubectl apply -k github.com/llm-d/llm-d-workload-variant-autoscaler/config/base/crd?ref=main
     ```
 
-5. Install WVA controller with Kustomize:
+5. Install the WVA controller. Point the overlay at `${WVA_NAMESPACE}`, then apply it
+   (the overlay carries its own namespace, so no `-n` is needed):
 
     ```bash
-    kubectl apply -k ${REPO_ROOT}/guides/workload-autoscaling/wva-config/platform/${PLATFORM} -n ${WVA_NAMESPACE}
+    (cd ${REPO_ROOT}/guides/workload-autoscaling/wva-config/platform/${PLATFORM} \
+       && kustomize edit set namespace ${WVA_NAMESPACE})
+
+    kubectl apply -k ${REPO_ROOT}/guides/workload-autoscaling/wva-config/platform/${PLATFORM}
     ```
+
+    > [!NOTE]
+    > This requires the [`kustomize`](https://kustomize.io/) CLI and updates the
+    > `namespace:` field in `wva-config/platform/${PLATFORM}/kustomization.yaml`. To
+    > revert that local change afterwards, run `git checkout` on the file.
 
 ## Verify Installation
 
@@ -241,7 +250,10 @@ kubectl delete -k optimized-baseline-autoscaling/hpa -n ${NAMESPACE}
 Remove the WVA controller with Kustomize:
 
 ```bash
-kubectl delete -k ${REPO_ROOT}/guides/workload-autoscaling/wva-config/platform/${PLATFORM} -n ${WVA_NAMESPACE}
+(cd ${REPO_ROOT}/guides/workload-autoscaling/wva-config/platform/${PLATFORM} \
+   && kustomize edit set namespace ${WVA_NAMESPACE})
+
+kubectl delete -k ${REPO_ROOT}/guides/workload-autoscaling/wva-config/platform/${PLATFORM}
 ```
 
 If you used KEDA, delete the ScaledObject:

--- a/guides/workload-autoscaling/wva-config/platform/ocp/kustomization.yaml
+++ b/guides/workload-autoscaling/wva-config/platform/ocp/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: llm-d-optimized-baseline
+
 resources:
   - github.com/llm-d/llm-d-workload-variant-autoscaler/config/overlays/namespace-scoped/openshift?ref=main
   - ../../base


### PR DESCRIPTION
Fixes llm-d/llm-d-workload-variant-autoscaler#1327

## Why step 6 didn't work
Step 6 installed the controller with `kubectl apply -k <overlay> -n ${WVA_NAMESPACE}`. The platform overlays a fixed namespace via a kustomize `namespace:` transformer (`wva-system` on ocp, `llm-d-optimized-baseline` on k8s). `-n` can't override that, so apply failed with:

```
the namespace from the provided object "wva-system" does not match the namespace "..."
```

## Fix

- `platform/ocp`: add `namespace`: `llm-d-optimized-baseline` so it matches `platform/k8s` and the documented default.
- Guide install/cleanup: replace `-n` with `kustomize edit set namespace ${WVA_NAMESPACE}` before apply/delete. The transformer retargets every resource, the CRB subjects, and the bundled Namespace object, so any `WVA_NAMESPACE` works on both platforms.

## Why this approach

Kustomize can't read env vars, and a `${WVA_NAMESPACE}` placeholder in the committed overlays would fail CI's `--dry-run=server` (invalid namespace name). Setting the namespace at install time keeps the committed overlays valid (CI/nightly untouched) and keeps `WVA_NAMESPACE` the single knob.

## Trade-off

`kustomize edit set namespace` modifies the tracked `platform/${PLATFORM}/kustomization.yaml` in place, so a non-default `WVA_NAMESPACE` leaves the file modified and it must be reverted with `git checkout`. It also adds a `kustomize` CLI dependency.

## Testing 

Deployed on OpenShift into a non-default namespace: install succeeds with no namespace-mismatch errors, all resources and CRB subjects land in the target namespace, and controller runs.