### PR TITLE
Prevent Incorrect Load-Aware Routing for AMD SGLang Backends

### DIFF
--- a/guides/optimized-baseline/modelserver/amd/sglang/kustomization.yaml
+++ b/guides/optimized-baseline/modelserver/amd/sglang/kustomization.yaml
@@ -14,6 +14,7 @@ labels:
       llm-d.ai/model: Qwen3-32B
       llm-d.ai/accelerator-variant: gpu
       llm-d.ai/accelerator-vendor: amd
+      llm-d.ai/engine-type: sglang
     includeSelectors: true
     includeTemplates: true
 patches:


### PR DESCRIPTION
  In scenarios where EPP pulls core metrics from model server Pods for load-aware or KV-cache-aware routing, SGLang workloads must identify themselves as the sglang engine. 
  
  This project does that through the Pod label `llm-d.ai/engine-type: sglang`. Without that label, EPP falls back to the default vLLM engine mapping and reads vLLM metric names, which do not match SGLang  metrics. 
  
  Other comparable SGLang deployment variants already carry this label, so the AMD SGLang optimized-baseline overlay was the missing outlier.
  
https://github.com/llm-d/llm-d/blob/main/guides/pd-disaggregation/modelserver/gpu/sglang/base/kustomization.yaml
 
```
labels:
  - pairs:
      llm-d.ai/engine-type: sglang
```

This requirement is also stated in https://github.com/llm-d/llm-d/blob/main/docs/architecture/core/model-servers.md

```yaml
metadata:
  labels:
    llm-d.ai/engine-type: vllm # other options: sglang, trtllm-serve, triton-tensorrt-llm
```

