### PR TITLE
Context Length Aware P/D Example

### DIFF
--- a/guides/context-length-aware-pd/README.md
+++ b/guides/context-length-aware-pd/README.md
@@ -1,0 +1,150 @@
+# Context-Length-Aware Prefill Routing
+
+A minimal, kustomize-free example: `Qwen/Qwen3-0.6B` served with P/D disaggregation, where
+prefill is split into two pools by request context length.
+
+| Deployment      | Role      | `llm-d.ai/context-length-range` |
+| --------------- | --------- | ------------------------------- |
+| `decode`        | `decode`  | *(none)*                        |
+| `prefill-short` | `prefill` | `0-1000`                        |
+| `prefill-long`  | `prefill` | `1000-32768`                    |
+
+All three land in one InferencePool (selected by `llm-d.ai/guide: context-length-aware`).
+On each request, the EPP runs two scheduling profiles. The `prefill` profile first applies
+`prefill-filter` to narrow to the two prefill deployments, then the
+[`context-length-aware`](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/scorer/contextlengthaware)
+plugin — with `enableFiltering: true` — drops whichever prefill pool does not cover the
+request's token count. The `decode` profile is untouched: decode pods carry no range label,
+and the plugin passes unlabeled pods through.
+
+## Notes on the range label
+
+* Both bounds are parsed with `strconv.Atoi`, so **`Max`, `inf`, and other non-integers do
+  not work** — a pod whose label fails to parse is silently dropped from every prefill
+  candidate set. Use a concrete integer; here `32768` matches `--max-model-len`.
+* The format is exactly `min-max` split on `-`, so negative bounds are also unparseable.
+* Ranges are inclusive on both ends. `0-1000` and `1000-32768` overlap at exactly 1000;
+  both pods survive filtering and the scorer breaks the tie (tighter range and more
+  headroom score higher).
+* With `enableFiltering: true`, a request above 32768 tokens matches no prefill pod. That
+  request would exceed `--max-model-len` anyway, but the failure surfaces in the EPP rather
+  than as a vLLM 400.
+
+## Token counting
+
+Token counts come from the `token-producer` plugin. This example uses its tokenizer-free
+`estimate` backend: it packs the request's input bytes into pseudo-tokens at a fixed
+**4 bytes per token**. No tokenizer to load, no model download, no network call.
+
+The plugin block in `router.values.yaml` is actually optional. `context-length-aware`
+declares `TokenizedPrompt` as a *required* input, and when nothing produces that key the
+framework instantiates the default producer for it with nil parameters — which is
+`token-producer` on the `estimate` backend. Deleting the block gives you the identical
+behavior; it is written out so the choice is visible instead of implicit.
+
+What "imprecise" costs you here:
+
+* For ordinary English prose, 4 bytes/token is close to real BPE behavior, so requests near
+  the 1000 boundary may land on either side. The 1k split is a routing heuristic, not a
+  correctness constraint — both pools serve the same model with the same `--max-model-len`,
+  so a misroute is a performance detail, not a failure.
+* Code, JSON, CJK, and other non-prose inputs drift furthest from 4 bytes/token.
+* Chat requests estimate over the flattened role + content bytes, so the chat template's own
+  tokens are not counted.
+* A `/v1/completions` request that sends `prompt` as **token IDs** rather than a string
+  bypasses estimation entirely — those are already real tokens and pass straight through.
+
+### Switching to exact counts
+
+If you need the boundary measured against real tokenization, uncomment the
+`prefill-tokenizer` Service in `manifest.yaml` and point the producer at vLLM's
+`/v1/completions/render` endpoint:
+
+```yaml
+- type: token-producer
+  parameters:
+    modelName: Qwen/Qwen3-0.6B
+    vllm:
+      url: http://prefill-tokenizer:8000
+```
+
+This adds a per-request HTTP call from the EPP to a prefill pod on the hot path (5s default
+timeout), and makes scheduling depend on prefill pods being reachable. That is the tradeoff
+the `estimate` backend exists to avoid.
+
+## Deploy
+
+```bash
+export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
+source ${REPO_ROOT}/guides/env.sh
+export NAMESPACE="llm-d-context-length-aware"
+
+kubectl create namespace ${NAMESPACE} --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -f ${REPO_ROOT}/guides/context-length-aware-pd/manifest.yaml -n ${NAMESPACE}
+
+helm install context-length-aware \
+    ${ROUTER_STANDALONE_CHART} \
+    -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
+    -f ${REPO_ROOT}/guides/context-length-aware-pd/router.values.yaml \
+    -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
+```
+
+`Qwen/Qwen3-0.6B` is a public model, so no `llm-d-hf-token` secret is required.
+
+## Verify the split
+
+Port-forward the router and send a short and a long prompt:
+
+```bash
+kubectl port-forward -n ${NAMESPACE} svc/context-length-aware-epp 8000:80
+```
+
+```bash
+python3 ${REPO_ROOT}/guides/context-length-aware-pd/verify.py
+```
+
+`verify.py` is stdlib-only — no `pip install` — and sends one short prompt and one
+~31k-estimated-token prompt.
+
+Then confirm which prefill pod served each request:
+
+```bash
+kubectl logs -n ${NAMESPACE} deploy/prefill-short --tail=20
+kubectl logs -n ${NAMESPACE} deploy/prefill-long  --tail=20
+```
+
+Raising the EPP log level (`--set router.epp.flags.v=4`) surfaces the plugin's own
+`Filtered endpoints` / `Scored endpoints` lines with the token count it computed.
+
+### Prompt-length histogram per pod
+
+vLLM publishes a `vllm:request_prompt_tokens` histogram on `/metrics`. Scraping it from each
+prefill pod shows the split directly: the short pool's requests all land in the low buckets,
+the long pool's only in the high ones.
+
+```bash
+for dep in prefill-short prefill-long; do
+    pod=$(kubectl get pod -n ${NAMESPACE} -l app=${dep} \
+        -o jsonpath='{.items[0].metadata.name}')
+    kubectl port-forward -n ${NAMESPACE} pod/${pod} 8001:8000 >/dev/null 2>&1 &
+    pf=$!
+    sleep 2
+
+    echo "=== ${dep} (${pod})"
+    curl -s http://localhost:8001/metrics \
+        | grep -E '^vllm:request_prompt_tokens_(bucket|count|sum)'
+
+    kill ${pf}
+done
+```
+
+Decode serves `/metrics` from vLLM on **8200**, not 8000 — port 8000 there is the routing
+proxy. Use `8001:8200` to scrape `deploy/decode`; its histogram sees every request, since
+decode handles both pools' traffic.
+
+Histogram buckets are cumulative (`le` is "less than or equal"), so the number of requests in
+a bucket is its count minus the previous bucket's. The fastest sanity check is
+`_sum / _count`: mean prompt length, which should sit far below 1000 for `prefill-short` and
+well above it for `prefill-long`. Note this is vLLM's *real* token count, not the EPP's
+4-bytes-per-token estimate, so the two disagree near the boundary — that is the estimator's
+error, made visible.

