### PR TITLE
fix(wva): migrate nightly + guide from Prometheus Adapter to KEDA

### DIFF
--- a/docs/well-lit-paths/foundations/workload-autoscaling.md
+++ b/docs/well-lit-paths/foundations/workload-autoscaling.md
@@ -26,7 +26,7 @@ The Workload Variant Autoscaler (WVA) is designed for operators running multiple
 
 * **Best for**: Multi-variant deployments where cost-aware capacity allocation is required.
 * **Signals**: KV cache utilization, queue depth, energy/performance budgets.
-* **Components**: WVA controller and `VariantAutoscaling` CRD.
+* **Components**: WVA controller and KEDA. WVA publishes a `wva_desired_replicas` metric for any KEDA `ScaledObject` (or HPA) annotated with `llm-d.ai/managed: "true"`, and KEDA drives the scale from it. The `VariantAutoscaling` CRD is deprecated as of llm-d 0.8.0.
 
 ## Choosing a Path
 

--- a/guides/workload-autoscaling/README.wva.md
+++ b/guides/workload-autoscaling/README.wva.md
@@ -71,30 +71,23 @@ export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
       --dry-run=client -o yaml | kubectl apply -f - -n ${WVA_NAMESPACE}
     ```
 
-3. Configure Prometheus Adapter Rules (if using Prometheus Adapter as the external metrics provider for WVA):
+3. Verify KEDA is installed. WVA only watches ScaledObjects if the KEDA CRD is present **when the controller starts**, so install KEDA before WVA:
 
     ```bash
-    helm upgrade prometheus-adapter prometheus-community/prometheus-adapter \
-      --namespace ${MONITORING_NAMESPACE} \
-      --reuse-values \
-      --values ${REPO_ROOT}/guides/workload-autoscaling/components/prometheus-adapter/wva-adapter-values.yaml
+    kubectl get crd scaledobjects.keda.sh
     ```
 
-4. Verify the external metrics adapter is registered:
+    > [!NOTE]
+    > If you are still on the deprecated Prometheus Adapter, see [promadapter.md](./promadapter.md).
+    > WVA no longer installs or supports it.
 
-    ```bash
-    kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1"
-
-    {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"external.metrics.k8s.io/v1beta1","resources":[{"name":"wva_desired_replicas","singularName":"","namespaced":true,"kind":"ExternalMetricValueList","verbs":["get"]}]}
-    ```
-
-5. Install WVA CRDs:
+4. Install WVA CRDs:
 
     ```bash
     kubectl apply -k github.com/llm-d/llm-d-workload-variant-autoscaler/config/base/crd?ref=main
     ```
 
-6. Install WVA controller with Kustomize:
+5. Install WVA controller with Kustomize:
 
     ```bash
     kubectl apply -k ${REPO_ROOT}/guides/workload-autoscaling/wva-config/platform/${PLATFORM} -n ${WVA_NAMESPACE}

--- a/guides/workload-autoscaling/optimized-baseline-autoscaling/keda/wva-scaledobject.yaml
+++ b/guides/workload-autoscaling/optimized-baseline-autoscaling/keda/wva-scaledobject.yaml
@@ -1,17 +1,30 @@
-# KEDA ScaledObject with wva_desired_replica metric
+# KEDA ScaledObject driven by WVA's wva_desired_replicas metric.
 #
 # This ScaledObject replaces both Prometheus Adapter and the standard HPA.
 # KEDA creates its own HPA from this ScaledObject — do NOT apply hpa.yaml alongside it.
 #
-# Update `serverAddress` below to match your Prometheus endpoint.
+# The llm-d.ai/* annotations are what make WVA aware of this variant: WVA watches
+# ScaledObjects (and HPAs) bearing llm-d.ai/managed: "true" and emits wva_desired_replicas
+# for them. Without the annotations the object is invisible to WVA, the metric is never
+# published, and KEDA sits on its fallback replica count.
+#
+# Update `serverAddress` and the namespace in the trigger query to match your cluster.
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: optimized-baseline-nvidia-gpu-vllm-decode-scaler
+  annotations:
+    llm-d.ai/managed: "true"
+    llm-d.ai/model-id: "Qwen3-32B"
+    llm-d.ai/variant-cost: "30.0"
   labels:
