### PR TITLE
Rearrange FOSSA Status badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ llm-d is a high-performance distributed inference serving stack optimized for pr
 llm-d is a [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io/) sandbox project, founded by Red Hat, Google Cloud, IBM Research, CoreWeave, and NVIDIA.
 
 
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fllm-d%2Fllm-d.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fllm-d%2Fllm-d?ref=badge_large)
-
 ## What does llm-d offer to production inference?
 
 Model servers like [vLLM](https://docs.vllm.ai) and [SGLang](https://github.com/sgl-project/sglang) handle efficiently running large language models on accelerators. llm-d provides state-of-the-art orchestration and optimizations above model servers to serve high-scale real-world traffic efficiently and reliably. Our offerings are organized into four core themes:
@@ -95,3 +93,5 @@ We adhere to the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/
 ## License
 
 This project is licensed under Apache License 2.0. See the [LICENSE file](LICENSE) for details.
+
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fllm-d%2Fllm-d.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fllm-d%2Fllm-d?ref=badge_large)


### PR DESCRIPTION
Moved FOSSA Status badge to the end of the README.