--- a/guides/context-length-aware-pd/manifest.yaml
+++ b/guides/context-length-aware-pd/manifest.yaml
@@ -1,0 +1,332 @@
+# Qwen3-0.6B with P/D disaggregation and context-length-aware prefill routing.
+#
+# Three deployments, all selected into the same InferencePool:
+#   decode         llm-d.ai/role=decode
+#   prefill-short  llm-d.ai/role=prefill  llm-d.ai/context-length-range="0-1000"
+#   prefill-long   llm-d.ai/role=prefill  llm-d.ai/context-length-range="1000-32768"
+#
+# The EPP `prefill-filter` narrows the prefill profile to role=prefill pods, then
+# `context-length-aware` (enableFiltering: true) picks short vs long by token count.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+  labels:
+    llm-d.ai/guide: context-length-aware
+    llm-d.ai/model: qwen3-0-6b
+    llm-d.ai/role: decode
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: decode
+  template:
+    metadata:
+      labels:
+        app: decode
+        llm-d.ai/guide: context-length-aware
+        llm-d.ai/model: qwen3-0-6b
+        llm-d.ai/role: decode
+    spec:
+      initContainers:
+        # Native sidecar: terminates client traffic on 8000, drives the NIXL
+        # prefill handshake, then proxies to the local vLLM on 8200.
+        - name: routing-proxy
+          image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0
+          imagePullPolicy: Always
+          restartPolicy: Always
+          args:
+            - --port=8000
+            - --vllm-port=8200
+            - --kv-connector=nixlv2
+            - --zap-log-level=1
+            - --secure-proxy=false
+          ports:
+            - name: sidecar
+              containerPort: 8000
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+      containers:
+        - name: modelserver
+          image: vllm/vllm-openai:v0.23.0
+          command: ["vllm", "serve"]
+          args:
+            - Qwen/Qwen3-0.6B
+            - --port=8200
+            - --max-model-len=32768
+            - --tensor-parallel-size=1
+            - --disable-access-log-for-endpoints=/health,/metrics,/v1/models
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_consumer"}'
+            - --enable-log-requests
+          env:
+            - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            # Workaround for vllm-project/vllm#44548, needed on vLLM v0.20.0+.
+            - name: USER
+              value: llm-d
+          ports:
+            - name: modelserver
+              containerPort: 8200
+              protocol: TCP
+            - name: nixl
+              containerPort: 5600
+              protocol: TCP
+          resources:
+            limits:
+              cpu: "4"
+              memory: 16Gi
+              nvidia.com/gpu: "1"
+            requests:
+              cpu: "4"
+              memory: 16Gi
+              nvidia.com/gpu: "1"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: modelserver
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /v1/models
+              port: modelserver
+            periodSeconds: 5
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /v1/models
+              port: modelserver
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            failureThreshold: 60
+          volumeMounts:
+            - { name: shm, mountPath: /dev/shm }
+            - { name: cache, mountPath: /.cache }
+            - { name: config, mountPath: /.config }
+            - { name: triton, mountPath: /.triton }
+      volumes:
+        - name: shm
+          emptyDir: { medium: Memory, sizeLimit: 2Gi }
+        - name: cache
+          emptyDir: {}
+        - name: config
+          emptyDir: {}
+        - name: triton
+          emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prefill-short
+  labels:
+    llm-d.ai/guide: context-length-aware
+    llm-d.ai/model: qwen3-0-6b
+    llm-d.ai/role: prefill
+    llm-d.ai/context-length-range: "0-1000"
+spec:
+  replicas: 1
+  # The range label is deliberately not part of the selector: selectors are
+  # immutable, and you want to be able to retune the boundary in place.
+  selector:
+    matchLabels:
+      app: prefill-short
+  template:
+    metadata:
+      labels:
+        app: prefill-short
+        llm-d.ai/guide: context-length-aware
+        llm-d.ai/model: qwen3-0-6b
+        llm-d.ai/role: prefill
+        llm-d.ai/context-length-range: "0-1000"
+    spec:
+      containers:
+        - name: modelserver
+          image: vllm/vllm-openai:v0.23.0
+          command: ["vllm", "serve"]
+          args:
+            - Qwen/Qwen3-0.6B
+            - --port=8000
+            - --max-model-len=32768
+            - --tensor-parallel-size=1
+            - --disable-access-log-for-endpoints=/health,/metrics,/v1/models
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}'
+            - --enable-log-requests
+          env:
+            - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            # vLLM's default keep-alive (5s) is shorter than the sidecar's idle
+            # conn timeout (90s), which causes TCP RSTs on connection reuse.
+            - name: VLLM_HTTP_TIMEOUT_KEEP_ALIVE
+              value: "120"
+          ports:
+            - name: modelserver
+              containerPort: 8000
+              protocol: TCP
+            - name: nixl
+              containerPort: 5600
+              protocol: TCP
+          resources:
+            limits:
+              cpu: "4"
+              memory: 16Gi
+              nvidia.com/gpu: "1"
+            requests:
+              cpu: "4"
+              memory: 16Gi
+              nvidia.com/gpu: "1"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: modelserver
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /v1/models
+              port: modelserver
+            periodSeconds: 5
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /v1/models
+              port: modelserver
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            failureThreshold: 60
+          volumeMounts:
+            - { name: shm, mountPath: /dev/shm }
+            - { name: cache, mountPath: /.cache }
+            - { name: config, mountPath: /.config }
+            - { name: triton, mountPath: /.triton }
+      volumes:
+        - name: shm
+          emptyDir: { medium: Memory, sizeLimit: 2Gi }
+        - name: cache
+          emptyDir: {}
+        - name: config
+          emptyDir: {}
+        - name: triton
+          emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prefill-long
+  labels:
+    llm-d.ai/guide: context-length-aware
+    llm-d.ai/model: qwen3-0-6b
+    llm-d.ai/role: prefill
+    llm-d.ai/context-length-range: "1000-32768"
+spec:
+  replicas: 1
+  # The range label is deliberately not part of the selector: selectors are
+  # immutable, and you want to be able to retune the boundary in place.
+  selector:
+    matchLabels:
+      app: prefill-long
+  template:
+    metadata:
+      labels:
+        app: prefill-long
+        llm-d.ai/guide: context-length-aware
+        llm-d.ai/model: qwen3-0-6b
+        llm-d.ai/role: prefill
+        llm-d.ai/context-length-range: "1000-32768"
+    spec:
+      containers:
+        - name: modelserver
+          image: vllm/vllm-openai:v0.23.0
+          command: ["vllm", "serve"]
+          args:
+            - Qwen/Qwen3-0.6B
+            - --port=8000
+            - --max-model-len=32768
+            - --disable-access-log-for-endpoints=/health,/metrics,/v1/models
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}'
+            - --enable-log-requests
+          env:
+            - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: VLLM_HTTP_TIMEOUT_KEEP_ALIVE
+              value: "120"
+          ports:
+            - name: modelserver
+              containerPort: 8000
+              protocol: TCP
+            - name: nixl
+              containerPort: 5600
+              protocol: TCP
+          resources:
+            limits:
+              cpu: "4"
+              memory: 16Gi
+              nvidia.com/gpu: "1"
+            requests:
+              cpu: "4"
+              memory: 16Gi
+              nvidia.com/gpu: "1"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: modelserver
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /v1/models
+              port: modelserver
+            periodSeconds: 5
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /v1/models
+              port: modelserver
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            failureThreshold: 60
+          volumeMounts:
+            - { name: shm, mountPath: /dev/shm }
+            - { name: cache, mountPath: /.cache }
+            - { name: config, mountPath: /.config }
+            - { name: triton, mountPath: /.triton }
+      volumes:
+        - name: shm
+          emptyDir: { medium: Memory, sizeLimit: 2Gi }
+        - name: cache
+          emptyDir: {}
+        - name: config
+          emptyDir: {}
+        - name: triton
+          emptyDir: {}
+---
+# Not needed by default. The EPP's token-producer uses the tokenizer-free
+# `estimate` backend, which makes no network call. Uncomment this Service only if
+# you switch to exact tokenization via vLLM's /v1/*/render endpoints (see README).
+#
+# apiVersion: v1
+# kind: Service
+# metadata:
+#   name: prefill-tokenizer
+#   labels:
+#     llm-d.ai/guide: context-length-aware
+# spec:
+#   selector:
+#     llm-d.ai/guide: context-length-aware
+#     llm-d.ai/role: prefill
+#   ports:
+#     - name: http
+#       port: 8000
+#       targetPort: modelserver
+#       protocol: TCP

