### PR TITLE
[docs] Add DisaggregatedSet variant of the P/D disaggregation guide

### DIFF
--- a/.github/workflows/ci-kustomize-dry-run.yaml
+++ b/.github/workflows/ci-kustomize-dry-run.yaml
@@ -188,6 +188,16 @@ jobs:
       - name: Install GKE CRDs
         run: .github/scripts/install-gke-crds.sh
 
+      - name: Install LWS and DisaggregatedSet CRDs
+        run: |
+          kubectl apply --server-side -f \
+            https://raw.githubusercontent.com/kubernetes-sigs/lws/v0.9.0/config/crd/bases/leaderworkerset.x-k8s.io_leaderworkersets.yaml
+          # DisaggregatedSet with spec.slices is merged upstream but not yet in a
+          # tagged release; pin to the lws main commit the DS guide variant was
+          # validated against. TODO: switch to the release tag once lws v0.10.0 ships.
+          kubectl apply --server-side -f \
+            https://raw.githubusercontent.com/kubernetes-sigs/lws/7072b297f13dab0ca0e92dc45b2076ea63a35e01/config/crd/bases/disaggregatedset.x-k8s.io_disaggregatedsets.yaml
+
       - name: Dry-run router charts
         run: |
           CHART_VERSION=v0

--- a/guides/pd-disaggregation/README.ds.md
+++ b/guides/pd-disaggregation/README.ds.md
@@ -136,8 +136,8 @@ A stuck slice degrades only itself; the other slices keep serving and finish the
 
 ### Pin slices to accelerator domains (placement policy)
 
