### PR TITLE
CI: extract duplicated guide rendering into scripts/render.sh

### DIFF
--- a/.github/workflows/ci-kustomize-dry-run.yaml
+++ b/.github/workflows/ci-kustomize-dry-run.yaml
@@ -6,6 +6,8 @@ on:
     paths:
       - .github/workflows/ci-kustomize-dry-run.yaml
       - .github/scripts/**
+      - scripts/render.sh
+      - guides/env.sh
       - guides/recipes/**
       - guides/optimized-baseline/**
       - guides/pd-disaggregation/**
@@ -36,6 +38,8 @@ jobs:
             optimized-baseline:
               - .github/workflows/ci-kustomize-dry-run.yaml
               - .github/scripts/install-gke-crds.sh
+              - scripts/render.sh
+              - guides/env.sh
               - guides/recipes/gateway/install-gateway-crds.sh
               - guides/recipes/observability/install-prometheus-grafana.sh
               - guides/recipes/modelserver/**
@@ -44,24 +48,24 @@ jobs:
             pd-disaggregation:
               - .github/workflows/ci-kustomize-dry-run.yaml
               - helpers/client-setup/install-deps.sh
+              - scripts/render.sh
+              - guides/env.sh
               - guides/recipes/gateway/install-gateway-crds.sh
               - guides/recipes/observability/install-prometheus-grafana.sh
               - guides/pd-disaggregation/**
             precise-prefix-cache-routing:
               - .github/workflows/ci-kustomize-dry-run.yaml
               - helpers/client-setup/install-deps.sh
+              - scripts/render.sh
+              - guides/env.sh
               - guides/recipes/gateway/install-gateway-crds.sh
               - guides/recipes/observability/install-prometheus-grafana.sh
               - guides/precise-prefix-cache-routing/**
-            simulated-accelerators:
-              - .github/workflows/ci-kustomize-dry-run.yaml
-              - helpers/client-setup/install-deps.sh
-              - guides/recipes/gateway/install-gateway-crds.sh
-              - guides/recipes/observability/install-prometheus-grafana.sh
-              - guides/simulated-accelerators/**
             workload-autoscaling:
               - .github/workflows/ci-kustomize-dry-run.yaml
               - .github/scripts/install-gke-crds.sh
+              - scripts/render.sh
+              - guides/env.sh
               - guides/recipes/gateway/install-gateway-crds.sh
               - guides/recipes/observability/install-prometheus-grafana.sh
               - guides/workload-autoscaling/**
@@ -100,29 +104,25 @@ jobs:
 
       - name: Dry-run router charts
         run: |
-          CHART_VERSION=v0
           failed=0
-          for chart in llm-d-router-standalone llm-d-router-gateway; do
+          for chart in standalone gateway; do
             echo ""
             echo "========================================"
-            echo "optimized-baseline: router (${chart})"
+            echo "optimized-baseline: router (llm-d-router-${chart})"
             echo "========================================"
-            echo "--- helm template ---"
-            if ! helm template optimized-baseline-router \
-              "oci://ghcr.io/llm-d/charts/${chart}" \
-              -f guides/recipes/router/base.values.yaml \
-              -f guides/recipes/router/features/monitoring.values.yaml \
-              -f guides/optimized-baseline/router/optimized-baseline.values.yaml \
-              --version "${CHART_VERSION}" > /tmp/rendered.yaml; then
-              echo "FAIL: helm template failed for ${chart}"
+            echo "--- helm template (scripts/render.sh) ---"
+            if ! scripts/render.sh router optimized-baseline \
+              --chart "${chart}" --monitoring \
+              --release optimized-baseline-router > /tmp/rendered.yaml; then
+              echo "FAIL: helm template failed for llm-d-router-${chart}"
               failed=1
               continue
             fi
             echo "--- kubectl apply --dry-run=server ---"
             if kubectl apply --dry-run=server -f /tmp/rendered.yaml; then
-              echo "PASS: optimized-baseline / router (${chart})"
+              echo "PASS: optimized-baseline / router (llm-d-router-${chart})"
             else
-              echo "FAIL: optimized-baseline / router (${chart})"
+              echo "FAIL: optimized-baseline / router (llm-d-router-${chart})"
               failed=1
             fi
           done
@@ -143,8 +143,8 @@ jobs:
             echo "========================================"
             echo "optimized-baseline: ${name}"
             echo "========================================"
-            echo "--- kustomize build ---"
-            if ! kustomize build "${kust_dir}" > /tmp/rendered.yaml; then
+            echo "--- kustomize build (scripts/render.sh) ---"
+            if ! scripts/render.sh overlay "${kust_dir}" > /tmp/rendered.yaml; then
               echo "FAIL: kustomize build failed for ${name}"
               failed=1
               continue
@@ -201,29 +201,25 @@ jobs:
 
       - name: Dry-run router charts
         run: |
-          CHART_VERSION=v0
           failed=0
-          for chart in llm-d-router-standalone llm-d-router-gateway; do
+          for chart in standalone gateway; do
             echo ""
             echo "========================================"
-            echo "pd-disaggregation: router (${chart})"
+            echo "pd-disaggregation: router (llm-d-router-${chart})"
             echo "========================================"
-            echo "--- helm template ---"
-            if ! helm template pd-disaggregation-router \
-              "oci://ghcr.io/llm-d/charts/${chart}" \
-              -f guides/recipes/router/base.values.yaml \
-              -f guides/recipes/router/features/monitoring.values.yaml \
-              -f guides/pd-disaggregation/router/pd-disaggregation.values.yaml \
-              --version "${CHART_VERSION}" > /tmp/rendered.yaml; then
-              echo "FAIL: helm template failed for ${chart}"
+            echo "--- helm template (scripts/render.sh) ---"
+            if ! scripts/render.sh router pd-disaggregation \
+              --chart "${chart}" --monitoring \
+              --release pd-disaggregation-router > /tmp/rendered.yaml; then
+              echo "FAIL: helm template failed for llm-d-router-${chart}"
               failed=1
               continue
             fi
             echo "--- kubectl apply --dry-run=server ---"
             if kubectl apply --dry-run=server -f /tmp/rendered.yaml; then
-              echo "PASS: pd-disaggregation / router (${chart})"
+              echo "PASS: pd-disaggregation / router (llm-d-router-${chart})"
             else
-              echo "FAIL: pd-disaggregation / router (${chart})"
+              echo "FAIL: pd-disaggregation / router (llm-d-router-${chart})"
               failed=1
             fi
           done
@@ -246,8 +242,8 @@ jobs:
             echo "========================================"
             echo "pd-disaggregation: ${name}"
             echo "========================================"
-            echo "--- kustomize build ---"
-            if ! kustomize build "${kust_dir}" > /tmp/rendered.yaml; then
+            echo "--- kustomize build (scripts/render.sh) ---"
+            if ! scripts/render.sh overlay "${kust_dir}" > /tmp/rendered.yaml; then
               echo "FAIL: kustomize build failed for ${name}"
               failed=1
               continue
@@ -293,17 +289,13 @@ jobs:
         # Tokenization runs as a standalone render Service (../render/), not a
         # chart-injected sidecar (the chart's tokenizer sidecar is off by default).
         run: |
-          CHART_VERSION=v0
           echo ""
           echo "========================================"
           echo "precise-prefix-cache-routing: router (EPP, render via Service)"
           echo "========================================"
-          echo "--- helm template ---"
-          if ! helm template precise-prefix-cache-routing \
-            "oci://ghcr.io/llm-d/charts/llm-d-router-standalone" \
-            -f guides/recipes/router/base.values.yaml \
-            -f guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml \
-            --version "${CHART_VERSION}" > /tmp/rendered.yaml; then
+          echo "--- helm template (scripts/render.sh) ---"
+          if ! scripts/render.sh router precise-prefix-cache-routing \
+            --chart standalone > /tmp/rendered.yaml; then
             echo "FAIL: helm template failed"
             exit 1
           fi
@@ -322,8 +314,8 @@ jobs:
           echo "========================================"
           echo "precise-prefix-cache-routing: render (vllm-render Service)"
           echo "========================================"
-          echo "--- kustomize build ---"
-          if ! kustomize build guides/precise-prefix-cache-routing/render > /tmp/rendered.yaml; then
+          echo "--- kustomize build (scripts/render.sh) ---"
+          if ! scripts/render.sh overlay guides/precise-prefix-cache-routing/render > /tmp/rendered.yaml; then
             echo "FAIL: kustomize build failed for render"
             exit 1
           fi
@@ -350,8 +342,8 @@ jobs:
             echo "========================================"
             echo "precise-prefix-cache-routing: ${name}"
             echo "========================================"
-            echo "--- kustomize build ---"
-            if ! kustomize build "${kust_dir}" > /tmp/rendered.yaml; then
+            echo "--- kustomize build (scripts/render.sh) ---"
+            if ! scripts/render.sh overlay "${kust_dir}" > /tmp/rendered.yaml; then
               echo "FAIL: kustomize build failed for ${name}"
               failed=1
               continue
@@ -408,8 +400,8 @@ jobs:
             echo "========================================"
             echo "workload-autoscaling: ${name}"
             echo "========================================"
-            echo "--- kustomize build ---"
-            if ! kustomize build "${kust_dir}" > /tmp/rendered.yaml; then
+            echo "--- kustomize build (scripts/render.sh) ---"
+            if ! scripts/render.sh overlay "${kust_dir}" > /tmp/rendered.yaml; then
               echo "FAIL: kustomize build failed for ${name}"
               failed=1
               continue

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         language: system
         entry: shellcheck
         args: [-x, --severity=warning]
-        files: ^docker/scripts/.*\.sh$
+        files: ^(docker/scripts/.*\.sh|scripts/render\.sh)$
         types: [shell]
 
       - id: lint-envvars

--- a/scripts/render.sh
+++ b/scripts/render.sh
@@ -1,0 +1,425 @@
+#!/usr/bin/env bash
+# -*- indent-tabs-mode: nil; tab-width: 4; sh-indentation: 4; -*-
+#
+# render.sh - hydrate llm-d guide manifests into plain YAML.
+#
+# Renders the same manifests the guide READMEs deploy (helm router chart +
+# kustomize model server overlays) without installing anything, so the full
+# stack can be inspected, diffed, reviewed, or applied with plain kubectl.
+#
+# stdout carries only manifests; all logging goes to stderr. The output of
+# `router` and `overlay` is byte-identical to the underlying `helm template`
+# and `kustomize build` commands documented in the guides.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+export REPO_ROOT
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/guides/env.sh"
+
+GUIDES_DIR="${REPO_ROOT}/guides"
+BASE_VALUES="${GUIDES_DIR}/recipes/router/base.values.yaml"
+FEATURES_DIR="${GUIDES_DIR}/recipes/router/features"
+
+print_help() {
+    cat <<'EOF'
+Usage: scripts/render.sh <command> [arguments] [options]
+
+Render llm-d guide manifests (helm router chart + kustomize overlays) to
+plain YAML. stdout carries only manifests; logs go to stderr.
+
+Commands:
+  router <guide>    Render the llm-d router helm chart(s) for a guide
+  overlay <dir>     Render a single kustomize overlay directory
+  list <guide>      List all buildable kustomize overlays of a guide
+  all <guide>       Render the router plus overlays of a guide
+
+Router options (for `router` and `all`):
+  --chart standalone|gateway|both
+                    Which router chart to render (default: standalone)
+  --release NAME    Helm release name (default: the guide name, which the
+                    guide READMEs require for inference pool pairing)
+  --version VER     Chart version override (default: ROUTER_CHART_VERSION
+                    from guides/env.sh)
+  --monitoring      Layer recipes/router/features/monitoring.values.yaml
+  --feature NAME    Layer recipes/router/features/NAME.values.yaml (or
+                    NAME.yaml, e.g. httproute-flags); repeatable, applied
+                    in the order given
+  --guide-values FILE
+                    Replace the default guide values file
+                    (guides/<guide>/router/<guide>.values.yaml), for
+                    variants such as optimized-baseline-trtllm.values.yaml
+  -f, --values FILE Extra values file layered AFTER the guide values;
+                    repeatable (e.g. wide-ep-lws router/xpu.values.yaml)
+  --set KEY=VALUE   Passed through to helm; repeatable
+  -n, --namespace NS
+                    Namespace passed to helm template (default: helm's own
+                    default)
+
+`all` options:
+  --modelserver PATH
+                    Render only the named model server overlay(s), PATH
+                    relative to guides/<guide>/modelserver/; repeatable.
+                    Default: every overlay found under the guide.
+
+General options:
+  -o, --output DIR  Write one YAML file per rendered unit into DIR, each
+                    with a generated-by header. Default: raw stdout.
+  -h, --help        Show this help
+
+Examples:
+  # Full stack for pd-disaggregation on GPU + GKE, standalone router:
+  scripts/render.sh all pd-disaggregation --modelserver gpu/vllm/gke -o rendered/
+
+  # Router only, with monitoring, gateway mode (mirrors the README helm flags):
+  scripts/render.sh router pd-disaggregation --monitoring \
+      --chart gateway --feature httproute-flags --set provider.name=gke
+
+  # One overlay, straight to stdout:
+  scripts/render.sh overlay guides/pd-disaggregation/modelserver/gpu/vllm/gke
+
+Note: helm values are layered in the fixed order base -> features -> guide
+values -> extra --values -> --set, matching the guide READMEs. Escaping
+inside --set values follows helm's own rules.
+EOF
+}
+
+log() { echo "$*" >&2; }
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+require_cmd() {
+    command -v "$1" >/dev/null 2>&1 || die "'$1' is required but not found in PATH"
+}
+
+# --- kustomize tool selection: prefer the standalone binary (what CI uses),
+# --- fall back to kubectl's embedded kustomize for users who only have kubectl.
+KUSTOMIZE_CMD=()
+init_kustomize() {
+    if [[ ${#KUSTOMIZE_CMD[@]} -gt 0 ]]; then return 0; fi
+    if command -v kustomize >/dev/null 2>&1; then
+        KUSTOMIZE_CMD=(kustomize build)
+    elif command -v kubectl >/dev/null 2>&1; then
+        KUSTOMIZE_CMD=(kubectl kustomize)
+        log "note: 'kustomize' not found, using 'kubectl kustomize' (embedded kustomize version may differ)"
+    else
+        die "neither 'kustomize' nor 'kubectl' found in PATH"
+    fi
+}
+
+resolve_guide_dir() {
+    local guide="$1"
+    case "$guide" in
+        */*|.|..) die "'$guide' is not a guide name (expected a directory name under guides/)" ;;
+    esac
+    [[ -d "${GUIDES_DIR}/${guide}" ]] || die "guide '${guide}' not found under guides/"
+    printf '%s\n' "${GUIDES_DIR}/${guide}"
+}
+
+resolve_feature_file() {
+    local name="$1"
+    if [[ -f "${FEATURES_DIR}/${name}.values.yaml" ]]; then
+        printf '%s\n' "${FEATURES_DIR}/${name}.values.yaml"
+    elif [[ -f "${FEATURES_DIR}/${name}.yaml" ]]; then
+        printf '%s\n' "${FEATURES_DIR}/${name}.yaml"
+    else
+        die "unknown feature '${name}'; available: $(cd "${FEATURES_DIR}" && ls -- *.yaml 2>/dev/null | sed 's/\.values\.yaml$//;s/\.yaml$//' | tr '\n' ' ')"
+    fi
+}
+
+resolve_chart_ref() {
+    local kind="$1" ref
+    case "$kind" in
+        standalone) ref="${ROUTER_STANDALONE_CHART}" ;;
+        gateway)    ref="${ROUTER_GATEWAY_CHART}" ;;
+        *) die "internal: unknown chart kind '${kind}'" ;;
+    esac
+    printf '%s\n' "$ref"
+}
+
+resolve_chart_version() {
+    if [[ -n "$CHART_VERSION_OVERRIDE" ]]; then
+        printf '%s\n' "$CHART_VERSION_OVERRIDE"
+    else
+        printf '%s\n' "${ROUTER_CHART_VERSION}"
+    fi
+}
+
+repo_relative() {
+    local abs
+    abs="$(cd "$1" && pwd)"
+    printf '%s\n' "${abs#"${REPO_ROOT}"/}"
+}
+
+# Unit name for output files: path relative to the current guide dir when
+# under it (modelserver-gpu-vllm-gke), else relative to guides/ or the repo.
+unit_name_for_dir() {
+    local dir="$1" abs rel
+    abs="$(cd "$dir" && pwd)"
+    if [[ -n "${GUIDE_DIR}" && "$abs" == "${GUIDE_DIR}"/* ]]; then
+        rel="${abs#"${GUIDE_DIR}"/}"
+    elif [[ "$abs" == "${GUIDES_DIR}"/* ]]; then
+        rel="${abs#"${GUIDES_DIR}"/}"
+    elif [[ "$abs" == "${REPO_ROOT}"/* ]]; then
+        rel="${abs#"${REPO_ROOT}"/}"
+    else
+        rel="$(basename "$abs")"
+    fi
+    printf '%s\n' "${rel//\//-}"
+}
+
+# All standalone-buildable kustomization dirs of a guide (absolute paths):
+# every kustomization.yaml, excluding kustomize components (not buildable).
+list_overlays() {
+    local guide_dir="$1" f
+    find "$guide_dir" -name kustomization.yaml | sort | while IFS= read -r f; do
+        case "$f" in */components/*) continue ;; esac
+        grep -Eq '^kind:[[:space:]]*Component[[:space:]]*$' "$f" && continue
+        dirname "$f"
+    done
+}
+
+# emit_unit NAME HEADER_LINE... < rendered-manifests
+# In -o mode writes DIR/NAME.yaml with a generated-by header; otherwise
+# streams to stdout, inserting a `---` separator between units when the
+# next unit does not start with one (helm output does, kustomize's doesn't).
+EMITTED=0
+emit_unit() {
+    local name="$1"; shift
+    if [[ ! -s "$TMPFILE" ]]; then
+        log "note: '${name}' rendered no resources; skipping"
+        return 0
+    fi
+    if [[ -n "$OUTPUT_DIR" ]]; then
+        mkdir -p "$OUTPUT_DIR"
+        local out="${OUTPUT_DIR}/${name}.yaml" line
+        {
+            printf '# Generated by scripts/render.sh -- DO NOT EDIT; regenerate with:\n'
+            printf '#   scripts/render.sh %s\n' "${ORIG_ARGS_STR}"
+            for line in "$@"; do
+                printf '# %s\n' "$line"
+            done
+            cat "$TMPFILE"
+        } > "$out"
+        log "wrote ${out}"
+    else
+        if [[ "$EMITTED" -gt 0 && "$(head -c 3 "$TMPFILE")" != "---" ]]; then
+            printf -- '---\n'
+        fi
+        cat "$TMPFILE"
+    fi
+    EMITTED=$((EMITTED + 1))
+}
+
+# render_router KIND -> renders one chart into TMPFILE and emits it.
+# Returns non-zero (without exiting) on helm failure so `all` can continue.
+render_router() {
+    local kind="$1" chart_ref ver v
+    chart_ref="$(resolve_chart_ref "$kind")"
+    ver="$(resolve_chart_version)"
+    local -a args=(template "$RELEASE" "$chart_ref")
+    for v in "${VALUES_FILES[@]}"; do
+        args+=(-f "$v")
+    done
+    args+=(--version "$ver")
+    if [[ -n "$NAMESPACE" ]]; then
+        args+=(-n "$NAMESPACE")
+    fi
+    for v in ${SET_ARGS[@]+"${SET_ARGS[@]}"}; do
+        args+=(--set "$v")
+    done
+    if ! helm "${args[@]}" > "$TMPFILE"; then
+        return 1
+    fi
+    local values_desc="" f
+    for f in "${VALUES_FILES[@]}"; do
+        values_desc="${values_desc}${values_desc:+, }${f#"${REPO_ROOT}"/}"
+    done
+    emit_unit "router-${kind}" \
+        "Chart: ${chart_ref} (version ${ver}), release: ${RELEASE}" \
+        "Values: ${values_desc}"
+}
+
+# render_overlay DIR -> kustomize build into TMPFILE and emit.
+# Returns non-zero (without exiting) on build failure so `all` can continue.
+render_overlay() {
+    local dir="$1"
+    [[ -d "$dir" ]] || die "overlay directory '${dir}' not found"
+    [[ -f "${dir}/kustomization.yaml" ]] || die "no kustomization.yaml in '${dir}'"
+    if ! "${KUSTOMIZE_CMD[@]}" "$dir" > "$TMPFILE"; then
+        return 1
+    fi
+    emit_unit "$(unit_name_for_dir "$dir")" "Overlay: $(repo_relative "$dir")"
+}
+
+# Resolve the router values layering for the current guide into VALUES_FILES:
+# base -> features (flag order) -> guide values (or --guide-values) -> extras.
+resolve_values_files() {
+    local guide="$1" guide_values f
+    if [[ -n "$GUIDE_VALUES_OVERRIDE" ]]; then
+        guide_values="$GUIDE_VALUES_OVERRIDE"
+        [[ -f "$guide_values" ]] || die "values file '${guide_values}' not found"
+    else
+        guide_values="${GUIDE_DIR}/router/${guide}.values.yaml"
+        [[ -f "$guide_values" ]] || die "guide '${guide}' has no router values file ($(repo_relative "${GUIDE_DIR}")/router/${guide}.values.yaml); use 'overlay' or 'all' for kustomize-only guides"
+    fi
+    VALUES_FILES=("$BASE_VALUES")
+    for f in ${FEATURES[@]+"${FEATURES[@]}"}; do
+        VALUES_FILES+=("$(resolve_feature_file "$f")")
+    done
+    VALUES_FILES+=("$guide_values")
+    for f in ${EXTRA_VALUES[@]+"${EXTRA_VALUES[@]}"}; do
+        [[ -f "$f" ]] || die "values file '${f}' not found"
+        VALUES_FILES+=("$f")
+    done
+}
+
+router_kinds() {
+    case "$CHART_MODE" in
+        standalone|gateway) printf '%s\n' "$CHART_MODE" ;;
+        both) printf 'standalone\ngateway\n' ;;
+        *) die "--chart must be standalone, gateway, or both (got '${CHART_MODE}')" ;;
+    esac
+}
+
+cmd_router() {
+    GUIDE_DIR="$(resolve_guide_dir "$TARGET")"
+    require_cmd helm
+    resolve_values_files "$TARGET"
+    RELEASE="${RELEASE:-$TARGET}"
+    local kind
+    for kind in $(router_kinds); do
+        render_router "$kind" || die "helm template failed for chart kind '${kind}'"
+    done
+}
+
+cmd_overlay() {
+    init_kustomize
+    render_overlay "$TARGET"
+}
+
+cmd_list() {
+    GUIDE_DIR="$(resolve_guide_dir "$TARGET")"
+    local d
+    while IFS= read -r d; do
+        repo_relative "$d"
+    done < <(list_overlays "$GUIDE_DIR")
+}
+
+cmd_all() {
+    GUIDE_DIR="$(resolve_guide_dir "$TARGET")"
+    init_kustomize
+    local rc=0 kind d m
+
+    if [[ -d "${GUIDE_DIR}/router" ]]; then
+        require_cmd helm
+        resolve_values_files "$TARGET"
+        RELEASE="${RELEASE:-$TARGET}"
+        for kind in $(router_kinds); do
+            if ! render_router "$kind"; then
+                log "FAIL: router (${kind})"
+                rc=1
+            fi
+        done
+    else
+        log "note: guide '${TARGET}' has no router/ directory; skipping router rendering"
+    fi
+
+    local -a overlays=()
+    if [[ ${#MODELSERVERS[@]} -gt 0 ]]; then
+        for m in "${MODELSERVERS[@]}"; do
+            d="${GUIDE_DIR}/modelserver/${m}"
+            [[ -f "${d}/kustomization.yaml" ]] || die "no kustomization.yaml at $(repo_relative "$GUIDE_DIR")/modelserver/${m}; run 'scripts/render.sh list ${TARGET}' to see available overlays"
+            overlays+=("$d")
+        done
+    else
+        while IFS= read -r d; do
+            overlays+=("$d")
+        done < <(list_overlays "$GUIDE_DIR")
+    fi
+    for d in ${overlays[@]+"${overlays[@]}"}; do
+        if ! render_overlay "$d"; then
+            log "FAIL: overlay $(repo_relative "$d")"
+            rc=1
+        fi
+    done
+    return "$rc"
+}
+
+main() {
+    [[ $# -ge 1 ]] || { print_help >&2; exit 1; }
+    case "$1" in
+        -h|--help) print_help; exit 0 ;;
+    esac
+    CMD="$1"; shift
+    case "$CMD" in
+        router|overlay|list|all) ;;
+        *) die "unknown command '${CMD}' (see --help)" ;;
+    esac
+
+    ORIG_ARGS_STR="${CMD}${*:+ $*}"
+    TARGET=""
+    CHART_MODE="standalone"
+    RELEASE=""
+    CHART_VERSION_OVERRIDE=""
+    FEATURES=()
+    GUIDE_VALUES_OVERRIDE=""
+    EXTRA_VALUES=()
+    SET_ARGS=()
+    NAMESPACE=""
+    MODELSERVERS=()
+    OUTPUT_DIR=""
+    GUIDE_DIR=""
+    VALUES_FILES=()
+    local router_flag="" ms_flag="" out_flag=""
+
+    req() { [[ $# -eq 2 && -n "$2" ]] || die "option '$1' requires a value"; }
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --chart)        req "$1" "${2:-}"; CHART_MODE="$2"; router_flag="$1"; shift 2 ;;
+            --release)      req "$1" "${2:-}"; RELEASE="$2"; router_flag="$1"; shift 2 ;;
+            --version)      req "$1" "${2:-}"; CHART_VERSION_OVERRIDE="$2"; router_flag="$1"; shift 2 ;;
+            --monitoring)   FEATURES+=("monitoring"); router_flag="$1"; shift ;;
+            --feature)      req "$1" "${2:-}"; FEATURES+=("$2"); router_flag="$1"; shift 2 ;;
+            --guide-values) req "$1" "${2:-}"; GUIDE_VALUES_OVERRIDE="$2"; router_flag="$1"; shift 2 ;;
+            -f|--values)    req "$1" "${2:-}"; EXTRA_VALUES+=("$2"); router_flag="$1"; shift 2 ;;
+            --set)          req "$1" "${2:-}"; SET_ARGS+=("$2"); router_flag="$1"; shift 2 ;;
+            -n|--namespace) req "$1" "${2:-}"; NAMESPACE="$2"; router_flag="$1"; shift 2 ;;
+            --modelserver)  req "$1" "${2:-}"; MODELSERVERS+=("$2"); ms_flag="$1"; shift 2 ;;
+            -o|--output)    req "$1" "${2:-}"; OUTPUT_DIR="$2"; out_flag="$1"; shift 2 ;;
+            -h|--help)      print_help; exit 0 ;;
+            -*)             die "unknown option '$1' (see --help)" ;;
+            *)
+                [[ -z "$TARGET" ]] || die "unexpected argument '$1'"
+                TARGET="$1"; shift ;;
+        esac
+    done
+
+    [[ -n "$TARGET" ]] || die "command '${CMD}' requires an argument (see --help)"
+    case "$CMD" in
+        overlay|list)
+            [[ -z "$router_flag" ]] || die "option '${router_flag}' is not valid for command '${CMD}'"
+            [[ -z "$ms_flag" ]] || die "option '${ms_flag}' is not valid for command '${CMD}'"
+            ;;
+        router)
+            [[ -z "$ms_flag" ]] || die "option '${ms_flag}' is only valid for command 'all'"
+            ;;
+    esac
+    if [[ "$CMD" == "list" && -n "$out_flag" ]]; then
+        die "option '${out_flag}' is not valid for command 'list'"
+    fi
+
+    TMPFILE="$(mktemp)"
+    trap 'rm -f "$TMPFILE"' EXIT
+
+    case "$CMD" in
+        router)  cmd_router ;;
+        overlay) cmd_overlay ;;
+        list)    cmd_list ;;
+        all)     cmd_all ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Problem

`ci-kustomize-dry-run.yaml` encodes "how to hydrate a guide" inline, repeatedly:

- The router helm values layering (`base.values.yaml` + features + guide values) is copy-pasted **three times**, once per guide job, each hardcoding chart names, versions, and release names.
- `kustomize build` is invoked from **four differently-shaped loops**.

Every new guide job grows the workflow by another copy, and each copy must be kept in sync with the guide READMEs by hand. Small inconsistencies already exist between the copies (whether the monitoring layer is included, release naming conventions), which is the expected failure mode of this structure.

## What this PR does

Extracts the render commands into `scripts/render.sh` and refactors the workflow to call it. **Scope is deliberately minimal:**

- The workflow keeps its own overlay discovery loops, CRD install steps, per-unit pass/fail accounting, and `kubectl apply --dry-run=server`. Only the `helm template` / `kustomize build` lines are replaced.
- Deliberately preserved as-is (each is a candidate for its own follow-up, not silently changed here): the dev chart channel (`llm-d-router-*-dev` at `v0`), the existing release names (`optimized-baseline-router`, `pd-disaggregation-router`), and the existing per-job overlay discovery globs.
- Cleanups: removes the dead `simulated-accelerators` filter (no job, no output, no such guide directory), adds `scripts/render.sh` + `guides/env.sh` to the path filters, and extends shellcheck pre-commit coverage to the new script.

## Why this cannot break CI

The script's stdout carries only manifests (all logging goes to stderr), so `render.sh ... > /tmp/rendered.yaml` is a drop-in for the old commands. Verified locally:

- **Router units (5/5 byte-identical):** for each router render the workflow performs (optimized-baseline standalone + gateway, pd-disaggregation standalone + gateway, precise-prefix-cache-routing standalone), ran the old inline `helm template` and the new `render.sh` invocation back-to-back and diffed: empty. A control run (old command twice) confirmed template determinism against the floating `v0` tag first.
- **Overlays (18/18 byte-identical):** enumerated exactly the overlay set the workflow builds today using the workflow's own globs/find, diffed `kustomize build` against `render.sh overlay` for each: empty. `render.sh overlay <dir>` runs the same `kustomize build <dir>` underneath.
- shellcheck (`-x --severity=warning`, same as the hook) and yamllint (repo config) are clean.
- This PR touches the workflow file itself, which is in every path filter, so **all four dry-run jobs execute against this change** - a green run here is direct end-to-end evidence.

## Follow-ups this unlocks (separate PRs)

With rendering centralized, the workflow can be improved incrementally:

1. **Rendered-manifest diff in the job summary**: render base and head refs, publish the hydrated diff to `$GITHUB_STEP_SUMMARY`, so a one-line values change shows its full blast radius at review time (no extra permissions needed).
2. **Close the overlay coverage gap**: the existing 2-level globs in the optimized-baseline and pd-disaggregation jobs skip overlays whose kustomization sits at depth 3 (`gpu/vllm/base`, `gpu/*/gke`, `tpu/*`), so the default GPU paths are not currently dry-run. `render.sh list <guide>` already discovers these correctly (recursive, excludes kustomize components); switching the loops over is a small, reviewable change once any newly-surfaced failures are addressed.
3. **Revisit dev vs release chart validation**: CI validates the `-dev` charts at `v0` while the READMEs deploy release charts at `ROUTER_CHART_VERSION` - worth deciding whether CI should (also) validate what users actually install.

## Add-on: usable outside CI

Because the script encodes the same layering the READMEs document, it doubles as an inspection tool for users who want to see the full hydrated stack of a guide before or instead of deploying with helm:

```bash
# full stack for pd-disaggregation on GPU + GKE, standalone router
scripts/render.sh all pd-disaggregation --modelserver gpu/vllm/gke -o rendered/
```

Output defaults to release charts pinned in `guides/env.sh` (what the READMEs install); `--dev` selects the dev channel CI validates.