--- a/guides/context-length-aware-pd/manifest.yaml
+++ b/guides/context-length-aware-pd/manifest.yaml
@@ -61,7 +61,6 @@ spec:
             - --disable-access-log-for-endpoints=/health,/metrics,/v1/models
             - --kv-transfer-config
             - '{"kv_connector":"NixlConnector","kv_role":"kv_consumer"}'
-            - --enable-log-requests
           env:
             - name: VLLM_NIXL_SIDE_CHANNEL_HOST
               valueFrom:
@@ -157,7 +156,6 @@ spec:
             - --disable-access-log-for-endpoints=/health,/metrics,/v1/models
             - --kv-transfer-config
             - '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}'
-            - --enable-log-requests
           env:
             - name: VLLM_NIXL_SIDE_CHANNEL_HOST
               valueFrom:
@@ -253,7 +251,6 @@ spec:
             - --disable-access-log-for-endpoints=/health,/metrics,/v1/models
             - --kv-transfer-config
             - '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}'
-            - --enable-log-requests
           env:
             - name: VLLM_NIXL_SIDE_CHANNEL_HOST
               valueFrom:

--- a/guides/context-length-aware-pd/manifest.yaml
+++ b/guides/context-length-aware-pd/manifest.yaml
@@ -66,9 +66,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            # Workaround for vllm-project/vllm#44548, needed on vLLM v0.20.0+.
-            - name: USER
-              value: llm-d
           ports:
             - name: modelserver
               containerPort: 8200