-> [!WARNING]
-> `spec.placementPolicy` is **not yet merged or released** in LWS — it is under development (tracked in [lws#848](https://github.com/kubernetes-sigs/lws/issues/848)). Unlike `slices`, which is merged upstream and ships in the next LWS release, the example below only works with a controller built from the in-progress placement-policy branch. On released controllers the field is rejected by the CRD schema.
+> [!NOTE]
+> `spec.placementPolicy` is merged upstream ([lws#916](https://github.com/kubernetes-sigs/lws/pull/916), [KEP-848](https://github.com/kubernetes-sigs/lws/tree/main/keps/848-disaggregatedset-placement-policy)) and, like `slices`, ships in the next LWS release after `v0.9.0`. Controllers at `v0.9.0` or older reject the field.
 
 To confine each slice to one topology domain and spread slices across domains, set `placementPolicy` (a commented example ships in `modelserver/gpu/vllm-ds/disaggregatedset.yaml`):
 

--- a/guides/pd-disaggregation/README.ds.md
+++ b/guides/pd-disaggregation/README.ds.md
@@ -102,53 +102,15 @@ Follow the [monitoring section of the main guide](./README.md#3-enable-monitorin
 
 ## Operating the DisaggregatedSet
 
-### Scale the number of slices
+Day-to-day mechanics (scaling slices, scaling role replicas, rolling updates, placement policy) are DisaggregatedSet features rather than anything llm-d specific, and are documented in the [LWS DisaggregatedSet docs](https://lws.sigs.k8s.io/docs/examples/disaggregatedset/). The notes that matter for this guide:
 
-Add a third complete P/D copy (4 more prefill, 1 more decode). Because `slices` is excluded from the revision hash, this stands up slice 2 at the current revision **without touching slices 0 and 1**:
-
-```bash
-kubectl patch disaggregatedset pd-disagg -n ${NAMESPACE} --type merge -p '{"spec":{"slices":3}}'
-```
-
-Scaling down deletes the highest-indexed slices' resources directly; lower slices are untouched.
-
-### Scale replicas within a role
-
-Per-role `replicas` applies **per slice**. With 2 slices, raising prefill replicas from 4 to 6 yields 12 prefill instances in total:
-
-```bash
-kubectl patch disaggregatedset pd-disagg -n ${NAMESPACE} --type json \
-  -p '[{"op": "replace", "path": "/spec/roles/0/spec/replicas", "value": 6}]'
-```
-
-This is how you tune your xPyD ratio (see [P/D Best Practices](./README.md#pd-best-practices)) — the ratio is defined once and holds in every slice.
-
-### Rolling updates
-
-Any change to a role's pod template (image, flags, resources) creates a new revision, and each slice rolls to it **independently**, always keeping a complete same-version P/D set serving per slice. While a slice is mid-rollout you will see two revisions of its LWS at once (old draining, new filling). Watch a single slice with:
-
-```bash
-kubectl get leaderworkerset -n ${NAMESPACE} \
-  -l disaggregatedset.x-k8s.io/name=pd-disagg,disaggregatedset.x-k8s.io/slice=0 -w
-```
-
-A stuck slice degrades only itself; the other slices keep serving and finish their own rollouts.
-
-### Pin slices to accelerator domains (placement policy)
+* **Scaling `slices` adds or removes complete P/D copies** (4 prefill + 1 decode each) at the current revision, without touching existing slices.
+* **Per-role `replicas` applies per slice**, so your xPyD ratio (see [P/D Best Practices](./README.md#pd-best-practices)) is defined once and holds in every slice. With 2 slices, raising prefill replicas from 4 to 6 yields 12 prefill instances in total.
+* **Rolling updates proceed independently per slice**, always keeping a complete same-version P/D set serving in each slice. A stuck slice degrades only itself.
+* **Placement policy pins each complete P/D copy to one topology domain.** Use the node-label key that identifies your low-latency domain (for example a rack or NVLink-domain label on NVL72-class systems) so prefill-to-decode KV-cache transfer stays inside the domain. A commented example ships in `modelserver/gpu/vllm-ds/disaggregatedset.yaml`.
 
 > [!NOTE]
 > `spec.placementPolicy` is merged upstream ([lws#916](https://github.com/kubernetes-sigs/lws/pull/916), [KEP-848](https://github.com/kubernetes-sigs/lws/tree/main/keps/848-disaggregatedset-placement-policy)) and, like `slices`, ships in the next LWS release after `v0.9.0`. Controllers at `v0.9.0` or older reject the field.
-
-To confine each slice to one topology domain and spread slices across domains, set `placementPolicy` (a commented example ships in `modelserver/gpu/vllm-ds/disaggregatedset.yaml`):
-
-```yaml
-spec:
-  placementPolicy:
-    type: ExclusiveSlice # or ExclusiveTopology for a 1:1 domain-to-slice mapping across all DisaggregatedSets
-    topology: topology.kubernetes.io/zone # any node-label key: zone, rack, NVLink-domain, ...
-```
-
-Use the node-label key that identifies your low-latency domain — for example a rack or NVLink-domain label on NVL72-class systems — so prefill-to-decode KV-cache transfer stays inside the domain. The controller injects the affinity when it creates a LeaderWorkerSet, so changing the policy takes effect on each slice's next rollout.
 
 ## Verification
 

--- a/guides/pd-disaggregation/README.ds.md
+++ b/guides/pd-disaggregation/README.ds.md
@@ -1,0 +1,195 @@
+# P/D Disaggregation with DisaggregatedSet
+
+This guide deploys the same `openai/gpt-oss-120b` prefill-decode disaggregated stack as the main guide, but manages the whole P/D topology with a single [DisaggregatedSet](https://lws.sigs.k8s.io/docs/concepts/disaggregatedset/) resource from [LeaderWorkerSet (LWS)](https://lws.sigs.k8s.io/) instead of two independent Deployments.
+
+For a comprehensive overview of P/D disaggregation architecture, best practices, and benchmarking, please refer to the **[Unified P/D Disaggregation Guide](./README.md)**.
+
+## Why DisaggregatedSet?
+
+The Deployment-based variant of this guide manages prefill and decode as two unrelated workloads: nothing ties their versions together, rollouts are uncoordinated, and running several identical copies of the topology means duplicating manifests. DisaggregatedSet addresses this by making the P/D topology a first-class API object:
+
+* **One declarative unit** — the prefill and decode roles (replicas, rollout strategy, and pod template each) live in a single custom resource. Each role maps to a managed LeaderWorkerSet, so all LWS capabilities (multi-host groups, subgroup policies, exclusive placement) remain available per role.
+* **Coordinated rollouts** — a template change rolls prefill and decode as one version-synchronized unit, preserving your xPyD ratio throughout the update instead of letting two Deployments drift.
+* **Slices** — `spec.slices` replicates the entire role topology into N independent copies. Each slice is a complete prefill+decode set with its own rollout clock and a stable identity (`disaggregatedset.x-k8s.io/slice` label). Changing `slices` is a pure scale operation: it never re-rolls existing slices.
+* **Placement policy** — `spec.placementPolicy` builds on the slice identity to confine each complete P/D copy to a single topology domain (a rack, NVLink domain, or zone) and spread slices across domains, so KV-cache handoff stays within a low-latency domain.
+
+### Topology in this guide
+
+Instead of one flat 8-prefill/2-decode pool, this variant deploys **2 slices**, each a complete copy of the topology:
+
+* Per slice: 4 TP=1 Prefill instances + 1 TP=4 Decode instance
+* Total: 8 TP=1 Prefill + 2 TP=4 Decode — the same aggregate capacity (16 GPUs) as the [main guide](./README.md#overview)
+
+Each slice can be rolled, recovered, or (with placement policy) pinned to an accelerator domain independently of the other.
+
+> [!NOTE]
+> Slices are a deployment-topology construct: they govern rollout, scale, and placement. The llm-d Router (EPP) still discovers all prefill and decode pods by label as flat pools and may pair a prefill in one slice with a decode in another. If you use placement policy to confine slices to separate network domains, make sure cross-domain NIXL transfers remain possible on your fabric.
+
+## Prerequisites
+
+### 1. LWS Controller with DisaggregatedSet
+
+This variant requires the LWS controller manager with the DisaggregatedSet API. The `slices` field used here was added after LWS `v0.9.0` — install `v0.10.0` or newer (see the [LWS installation guide](https://lws.sigs.k8s.io/docs/installation/#disaggregatedset) for the current release and options):
+
+```bash
+export LWS_CHART_VERSION=0.10.0
+helm install lws oci://registry.k8s.io/lws/charts/lws \
+  --version=${LWS_CHART_VERSION} \
+  --namespace lws-system \
+  --create-namespace \
+  --set enableDisaggregatedSet=true \
+  --wait --timeout 300s
+```
+
+Verify the controller is available and the CRD is registered:
+
+```bash
+kubectl wait deploy/lws-controller-manager -n lws-system --for=condition=available --timeout=5m
+kubectl get crd disaggregatedsets.disaggregatedset.x-k8s.io
+```
+
+### 2. Cluster and Repo Setup
+
+Complete the **[Prerequisites](./README.md#prerequisites)** section of the main guide: client tools, repo checkout, environment variables, Gateway API Inference Extension CRDs, target namespace, and the `llm-d-hf-token` secret. The same environment variables apply:
+
+```bash
+export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
+source ${REPO_ROOT}/guides/env.sh
+export GUIDE_NAME="pd-disaggregation"
+export NAMESPACE="llm-d-pd-disaggregation"
+export MODEL_NAME="openai/gpt-oss-120b"
+```
+
+## Installation Instructions
+
+### 1. Deploy the llm-d Router
+
+Deploy the router in either Standalone or Gateway mode by following the exact instructions in the **[Deploy the llm-d Router](./README.md#1-deploy-the-llm-d-router)** section of the main guide. Nothing changes here: the EPP discovers model server pods by label (`llm-d.ai/guide` and `llm-d.ai/role`), which the DisaggregatedSet's pod templates carry, so routing is identical regardless of which workload controller manages the pods.
+
+### 2. Deploy the Model Server
+
+Apply the DisaggregatedSet overlay:
+
+```bash
+kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/gpu/vllm-ds
+```
+
+This creates one `DisaggregatedSet` named `pd-disagg`. The controller fans it out into one LeaderWorkerSet per `(slice, role)`, named `<ds>-<slice>-<revision>-<role>`:
+
+```bash
+kubectl get leaderworkerset -n ${NAMESPACE} -l disaggregatedset.x-k8s.io/name=pd-disagg
+
+# NAME                           READY   DESIRED   UP-TO-DATE   AGE
+# pd-disagg-0-785b966c-decode    1       1         1            2m
+# pd-disagg-0-785b966c-prefill   4       4         4            2m
+# pd-disagg-1-785b966c-decode    1       1         1            2m
+# pd-disagg-1-785b966c-prefill   4       4         4            2m
+```
+
+> [!NOTE]
+> The revision hash (`785b966c` above) is generated dynamically and changes on each rollout. Always query child objects through labels (`disaggregatedset.x-k8s.io/name`, `.../slice`, `.../role`) rather than hardcoded names.
+
+Check readiness per slice and role through the child LeaderWorkerSets, e.g. for slice 0:
+
+```bash
+kubectl get leaderworkerset -n ${NAMESPACE} \
+  -l disaggregatedset.x-k8s.io/name=pd-disagg,disaggregatedset.x-k8s.io/slice=0
+```
+
+### 3. Enable Monitoring (optional)
+
+Follow the [monitoring section of the main guide](./README.md#3-enable-monitoring-optional) — the model server pods carry the same labels as the Deployment-based variant, so the same monitoring resources apply.
+
+## Operating the DisaggregatedSet
+
+### Scale the number of slices
+
+Add a third complete P/D copy (4 more prefill, 1 more decode). Because `slices` is excluded from the revision hash, this stands up slice 2 at the current revision **without touching slices 0 and 1**:
+
+```bash
+kubectl patch disaggregatedset pd-disagg -n ${NAMESPACE} --type merge -p '{"spec":{"slices":3}}'
+```
+
+Scaling down deletes the highest-indexed slices' resources directly; lower slices are untouched.
+
+### Scale replicas within a role
+
+Per-role `replicas` applies **per slice**. With 2 slices, raising prefill replicas from 4 to 6 yields 12 prefill instances in total:
+
+```bash
+kubectl patch disaggregatedset pd-disagg -n ${NAMESPACE} --type json \
+  -p '[{"op": "replace", "path": "/spec/roles/0/spec/replicas", "value": 6}]'
+```
+
+This is how you tune your xPyD ratio (see [P/D Best Practices](./README.md#pd-best-practices)) — the ratio is defined once and holds in every slice.
+
+### Rolling updates
+
+Any change to a role's pod template (image, flags, resources) creates a new revision, and each slice rolls to it **independently**, always keeping a complete same-version P/D set serving per slice. While a slice is mid-rollout you will see two revisions of its LWS at once (old draining, new filling). Watch a single slice with:
+
+```bash
+kubectl get leaderworkerset -n ${NAMESPACE} \
+  -l disaggregatedset.x-k8s.io/name=pd-disagg,disaggregatedset.x-k8s.io/slice=0 -w
+```
+
+A stuck slice degrades only itself; the other slices keep serving and finish their own rollouts.
+
+### Pin slices to accelerator domains (placement policy)
+
+> [!WARNING]
+> `spec.placementPolicy` is **not yet merged or released** in LWS — it is under development (tracked in [lws#848](https://github.com/kubernetes-sigs/lws/issues/848)). Unlike `slices`, which is merged upstream and ships in the next LWS release, the example below only works with a controller built from the in-progress placement-policy branch. On released controllers the field is rejected by the CRD schema.
+
+To confine each slice to one topology domain and spread slices across domains, set `placementPolicy` (a commented example ships in `modelserver/gpu/vllm-ds/disaggregatedset.yaml`):
+
+```yaml
+spec:
+  placementPolicy:
+    type: ExclusiveSlice # or ExclusiveTopology for a 1:1 domain-to-slice mapping across all DisaggregatedSets
+    topology: topology.kubernetes.io/zone # any node-label key: zone, rack, NVLink-domain, ...
+```
+
+Use the node-label key that identifies your low-latency domain — for example a rack or NVLink-domain label on NVL72-class systems — so prefill-to-decode KV-cache transfer stays inside the domain. The controller injects the affinity when it creates a LeaderWorkerSet, so changing the policy takes effect on each slice's next rollout.
+
+## Verification
+
+Follow the **[Verification steps in the main guide](./README.md#verification)** to retrieve the proxy IP and send a test request — the model name and request are identical:
+
+```bash
+curl -X POST http://${IP}/v1/completions \
+    -H 'Content-Type: application/json' \
+    -d '{
+        "model": "openai/gpt-oss-120b",
+        "prompt": "How are you today?"
+    }' | jq
+```
+
+You can confirm both roles participate by checking pod logs per role:
+
+```bash
+kubectl logs -n ${NAMESPACE} -l llm-d.ai/role=prefill --tail=10
+kubectl logs -n ${NAMESPACE} -l llm-d.ai/role=decode --tail=10
+```
+
+## Benchmarking
+
+The deployed stack has the same aggregate topology, model, and endpoint as the Deployment-based variant, so the **[Benchmarking section of the main guide](./README.md#benchmarking)** applies verbatim — install `llmdbenchmark`, resolve the endpoint, and run the `guide_pd-disaggregation_1.yaml` workload profile.
+
+## Cleanup
+
+Remove the router:
+
+```bash
+helm uninstall ${GUIDE_NAME} -n ${NAMESPACE}
+```
+
+Remove the model server. Deleting the DisaggregatedSet cascades to all child LeaderWorkerSets, their pods, and per-slice Services:
+
+```bash
+kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/gpu/vllm-ds
+```
+
+## Further Reading
+
+* [DisaggregatedSet concepts](https://lws.sigs.k8s.io/docs/concepts/disaggregatedset/) and [API reference](https://lws.sigs.k8s.io/docs/reference/disaggregatedset.v1/)
+* [KEP-766: DisaggregatedSet](https://github.com/kubernetes-sigs/lws/tree/main/keps/766-DisaggregatedSet) — the coordinated multi-role rollout design
+* [KEP-846: DisaggregatedSet Slices](https://github.com/kubernetes-sigs/lws/tree/main/keps/846-disaggregatedset-slices) — slice semantics, naming, and scale behavior

--- a/guides/pd-disaggregation/README.ds.md
+++ b/guides/pd-disaggregation/README.ds.md
@@ -188,6 +188,14 @@ Remove the model server. Deleting the DisaggregatedSet cascades to all child Lea
 kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/gpu/vllm-ds
 ```
 
+## Known Issues
+
+Testing this guide surfaced the following upstream issues in the DisaggregatedSet controller (being filed against [kubernetes-sigs/lws](https://github.com/kubernetes-sigs/lws)). None affect the deploy, slice scaling, or serving paths above.
+
+1. **Rolling update can drain the old revision immediately when replicas change with the template.** If a single apply changes a role's pod template *and* its `replicas`, the planner can scale the old revision to zero before any new pod is ready, causing an outage. Until fixed, change the template and replica counts in **separate applies**.
+2. **Rolling updates can stall on fully allocated clusters.** With `maxSurge: 0`, the controller creates new pods before draining their old counterparts, then waits for them to become ready. On a cluster with no spare accelerators the new pods stay Pending and the rollout never progresses. Until fixed, ensure at least one decode's worth of free accelerators before a template change (for example by scaling `slices` down by one first), or unstick a stalled rollout by scaling the old revision's LeaderWorkerSet down manually.
+3. **`status.roleStatuses` is not yet populated.** The API defines it, but the controller does not write status today. Use the label-based LeaderWorkerSet queries shown in this guide instead.
+
 ## Further Reading
 
 * [DisaggregatedSet concepts](https://lws.sigs.k8s.io/docs/concepts/disaggregatedset/) and [API reference](https://lws.sigs.k8s.io/docs/reference/disaggregatedset.v1/)

--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -12,6 +12,11 @@ This guide deploys `openai/gpt-oss-120b` with prefill-decode disaggregation, imp
 * 8 TP=1 Prefill Instances
 * 2 TP=4 Decode Instances
 
+This guide also has two alternate variants:
+
+* **[Google TPU](./README.tpu.md)** — the same P/D pattern on GKE TPU (v6e & v7x).
+* **[DisaggregatedSet](./README.ds.md)** — the same deployment managed as a single LWS `DisaggregatedSet` resource, with coordinated P/D rollouts, `slices` for replicating the whole topology into independent copies, and per-domain placement policy.
+
 ### P/D Best Practices
 
 P/D disaggregation provides more flexibility in navigating the trade-off between throughput and interactivity([ref](https://arxiv.org/html/2506.05508v1)).
@@ -39,6 +44,7 @@ This guide includes configuration for the following accelerators:
 | Backend             | Directory                  | Notes                                                    |
 | ------------------- | -------------------------- | -------------------------------------------------------- |
 | NVIDIA GPU (vLLM)   | `modelserver/gpu/vllm/`    | vLLM, tested nightly on GKE (see [Cluster Pre-provisioning](#gke-cluster-pre-provisioning-with-dra--rdmaroce)) |
+| NVIDIA GPU (vLLM + DisaggregatedSet) | `modelserver/gpu/vllm-ds/` | Manages the whole P/D topology as one LWS `DisaggregatedSet` with `slices`, see [DisaggregatedSet Guide](./README.ds.md) |
 | NVIDIA GPU (SGLang) | `modelserver/gpu/sglang/`  | SGLang, validated each release                           |
 | Google TPU          | `modelserver/tpu/v6/vllm/` & `modelserver/tpu/v7/vllm/` | GKE TPU (v6e & v7x), see [TPU Guide](./README.tpu.md) |
 | AMD GPU             | `modelserver/amd/vllm/`    | AMD GPU, community contributed                           |

--- a/guides/pd-disaggregation/modelserver/gpu/vllm-ds/disaggregatedset.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm-ds/disaggregatedset.yaml
@@ -23,10 +23,9 @@ spec:
   # LeaderWorkerSet is created, so enabling this takes effect on the next
   # rollout. ExclusiveTopology additionally guarantees at most one slice per
   # domain across all DisaggregatedSets.
-  # NOTE: placementPolicy is not yet merged/released in LWS (tracked in
-  # https://github.com/kubernetes-sigs/lws/issues/848); released controllers
-  # reject this field. slices, by contrast, is merged and ships in the next
-  # LWS release.
+  # NOTE: placementPolicy is merged upstream (kubernetes-sigs/lws#916) and,
+  # like slices, ships in the next LWS release after v0.9.0. Controllers at
+  # v0.9.0 or older reject this field.
   # placementPolicy:
   #   type: ExclusiveSlice
   #   topology: topology.kubernetes.io/zone

--- a/guides/pd-disaggregation/modelserver/gpu/vllm-ds/disaggregatedset.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm-ds/disaggregatedset.yaml
@@ -1,0 +1,287 @@
+apiVersion: disaggregatedset.x-k8s.io/v1
+kind: DisaggregatedSet
+metadata:
+  name: pd-disagg
+  labels:
+    llm-d.ai/inference-serving: "true"
+    llm-d.ai/guide: pd-disaggregation
+    llm-d.ai/accelerator-variant: gpu
+    llm-d.ai/accelerator-vendor: nvidia
+    llm-d.ai/engine-type: vllm
+    llm-d.ai/model: gpt-oss-120b
+spec:
+  # Two independent copies of the whole P/D topology. Each slice is a complete
+  # 4-prefill + 1-decode set that rolls out and recovers on its own clock.
+  # Aggregate capacity matches the Deployment-based variant of this guide:
+  # 8 x TP=1 prefill and 2 x TP=4 decode. Changing slices is a pure scale
+  # operation and never triggers a rollout of existing slices.
+  slices: 2
+
+  # Optionally confine each slice to a single topology domain (rack, NVLink
+  # domain, zone, ...) and spread slices across domains, so prefill hands KV
+  # cache to decode within the domain. Affinity is injected when a
+  # LeaderWorkerSet is created, so enabling this takes effect on the next
+  # rollout. ExclusiveTopology additionally guarantees at most one slice per
+  # domain across all DisaggregatedSets.
+  # NOTE: placementPolicy is not yet merged/released in LWS (tracked in
+  # https://github.com/kubernetes-sigs/lws/issues/848); released controllers
+  # reject this field. slices, by contrast, is merged and ships in the next
+  # LWS release.
+  # placementPolicy:
+  #   type: ExclusiveSlice
+  #   topology: topology.kubernetes.io/zone
+
+  roles:
+    - name: prefill
+      spec:
+        replicas: 4 # per slice
+        rolloutStrategy:
+          rollingUpdateConfiguration:
+            maxSurge: 0
+            maxUnavailable: 1
+        leaderWorkerTemplate:
+          size: 1 # single-host: each group is one pod
+          workerTemplate:
+            metadata:
+              labels:
+                llm-d.ai/inference-serving: "true"
+                llm-d.ai/guide: pd-disaggregation
+                llm-d.ai/accelerator-variant: gpu
+                llm-d.ai/accelerator-vendor: nvidia
+                llm-d.ai/engine-type: vllm
+                llm-d.ai/model: gpt-oss-120b
+                llm-d.ai/role: prefill
+            spec:
+              serviceAccountName: pd-disagg
+              containers:
+                - name: modelserver
+                  image: REPLACE_MODEL_SERVER_IMAGE
+                  command: ["vllm", "serve"]
+                  args:
+                    - "openai/gpt-oss-120b"
+                    - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+                    - "--tensor-parallel-size=1"
+                    - "--block-size=128"
+                    - "--kv-transfer-config"
+                    - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+                    - "--no-disable-hybrid-kv-cache-manager"
+                  env:
+                    - name: HF_TOKEN
+                      valueFrom:
+                        secretKeyRef:
+                          name: llm-d-hf-token
+                          key: HF_TOKEN
+                    - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: status.podIP
+                    # NOTE: vLLM 0.19.X and 0.20.X images ship both nixl-cu13 and nixl-cu12;
+                    # NIXL can pick the wrong UCX libraries. Uncomment UCX_MODULE_DIR only
+                    # if you are running a cu129 version of vLLM.
+                    # - name: UCX_MODULE_DIR
+                    #   value: /usr/local/lib/python3.12/dist-packages/nixl_cu12.libs/ucx
+                    # Default vLLM keep-alive (5s) is shorter than llm-d-routing-sidecar's default idle
+                    # conn timeout (90s, from Go http.Transport), causing TCP RSTs on reuse.
+                    # Server keep-alive must be >= sidecar idle timeout; configured to 120s.
+                    - name: VLLM_HTTP_TIMEOUT_KEEP_ALIVE
+                      value: "120"
+                    # Workaround for https://github.com/vllm-project/vllm/issues/44548,
+                    # required with vLLM v0.20.0+ due to torch 2.11. The gpu-vllm images
+                    # component injects this into Deployments and LeaderWorkerSets, but its
+                    # patch does not target DisaggregatedSet, so it is set inline here.
+                    - name: USER
+                      value: llm-d
+                  ports:
+                    - name: modelserver
+                      containerPort: 8000
+                      protocol: TCP
+                    - name: nixl
+                      containerPort: 5600
+                      protocol: TCP
+                  resources:
+                    limits:
+                      cpu: "8"
+                      memory: 16Gi
+                      nvidia.com/gpu: "1"
+                    requests:
+                      cpu: "8"
+                      memory: 16Gi
+                      nvidia.com/gpu: "1"
+                  startupProbe:
+                    httpGet:
+                      path: /v1/models
+                      port: modelserver
+                    initialDelaySeconds: 15
+                    periodSeconds: 30
+                    timeoutSeconds: 5
+                    failureThreshold: 120
+                  livenessProbe:
+                    httpGet:
+                      path: /health
+                      port: modelserver
+                    periodSeconds: 10
+                    timeoutSeconds: 5
+                    failureThreshold: 3
+                  readinessProbe:
+                    httpGet:
+                      path: /v1/models
+                      port: modelserver
+                    periodSeconds: 5
+                    timeoutSeconds: 2
+                    failureThreshold: 3
+                  volumeMounts:
+                    - mountPath: /dev/shm
+                      name: shm
+                    - mountPath: /.cache
+                      name: torch-compile-cache
+                    - mountPath: /.config
+                      name: vllm-config
+                    - mountPath: /.triton
+                      name: triton-cache
+              volumes:
+                - name: shm
+                  emptyDir:
+                    medium: Memory
+                    sizeLimit: 20Gi
+                - name: torch-compile-cache
+                  emptyDir: {}
+                - name: vllm-config
+                  emptyDir: {}
+                - name: triton-cache
+                  emptyDir: {}
+
+    - name: decode
+      spec:
+        replicas: 1 # per slice
+        rolloutStrategy:
+          rollingUpdateConfiguration:
+            # Surge so a slice never loses its only decode during a rollout.
+            # Requires 4 spare GPUs while a slice rolls; set maxSurge: 0 /
+            # maxUnavailable: 1 instead on capacity-constrained clusters.
+            maxSurge: 1
+            maxUnavailable: 0
+        leaderWorkerTemplate:
+          size: 1 # single-host: each group is one pod
+          workerTemplate:
+            metadata:
+              labels:
+                llm-d.ai/inference-serving: "true"
+                llm-d.ai/guide: pd-disaggregation
+                llm-d.ai/accelerator-variant: gpu
+                llm-d.ai/accelerator-vendor: nvidia
+                llm-d.ai/engine-type: vllm
+                llm-d.ai/model: gpt-oss-120b
+                llm-d.ai/role: decode
+            spec:
+              serviceAccountName: pd-disagg
+              initContainers:
+                - name: routing-proxy
+                  image: REPLACE_ROUTING_SIDECAR_IMAGE
+                  imagePullPolicy: Always
+                  args:
+                    - --port=8000
+                    - --vllm-port=8200
+                    - --kv-connector=nixlv2
+                    - --zap-log-level=1
+                    - --secure-proxy=false
+                  ports:
+                    - name: sidecar
+                      containerPort: 8000
+                      protocol: TCP
+                  resources: {}
+                  restartPolicy: Always
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    runAsNonRoot: true
+              containers:
+                - name: modelserver
+                  image: REPLACE_MODEL_SERVER_IMAGE
+                  command: ["vllm", "serve"]
+                  args:
+                    - "openai/gpt-oss-120b"
+                    - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+                    - "--tensor-parallel-size=4"
+                    - "--block-size=128"
+                    - "--kv-transfer-config"
+                    - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
+                    - "--no-disable-hybrid-kv-cache-manager"
+                    - "--port=8200"
+                  env:
+                    - name: HF_TOKEN
+                      valueFrom:
+                        secretKeyRef:
+                          name: llm-d-hf-token
+                          key: HF_TOKEN
+                    - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: status.podIP
+                    # NOTE: vLLM 0.19.X and 0.20.X images ship both nixl-cu13 and nixl-cu12;
+                    # NIXL can pick the wrong UCX libraries. Uncomment UCX_MODULE_DIR only
+                    # if you are running a cu129 version of vLLM.
+                    # - name: UCX_MODULE_DIR
+                    #   value: /usr/local/lib/python3.12/dist-packages/nixl_cu12.libs/ucx
+                    # Workaround for https://github.com/vllm-project/vllm/issues/44548,
+                    # required with vLLM v0.20.0+ due to torch 2.11. The gpu-vllm images
+                    # component injects this into Deployments and LeaderWorkerSets, but its
+                    # patch does not target DisaggregatedSet, so it is set inline here.
+                    - name: USER
+                      value: llm-d
+                  ports:
+                    - name: modelserver
+                      containerPort: 8200
+                      protocol: TCP
+                    - name: nixl
+                      containerPort: 5600
+                      protocol: TCP
+                  resources:
+                    limits:
+                      cpu: "16"
+                      memory: 64Gi
+                      nvidia.com/gpu: "4"
+                    requests:
+                      cpu: "16"
+                      memory: 64Gi
+                      nvidia.com/gpu: "4"
+                  startupProbe:
+                    httpGet:
+                      path: /v1/models
+                      port: modelserver
+                    initialDelaySeconds: 15
+                    periodSeconds: 30
+                    timeoutSeconds: 5
+                    failureThreshold: 120
+                  livenessProbe:
+                    httpGet:
+                      path: /health
+                      port: modelserver
+                    periodSeconds: 10
+                    timeoutSeconds: 5
+                    failureThreshold: 3
+                  readinessProbe:
+                    httpGet:
+                      path: /v1/models
+                      port: modelserver
+                    periodSeconds: 5
+                    timeoutSeconds: 2
+                    failureThreshold: 3
+                  volumeMounts:
+                    - mountPath: /dev/shm
+                      name: shm
+                    - mountPath: /.cache
+                      name: torch-compile-cache
+                    - mountPath: /.config
+                      name: vllm-config
+                    - mountPath: /.triton
+                      name: triton-cache
+              volumes:
+                - name: shm
+                  emptyDir:
+                    medium: Memory
+                    sizeLimit: 20Gi
+                - name: torch-compile-cache
+                  emptyDir: {}
+                - name: vllm-config
+                  emptyDir: {}
+                - name: triton-cache
+                  emptyDir: {}

--- a/guides/pd-disaggregation/modelserver/gpu/vllm-ds/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm-ds/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - serviceaccount.yaml
+  - disaggregatedset.yaml
+
+# Resolve the REPLACE_MODEL_SERVER_IMAGE / REPLACE_ROUTING_SIDECAR_IMAGE
+# placeholders to the same pinned images used by the Deployment-based overlays.
+components:
+  - ../../../../recipes/modelserver/components/images/gpu-vllm
+  - ../../../../recipes/modelserver/components/images/routing-sidecar

--- a/guides/pd-disaggregation/modelserver/gpu/vllm-ds/serviceaccount.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm-ds/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pd-disagg
+automountServiceAccountToken: false


### PR DESCRIPTION
## What

Adds a third variant of the pd-disaggregation guide (alongside the default Deployment-based guide and the TPU variant) that manages the whole P/D topology with a single LWS DisaggregatedSet resource:

1. `guides/pd-disaggregation/README.ds.md`: DS prerequisites, deploy, slice operations (scale slices, per-role replicas, per-slice rolling updates, placement policy), verification, benchmarking, cleanup.
2. `guides/pd-disaggregation/modelserver/gpu/vllm-ds/`: Kustomize overlay with the DS manifest, prefill/decode roles carrying the same vLLM args, routing-proxy sidecar, probes, and labels as the Deployment-based overlay; slices: 2 (2 × [4 × TP1 prefill + 1 × TP4 decode], same 16-GPU aggregate as the main guide). Images resolved via the shared gpu-vllm / routing-sidecar components.
- `guides/pd-disaggregation/README.md`: variants blurb + backends-table row linking the new guide.

## Why

The Deployment-based guide manages prefill and decode as two seperate workloads with no version coupling. This results in uncoordinated rollouts and duplicated manifests. DisaggregatedSet makes the P/D topology one declarative unit with version-synchronized per-slice rollouts. It also adds the slices feature: allowing for an arbitrary number of `slices: N` independent complete copies of each LWS role, and (upcoming) per-domain placement policy (see link below). Router integration is unchanged as EPP discovers pods by the same labels regardless of workload controller.

## Requirements / caveats

- Requires the LWS controller with DisaggregatedSet enabled; spec.slices is merged upstream and ships in the next LWS release (> v0.9.0).
- spec.placementPolicy is documented but not yet merged in LWS (kubernetes-sigs/lws#848). The guide and manifest carry explicit notes on this, and the field is commented out.
- As mentioned before, EPP schedules across slices as flat pools. DS is not concerned with routing.

## Testing

- kubectl kustomize builds cleanly, DS fan-out, naming (`<ds>-<slice>-<revision>-<role>`), labels, and per-slice Services validated on GKE.
- Slices scale up/down at constant revision with zero disruption to existing slices
- per-role replica scaling applied per-slice without a rollout; independent per-slice rolling updates; cascade cleanup.
- tested e2e (with 16 × A100, guide-shape topology, NIXL over TCP): disaggregated serving through the llm-d router in both standalone and GKE Inference Gateway modes, heterogeneous TP1→TP4 KV transfer confirmed (TransferTopology tp_ratio=4), and benchmarked with inference-perf (8 qps: 720/720 success, TTFT p90 680 ms, ITL p50 4.8 ms).


> NOTE: Testing surfaced two upstream LWS rolling-update planner issues:
> 1. Instant old-revision drain when replicas change with a template
> 2. rollout deadlock on fully-allocated clusters

> These are being looked at and neither are issues for the sake of this guide. There's a note on them at the bottom of the readme and they should be removed once fixed. 