### PR TITLE
update(agentic-serving): enable VLLM_PREFIX_CACHE_RETENTION_INTERVAL=0 for Nemotron-3-Ultra

### DIFF
--- a/guides/agentic-serving/modelserver/gpu/vllm/nemotron-3-ultra/patch-decode.yaml
+++ b/guides/agentic-serving/modelserver/gpu/vllm/nemotron-3-ultra/patch-decode.yaml
@@ -36,6 +36,9 @@ spec:
             - '{"kv_connector":"MultiConnector","kv_role":"kv_both","kv_load_failure_policy":"fail","kv_connector_extra_config":{"connectors":[{"kv_connector":"NixlConnector","kv_role":"kv_consumer","kv_connector_extra_config":{"bidirectional_kv_xfer":true}},{"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"cpu_bytes_to_use":214748364800,"lazy_offload":true}}]}}'
             - "--port=8200"
           env:
+            # Set for Mamba-hybrid model only; improves multi-turn prefix caching.
+            - name: VLLM_PREFIX_CACHE_RETENTION_INTERVAL
+              value: "0"
             - name: HF_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/guides/agentic-serving/modelserver/gpu/vllm/nemotron-3-ultra/patch-prefill.yaml
+++ b/guides/agentic-serving/modelserver/gpu/vllm/nemotron-3-ultra/patch-prefill.yaml
@@ -23,6 +23,9 @@ spec:
             - "--kv-transfer-config"
             - '{"kv_connector":"MultiConnector","kv_role":"kv_both","kv_load_failure_policy":"fail","kv_connector_extra_config":{"connectors":[{"kv_connector":"NixlConnector","kv_role":"kv_producer","kv_connector_extra_config":{"bidirectional_kv_xfer":true}},{"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"cpu_bytes_to_use":214748364800,"lazy_offload":true}}]}}'
           env:
+            # Set on Mamba-hybrid model only; improves multi-turn prefix caching.
+            - name: VLLM_PREFIX_CACHE_RETENTION_INTERVAL
+              value: "0"
             - name: HF_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/guides/agentic-serving/nemotron-3-ultra-550b-h200.md
+++ b/guides/agentic-serving/nemotron-3-ultra-550b-h200.md
@@ -18,6 +18,11 @@ configuration layers the agentic optimizations onto disaggregated serving:
   replicas) — to extend the cacheable working set far beyond HBM for long, resumable sessions.
 - **FP8 block weights + FP8 KV cache** to fit the `~563 GB` of weights at `TP=8` and leave KV
   headroom; the MoE is served with Expert Parallelism.
+- **`VLLM_PREFIX_CACHE_RETENTION_INTERVAL=0`** to raise multi-turn prefix-cache hit rates. This is
+  enabled here because `RedHatAI/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8-block` is a
+  [Mamba-hybrid model](https://huggingface.co/RedHatAI/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8-block/blob/main/config.json)
+  (`NemotronHForCausalLM`); vLLM rejects the flag on full-attention models, so it is set
+  per-deployment rather than in the baseline manifests.
 
 > 🚧 This deployment uses development images (the endpoint-picker and the disaggregation routing
 > sidecar) for the P/D-disaggregation scheduling plugins. Pin them to a release before relying on
@@ -35,14 +40,15 @@ configuration layers the agentic optimizations onto disaggregated serving:
 
 ### Supported Hardware Backends
 
-| Backend             | Directory                                       | Notes                                            |
-| ------------------- | ----------------------------------------------- | ------------------------------------------------ |
-| NVIDIA GPU (vLLM)   | `modelserver/gpu/vllm/nemotron-3-ultra/`        | 8× H200, P/D disaggregated (6 prefill / 2 decode) |
+| Backend           | Directory                                | Notes                                             |
+| ----------------- | ---------------------------------------- | ------------------------------------------------- |
+| NVIDIA GPU (vLLM) | `modelserver/gpu/vllm/nemotron-3-ultra/` | 8× H200, P/D disaggregated (6 prefill / 2 decode) |
 
 ## Prerequisites
 
 - Installed proper client tools (kubectl, helm).
 - Set the following environment variables:
+
   ```bash
   export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
   source ${REPO_ROOT}/guides/env.sh

--- a/guides/recipes/modelserver/components/images/gpu-vllm/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/gpu-vllm/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Component
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: vllm/vllm-openai
-    newTag: v0.23.0
+    newTag: v0.25.0
 
 # Workaround for https://github.com/vllm-project/vllm/issues/44548, required with vLLM v0.20.0+ due to torch 2.11
 patches:


### PR DESCRIPTION
# Description
- set VLLM_PREFIX_CACHE_RETENTION_INTERVAL to 0 on both prefill and decode patch to raise multiturn prefix-cache hit rates for agentic serving . 
- bump vllm image to 0.25.0 to work with the feature https://github.com/vllm-project/vllm/pull/45845
- vllm reject it on full attnetion models e.g Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 is left unchanged which can fail at startup
- lint from precommit

# Related issue
fixes:  https://github.com/llm-d/llm-d/issues/2020