### PR TITLE
Fix: vLLM startup failure in XPU tiered prefix cache path

### DIFF
--- a/guides/tiered-prefix-cache/modelserver/xpu/vllm/base/patch-vllm.yaml
+++ b/guides/tiered-prefix-cache/modelserver/xpu/vllm/base/patch-vllm.yaml
@@ -20,6 +20,8 @@ spec:
           securityContext:
             privileged: true
           env:
+            - name: USER
+              value: llm-d
             - name: HF_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
  The new XPU tiered-prefix-cache vLLM deployment path, misses the USER=llm-d workaround for the
  XPU + vLLM + Kubernetes/OpenShift guide scenario.

  This fix adds the same USER environment variable to the new XPU tiered-prefix-cache base deployment so the LMCache overlay inherits it.
  
  
  As reference, the shared XPU vLLM component already documents that `USER` is required for this runtime:

  https://github.com/llm-d/llm-d/blob/main/guides/recipes/modelserver/components/images/xpu-vllm/kustomization.yaml

  ```yaml
  # Workaround for https://github.com/vllm-project/vllm/issues/44548, required with vLLM v0.20.0+ due to torch 2.11+
  # See: https://github.com/vllm-project/vllm/blob/main/requirements/xpu.txt#L15
  value:
    name: USER
    value: llm-d
```

  llm-d applied this workaround broadly in PR #1885. The underlying issue is documented in:

  - https://github.com/llm-d/llm-d-benchmark/pull/1573
  - https://github.com/vllm-project/vllm/issues/44548

  the specific issue is following:

 During startup, vLLM triggers PyTorch Inductor/cache-related logic that reads the current username. In environments such as OpenShift, Pods may run with a random UID that is not present in /etc/passwd. The getpass.getuser()/pwd.getpwuid() path can then raise `KeyError: uid not found`, causing the vLLM container to fail during startup.



