### PR TITLE
Add engine-type: sglang label to optimized-baseline kustomization

### DIFF
--- a/guides/optimized-baseline/modelserver/gpu/sglang/base/kustomization.yaml
+++ b/guides/optimized-baseline/modelserver/gpu/sglang/base/kustomization.yaml
@@ -14,6 +14,7 @@ labels:
       llm-d.ai/model: Qwen3-32B
       llm-d.ai/accelerator-variant: gpu
       llm-d.ai/accelerator-vendor: nvidia
+      llm-d.ai/engine-type: sglang 
     includeSelectors: true
     includeTemplates: true
 patches:

--- a/guides/optimized-baseline/modelserver/gpu/sglang/base/patch-sglang.yaml
+++ b/guides/optimized-baseline/modelserver/gpu/sglang/base/patch-sglang.yaml
@@ -38,18 +38,20 @@ spec:
             #   value: "0.1"
           resources:
             limits:
-              nvidia.com/gpu: "2"
-              cpu: "8"
-              memory: 64Gi
+              cpu: '16'
+              memory: 128Gi
+              nvidia.com/gpu: 2
             requests:
-              nvidia.com/gpu: "2"
-              cpu: "2"
-              memory: 32Gi
+              cpu: '8'
+              memory: 96Gi
+              nvidia.com/gpu: 2
           volumeMounts:
-            - mountPath: /.config
-              name: metrics-volume
             - mountPath: /dev/shm
               name: dshm
+            - mountPath: /.cache
+              name: sglang-cache
+            - mountPath: /.triton
+              name: triton-cache
           startupProbe:
             initialDelaySeconds: 15
             periodSeconds: 30
@@ -64,9 +66,12 @@ spec:
             timeoutSeconds: 2
             failureThreshold: 3
       volumes:
-        - name: metrics-volume
-          emptyDir: {}
         - name: dshm
           emptyDir:
             medium: Memory
             sizeLimit: 20Gi
+        - name: sglang-cache
+          emptyDir: {}
+        - name: triton-cache
+          emptyDir: {}
+


### PR DESCRIPTION
EPP defaults to vLLM metric names when engine-type is unset, causing all core-metrics extraction to fail on SGLang pods.