+    # WVA copies these labels onto the variant it derives from this object; the
+    # accelerator label feeds its cost/capacity optimization.
+    inference.optimization/acceleratorName: "H100"
+    llm-d.ai/inference-serving: "true"
+    llm-d.ai/guide: "optimized-baseline"
     app: optimized-baseline-nvidia-gpu-vllm-decode
     scaler: keda-workload-variant-autoscaler
-    llm-d.ai/guide: "optimized-baseline"
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -54,12 +67,20 @@ spec:
     name: wva-desired-replicas
     metadata:
       serverAddress: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
+      # `namespace` is the Prometheus scrape-target label — the namespace the WVA controller
+      # runs in, which this guide installs alongside the workload. If you run WVA in a
+      # different namespace, Prometheus renames the metric's own namespace label to
+      # `exported_namespace` on collision, and this selector must use that instead.
       query: |
         wva_desired_replicas{
           variant_name="optimized-baseline-nvidia-gpu-vllm-decode",
-          exported_namespace="llm-d-optimized-baseline"
+          namespace="llm-d-optimized-baseline"
         }
       threshold: "1"
       activationThreshold: "0"
+      # AverageValue, not Value: for External metrics the HPA scales a `Value` target by the
+      # current replica count (desired = ceil(metric / target * replicas)), which turns a
+      # desired-replica metric into runaway growth. AverageValue divides that back out, making
+      # this a direct passthrough of wva_desired_replicas.
       metricType: AverageValue
       unsafeSsl: "true"

