### PR TITLE
docs(router): correct EPP running request metric references

### DIFF
--- a/docs/architecture/core/router/epp/request-handling.md
+++ b/docs/architecture/core/router/epp/request-handling.md
@@ -96,7 +96,7 @@ The Request Handling subsystem exposes metrics tracking request volume, success,
 |--------|------|-------------|--------|
 | `inference_objective_request_total` | Counter | Total request count per model | `model_name`, `target_model_name`, `priority` |
 | `inference_objective_request_error_total` | Counter | Total error count per model | `model_name`, `target_model_name`, `error_code` |
-| `inference_objective_running_requests` | Gauge | Currently active requests per model | `model_name` |
+| `llm_d_epp_request_running` | Gauge | Current active running requests | `model_name`, `target_model_name`, `fairness_id`, `priority` |
 
 #### Latency & SLOs
 

--- a/docs/architecture/core/router/epp/scheduling.md
+++ b/docs/architecture/core/router/epp/scheduling.md
@@ -165,8 +165,9 @@ The following metrics provide visibility into the InferencePool health and sched
 | `llm_d_epp_ready_endpoints` | Gauge | `name` | Number of ready pods in the pool |
 | `llm_d_epp_average_kv_cache_utilization` | Gauge | `name` | Average KV cache utilization across the pool |
 | `llm_d_epp_average_queue_size` | Gauge | `name` | Average number of pending requests across the pool |
+| `llm_d_epp_average_running_requests` | Gauge | `name` | Average number of running requests across the pool |
 | `llm_d_epp_per_endpoint_queue_size` | Gauge | `model_server_pod`, `name` | Queue size for each individual pod |
-| `llm_d_epp_request_running` | Gauge | `name` | Average number of running requests across the pool |
+| `llm_d_epp_request_running` | Gauge | `model_name`, `target_model_name`, `fairness_id`, `priority` | Current active running requests |
 
 #### Scheduler Performance Metrics
 


### PR DESCRIPTION
## Summary

This PR corrects two stale EPP running-request metric references in the core router documentation:

- replaces the deprecated `inference_objective_running_requests` reference with `llm_d_epp_request_running`
- distinguishes the request-level `llm_d_epp_request_running` metric from the pool-level `llm_d_epp_average_running_requests` metric
- updates the documented descriptions and labels accordingly

## Context

These inconsistencies were discovered while working on [llm-d/llm-d#1981](https://github.com/llm-d/llm-d/pull/1981), which updates the HPA and EPP Metrics guide to use KEDA and adds reusable KEDA configuration assets.

The fixes were initially included in that PR because the autoscaling guide references the same EPP metrics.

## Why this is a separate PR

Following @lionelvillard's review suggestion on [llm-d/llm-d#1981](https://github.com/llm-d/llm-d/pull/1981), the changes to:

- `docs/architecture/core/router/epp/request-handling.md`
- `docs/architecture/core/router/epp/scheduling.md`

were removed from the autoscaling PR and moved into this separate PR.

These files belong to the core Router/EPP documentation and have different owners from the autoscaling guide. Splitting the changes keeps [llm-d/llm-d#1981](https://github.com/llm-d/llm-d/pull/1981) focused on KEDA and autoscaling, while allowing the router documentation updates to be reviewed by the appropriate owners.

## Changes

- corrected the running-request metric used in the request-handling documentation
- clarified the difference between request-level and pool-level running-request metrics in the scheduling documentation
- corrected the associated metric label information