### PR TITLE
feat(guides): add GKE A4X (GB200) P/D disaggregation overlay

### DIFF
--- a/docs/infrastructure/providers/gke/README.md
+++ b/docs/infrastructure/providers/gke/README.md
@@ -165,6 +165,66 @@ items:
 
 </details>
 
+### GKE A4X (GB200) Setup
+
+For GKE A4X (NVIDIA GB200) clusters, deploy model servers using the `gke/a4x` overlay path (`modelserver/gpu/vllm/gke/a4x`). This configuration enables native InfiniBand RDMA networking and GPUDirect Level 5 hardware acceleration:
+
+* **Driver Binding**: Configures `LD_PRELOAD=/usr/local/nvidia/lib64/libibverbs.so.1` to bind container processes directly to GKE's host-level gIB driver.
+* **Hardware Interconnect**: Configures `UCX_TLS=rc_mlx5,rc,cuda_copy,cuda_ipc,sm,shm,self` for hardware-accelerated InfiniBand transport.
+* **NCCL Acceleration**: Sets `NCCL_NET=gIB` (or `NCCL_ENV_PLUGIN=gcp`) and `NCCL_NET_GDR_LEVEL=5`.
+* **Host Driver Mounts**: Mounts host driver paths `/home/kubernetes/bin/gib` and `/home/kubernetes/bin/nvidia`.
+
+## Mitigating Hugging Face Model Download Rate Limiting
+
+When deploying large-scale model inference on GKE clusters (such as multi-replica prefill and decode deployments), concurrent model weight downloads across multiple pods can trigger Hugging Face HTTP 429 Rate Limiting errors, leading to container startup timeouts.
+
+To ensure resilient model loading across pods, consider the following strategies:
+
+### 1. Node-Level Host Caching
+
+Mount a local host directory to `/root/.cache/huggingface` inside workload pods so that multiple pods scheduled on the same node share cached weights without re-downloading across pod restarts.
+
+```yaml
+        env:
+        - name: HF_HOME
+          value: /root/.cache/huggingface
+        # ...
+        volumeMounts:
+        - mountPath: /root/.cache/huggingface
+          name: huggingface-cache
+      volumes:
+      - name: huggingface-cache
+        hostPath:
+          path: /var/cache/huggingface
+          type: DirectoryOrCreate
+```
+
+> [!NOTE]
+> The host path `/var/cache/huggingface` in the manifest snippet above serves as an illustrative reference. Users can configure any suitable host directory based on their node disk allocation and storage policies.
+
+### 2. Hub Timeouts & Startup Probe Tuning
+
+Configure download retry and timeout environment variables, and increase `startupProbe.failureThreshold` (e.g., to 240) to give pods sufficient headroom to complete initial model weight downloads under network constraints:
+
+```yaml
+        env:
+        - name: HF_HUB_DOWNLOAD_TIMEOUT
+          value: "60"
+        - name: HF_HUB_ETAG_TIMEOUT
+          value: "60"
+        - name: HF_HUB_DISABLE_XET
+          value: "1"
+        startupProbe:
+          failureThreshold: 240
+          periodSeconds: 30
+```
+
+### 3. Google Cloud Storage Integration (Recommended for Production)
+
+For large production workloads, store model weights in a Google Cloud Storage (GCS) bucket and mount the weights directly to pods. This completely eliminates external Hugging Face network dependencies during pod scaling.
+
+For step-by-step instructions, see the [GKE Hugging Face GCS Transfer Guide](https://gke-ai-labs.dev/docs/tutorials/storage/hf-gcs-transfer/).
+
 ### TPUs
 
 For all TPU machines, follow the [TPUs in GKE documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/tpus).

--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -146,8 +146,11 @@ Apply the Kustomize overlays for your specific backend (defaulting to NVIDIA GPU
 #### GPU
 
 Choose the overlay matching your infrastructure provider:
-- **GKE**: Deploys on GKE using Dynamic Resource Allocation (DRA) and DRANet (RoCE) as the default high-performance path. Ensure the cluster is configured accordingly (see [Cluster Pre-provisioning](#nvidia-gpu-on-gke-with-dra-rdmaroce)).
+- **GKE**: Deploys on GKE using Dynamic Resource Allocation (DRA) and DRANet (RoCE) as the default high-performance path. Ensure the cluster is configured accordingly (see [Cluster Pre-provisioning](#gke-cluster-pre-provisioning-with-dra--rdmaroce)).
 - **CoreWeave**: Deploys on CoreWeave.
+
+> [!TIP]
+> Check subdirectories under your provider folder (e.g. `modelserver/gpu/vllm/gke/a4x` for GKE A4X / GB200 platforms) for platform-specific overlays. If your target hardware has specialized driver, memory, or network interconnect requirements, default provider settings may not adapt to your platform, and you should select the corresponding platform sub-overlay (for example, `export INFRA_PROVIDER=gke/a4x`).
 
 ```bash
 export INFRA_PROVIDER=base # base | coreweave | gke | aws

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/gke/a4x/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/gke/a4x/kustomization.yaml
@@ -1,0 +1,160 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+components:
+  - ../../../../components/gke-rdma
+
+patches:
+  # Patch gke-rdma-template from gke-rdma component to request only DRANet (mrdma.google.com) on A4X
+  - patch: |-
+      apiVersion: resource.k8s.io/v1
+      kind: ResourceClaimTemplate
+      metadata:
+        name: gke-rdma-template
+      spec:
+        spec:
+          devices:
+            requests:
+              - name: nic
+                exactly:
+                  deviceClassName: mrdma.google.com
+                  allocationMode: ExactCount
+                  count: 1
+  # Configure prefill deployment with DRANet resourceClaims & A4X env and mounts
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: prefill
+      spec:
+        template:
+          spec:
+            resourceClaims:
+              - name: gke-rdma-claim
+                resourceClaimTemplateName: gke-rdma-template
+            containers:
+              - name: modelserver
+                resources:
+                  claims:
+                    - name: gke-rdma-claim
+                env:
+                  - name: LD_PRELOAD
+                    value: "/usr/local/nvidia/lib64/libibverbs.so.1"
+                  - name: LD_LIBRARY_PATH
+                    value: "/usr/local/nvidia/lib64:/usr/local/gib/lib"
+                  - name: UCX_TLS
+                    value: "rc_mlx5,rc,cuda_copy,cuda_ipc,sm,shm,self"
+                  - name: UCX_IB_ROCE_LOCAL_SUBNET
+                    value: "n"
+                  - name: UCX_IB_GPU_DIRECT_RDMA
+                    value: "y"
+                  - name: UCX_IB_GDA_DMABUF_ENABLE
+                    value: "y"
+                  - name: NCCL_NET
+                    value: "gIB"
+                  - name: NCCL_PXN_C2C
+                    value: "1"
+                  - name: NCCL_IB_ADAPTIVE_ROUTING
+                    value: "1"
+                  - name: NCCL_IB_QPS_PER_CONNECTION
+                    value: "4"
+                  - name: NCCL_IB_TC
+                    value: "52"
+                  - name: NCCL_IB_FIFO_TC
+                    value: "84"
+                  - name: NCCL_NET_GDR_LEVEL
+                    value: "5"
+                  - name: NCCL_NET_GDR_READ
+                    value: "1"
+                  - name: NCCL_SOCKET_IFNAME
+                    value: "eth0"
+                securityContext:
+                  capabilities:
+                    add: ["IPC_LOCK", "NET_ADMIN"]
+                volumeMounts:
+                  - mountPath: /usr/local/gib
+                    name: gib
+                  - mountPath: /usr/local/nvidia
+                    name: library-dir-host
+            volumes:
+              - name: gib
+                hostPath:
+                  path: /home/kubernetes/bin/gib
+              - name: library-dir-host
+                hostPath:
+                  path: /home/kubernetes/bin/nvidia
+  # Configure decode deployment with DRANet resourceClaims & A4X env and mounts
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: decode
+      spec:
+        template:
+          spec:
+            resourceClaims:
+              - name: gke-rdma-claim-0
+                resourceClaimTemplateName: gke-rdma-template
+              - name: gke-rdma-claim-1
+                resourceClaimTemplateName: gke-rdma-template
+              - name: gke-rdma-claim-2
+                resourceClaimTemplateName: gke-rdma-template
+              - name: gke-rdma-claim-3
+                resourceClaimTemplateName: gke-rdma-template
+            containers:
+              - name: modelserver
+                resources:
+                  claims:
+                    - name: gke-rdma-claim-0
+                    - name: gke-rdma-claim-1
+                    - name: gke-rdma-claim-2
+                    - name: gke-rdma-claim-3
+                env:
+                  - name: LD_PRELOAD
+                    value: "/usr/local/nvidia/lib64/libibverbs.so.1"
+                  - name: LD_LIBRARY_PATH
+                    value: "/usr/local/nvidia/lib64:/usr/local/gib/lib"
+                  - name: UCX_TLS
+                    value: "rc_mlx5,rc,cuda_copy,cuda_ipc,sm,shm,self"
+                  - name: UCX_IB_ROCE_LOCAL_SUBNET
+                    value: "n"
+                  - name: UCX_IB_GPU_DIRECT_RDMA
+                    value: "y"
+                  - name: UCX_IB_GDA_DMABUF_ENABLE
+                    value: "y"
+                  - name: NCCL_NET
+                    value: "gIB"
+                  - name: NCCL_PXN_C2C
+                    value: "1"
+                  - name: NCCL_IB_ADAPTIVE_ROUTING
+                    value: "1"
+                  - name: NCCL_IB_QPS_PER_CONNECTION
+                    value: "4"
+                  - name: NCCL_IB_TC
+                    value: "52"
+                  - name: NCCL_IB_FIFO_TC
+                    value: "84"
+                  - name: NCCL_NET_GDR_LEVEL
+                    value: "5"
+                  - name: NCCL_NET_GDR_READ
+                    value: "1"
+                  - name: NCCL_SOCKET_IFNAME
+                    value: "eth0"
+                securityContext:
+                  capabilities:
+                    add: ["IPC_LOCK", "NET_ADMIN"]
+                volumeMounts:
+                  - mountPath: /usr/local/gib
+                    name: gib
+                  - mountPath: /usr/local/nvidia
+                    name: library-dir-host
+            volumes:
+              - name: gib
+                hostPath:
+                  path: /home/kubernetes/bin/gib
+              - name: library-dir-host
+                hostPath:
+                  path: /home/kubernetes/bin/nvidia


### PR DESCRIPTION
## Summary

This PR adds support for **GKE A4X (NVIDIA GB200)** nodes within the `pd-disaggregation` guide under `guides/pd-disaggregation/modelserver/gpu/vllm/gke/a4x/`.

On GKE A4X, GPU devices are managed via the standard NVIDIA Device Plugin (`nvidia.com/gpu`), while multi-rail InfiniBand network interfaces are provisioned via **DRANet** (`mrdma.google.com`). This overlay configures host-level driver integration and UCX/NCCL parameters to enforce GPUDirect RDMA

---

## Key Changes

### 1. Kustomize Overlay (`modelserver/gpu/vllm/gke/a4x/`)
- **DRANet Resource Claims**: Patches the `gke-rdma-template` to request DRANet (`mrdma.google.com`, `ExactCount: 1`) for network interfaces while maintaining GPU limits (`nvidia.com/gpu`).
- **Host gIB Driver Preload**: Configures `LD_PRELOAD=/usr/local/nvidia/lib64/libibverbs.so.1` and `LD_LIBRARY_PATH="/usr/local/nvidia/lib64:/usr/local/gib/lib"` to bind to GKE's host-level gIB driver.
- **Hardware Interconnect Lockdown**: Sets `UCX_TLS=rc_mlx5,rc,cuda_copy,cuda_ipc,sm,shm,self`, `NCCL_NET=gIB`, and `NCCL_NET_GDR_LEVEL=5`.
- **Host Mounts**: Mounts host driver binaries at `/home/kubernetes/bin/gib` (`/usr/local/gib`) and `/home/kubernetes/bin/nvidia` (`/usr/local/nvidia`).

### 2. Documentation Updates
- **`guides/pd-disaggregation/README.md`**: Added guidance and a `[!TIP]` block detailing how to select specialized provider sub-overlays (e.g. `gke/a4x`) for targeted hardware variants.
- **`docs/infrastructure/providers/gke/README.md`**: 
  - Added a dedicated section for **GKE A4X (GB200) Workload Setup**.
  - Added an independent section on **Mitigating Hugging Face Model Download Rate Limiting** covering host-level caching and GCS bucket mounts.

---

## Verification

Validated using Kustomize dry-run builds:
```bash
kubectl kustomize guides/pd-disaggregation/modelserver/gpu/vllm/gke/a4x/
