### PR TITLE
docs: update agentic-serving guide and well-lit paths

### DIFF
--- a/guides/agentic-serving/README.md
+++ b/guides/agentic-serving/README.md
@@ -31,6 +31,23 @@ sets the broader direction: **session-graph orchestration**, **program-aware sch
 fan-out. See the [workload page](../../docs/well-lit-paths/workloads/agentic-serving.md#direction) for the full
 direction and further reading.
 
+## Routing Configuration
+
+For agentic workloads, sessions typically consist of long-running, multi-turn interactions where the system prompt is shared but session-specific context diverges rapidly. To optimize routing for these workloads, configure both the `prefix-cache-scorer` (with length awareness enabled) and the `session-affinity-scorer`. 
+
+Length awareness allows shorter sessions to migrate freely when pods are overloaded, while session affinity keeps the rapidly diverging chat history sticky to the original pod. Here is the recommended configuration snippet:
+
+```yaml
+- type: prefix-cache-scorer
+  parameters:
+    matchLengthWeight: 0.8
+    matchLengthScaleTokens: 16000
+
+- type: session-affinity-scorer
+  parameters:
+    headerName: x-session-token
+```
+
 ## Deployments
 
 The layers above compose into deployments spanning a range of capabilities and operational

--- a/guides/agentic-serving/router/agentic-serving-gpu.values.yaml
+++ b/guides/agentic-serving/router/agentic-serving-gpu.values.yaml
@@ -42,14 +42,29 @@ router:
           name: gpu-prefix-cache-scorer
           parameters:
             prefixMatchInfoProducerName: gpu-prefix-cache-producer
+            matchLengthWeight: 0.8
+            matchLengthScaleTokens: 16000
         - type: prefix-cache-scorer
           name: cpu-prefix-cache-scorer
           parameters:
             prefixMatchInfoProducerName: cpu-prefix-cache-producer
+            matchLengthWeight: 0.8
+            matchLengthScaleTokens: 16000
+        - type: session-affinity-scorer
+          name: session-affinity-decode
+          parameters:
+            headerName: x-session-token
+        - type: session-affinity-scorer
+          name: session-affinity-prefill
+          parameters:
+            headerName: x-session-token-prefill
+            profileName: prefill
         schedulingProfiles:
         - name: prefill
           plugins:
           - pluginRef: prefill-filter
+          - pluginRef: session-affinity-prefill
+            weight: 5
           - pluginRef: gpu-prefix-cache-scorer
             weight: 4
           - pluginRef: cpu-prefix-cache-scorer
@@ -63,6 +78,8 @@ router:
         - name: decode
           plugins:
           - pluginRef: decode-filter
+          - pluginRef: session-affinity-decode
+            weight: 5
           - pluginRef: active-request-scorer
             weight: 2
           - pluginRef: gpu-prefix-cache-scorer

--- a/guides/agentic-serving/router/agentic-serving.values.yaml
+++ b/guides/agentic-serving/router/agentic-serving.values.yaml
@@ -31,9 +31,14 @@ router:
         - type: prefix-cache-affinity-filter
           parameters:
             peakPrefillThroughput: 16444
+        - type: session-affinity-scorer
+          parameters:
+            headerName: x-session-token
         schedulingProfiles:
         - name: default
           plugins:
+          - pluginRef: session-affinity-scorer
+            weight: 5
           - pluginRef: prefix-cache-affinity-filter
           - pluginRef: token-load-scorer
 


### PR DESCRIPTION
## What type of PR is this?

/kind documentation

---

## What this PR does / why we need it

This PR updates the **agentic-serving** guide to include recommended routing configurations for agentic workloads.

Specifically, it adds guidance on configuring:

- `prefix-cache-scorer` with **prefix match length awareness** enabled to improve stickiness for long-running sessions while reducing unnecessary migration for shorter requests.
- `session-affinity-scorer` to improve routing consistency for multi-turn agentic conversations where requests within a session share context but diverge significantly across sessions.

These recommendations help optimize routing for long-running, multi-turn interactions in which the initial system prompt may be shared, but subsequent conversation context quickly becomes unique.

This is a companion PR to the corresponding **llm-d-router** changes:
https://github.com/llm-d/llm-d-router/pull/1958

Together, these changes ensure that the high-level documentation and well-lit paths accurately reflect the latest routing configuration recommendations for agentic workloads.



## Release note

```release-note
NONE
```