### PR TITLE
Fix return type annotation

### DIFF
--- a/scripts/sync-nightly-matrix.py
+++ b/scripts/sync-nightly-matrix.py
@@ -72,7 +72,7 @@ def _extract_badge_name(path: Path) -> str | None:
     return m.group(1) if m else None
 
 
-def discover_workflows() -> dict[tuple[str, str, str], list[str]]:
+def discover_workflows() -> dict[tuple[str, str, str], list[tuple[str, str, str]]]:
     """Scan the workflows directory and return a mapping.
 
     Returns:


### PR DESCRIPTION
The `return` type annotation was a lie. The function signature declared `list[str]` as the dict's value type, but the function body at line 98 appends `(accelerator, filename, badge_name)` (a `tuple[str, str, str]` )into those lists, and the local variable result at line 82 was already correctly typed.

The fix is correcting the return type to match the actual value `list[tuple[str, str, str]]`. 