### PR TITLE
Docs: fix broken multimodal guide link in EPP HTTP APIs reference

### DIFF
--- a/docs/api-reference/epp-http-apis.md
+++ b/docs/api-reference/epp-http-apis.md
@@ -17,7 +17,7 @@ This document lists the HTTP APIs the [Endpoint Picker (EPP)](../architecture/co
 
 ## Request Examples
 
-The examples below parameterize the model as `${MODEL_NAME}` and the proxy endpoint as `${IP}`. Set `${MODEL_NAME}` to [`Qwen/Qwen3-VL-32B-Instruct`](https://huggingface.co/Qwen/Qwen3-VL-32B-Instruct) from the [multimodal optimized-baseline guide](../../guides/multimodal-serving/optimized-baseline/README.md), and set `${IP}` to the proxy endpoint IP retrieved per that guide's verification steps.
+The examples below parameterize the model as `${MODEL_NAME}` and the proxy endpoint as `${IP}`. Set `${MODEL_NAME}` to [`Qwen/Qwen3-VL-32B-Instruct`](https://huggingface.co/Qwen/Qwen3-VL-32B-Instruct) from the [multimodal aggregation guide](../../guides/multimodal-serving/aggregation/README.md), and set `${IP}` to the proxy endpoint IP retrieved per that guide's verification steps.
 
 ```bash
 export MODEL_NAME=Qwen/Qwen3-VL-32B-Instruct


### PR DESCRIPTION
## Summary

Fixes a broken link in the EPP HTTP APIs reference. `docs/api-reference/epp-http-apis.md` linked to `guides/multimodal-serving/optimized-baseline`, which 404s — that path doesn't exist. The multimodal guide has `aggregation` and `e-disaggregation` variants; this repoints the link (and its text) to the multimodal **aggregation** guide.

## Related issue(s)

Surfaced by the website link checker on `llm-d/llm-d.github.io` (docs are synced from this repo, so the fix flows to the site on the next sync).

## (Optional) Testing Instructions

Verified `guides/multimodal-serving/aggregation/README.md` exists and the previous target does not.