--- a/guides/workload-autoscaling/promadapter.md
+++ b/guides/workload-autoscaling/promadapter.md
@@ -2,6 +2,8 @@
 
 > [!WARNING]
 > The Prometheus Adapter project is planned for deprecation ([kubernetes-sigs/prometheus-adapter#701](https://github.com/kubernetes-sigs/prometheus-adapter/issues/701)). It is recommended to use KEDA for autoscaling.
+>
+> **For WVA, the Prometheus Adapter is no longer supported.** WVA removed it as a scaler backend in [llm-d-workload-variant-autoscaler#1399](https://github.com/llm-d/llm-d-workload-variant-autoscaler/pull/1399); KEDA is the sole backend. Note that KEDA and the Prometheus Adapter both serve the `v1beta1.external.metrics.k8s.io` APIService and cannot coexist — running both breaks metric delivery for whichever one does not own it. Migrate via [Using KEDA with WVA](./README.wva.md#using-keda-with-wva-recommended). This page remains for the HPA + EPP metrics path.
 
 The Prometheus Adapter bridges Prometheus metrics to the Kubernetes External Metrics API, which the HPA uses to read EPP and WVA signals.
 

--- a/guides/workload-autoscaling/scripts/nightly-deploy-cks.sh
+++ b/guides/workload-autoscaling/scripts/nightly-deploy-cks.sh
@@ -1,38 +1,118 @@
 #!/usr/bin/env bash
+# Deploy the WVA + optimized-baseline stack on CKS (CoreWeave Kubernetes) in a single namespace.
+#
+# NOTE: OpenShift (nightly-deploy-ocp.sh) is the supported/priority path; this script is
+# best-effort. Two assumptions here are unverified on the CKS nightly cluster:
+#   - KEDA is installed (checked below, fails loudly if not).
+#   - A monitoring stack serves Prometheus at prometheus-operated.llm-d-monitoring:9090 —
+#     the endpoint wva-config/platform/k8s pins PROMETHEUS_BASE_URL to. Override with
+#     PROMETHEUS_ADDRESS if that is wrong.
+#
+# Environment variables:
+#   NAMESPACE             target namespace for ALL resources (set by the nightly workflow)
+#   WVA_TAG               WVA controller image tag override (default: unset = upstream default)
+#   OUTPUT_DIR            where to write the generated overlay (default: mktemp -d)
+#   PROMETHEUS_ADDRESS    Prometheus endpoint KEDA queries
+#   ROUTER_CHART_VERSION  EPP router chart version (default: set by guides/env.sh)
+
 set -euo pipefail
+
+if command -v grealpath &>/dev/null; then
+  _realpath=grealpath          # macOS: brew install coreutils
+elif realpath --version &>/dev/null 2>&1; then
+  _realpath=realpath           # Linux GNU coreutils
+else
+  echo "ERROR: GNU realpath not found. On macOS install it with: brew install coreutils" >&2
+  exit 1
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 source "${REPO_ROOT}/guides/env.sh"
 
-# WVA kustomize builds target namespace llm-d-autoscaler (do not pass a conflicting kubectl -n).
-WVA_DEPLOY_NS=llm-d-autoscaler
+NAMESPACE="${NAMESPACE:-llm-d-optimized-baseline}"
+WVA_TAG="${WVA_TAG:-}"
+OUTPUT_DIR="${OUTPUT_DIR:-$(mktemp -d -t nightly-deploy-cks.XXXXXX)}"
+PROMETHEUS_ADDRESS="${PROMETHEUS_ADDRESS:-https://prometheus-operated.llm-d-monitoring.svc.cluster.local:9090}"
+
+mkdir -p "${OUTPUT_DIR}"
+
+# Nightly-only model server tweaks: GPU priority class, writable Triton cache, 2 replicas.
 yq '.spec.template.spec.priorityClassName="nightly-gpu-critical"' -i guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
 yq '.spec.template.spec.volumes += {"name": "triton-cache", "emptyDir": {}}' -i guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
 yq '.spec.template.spec.containers[0].volumeMounts += {"mountPath": "/.triton", "name": "triton-cache"}' -i guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
 yq '.spec.replicas=2' -i guides/optimized-baseline/modelserver/gpu/vllm/base/patch-vllm.yaml
-kubectl apply -k guides/optimized-baseline/modelserver/gpu/vllm/base -n ${NAMESPACE}
+kubectl apply -k guides/optimized-baseline/modelserver/gpu/vllm/base -n "${NAMESPACE}"
+
 helm install workload-variant-autoscaler-inferencepool-standalone \
-  ${ROUTER_STANDALONE_CHART} \
+  "${ROUTER_STANDALONE_CHART}" \
   -f guides/recipes/router/base.values.yaml \
   -f guides/optimized-baseline/router/optimized-baseline.values.yaml \
-  -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
+  -n "${NAMESPACE}" --version "${ROUTER_CHART_VERSION}"
 
-# Override WVA controller image to the nightly build from this run
-if [ -n "$WVA_TAG" ]; then
-  export WVA_TAG
-  yq -i '.images = [{"name": "controller", "newName": "ghcr.io/llm-d/llm-d-workload-variant-autoscaler", "newTag": strenv(WVA_TAG)}]' \
-    guides/workload-autoscaling/wva-config/base/kustomization.yaml
+# kustomize rejects absolute resource paths, so reference the repo relative to OUTPUT_DIR.
+REL="$("${_realpath}" --relative-to="${OUTPUT_DIR}" "${REPO_ROOT}")"
+
+# platform/k8s pins namespace llm-d-optimized-baseline; wrap it so everything lands in NAMESPACE.
+cat > "${OUTPUT_DIR}/kustomization.yaml" <<EOF
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ${NAMESPACE}
+resources:
+  - ${REL}/guides/workload-autoscaling/wva-config/platform/k8s/
+  - ${REL}/guides/workload-autoscaling/optimized-baseline-autoscaling/keda/
+patches:
+  # The namespace and Prometheus endpoint live inside KEDA trigger strings, so the kustomize
+  # namespace transformer cannot reach them — rewrite them explicitly.
+  - patch: |-
+      - op: replace
+        path: /spec/triggers/0/metadata/query
+        value: |
+          wva_desired_replicas{
+            variant_name="optimized-baseline-nvidia-gpu-vllm-decode",
+            namespace="${NAMESPACE}"
+          }
+      - op: replace
+        path: /spec/triggers/0/metadata/serverAddress
+        value: ${PROMETHEUS_ADDRESS}
+      - op: replace
+        path: /spec/maxReplicaCount
+        value: 2
+    target:
+      kind: ScaledObject
+      name: optimized-baseline-nvidia-gpu-vllm-decode-scaler
+EOF
+
+if [ -n "${WVA_TAG}" ]; then
+  cat >> "${OUTPUT_DIR}/kustomization.yaml" <<EOF
+images:
+  - name: ghcr.io/llm-d/llm-d-workload-variant-autoscaler
+    newTag: ${WVA_TAG}
+EOF
 fi
 
-# Kustomization validation dry run
-kubectl kustomize guides/workload-autoscaling/wva-config/platform/cks >/dev/null
+echo "==> Validating kustomization"
+kubectl kustomize "${OUTPUT_DIR}" >/dev/null
 
-# apply WVA assets
-kubectl apply -k guides/workload-autoscaling/wva-config/platform/cks
+# KEDA is the external metrics provider (Prometheus Adapter was retired upstream in
+# llm-d-workload-variant-autoscaler#1399). WVA only registers its ScaledObject reconciler if
+# the KEDA CRD exists when the controller starts, so check before deploying the controller.
+echo "==> Checking for KEDA"
+if ! kubectl get crd scaledobjects.keda.sh >/dev/null 2>&1; then
+  echo "ERROR: CRD scaledobjects.keda.sh not found — install KEDA on the cluster before WVA." >&2
+  exit 1
+fi
 
-# Validate WVA controller is ready, then apply autoscaling resources
-kubectl wait deployment/workload-variant-autoscaler-controller-manager \
-  -n "${WVA_DEPLOY_NS}" --for=condition=Available --timeout=300s
-kubectl apply -k guides/workload-autoscaling/optimized-baseline-autoscaling/hpa -n "${NAMESPACE}"
-kubectl get variantautoscaling,hpa -n "${NAMESPACE}"
+echo "==> Applying WVA + autoscaling assets"
+kubectl apply -k "${OUTPUT_DIR}"
+
+echo "==> Waiting for WVA controller to become Available"
+kubectl wait deployment/wva-controller-manager \
+  -n "${NAMESPACE}" --for=condition=Available --timeout=300s
+
+echo "==> Waiting for the ScaledObject to be Ready"
+kubectl wait scaledobject/optimized-baseline-nvidia-gpu-vllm-decode-scaler \
+  -n "${NAMESPACE}" --for=condition=Ready --timeout=300s
+
+echo "==> Listing autoscaling resources"
+kubectl get scaledobject,hpa -n "${NAMESPACE}"

--- a/guides/workload-autoscaling/scripts/nightly-deploy-ocp.sh
+++ b/guides/workload-autoscaling/scripts/nightly-deploy-ocp.sh
@@ -47,12 +47,25 @@ namespace: ${NAMESPACE}
 resources:
   - ${REL}/guides/workload-autoscaling/wva-config/platform/ocp/
   - ${REL}/guides/optimized-baseline/modelserver/gpu/vllm/base/
-  - ${REL}/guides/workload-autoscaling/optimized-baseline-autoscaling/hpa/
+  - ${REL}/guides/workload-autoscaling/optimized-baseline-autoscaling/keda/
 patches:
-  - path: patch-hpa-exported-ns.yaml
+  # The namespace lives inside a PromQL string, so the kustomize namespace transformer above
+  # cannot reach it — rewrite the query explicitly. maxReplicaCount is capped at the GPU budget
+  # the nightly reserves (2), rather than the guide's default of 10.
+  - patch: |-
+      - op: replace
+        path: /spec/triggers/0/metadata/query
+        value: |
+          wva_desired_replicas{
+            variant_name="optimized-baseline-nvidia-gpu-vllm-decode",
+            namespace="${NAMESPACE}"
+          }
+      - op: replace
+        path: /spec/maxReplicaCount
+        value: 2
     target:
-      kind: HorizontalPodAutoscaler
-      name: optimized-baseline-nvidia-gpu-vllm-decode
+      kind: ScaledObject
+      name: optimized-baseline-nvidia-gpu-vllm-decode-scaler
   - path: patch-vllm.yaml
     target:
       kind: Deployment
@@ -88,28 +101,20 @@ images:
 EOF
 fi
 
-cat > "${OUTPUT_DIR}/patch-hpa-exported-ns.yaml" <<EOF
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: optimized-baseline-nvidia-gpu-vllm-decode
-spec:
-  metrics:
-    - type: External
-      external:
-        metric:
-          name: wva_desired_replicas
-          selector:
-            matchLabels:
-              variant_name: optimized-baseline-nvidia-gpu-vllm-decode
-              exported_namespace: ${NAMESPACE}
-        target:
-          type: AverageValue
-          averageValue: "1"
-EOF
-
 echo "==> Validating kustomization"
 kubectl kustomize "${OUTPUT_DIR}" >/dev/null
+
+# KEDA is the external metrics provider (Prometheus Adapter was retired upstream in
+# llm-d-workload-variant-autoscaler#1399). WVA only registers its ScaledObject reconciler
+# if the KEDA CRD is present when the controller starts, so check before deploying it.
+# On OpenShift, KEDA is expected to be operator-managed and is never installed from here.
+echo "==> Checking for KEDA"
+if ! kubectl get crd scaledobjects.keda.sh >/dev/null 2>&1; then
+  echo "ERROR: CRD scaledobjects.keda.sh not found." >&2
+  echo "       KEDA must be installed on the cluster (Custom Metrics Autoscaler operator on OpenShift)" >&2
+  echo "       before the WVA controller starts, or WVA will not watch ScaledObjects." >&2
+  exit 1
+fi
 
 echo "==> Ensuring namespace ${NAMESPACE} exists"
 kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
@@ -128,5 +133,12 @@ echo "==> Waiting for WVA controller to become Available"
 kubectl wait deployment/wva-controller-manager \
   -n "${NAMESPACE}" --for=condition=Available --timeout=300s
 
+echo "==> Waiting for the ScaledObject to be Ready"
+# Ready means KEDA accepted the trigger and created its HPA. It does NOT mean WVA is
+# publishing wva_desired_replicas yet — that needs a Prometheus scrape cycle.
+kubectl wait scaledobject/optimized-baseline-nvidia-gpu-vllm-decode-scaler \
+  -n "${NAMESPACE}" --for=condition=Ready --timeout=300s
+
 echo "==> Listing autoscaling resources"
-kubectl get variantautoscaling,hpa -n "${NAMESPACE}"
+# KEDA owns the HPA (wva-keda-hpa-*); we no longer create one ourselves.
+kubectl get scaledobject,hpa -n "${NAMESPACE}"


### PR DESCRIPTION
Moves the WVA nightlies and guide off Prometheus Adapter and onto KEDA.
WVA repo already made this switch - [llm-d-workload-variant-autoscaler#1399](https://github.com/llm-d/llm-d-workload-variant-autoscaler/pull/1399) removed the adapter entirely, leaving KEDA as the only supported scaler backend. Our guide already said KEDA was recommended, but the nightlies still deployed the plain HPA + adapter path, and the KEDA manifest that came with the docs had never been run by CI.