--- a/guides/context-length-aware-pd/router.values.yaml
+++ b/guides/context-length-aware-pd/router.values.yaml
@@ -1,0 +1,82 @@
+router:
+  extraServicePorts:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8081
+
+  epp:
+    # Override base.values.yaml's `v: 2`. At v=4 the scheduling plugins log each
+    # request's token count and the per-pod filter/score decisions.
+    flags:
+      v: 4
+    pluginsConfigFile: "pd-config.yaml"
+    pluginsCustomConfig:
+      pd-config.yaml: |
+        apiVersion: llm-d.ai/v1alpha1
+        kind: EndpointPickerConfig
+        plugins:
+        # --- P/D disaggregation ---
+        - type: disagg-headers-handler
+        - type: always-disagg-pd-decider
+        - type: disagg-profile-handler
+          parameters:
+            deciderPluginName: always-disagg-pd-decider
+        - type: prefill-filter
+        - type: decode-filter
+
+        # Imprecise token counting: the tokenizer-free `estimate` backend packs
+        # the request's input bytes at 4 bytes per pseudo-token. No tokenizer, no
+        # model download, no network call to vLLM.
+        #
+        # This whole block is optional. `context-length-aware` declares
+        # TokenizedPrompt as a required input, so if no token-producer is
+        # configured the framework auto-creates one with nil parameters — which
+        # lands on exactly this same `estimate` backend. It is spelled out here
+        # so the choice is visible rather than implicit.
+        #
+        # To get exact counts instead, swap `estimate` for the vLLM /render
+        # backend (see README):
+        #   parameters:
+        #     modelName: Qwen/Qwen3-0.6B
+        #     vllm: { url: http://prefill-tokenizer:8000 }
+        - type: token-producer
+          parameters:
+            estimate: {}
+
+        # Reads llm-d.ai/context-length-range off each pod. With enableFiltering,
+        # a pod whose "min-max" range does not contain the request's token count
+        # is dropped before scoring. Pods without the label are left untouched,
+        # so this is a no-op for the decode pods.
+        - type: context-length-aware
+          parameters:
+            label: llm-d.ai/context-length-range
+            enableFiltering: true
+
+        # --- generic load/affinity scorers ---
+        - type: prefix-cache-scorer
+        - type: queue-scorer
+        - type: kv-cache-utilization-scorer
+        - type: active-request-scorer
+
+        schedulingProfiles:
+        - name: prefill
+          plugins:
+          - pluginRef: prefill-filter
+          # Filters short-vs-long, then breaks ties among the survivors.
+          - pluginRef: context-length-aware
+            weight: 1
+          - pluginRef: prefix-cache-scorer
+            weight: 3
+          - pluginRef: queue-scorer
+            weight: 2
+          - pluginRef: active-request-scorer
+            weight: 2
+        - name: decode
+          plugins:
+          - pluginRef: decode-filter
+          - pluginRef: active-request-scorer
+
+  modelServers:
+    matchLabels:
+      llm-d.ai/guide: "context-length-aware"

