### PR TITLE
docs(guides): add KEDA + EPP Pool-Level Saturation Metrics autoscaling guide

### DIFF
--- a/guides/workload-autoscaling/README.epp-keda-saturation.md
+++ b/guides/workload-autoscaling/README.epp-keda-saturation.md
@@ -54,13 +54,20 @@ kubectl create secret generic prometheus-auth \
 
 ### 2. Apply KEDA ScaledObject and TriggerAuthentication
 
+For **Kubernetes (generic)**:
 ```bash
 kubectl apply -k ${REPO_ROOT}/guides/workload-autoscaling/optimized-baseline-autoscaling/keda-epp-saturation -n ${NAMESPACE}
 ```
 
-Before applying, edit the manifests to match your deployment:
+For **OpenShift**:
+```bash
+kubectl apply -k ${REPO_ROOT}/guides/workload-autoscaling/optimized-baseline-autoscaling/keda-epp-saturation/overlays/ocp -n ${NAMESPACE}
+```
+
+Before applying, edit the base manifests to match your deployment:
 - `scaledobject.yaml`: Update `inference_pool` label in the PromQL queries, `minReplicaCount`, `maxReplicaCount`, and thresholds for each trigger.
-- `triggerauthentication.yaml`: Verify `serverAddress` points to your Prometheus instance.
+- If using the base k8s config, also update `<prometheus-url>` in `serverAddress` to point to your Prometheus instance.
+- `triggerauthentication.yaml`: Verify the bearer token Secret contains valid credentials for Prometheus access.
 
 ## Verify
 

