### PR TITLE
docs: fix broken links and script paths in flow control guide

### DIFF
--- a/guides/flow-control/README.md
+++ b/guides/flow-control/README.md
@@ -420,4 +420,4 @@ kubectl kustomize ${REPO_ROOT}/guides/optimized-baseline/modelserver/gpu/vllm/ \
 
 ## Further Reading
 
-See [Flow Control architecture](../../docs/architecture/core/epp/flow-control.md) for full details of the design.
+See [Flow Control architecture](../../docs/architecture/core/router/epp/flow-control.md) for full details of the design.

--- a/guides/flow-control/tuning.md
+++ b/guides/flow-control/tuning.md
@@ -67,7 +67,7 @@ To find the physical VRAM limit, you must know the shape of your actual producti
 Pass all gathered parameters to the tuning wizard. The script applies queueing theory and statistical variance to output the exact limits you should configure.
 
 ```bash
-python3 scripts/tuning_wizard.py \
+python3 guides/flow-control/scripts/tuning_wizard.py \
   --throughput 12.5 \
   --latency-sec 3.45 \
   --gpu-blocks 21875 \


### PR DESCRIPTION
This PR resolves two documentation issues in the Flow Control guide to ensure a smooth user experience when setting up and tuning limits:

1. **Tuning Guide Path Fix** (`guides/flow-control/tuning.md`): Corrected the example command path to `guides/flow-control/scripts/tuning_wizard.py` instead of the root-level `scripts/` directory (which does not contain the script and fails with a `FileNotFoundError`).
2. **README Architecture Link Fix** (`guides/flow-control/README.md`): Corrected the broken relative link pointing to `../../docs/architecture/core/epp/flow-control.md` by updating it to point to `../../docs/architecture/core/router/epp/flow-control.md` to resolve 404 errors.

Fixes #1996.