--- a/guides/context-length-aware-pd/router.values.yaml
+++ b/guides/context-length-aware-pd/router.values.yaml
@@ -6,10 +6,6 @@ router:
       targetPort: 8081
 
   epp:
-    # Override base.values.yaml's `v: 2`. At v=4 the scheduling plugins log each
-    # request's token count and the per-pod filter/score decisions.
-    flags:
-      v: 4
     pluginsConfigFile: "pd-config.yaml"
     pluginsCustomConfig:
       pd-config.yaml: |

--- a/guides/context-length-aware-pd/verify.py
+++ b/guides/context-length-aware-pd/verify.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Send short and long prompts at the router, to exercise both prefill pools.
+
+Fires N requests in parallel per iteration, for M iterations. Every request
+carries a unique prefix so no two requests share a prefix-cache block.
+
+Assumes `kubectl port-forward svc/context-length-aware-epp 8000:80` is running.
+"""
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+
+URL = "http://localhost:8000/v1/completions"
+MODEL = "Qwen/Qwen3-0.6B"
+
+# The `estimate` token backend counts 4 bytes per token, so "hi " * 10000 is
+# ~7.5k estimated tokens: well over the 1000 boundary, still under max-model-len.
+BODIES = {
+    "short (-> prefill-short)": "word",
+    "long (-> prefill-long)": "hi " * 10000,
+}
+
+
+def complete(prompt: str) -> str:
+    body = json.dumps({"model": MODEL, "prompt": prompt, "max_tokens": 10})
+    req = urllib.request.Request(
+        URL, data=body.encode(), headers={"Content-Type": "application/json"}
+    )
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        return json.load(resp)["choices"][0]["text"]
+
+
+def run_one(label: str, body: str) -> tuple[str, bool, str]:
+    # A unique prefix at position 0 diverges the token sequence from the very
+    # first block, so nothing downstream can hit the prefix cache either.
+    prompt = f"{uuid.uuid4().hex} {body}"
+    try:
+        return label, True, complete(prompt).replace("\n", " ")
+    except urllib.error.HTTPError as e:
+        return label, False, f"HTTP {e.code}: {e.read().decode()}"
+    except OSError as e:
+        return label, False, str(e)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("-n", "--parallel", type=int, default=8,
+                   help="requests fired in parallel per iteration, per prompt size")
+    p.add_argument("-m", "--iterations", type=int, default=5,
+                   help="number of iterations")
+    args = p.parse_args()
+
+    calls = [(label, body) for label, body in BODIES.items()
+             for _ in range(args.parallel)]
+    failures = 0
+
+    for i in range(args.iterations):
+        print(f"=== iteration {i + 1}/{args.iterations}: {len(calls)} requests")
+        with ThreadPoolExecutor(max_workers=len(calls)) as pool:
+            results = list(pool.map(lambda c: run_one(*c), calls))
+        for label, ok, text in results:
+            if not ok:
+                failures += 1
+                print(f"  {label}: {text}", file=sys.stderr)
+            else:
+                print(f"  {label}: {text}")
+
+    if failures:
+        print(f"{failures} request(s) failed", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
```
=== prefill-short (prefill-short-f9d75bf68-h2m58)
vllm:request_prompt_tokens_bucket{engine="0",le="1.0",model_name="Qwen/Qwen3-0.6B"} 2.0
vllm:request_prompt_tokens_bucket{engine="0",le="2.0",model_name="Qwen/Qwen3-0.6B"} 2.0
vllm:request_prompt_tokens_bucket{engine="0",le="5.0",model_name="Qwen/Qwen3-0.6B"} 2.0
vllm:request_prompt_tokens_bucket{engine="0",le="10.0",model_name="Qwen/Qwen3-0.6B"} 2.0
vllm:request_prompt_tokens_bucket{engine="0",le="20.0",model_name="Qwen/Qwen3-0.6B"} 2.0
vllm:request_prompt_tokens_bucket{engine="0",le="50.0",model_name="Qwen/Qwen3-0.6B"} 42.0
vllm:request_prompt_tokens_bucket{engine="0",le="100.0",model_name="Qwen/Qwen3-0.6B"} 42.0
vllm:request_prompt_tokens_bucket{engine="0",le="200.0",model_name="Qwen/Qwen3-0.6B"} 42.0
vllm:request_prompt_tokens_bucket{engine="0",le="500.0",model_name="Qwen/Qwen3-0.6B"} 42.0
vllm:request_prompt_tokens_bucket{engine="0",le="1000.0",model_name="Qwen/Qwen3-0.6B"} 42.0
vllm:request_prompt_tokens_bucket{engine="0",le="2000.0",model_name="Qwen/Qwen3-0.6B"} 42.0
vllm:request_prompt_tokens_bucket{engine="0",le="5000.0",model_name="Qwen/Qwen3-0.6B"} 42.0
vllm:request_prompt_tokens_bucket{engine="0",le="10000.0",model_name="Qwen/Qwen3-0.6B"} 42.0
vllm:request_prompt_tokens_bucket{engine="0",le="20000.0",model_name="Qwen/Qwen3-0.6B"} 42.0
vllm:request_prompt_tokens_bucket{engine="0",le="+Inf",model_name="Qwen/Qwen3-0.6B"} 42.0
vllm:request_prompt_tokens_count{engine="0",model_name="Qwen/Qwen3-0.6B"} 42.0
vllm:request_prompt_tokens_sum{engine="0",model_name="Qwen/Qwen3-0.6B"} 1175.0
[2]  + terminated  kubectl port-forward -n ${NAMESPACE} pod/${pod} 8001:8000 > /dev/null 2>&1
[2] 29793
=== prefill-long (prefill-long-857b5d799c-fwzql)
vllm:request_prompt_tokens_bucket{engine="0",le="1.0",model_name="Qwen/Qwen3-0.6B"} 0.0
vllm:request_prompt_tokens_bucket{engine="0",le="2.0",model_name="Qwen/Qwen3-0.6B"} 0.0
vllm:request_prompt_tokens_bucket{engine="0",le="5.0",model_name="Qwen/Qwen3-0.6B"} 0.0
vllm:request_prompt_tokens_bucket{engine="0",le="10.0",model_name="Qwen/Qwen3-0.6B"} 0.0
vllm:request_prompt_tokens_bucket{engine="0",le="20.0",model_name="Qwen/Qwen3-0.6B"} 0.0
vllm:request_prompt_tokens_bucket{engine="0",le="50.0",model_name="Qwen/Qwen3-0.6B"} 0.0
vllm:request_prompt_tokens_bucket{engine="0",le="100.0",model_name="Qwen/Qwen3-0.6B"} 0.0
vllm:request_prompt_tokens_bucket{engine="0",le="200.0",model_name="Qwen/Qwen3-0.6B"} 0.0
vllm:request_prompt_tokens_bucket{engine="0",le="500.0",model_name="Qwen/Qwen3-0.6B"} 0.0
vllm:request_prompt_tokens_bucket{engine="0",le="1000.0",model_name="Qwen/Qwen3-0.6B"} 0.0
vllm:request_prompt_tokens_bucket{engine="0",le="2000.0",model_name="Qwen/Qwen3-0.6B"} 0.0
vllm:request_prompt_tokens_bucket{engine="0",le="5000.0",model_name="Qwen/Qwen3-0.6B"} 0.0
vllm:request_prompt_tokens_bucket{engine="0",le="10000.0",model_name="Qwen/Qwen3-0.6B"} 0.0
vllm:request_prompt_tokens_bucket{engine="0",le="20000.0",model_name="Qwen/Qwen3-0.6B"} 42.0
vllm:request_prompt_tokens_bucket{engine="0",le="+Inf",model_name="Qwen/Qwen3-0.6B"} 42.0
vllm:request_prompt_tokens_count{engine="0",model_name="Qwen/Qwen3-0.6B"} 42.0
vllm:request_prompt_tokens_sum{engine="0",model_name="Qwen/Qwen3-0.6B"} 421194.0
```