--- a/guides/workload-autoscaling/README.epp-keda-saturation.md
+++ b/guides/workload-autoscaling/README.epp-keda-saturation.md
@@ -1,0 +1,92 @@
+# KEDA + EPP Pool-Level Saturation Metrics
+
+KEDA queries Prometheus directly for two EPP-emitted, InferencePool-scoped signals and scales the model server `Deployment` accordingly. No WVA controller, no Prometheus Adapter — just KEDA, Prometheus, and your model servers.
+
+## Metrics
+
+| Metric | Type | Description | Label |
+|---|---|---|---|
+| `llm_d_epp_flow_control_pool_saturation` | Gauge | Pool saturation level (0.0 to 1.0+). Values above 1.0 indicate the pool is overloaded and throttling requests. | `inference_pool` |
+| `inference_objective_running_requests` | Gauge | Current number of active in-flight requests across the pool. | `model_name` |
+
+For details on these metrics, see:
+- [EPP Flow Control Metrics](../../docs/architecture/core/router/epp/flow-control.md#metrics--observability)
+- [EPP Request Handling Metrics](../../docs/architecture/core/router/epp/request-handling.md)
+
+## Prerequisites
+
+Before proceeding, ensure you have:
+
+1. **Monitoring stack with Prometheus over HTTPS** — See [autoscaling prerequisites](README.md#prerequisites) and [Prometheus Setup Guide](../../docs/operations/observability/setup.md).
+
+2. **KEDA installed in your cluster** — Follow the [KEDA deployment guide](https://keda.sh/docs/2.20/deploy/).
+
+   > [!NOTE]
+   > On OpenShift, use the [Custom Metrics Autoscaler Operator](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/nodes/automatically-scaling-pods-with-the-custom-metrics-autoscaler-operator).
+
+3. **Optimized-baseline deployment** — Complete the [optimized-baseline guide](../optimized-baseline/README.md).
+
+## Set Namespaces
+
+```bash
+# Namespace where your inference deployment is running
+export NAMESPACE=llm-d-optimized-baseline
+
+# Namespace where the monitoring stack (Prometheus) was installed
+export MONITORING_NAMESPACE=llm-d-monitoring
+
+export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
+```
+
+## Configure
+
+### 1. Extract Prometheus CA Certificate and Create Secret
+
+```bash
+# Extract Prometheus CA cert
+PROMETHEUS_CA_CERT=$(kubectl get secret prometheus-web-tls -n ${MONITORING_NAMESPACE} -o jsonpath='{.data.tls\.crt}' | base64 -d)
+
+# Create generic secret with the CA cert for KEDA to access Prometheus API securely
+kubectl create secret generic prometheus-auth \
+  --from-literal=ca.crt="${PROMETHEUS_CA_CERT}" \
+  --dry-run=client -o yaml | kubectl apply -f - -n ${NAMESPACE}
+```
+
+### 2. Apply KEDA ScaledObject and TriggerAuthentication
+
+```bash
+kubectl apply -k ${REPO_ROOT}/guides/workload-autoscaling/optimized-baseline-autoscaling/keda-epp-saturation -n ${NAMESPACE}
+```
+
+Before applying, edit the manifests to match your deployment:
+- `scaledobject.yaml`: Update `inference_pool` label in the PromQL queries, `minReplicaCount`, `maxReplicaCount`, and thresholds for each trigger.
+- `triggerauthentication.yaml`: Verify `serverAddress` points to your Prometheus instance.
+
+## Verify
+
+Check that the ScaledObject is ready and KEDA has created its HPA:
+
+```bash
+kubectl get scaledobject -n ${NAMESPACE}
+kubectl get hpa -n ${NAMESPACE}
+```
+
+Expected output:
+
+```
+NAME                                    READY   ACTIVE   AGE
+optimized-baseline-nvidia-gpu-vllm      True    True     1m
+
+NAME                                    REFERENCE                                      TARGETS         MINPODS   MAXPODS   REPLICAS   AGE
+keda-hpa-optimized-baseline-nvidia-gpu  Deployment/optimized-baseline-nvidia-gpu       0%, 0%          1         10        1          1m
+```
+
+> [!NOTE]
+> KEDA creates its own HPA object from the ScaledObject. Do **not** apply a separate `hpa.yaml` — doing so will cause conflicts.
+
+## Cleanup
+
+```bash
+kubectl delete -k ${REPO_ROOT}/guides/workload-autoscaling/optimized-baseline-autoscaling/keda-epp-saturation -n ${NAMESPACE}
+kubectl delete secret prometheus-auth -n ${NAMESPACE}
+```

--- a/guides/workload-autoscaling/README.md
+++ b/guides/workload-autoscaling/README.md
@@ -52,9 +52,7 @@ Adapter.
 
 ### KEDA + EPP Pool-Level Saturation Metrics
 
-The [KEDA + EPP Pool-Level Saturation Metrics](./README.epp-keda-saturation.md) path has KEDA query Prometheus directly for InferencePool-scoped saturation and running-request metrics, then scale the model server Deployment.
-
-KEDA consumes two EPP metrics — pool saturation level (0.0–1.0+, normalized measure of how loaded the pool is) and active in-flight request count — and drives scaling decisions. Well-suited for simple homogeneous deployments where each model scales independently and you want minimal operational overhead.
+- The [KEDA + EPP Pool-Level Saturation Metrics](./README.epp-keda-saturation.md) path has KEDA query Prometheus directly for InferencePool-scoped saturation and running-request metrics, then scale the model server Deployment. KEDA consumes two EPP metrics — pool saturation level (0.0–1.0+, normalized measure of how loaded the pool is) and active in-flight request count — and drives scaling decisions. Well-suited for simple homogeneous deployments where each model scales independently and you want minimal operational overhead.
 
 ### HPA + WVA Metrics
 

--- a/guides/workload-autoscaling/README.md
+++ b/guides/workload-autoscaling/README.md
@@ -7,11 +7,7 @@ Traditional autoscaling indicators like resource utilization metrics (CPU/GPU) a
 
 Effective LLM autoscaling requires proactive, SLO-aware signals that reflect the true state of the inference system — queue depth, in-flight request counts, and KV cache pressure — so that capacity can be added before end-user latency is impacted.
 
-This guide covers the autoscaling strategies available in llm-d. The EPP path
-uses KEDA as its user-facing scaling primitive, while the WVA path publishes a
-desired-replica metric for an HPA or KEDA. The paths differ in the use cases
-they target, the metrics that drive them, and the operational complexity they
-require.
+This guide covers the autoscaling strategies available in llm-d. The EPP paths use KEDA as the scaling primitive, while the WVA path publishes a desired-replica metric for an HPA or KEDA. The paths differ in the use cases they target, the metrics that drive them, and the operational complexity they require.
 
 ## Prerequisites
 
@@ -54,6 +50,12 @@ before users experience sustained queueing and to remove capacity when demand
 falls. This path requires KEDA and Prometheus; it does not require Prometheus
 Adapter.
 
+### KEDA + EPP Pool-Level Saturation Metrics
+
+The [KEDA + EPP Pool-Level Saturation Metrics](./README.epp-keda-saturation.md) path has KEDA query Prometheus directly for InferencePool-scoped saturation and running-request metrics, then scale the model server Deployment.
+
+This is a controller-free approach: no WVA controller, no Prometheus Adapter. KEDA consumes two EPP metrics — pool saturation level (0.0–1.0+, normalized measure of how loaded the pool is) and active in-flight request count — and drives scaling decisions. Well-suited for simple homogeneous deployments where each model scales independently and you want minimal operational overhead.
+
 ### HPA + WVA Metrics
 
 The [Workload Variant Autoscaler (WVA)](./README.wva.md) path integrates the Kubernetes Horizontal Pod Autoscaler (HPA) with the aggregated signal emitted by WVA: `wva_desired_replicas`.
@@ -62,13 +64,13 @@ WVA is designed for operators running multiple variants of the same model across
 
 ## Choosing a Scaling Signal
 
-| | [KEDA + EPP Metrics](./README.hpa-epp.md) | [HPA + WVA Metrics](./README.wva.md) |
-|---|---|---|
-| **Best for** | Deployments on homogeneous hardware where each target model-server pool can be isolated by metrics and scaled independently | Multi-variant deployments where cost-aware capacity allocation across heterogeneous shared hardware is required |
-| **Scaling signal** | EPP metrics such as queue depth and running request count | KV cache utilization, queue depth, performance budgets |
-| **Cost optimization** | None — scales based on load signals only | Optimizes across variants by preferring lower-cost hardware |
-| **Additional components** | Requires KEDA and Prometheus| Requires the WVA controller |
-| **Scale to zero** | Supported | Supported |
+| | [KEDA + EPP Metrics](./README.hpa-epp.md) | [KEDA + EPP Pool-Level Saturation](./README.epp-keda-saturation.md) | [HPA + WVA Metrics](./README.wva.md) |
+|---|---|---|---|
+| **Best for** | Homogeneous single-model deployments; KEDA with external metrics via Prometheus Adapter | Homogeneous single-model deployments; controller-free, minimal overhead | Multi-variant deployments with cost-aware placement across heterogeneous hardware |
+| **Scaling signal** | EPP metrics such as queue depth and running request count | Pool saturation level (0.0–1.0+) and running request count | KV cache utilization, queue depth, performance budgets |
+| **Cost optimization** | None — scales based on load signals only | None — scales based on load signals only | Optimizes across variants by preferring lower-cost hardware |
+| **Additional components** | KEDA and Prometheus Adapter | KEDA and Prometheus only | KEDA and WVA controller |
+| **Scale to zero** | Supported | Supported | Supported |
 
 ## Features
 

--- a/guides/workload-autoscaling/README.md
+++ b/guides/workload-autoscaling/README.md
@@ -50,9 +50,9 @@ before users experience sustained queueing and to remove capacity when demand
 falls. This path requires KEDA and Prometheus; it does not require Prometheus
 Adapter.
 
-### KEDA + EPP Pool-Level Saturation Metrics
+- KEDA + EPP Pool-Level Saturation Metrics
 
-- The [KEDA + EPP Pool-Level Saturation Metrics](./README.epp-keda-saturation.md) path has KEDA query Prometheus directly for InferencePool-scoped saturation and running-request metrics, then scale the model server Deployment. KEDA consumes two EPP metrics — pool saturation level (0.0–1.0+, normalized measure of how loaded the pool is) and active in-flight request count — and drives scaling decisions. Well-suited for simple homogeneous deployments where each model scales independently and you want minimal operational overhead.
+  The [KEDA + EPP Pool-Level Saturation Metrics](./README.epp-keda-saturation.md) path has KEDA query Prometheus directly for InferencePool-scoped saturation and running-request metrics, then scale the model server Deployment. KEDA consumes two EPP metrics — pool saturation level (0.0–1.0+, normalized measure of how loaded the pool is) and active in-flight request count — and drives scaling decisions. Well-suited for simple homogeneous deployments where each model scales independently and you want minimal operational overhead.
 
 ### HPA + WVA Metrics
 

--- a/guides/workload-autoscaling/README.md
+++ b/guides/workload-autoscaling/README.md
@@ -54,7 +54,7 @@ Adapter.
 
 The [KEDA + EPP Pool-Level Saturation Metrics](./README.epp-keda-saturation.md) path has KEDA query Prometheus directly for InferencePool-scoped saturation and running-request metrics, then scale the model server Deployment.
 
-This is a controller-free approach: no WVA controller, no Prometheus Adapter. KEDA consumes two EPP metrics — pool saturation level (0.0–1.0+, normalized measure of how loaded the pool is) and active in-flight request count — and drives scaling decisions. Well-suited for simple homogeneous deployments where each model scales independently and you want minimal operational overhead.
+KEDA consumes two EPP metrics — pool saturation level (0.0–1.0+, normalized measure of how loaded the pool is) and active in-flight request count — and drives scaling decisions. Well-suited for simple homogeneous deployments where each model scales independently and you want minimal operational overhead.
 
 ### HPA + WVA Metrics
 

--- a/guides/workload-autoscaling/optimized-baseline-autoscaling/keda-epp-saturation/kustomization.yaml
+++ b/guides/workload-autoscaling/optimized-baseline-autoscaling/keda-epp-saturation/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - scaledobject.yaml
+  - triggerauthentication.yaml

--- a/guides/workload-autoscaling/optimized-baseline-autoscaling/keda-epp-saturation/overlays/ocp/kustomization.yaml
+++ b/guides/workload-autoscaling/optimized-baseline-autoscaling/keda-epp-saturation/overlays/ocp/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../
+
+patchesStrategicMerge:
+  - scaledobject-patch.yaml

--- a/guides/workload-autoscaling/optimized-baseline-autoscaling/keda-epp-saturation/overlays/ocp/scaledobject-patch.yaml
+++ b/guides/workload-autoscaling/optimized-baseline-autoscaling/keda-epp-saturation/overlays/ocp/scaledobject-patch.yaml
@@ -1,0 +1,15 @@
+# OpenShift-specific patch for KEDA ScaledObject.
+# Uses OpenShift's thanos-querier service for Prometheus access.
+
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: optimized-baseline-nvidia-gpu-vllm-decode-saturation
+spec:
+  triggers:
+  - name: pool-saturation
+    metadata:
+      serverAddress: "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"
+  - name: running-requests
+    metadata:
+      serverAddress: "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"

--- a/guides/workload-autoscaling/optimized-baseline-autoscaling/keda-epp-saturation/scaledobject.yaml
+++ b/guides/workload-autoscaling/optimized-baseline-autoscaling/keda-epp-saturation/scaledobject.yaml
@@ -3,7 +3,7 @@
 # Before applying, update:
 #   - inference_pool label in both trigger queries (model pool name)
 #   - model_name label in running-requests query
-#   - serverAddress in triggerauthentication.yaml to match your Prometheus
+#   - serverAddress to match your Prometheus endpoint (see overlays/ for platform-specific examples)
 #   - minReplicaCount, maxReplicaCount, and thresholds to suit your model
 #
 # KEDA will create its own HPA from this ScaledObject. Do NOT apply a separate hpa.yaml.
@@ -26,7 +26,7 @@ spec:
   - type: prometheus
     name: pool-saturation
     metadata:
-      serverAddress: "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"
+      serverAddress: "https://<prometheus-url>"
       query: |
         max(llm_d_epp_flow_control_pool_saturation{inference_pool="<pool-name>"})
       threshold: "<saturation-threshold>"
@@ -38,7 +38,7 @@ spec:
   - type: prometheus
     name: running-requests
     metadata:
-      serverAddress: "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"
+      serverAddress: "https://<prometheus-url>"
       query: |
         sum(inference_objective_running_requests{model_name="<model-name>"})
       threshold: "<requests-per-replica-target>"

--- a/guides/workload-autoscaling/optimized-baseline-autoscaling/keda-epp-saturation/scaledobject.yaml
+++ b/guides/workload-autoscaling/optimized-baseline-autoscaling/keda-epp-saturation/scaledobject.yaml
@@ -1,0 +1,49 @@
+# KEDA ScaledObject for direct EPP pool-level saturation autoscaling.
+#
+# Before applying, update:
+#   - inference_pool label in both trigger queries (model pool name)
+#   - model_name label in running-requests query
+#   - serverAddress in triggerauthentication.yaml to match your Prometheus
+#   - minReplicaCount, maxReplicaCount, and thresholds to suit your model
+#
+# KEDA will create its own HPA from this ScaledObject. Do NOT apply a separate hpa.yaml.
+
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: optimized-baseline-nvidia-gpu-vllm-decode-saturation
+  labels:
+    app: optimized-baseline-nvidia-gpu-vllm-decode
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: optimized-baseline-nvidia-gpu-vllm-decode
+  minReplicaCount: 1
+  maxReplicaCount: 10
+  pollingInterval: 15
+  triggers:
+  - type: prometheus
+    name: pool-saturation
+    metadata:
+      serverAddress: "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"
+      query: |
+        max(llm_d_epp_flow_control_pool_saturation{inference_pool="<pool-name>"})
+      threshold: "<saturation-threshold>"
+      activationThreshold: "0"
+      metricType: AverageValue
+      authenticationRef:
+        name: prometheus-auth
+      unsafeSsl: "false"
+  - type: prometheus
+    name: running-requests
+    metadata:
+      serverAddress: "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"
+      query: |
+        sum(inference_objective_running_requests{model_name="<model-name>"})
+      threshold: "<requests-per-replica-target>"
+      activationThreshold: "0"
+      metricType: AverageValue
+      authenticationRef:
+        name: prometheus-auth
+      unsafeSsl: "false"

--- a/guides/workload-autoscaling/optimized-baseline-autoscaling/keda-epp-saturation/triggerauthentication.yaml
+++ b/guides/workload-autoscaling/optimized-baseline-autoscaling/keda-epp-saturation/triggerauthentication.yaml
@@ -1,0 +1,17 @@
+# KEDA TriggerAuthentication for Prometheus bearer token access.
+#
+# References the prometheus-auth Secret (bearerToken + ca.crt) created by the guide's Configure step.
+# Both triggers reference this CR to authenticate to Prometheus securely.
+
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: prometheus-auth
+spec:
+  secretTargetRef:
+  - parameter: bearerToken
+    name: prometheus-auth
+    key: bearerToken
+  - parameter: ca
+    name: prometheus-auth
+    key: ca.crt


### PR DESCRIPTION
## Summary

- New guide for direct EPP+KEDA saturation autoscaling without WVA controller
- KEDA + EPP Pool-Level Saturation Metrics subsection under KEDA + EPP Metrics path
- Separated k8s-only base config from OpenShift overlay for platform-specific customization
- Updated comparison table to include all three autoscaling paths

## Files Changed

- New: `guides/workload-autoscaling/README.epp-keda-saturation.md` — step-by-step guide
- New: `guides/workload-autoscaling/optimized-baseline-autoscaling/keda-epp-saturation/` — base KEDA manifests
- New: `guides/workload-autoscaling/optimized-baseline-autoscaling/keda-epp-saturation/overlays/ocp/` — OpenShift-specific patches
- Modified: `guides/workload-autoscaling/README.md` — added new path documentation and updated tables

## Test Plan

- [x] Verified KEDA manifests build cleanly with `kubectl kustomize`
- [x] Verified metrics (`llm_d_epp_flow_control_pool_saturation`, `inference_objective_running_requests`) match source definitions
- [x] Verified guide links and cross-references
- [x] All commits properly signed with DCO

🤖 Generated with [Claude Code](https://claude.com/claude-code)