### PR TITLE
test(autoscaling): validate initial KEDA+EPP state on OpenShift

### DIFF
--- a/.github/scripts/e2e/e2e-validate-keda-epp.sh
+++ b/.github/scripts/e2e/e2e-validate-keda-epp.sh
@@ -1,0 +1,636 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Validate the initial direct KEDA+EPP state on OpenShift. The generic inference
+# smoke runs before this script, so the EPP metric label sets should exist, but
+# this script does not generate autoscaling load or assert scale-up behavior.
+
+show_help() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Options:
+  -n, --namespace NAMESPACE   Kubernetes namespace (default: llm-d)
+  -m, --model MODEL_ID        Model discovered by the generic smoke validator
+  -h, --help                  Show this help and exit
+EOF
+  exit 0
+}
+
+NAMESPACE=llm-d
+CLI_MODEL_ID=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -n|--namespace) NAMESPACE="$2"; shift 2 ;;
+    -m|--model) CLI_MODEL_ID="$2"; shift 2 ;;
+    -h|--help) show_help ;;
+    *) echo "Unknown option: $1" >&2; show_help ;;
+  esac
+done
+
+EXPECTED_MODEL_ID="Qwen/Qwen3-32B"
+MODEL_DEPLOYMENT=optimized-baseline-nvidia-gpu-vllm-decode
+EPP_DEPLOYMENT=optimized-baseline-epp
+EPP_SERVICE=optimized-baseline-epp
+EPP_SERVICEMONITOR=optimized-baseline-epp-monitor
+MODEL_PODMONITOR=decode
+SCALEDOBJECT=optimized-baseline-keda-epp
+EXPECTED_HPA=keda-hpa-optimized-baseline
+AUTH_SERVICEACCOUNT=keda-epp-prometheus
+AUTH_SECRET=keda-prometheus-auth
+TRIGGER_AUTHENTICATION=keda-prometheus-auth
+THANOS_URL=https://thanos-querier.openshift-monitoring.svc.cluster.local:9091/api/v1/query
+POLL_TIMEOUT_SECONDS="${POLL_TIMEOUT_SECONDS:-300}"
+POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-10}"
+FALLBACK_POLL_INTERVAL_SECONDS="${FALLBACK_POLL_INTERVAL_SECONDS:-15}"
+FALLBACK_REQUIRED_STREAK="${FALLBACK_REQUIRED_STREAK:-4}"
+STABLE_REQUIRED_SAMPLES="${STABLE_REQUIRED_SAMPLES:-3}"
+STABLE_SAMPLE_INTERVAL_SECONDS="${STABLE_SAMPLE_INTERVAL_SECONDS:-15}"
+CURL_POD_NAME="curl-keda-epp-${RANDOM}-$$"
+ARTIFACT_DIR="${ARTIFACT_DIR:-/tmp/pod-logs-${GUIDE_NAME:-workload-autoscaling}}"
+HPA_NAME="${EXPECTED_HPA}"
+
+namespace_hash() {
+  if command -v sha256sum &>/dev/null; then
+    printf '%s' "$1" | sha256sum | cut -c1-8
+  else
+    printf '%s' "$1" | shasum -a 256 | cut -c1-8
+  fi
+}
+
+AUTH_CRB="keda-epp-prometheus-cluster-monitoring-view-$(namespace_hash "${NAMESPACE}")"
+mkdir -p "${ARTIFACT_DIR}"
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+capture_namespaced_resource() {
+  local resource="$1" file="$2"
+  kubectl get "${resource}" -n "${NAMESPACE}" -o yaml > "${ARTIFACT_DIR}/${file}" 2>&1 || true
+}
+
+diagnostic_dump() {
+  set +e
+  echo "=== Direct KEDA+EPP failure diagnostics ===" >&2
+  echo "Artifacts: ${ARTIFACT_DIR}" >&2
+
+  capture_namespaced_resource deployment/${EPP_DEPLOYMENT} router-deployment.yaml
+  capture_namespaced_resource service/${EPP_SERVICE} router-service.yaml
+  capture_namespaced_resource endpoints/${EPP_SERVICE} router-endpoints.yaml
+  capture_namespaced_resource servicemonitor/${EPP_SERVICEMONITOR} router-servicemonitor.yaml
+  capture_namespaced_resource deployment/${MODEL_DEPLOYMENT} model-deployment.yaml
+  capture_namespaced_resource podmonitor/${MODEL_PODMONITOR} model-podmonitor.yaml
+  capture_namespaced_resource scaledobject/${SCALEDOBJECT} scaledobject.yaml
+  capture_namespaced_resource triggerauthentication/${TRIGGER_AUTHENTICATION} triggerauthentication.yaml
+  capture_namespaced_resource serviceaccount/${AUTH_SERVICEACCOUNT} auth-serviceaccount.yaml
+
+  kubectl get secret/${AUTH_SECRET} -n "${NAMESPACE}" -o json 2>/dev/null \
+    | jq 'del(.data, .stringData)' > "${ARTIFACT_DIR}/auth-secret-metadata.json" 2>&1 || true
+  kubectl get replicasets -n "${NAMESPACE}" -o yaml \
+    > "${ARTIFACT_DIR}/replicasets.yaml" 2>&1 || true
+  kubectl get pods -n "${NAMESPACE}" -o yaml \
+    > "${ARTIFACT_DIR}/pods.yaml" 2>&1 || true
+  kubectl get events -n "${NAMESPACE}" --sort-by='.lastTimestamp' -o yaml \
+    > "${ARTIFACT_DIR}/events.yaml" 2>&1 || true
+
+  if [[ -n "${HPA_NAME}" ]]; then
+    capture_namespaced_resource "hpa/${HPA_NAME}" generated-hpa.yaml
+  else
+    kubectl get hpa -n "${NAMESPACE}" -o yaml \
+      > "${ARTIFACT_DIR}/generated-hpa.yaml" 2>&1 || true
+  fi
+
+  for selector in 'app=keda-operator' 'app.kubernetes.io/name=keda-operator'; do
+    if kubectl get pods -n openshift-keda -l "${selector}" -o name 2>/dev/null | grep -q .; then
+      kubectl logs -n openshift-keda -l "${selector}" --all-containers --tail=300 \
+        2>&1 | grep -E "${NAMESPACE}|${SCALEDOBJECT}" \
+        > "${ARTIFACT_DIR}/keda-operator-filtered.log" || true
+      break
+    fi
+  done
+
+  echo "--- ScaledObject conditions ---" >&2
+  kubectl get scaledobject/${SCALEDOBJECT} -n "${NAMESPACE}" \
+    -o jsonpath='{range .status.conditions[*]}{.type}={.status} ({.reason}: {.message}){"\n"}{end}' \
+    >&2 2>/dev/null || true
+  echo "--- Workload status ---" >&2
+  kubectl get deployment,replicaset,pod,hpa -n "${NAMESPACE}" -o wide >&2 2>/dev/null || true
+  echo "=== End direct KEDA+EPP diagnostics ===" >&2
+}
+
+cleanup_curl_pod() {
+  kubectl delete pod/${CURL_POD_NAME} -n "${NAMESPACE}" --ignore-not-found \
+    >/dev/null 2>&1 || true
+}
+
+finish() {
+  local status=$?
+  trap - EXIT
+  if [[ ${status} -ne 0 ]]; then
+    diagnostic_dump
+  fi
+  cleanup_curl_pod
+  exit "${status}"
+}
+trap finish EXIT
+
+assert_exists() {
+  local resource="$1"
+  kubectl get "${resource}" -n "${NAMESPACE}" >/dev/null 2>&1 \
+    || fail "expected ${resource} in namespace ${NAMESPACE}"
+}
+
+assert_absent() {
+  local resource="$1"
+  local output
+
+  if output="$(kubectl get "${resource}" -n "${NAMESPACE}" 2>&1)"; then
+    fail "forbidden WVA resource exists: ${resource}"
+  elif ! grep -Eqi '\(NotFound\)|not found' <<< "${output}"; then
+    fail "could not prove forbidden resource ${resource} is absent: ${output}"
+  fi
+}
+
+echo "==> Validating expected resource graph"
+[[ -z "${CLI_MODEL_ID}" || "${CLI_MODEL_ID}" == "${EXPECTED_MODEL_ID}" ]] \
+  || fail "generic smoke discovered ${CLI_MODEL_ID}, expected ${EXPECTED_MODEL_ID}"
+
+monitoring_label="$(kubectl get namespace "${NAMESPACE}" \
+  -o jsonpath='{.metadata.labels.openshift\.io/user-monitoring}' 2>/dev/null || true)"
+[[ "${monitoring_label}" == "true" ]] \
+  || fail "namespace ${NAMESPACE} is not labeled openshift.io/user-monitoring=true"
+
+for resource in \
+  deployment/${EPP_DEPLOYMENT} \
+  service/${EPP_SERVICE} \
+  servicemonitor/${EPP_SERVICEMONITOR} \
+  inferencepool/optimized-baseline \
+  deployment/${MODEL_DEPLOYMENT} \
+  podmonitor/${MODEL_PODMONITOR} \
+  serviceaccount/${AUTH_SERVICEACCOUNT} \
+  secret/${AUTH_SECRET} \
+  triggerauthentication/${TRIGGER_AUTHENTICATION} \
+  scaledobject/${SCALEDOBJECT}; do
+  assert_exists "${resource}"
+done
+
+kubectl get "clusterrolebinding/${AUTH_CRB}" -o json \
+  > "${ARTIFACT_DIR}/auth-clusterrolebinding.json" \
+  || fail "expected ClusterRoleBinding/${AUTH_CRB}"
+jq -e --arg namespace "${NAMESPACE}" '
+  .roleRef.kind == "ClusterRole" and
+  .roleRef.name == "cluster-monitoring-view" and
+  any(.subjects[]?;
+    .kind == "ServiceAccount" and
+    .name == "keda-epp-prometheus" and
+    .namespace == $namespace)
+' "${ARTIFACT_DIR}/auth-clusterrolebinding.json" >/dev/null \
+  || fail "ClusterRoleBinding/${AUTH_CRB} has the wrong role or subject"
+
+for resource in \
+  deployment/wva-controller-manager \
+  servicemonitor/wva-controller-manager-metrics-monitor \
+  scaledobject/optimized-baseline-nvidia-gpu-vllm-decode-scaler \
+  triggerauthentication/wva-prometheus-auth \
+  hpa/wva-keda-hpa-optimized-baseline-nvidia-gpu-vllm-decode; do
+  assert_absent "${resource}"
+done
+
+api_resources="$(kubectl api-resources --namespaced=true --verbs=list -o name)" \
+  || fail "could not enumerate namespaced API resources to check VariantAutoscaling absence"
+variant_resource="$(grep -E '^variantautoscalings\.' <<< "${api_resources}" | head -1 || true)"
+if [[ -n "${variant_resource}" ]]; then
+  variant_resources="$(kubectl get "${variant_resource}" -n "${NAMESPACE}" -o name)" \
+    || fail "could not list ${variant_resource} resources in namespace ${NAMESPACE}"
+  [[ -z "${variant_resources}" ]] \
+    || fail "VariantAutoscaling resources exist in namespace ${NAMESPACE}: ${variant_resources}"
+fi
+
+kubectl get service/${EPP_SERVICE} -n "${NAMESPACE}" -o json \
+  > "${ARTIFACT_DIR}/router-service.json"
+jq -e '
+  any(.spec.ports[]; .name == "http-metrics" and .port == 9090) and
+  any(.spec.ports[]; .name == "http" and .port == 80)
+' "${ARTIFACT_DIR}/router-service.json" >/dev/null \
+  || fail "${EPP_SERVICE} does not expose http-metrics:9090 and http:80"
+
+kubectl get servicemonitor/${EPP_SERVICEMONITOR} -n "${NAMESPACE}" -o json \
+  > "${ARTIFACT_DIR}/router-servicemonitor.json"
+jq -e '
+  any(.spec.endpoints[]; .port == "http-metrics" and .path == "/metrics")
+' "${ARTIFACT_DIR}/router-servicemonitor.json" >/dev/null \
+  || fail "${EPP_SERVICEMONITOR} does not scrape http-metrics:/metrics"
+jq -s -e '
+  .[0].spec.selector.matchLabels as $selector |
+  .[1].metadata.labels as $labels |
+  all($selector | to_entries[]; $labels[.key] == .value)
+' "${ARTIFACT_DIR}/router-servicemonitor.json" \
+  "${ARTIFACT_DIR}/router-service.json" >/dev/null \
+  || fail "ServiceMonitor selector does not match the EPP Service labels"
+
+kubectl get configmap/${EPP_DEPLOYMENT} -n "${NAMESPACE}" -o json \
+  > "${ARTIFACT_DIR}/router-configmap.json"
+jq -e '.data["optimized-baseline-keda-epp-plugins.yaml"] | contains("flowControl")' \
+  "${ARTIFACT_DIR}/router-configmap.json" >/dev/null \
+  || fail "EPP Flow Control configuration is not present"
+
+kubectl get deployment/${MODEL_DEPLOYMENT} -n "${NAMESPACE}" -o json \
+  > "${ARTIFACT_DIR}/model-deployment.json"
+kubectl get podmonitor/${MODEL_PODMONITOR} -n "${NAMESPACE}" -o json \
+  > "${ARTIFACT_DIR}/model-podmonitor.json"
+jq -e '
+  .spec.selector.matchLabels["llm-d.ai/role"] == "decode" and
+  any(.spec.podMetricsEndpoints[]; .port == "modelserver" and .path == "/metrics")
+' "${ARTIFACT_DIR}/model-podmonitor.json" >/dev/null \
+  || fail "PodMonitor/decode selector or endpoint is incorrect"
+jq -e '
+  .spec.template.metadata.labels["llm-d.ai/role"] == "decode" and
+  any(.spec.template.spec.containers[];
+    .name == "modelserver" and
+    any(.ports[]?; .name == "modelserver" and .containerPort == 8000))
+' "${ARTIFACT_DIR}/model-deployment.json" >/dev/null \
+  || fail "model pod labels or modelserver port do not match PodMonitor/decode"
+
+echo "==> Validating initial model and EPP readiness"
+jq -e '
+  .spec.replicas == 1 and
+  .status.readyReplicas == 1 and
+  .status.availableReplicas == 1
+' "${ARTIFACT_DIR}/model-deployment.json" >/dev/null \
+  || fail "model Deployment is not at spec/ready/available replicas 1"
+
+kubectl get deployment/${EPP_DEPLOYMENT} -n "${NAMESPACE}" -o json \
+  > "${ARTIFACT_DIR}/router-deployment.json"
+jq -e '.spec.replicas == 1 and .status.readyReplicas == 1 and .status.availableReplicas == 1' \
+  "${ARTIFACT_DIR}/router-deployment.json" >/dev/null \
+  || fail "EPP Deployment is not Ready at one replica"
+
+decode_pod_count="$(kubectl get pods -n "${NAMESPACE}" -l llm-d.ai/role=decode -o json \
+  | jq '[.items[] | select(.metadata.deletionTimestamp == null)] | length')"
+[[ "${decode_pod_count}" == "1" ]] \
+  || fail "expected exactly one non-terminating decode pod, found ${decode_pod_count}"
+
+echo "==> Requiring a stable initial Deployment, pod, and HPA replica invariant"
+initial_streak=0
+deadline=$((SECONDS + POLL_TIMEOUT_SECONDS))
+while (( SECONDS < deadline )); do
+  initial_sample_ok=false
+  if kubectl get deployment/${MODEL_DEPLOYMENT} -n "${NAMESPACE}" -o json \
+       > "${ARTIFACT_DIR}/model-deployment.json" 2>/dev/null && \
+     kubectl get "hpa/${HPA_NAME}" -n "${NAMESPACE}" -o json \
+       > "${ARTIFACT_DIR}/generated-hpa.json" 2>/dev/null && \
+     kubectl get pods -n "${NAMESPACE}" -l llm-d.ai/role=decode -o json \
+       > "${ARTIFACT_DIR}/decode-pods.json" 2>/dev/null && \
+     jq -e '
+       .spec.replicas == 1 and
+       .status.readyReplicas == 1 and
+       .status.availableReplicas == 1
+     ' "${ARTIFACT_DIR}/model-deployment.json" >/dev/null && \
+     jq -e '.status.currentReplicas == 1 and .status.desiredReplicas == 1' \
+       "${ARTIFACT_DIR}/generated-hpa.json" >/dev/null && \
+     jq -e '[.items[] | select(.metadata.deletionTimestamp == null)] | length == 1' \
+       "${ARTIFACT_DIR}/decode-pods.json" >/dev/null; then
+    initial_sample_ok=true
+  fi
+
+  if [[ "${initial_sample_ok}" == "true" ]]; then
+    initial_streak=$((initial_streak + 1))
+    echo "Initial replica sample ${initial_streak}/${STABLE_REQUIRED_SAMPLES}: Deployment=1 HPA=1 pods=1"
+    if (( initial_streak >= STABLE_REQUIRED_SAMPLES )); then
+      break
+    fi
+  else
+    initial_streak=0
+    echo "Initial replica invariant not yet stable: HPA=${HPA_NAME:-<none>}"
+  fi
+  sleep "${STABLE_SAMPLE_INTERVAL_SECONDS}"
+done
+(( initial_streak >= STABLE_REQUIRED_SAMPLES )) \
+  || fail "Deployment, HPA, and pod replica invariant did not hold for ${STABLE_REQUIRED_SAMPLES} samples"
+
+echo "==> Waiting for dedicated authentication Secret data"
+auth_ready=false
+for _ in $(seq 1 30); do
+  if kubectl get secret/${AUTH_SECRET} -n "${NAMESPACE}" -o json 2>/dev/null \
+      | jq -e '(.data.token | length > 0) and (.data["service-ca.crt"] | length > 0)' \
+        >/dev/null 2>&1; then
+    auth_ready=true
+    break
+  fi
+  sleep 5
+done
+[[ "${auth_ready}" == "true" ]] \
+  || fail "${AUTH_SECRET} did not receive token and service-ca.crt data"
+
+echo "==> Creating in-cluster metrics client"
+kubectl delete pod/${CURL_POD_NAME} -n "${NAMESPACE}" --ignore-not-found \
+  >/dev/null 2>&1 || true
+kubectl apply -f - <<EOF >/dev/null
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${CURL_POD_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/name: keda-epp-initial-state-validator
+spec:
+  serviceAccountName: ${AUTH_SERVICEACCOUNT}
+  restartPolicy: Never
+  containers:
+    - name: curl
+      image: curlimages/curl
+      command: ["sleep", "3600"]
+      volumeMounts:
+        - name: thanos-auth
+          mountPath: /var/run/keda-auth
+          readOnly: true
+  volumes:
+    - name: thanos-auth
+      secret:
+        secretName: ${AUTH_SECRET}
+        items:
+          - key: token
+            path: token
+          - key: service-ca.crt
+            path: service-ca.crt
+EOF
+kubectl wait pod/${CURL_POD_NAME} -n "${NAMESPACE}" \
+  --for=condition=Ready --timeout=120s >/dev/null \
+  || fail "in-cluster metrics client did not become Ready"
+
+echo "==> Verifying direct EPP metric families"
+DIRECT_METRICS="${ARTIFACT_DIR}/epp-metrics.txt"
+kubectl exec -n "${NAMESPACE}" "${CURL_POD_NAME}" -- \
+  curl --fail --silent --show-error --max-time 15 \
+  "http://${EPP_SERVICE}:9090/metrics" > "${DIRECT_METRICS}" \
+  || fail "could not query http://${EPP_SERVICE}:9090/metrics"
+
+for metric in llm_d_epp_flow_control_queue_size llm_d_epp_request_running; do
+  grep -Eq "^${metric}(\\{|[[:space:]])" "${DIRECT_METRICS}" \
+    || fail "direct EPP endpoint does not expose a sample for ${metric}"
+done
+grep -E '^llm_d_epp_(flow_control_queue_size|request_running)(\{|[[:space:]])' \
+  "${DIRECT_METRICS}" > "${ARTIFACT_DIR}/epp-metric-samples.txt"
+echo "Direct EPP metric samples (values of zero are valid):"
+sed -n '1,40p' "${ARTIFACT_DIR}/epp-metric-samples.txt"
+
+thanos_query() {
+  local query="$1" output="$2"
+  # The variables below expand inside the validation pod, not in this shell.
+  # shellcheck disable=SC2016
+  kubectl exec -n "${NAMESPACE}" "${CURL_POD_NAME}" -- \
+    sh -c '
+      token="$(cat /var/run/keda-auth/token)"
+      exec curl --fail --silent --show-error --max-time 30 \
+        --cacert /var/run/keda-auth/service-ca.crt \
+        -H "Authorization: Bearer ${token}" \
+        --get "$1" --data-urlencode "query=$2"
+    ' sh "${THANOS_URL}" "${query}" > "${output}" 2> "${output}.stderr"
+}
+
+validate_thanos_metric() {
+  local metric="$1" raw_query="$2" aggregate_query="$3"
+  local raw_file="${ARTIFACT_DIR}/thanos-${metric}-raw.json"
+  local aggregate_file="${ARTIFACT_DIR}/thanos-${metric}-aggregate.json"
+  local deadline=$((SECONDS + POLL_TIMEOUT_SECONDS))
+  local raw_count aggregate_count
+
+  while (( SECONDS < deadline )); do
+    if thanos_query "${raw_query}" "${raw_file}" && \
+       thanos_query "${aggregate_query}" "${aggregate_file}" && \
+       jq -e '.status == "success" and .data.resultType == "vector"' \
+         "${raw_file}" >/dev/null 2>&1 && \
+       jq -e '.status == "success" and .data.resultType == "vector"' \
+         "${aggregate_file}" >/dev/null 2>&1; then
+      raw_count="$(jq '.data.result | length' "${raw_file}")"
+      aggregate_count="$(jq '.data.result | length' "${aggregate_file}")"
+
+      if (( aggregate_count > 1 )); then
+        fail "aggregate ${metric} query returned ${aggregate_count} results; expected exactly one"
+      fi
+
+      if (( raw_count > 0 && aggregate_count == 1 )); then
+        jq -e --arg namespace "${NAMESPACE}" --arg service "${EPP_SERVICE}" \
+          --arg model "${EXPECTED_MODEL_ID}" '
+            all(.data.result[];
+              .metric.namespace == $namespace and
+              .metric.service == $service and
+              .metric.model_name == $model and
+              (.value | length == 2))
+          ' "${raw_file}" >/dev/null \
+          || fail "raw ${metric} series contain unexpected namespace, service, model, or value data"
+        jq -e '
+          .data.result[0].value as $value |
+          ($value | length == 2) and
+          ($value[0] | type == "number") and
+          ($value[1] | type == "string") and
+          ($value[1] | test("^-?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][-+]?[0-9]+)?$"))
+        ' "${aggregate_file}" >/dev/null \
+          || fail "aggregate ${metric} result has no numeric timestamp/value"
+
+        echo "Thanos ${metric} raw series (${raw_count} source series):"
+        jq -c '.data.result[] | {metric, value}' "${raw_file}"
+        echo "Thanos ${metric} aggregate result:"
+        jq -c '.data.result[0] | {metric, value}' "${aggregate_file}"
+        return 0
+      fi
+    fi
+    sleep "${POLL_INTERVAL_SECONDS}"
+  done
+
+  fail "Thanos did not return real raw and single aggregate ${metric} series within ${POLL_TIMEOUT_SECONDS}s"
+}
+
+echo "==> Verifying EPP metric series through authenticated Thanos"
+QUEUE_SELECTOR="llm_d_epp_flow_control_queue_size{namespace=\"${NAMESPACE}\",service=\"${EPP_SERVICE}\",model_name=\"${EXPECTED_MODEL_ID}\"}"
+QUEUE_QUERY="sum(${QUEUE_SELECTOR})"
+RUNNING_SELECTOR="llm_d_epp_request_running{namespace=\"${NAMESPACE}\",service=\"${EPP_SERVICE}\",model_name=\"${EXPECTED_MODEL_ID}\"}"
+RUNNING_QUERY="sum(${RUNNING_SELECTOR})"
+validate_thanos_metric queue-size "${QUEUE_SELECTOR}" "${QUEUE_QUERY}"
+validate_thanos_metric running-requests "${RUNNING_SELECTOR}" "${RUNNING_QUERY}"
+
+echo "==> Verifying ScaledObject readiness and sustained non-fallback health"
+kubectl wait scaledobject/${SCALEDOBJECT} -n "${NAMESPACE}" \
+  --for=condition=Ready --timeout=300s >/dev/null \
+  || fail "ScaledObject/${SCALEDOBJECT} did not become Ready"
+
+fallback_streak=0
+fallback_status=unknown
+health_exposed=false
+for _ in $(seq 1 20); do
+  kubectl get scaledobject/${SCALEDOBJECT} -n "${NAMESPACE}" -o json \
+    > "${ARTIFACT_DIR}/scaledobject.json"
+  fallback_status="$(jq -r '.status.conditions[]? | select(.type == "Fallback") | .status' \
+    "${ARTIFACT_DIR}/scaledobject.json")"
+  health_count="$(jq '(.status.health // {}) | length' "${ARTIFACT_DIR}/scaledobject.json")"
+  health_ok=true
+  if (( health_count > 0 )); then
+    health_exposed=true
+    if ! jq -e '
+      all((.status.health // {}) | to_entries[];
+        .value.status == "Happy" and ((.value.numberOfFailures // 0) == 0))
+    ' "${ARTIFACT_DIR}/scaledobject.json" >/dev/null; then
+      health_ok=false
+    fi
+    jq -c '.status.health' "${ARTIFACT_DIR}/scaledobject.json"
+  fi
+
+  if [[ "${fallback_status}" == "False" && "${health_ok}" == "true" ]]; then
+    fallback_streak=$((fallback_streak + 1))
+    echo "Fallback=False healthy sample ${fallback_streak}/${FALLBACK_REQUIRED_STREAK}"
+    if (( fallback_streak >= FALLBACK_REQUIRED_STREAK )); then
+      break
+    fi
+  else
+    fallback_streak=0
+    echo "Fallback/health not yet stable: Fallback=${fallback_status}, health_ok=${health_ok}"
+  fi
+  sleep "${FALLBACK_POLL_INTERVAL_SECONDS}"
+done
+(( fallback_streak >= FALLBACK_REQUIRED_STREAK )) \
+  || fail "Fallback=False did not hold with healthy triggers for ${FALLBACK_REQUIRED_STREAK} samples"
+if [[ "${health_exposed}" != "true" ]]; then
+  echo "NOTE: this KEDA version did not expose per-trigger status.health; Fallback and HPA metrics remain mandatory"
+fi
+
+echo "==> Discovering and validating the generated HPA"
+hpa_ready=false
+for _ in $(seq 1 30); do
+  if kubectl get scaledobject/${SCALEDOBJECT} -n "${NAMESPACE}" -o json \
+       > "${ARTIFACT_DIR}/scaledobject.json" 2>/dev/null && \
+     kubectl get "hpa/${HPA_NAME}" -n "${NAMESPACE}" -o json \
+       > "${ARTIFACT_DIR}/generated-hpa.json" 2>/dev/null; then
+    hpa_ready=true
+    break
+  fi
+  sleep "${POLL_INTERVAL_SECONDS}"
+done
+[[ "${hpa_ready}" == "true" ]] \
+  || fail "expected HPA/${HPA_NAME} was not available within ${POLL_TIMEOUT_SECONDS}s"
+
+reported_hpa_name="$(jq -r '.status.hpaName // empty' "${ARTIFACT_DIR}/scaledobject.json")"
+[[ -z "${reported_hpa_name}" || "${reported_hpa_name}" == "${EXPECTED_HPA}" ]] \
+  || fail "ScaledObject reported HPA ${reported_hpa_name}, expected ${EXPECTED_HPA}"
+
+scaledobject_uid="$(jq -r '.metadata.uid // empty' "${ARTIFACT_DIR}/scaledobject.json")"
+[[ -n "${scaledobject_uid}" ]] || fail "ScaledObject/${SCALEDOBJECT} has no metadata UID"
+jq -e --arg uid "${scaledobject_uid}" --arg name "${SCALEDOBJECT}" '
+  any(.metadata.ownerReferences[]?;
+    .apiVersion == "keda.sh/v1alpha1" and
+    .kind == "ScaledObject" and
+    .name == $name and
+    .uid == $uid and
+    .controller == true)
+' "${ARTIFACT_DIR}/generated-hpa.json" >/dev/null \
+  || fail "HPA/${HPA_NAME} is not controlled by the current ScaledObject UID"
+jq -e --arg deployment "${MODEL_DEPLOYMENT}" '
+  .spec.scaleTargetRef.apiVersion == "apps/v1" and
+  .spec.scaleTargetRef.kind == "Deployment" and
+  .spec.scaleTargetRef.name == $deployment and
+  .spec.minReplicas == 1 and
+  .spec.maxReplicas == 2 and
+  ([.spec.metrics[] | select(.type == "External")] | length == 2) and
+  (all(.spec.metrics[]; .type == "External" and .external.target.type == "AverageValue")) and
+  ([.spec.metrics[].external.target.averageValue] | sort == ["1", "16"])
+' "${ARTIFACT_DIR}/generated-hpa.json" >/dev/null \
+  || fail "HPA/${HPA_NAME} target, bounds, metric types, or AverageValue targets are incorrect"
+
+metric_status_ready=false
+deadline=$((SECONDS + POLL_TIMEOUT_SECONDS))
+while (( SECONDS < deadline )); do
+  kubectl get scaledobject/${SCALEDOBJECT} -n "${NAMESPACE}" -o json \
+    > "${ARTIFACT_DIR}/scaledobject.json"
+  kubectl get "hpa/${HPA_NAME}" -n "${NAMESPACE}" -o json \
+    > "${ARTIFACT_DIR}/generated-hpa.json"
+
+  scaledobject_metric_count="$(jq '(.status.externalMetricNames // []) | length' \
+    "${ARTIFACT_DIR}/scaledobject.json")"
+  scaledobject_metric_names="$(jq -r '.status.externalMetricNames[]?' \
+    "${ARTIFACT_DIR}/scaledobject.json" | sort -u | paste -sd, -)"
+  hpa_spec_metric_names="$(jq -r '.spec.metrics[]? | select(.type == "External") | .external.metric.name' \
+    "${ARTIFACT_DIR}/generated-hpa.json" | sort -u | paste -sd, -)"
+  hpa_current_metric_names="$(jq -r '.status.currentMetrics[]? | select(.type == "External") | .external.metric.name' \
+    "${ARTIFACT_DIR}/generated-hpa.json" | sort -u | paste -sd, -)"
+
+  optional_metric_names_ok=true
+  if (( scaledobject_metric_count > 0 )) && \
+     [[ "${scaledobject_metric_names}" != "${hpa_spec_metric_names}" ]]; then
+    optional_metric_names_ok=false
+  fi
+
+  if [[ "${optional_metric_names_ok}" == "true" && \
+        -n "${hpa_spec_metric_names}" && \
+        "${hpa_spec_metric_names}" == "${hpa_current_metric_names}" ]] && \
+     jq -e '
+       [.spec.metrics[]? | select(.type == "External") | .external.metric.name] as $specNames |
+       [.status.currentMetrics[]? | select(.type == "External")] as $currentMetrics |
+       [$currentMetrics[] | .external.metric.name] as $currentNames |
+       ($specNames | length == 2) and
+       ($currentMetrics | length == 2) and
+       ($specNames | unique | length == 2) and
+       ($currentNames | unique | length == 2) and
+       all($specNames[]; (type == "string") and (length > 0)) and
+       all($currentNames[]; (type == "string") and (length > 0)) and
+       all($currentMetrics[];
+         (.external.current.averageValue | type == "string") and
+         (.external.current.averageValue | test("^[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][+-]?[0-9]+|[numkKMGTP]*i?)?$")))
+     ' "${ARTIFACT_DIR}/generated-hpa.json" >/dev/null; then
+    metric_status_ready=true
+    break
+  fi
+  sleep "${POLL_INTERVAL_SECONDS}"
+done
+[[ "${metric_status_ready}" == "true" ]] \
+  || fail "HPA did not populate both expected external current metrics within ${POLL_TIMEOUT_SECONDS}s"
+
+echo "HPA external metrics: ${hpa_spec_metric_names}"
+jq -c '.status.currentMetrics' "${ARTIFACT_DIR}/generated-hpa.json"
+
+echo "==> Verifying stable one-replica initial state"
+for sample in $(seq 1 "${STABLE_REQUIRED_SAMPLES}"); do
+  kubectl get deployment/${MODEL_DEPLOYMENT} -n "${NAMESPACE}" -o json \
+    > "${ARTIFACT_DIR}/model-deployment.json"
+  kubectl get "hpa/${HPA_NAME}" -n "${NAMESPACE}" -o json \
+    > "${ARTIFACT_DIR}/generated-hpa.json"
+  kubectl get scaledobject/${SCALEDOBJECT} -n "${NAMESPACE}" -o json \
+    > "${ARTIFACT_DIR}/scaledobject.json"
+  kubectl get pods -n "${NAMESPACE}" -l llm-d.ai/role=decode -o json \
+    > "${ARTIFACT_DIR}/decode-pods.json"
+  kubectl get replicasets -n "${NAMESPACE}" -l llm-d.ai/role=decode -o json \
+    > "${ARTIFACT_DIR}/decode-replicasets.json"
+
+  jq -e '
+    .spec.replicas == 1 and
+    .status.replicas == 1 and
+    .status.updatedReplicas == 1 and
+    .status.readyReplicas == 1 and
+    .status.availableReplicas == 1
+  ' "${ARTIFACT_DIR}/model-deployment.json" >/dev/null \
+    || fail "model Deployment left the one-replica invariant during stable sample ${sample}"
+  jq -e '
+    .status.currentReplicas == 1 and
+    .status.desiredReplicas == 1 and
+    ([.status.currentMetrics[]? | select(.type == "External")] | length == 2)
+  ' "${ARTIFACT_DIR}/generated-hpa.json" >/dev/null \
+    || fail "HPA left desired/current replicas one or lost a metric during stable sample ${sample}"
+  jq -e '[.items[] | select(.metadata.deletionTimestamp == null)] | length == 1' \
+    "${ARTIFACT_DIR}/decode-pods.json" >/dev/null \
+    || fail "decode pod count changed during stable sample ${sample}"
+  jq -e '([.items[].spec.replicas] | add // 0) == 1 and ([.items[].status.replicas] | add // 0) == 1' \
+    "${ARTIFACT_DIR}/decode-replicasets.json" >/dev/null \
+    || fail "ReplicaSets contain more than one active model replica during stable sample ${sample}"
+  jq -e '
+    any(.status.conditions[]?; .type == "Fallback" and .status == "False")
+  ' "${ARTIFACT_DIR}/scaledobject.json" >/dev/null \
+    || fail "ScaledObject entered fallback during stable sample ${sample}"
+
+  echo "Stable sample ${sample}/${STABLE_REQUIRED_SAMPLES}: Deployment=1 HPA=1 pods=1"
+  if (( sample < STABLE_REQUIRED_SAMPLES )); then
+    sleep "${STABLE_SAMPLE_INTERVAL_SECONDS}"
+  fi
+done
+
+echo "Direct KEDA+EPP initial state is healthy: authenticated metrics, two HPA metrics, one model replica, no fallback."

--- a/.github/workflows/nightly-e2e-keda-epp-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-keda-epp-ibm-acc-gpu-vllm-x.yaml
@@ -1,0 +1,126 @@
+name: Initial KEDA+EPP State E2E (OCP GPU)
+
+on:
+  workflow_dispatch:
+    inputs:
+      skip_cleanup:
+        description: 'Keep namespaced and cluster-scoped resources for debugging'
+        required: false
+        type: boolean
+        default: false
+      pr_number:
+        description: 'PR number for comment-back (set by /test-nightly)'
+        required: false
+        type: string
+        default: ''
+      pr_repo:
+        description: 'Repository for PR comment-back'
+        required: false
+        type: string
+        default: 'llm-d/llm-d'
+      # The slash-command dispatcher sends the inputs below to every
+      # nightly-e2e-* workflow. This initial-state test accepts them for dispatch
+      # compatibility but intentionally does not run a benchmark or publish a badge.
+      workload:
+        description: 'Accepted for /test-nightly compatibility; unused in this slice'
+        required: false
+        type: string
+        default: 'sanity_random.yaml'
+      decode_pods:
+        description: 'Accepted for /test-nightly compatibility; model replicas remain one'
+        required: false
+        type: string
+        default: '1'
+      prefill_pods:
+        description: 'Accepted for /test-nightly compatibility; no prefill deployment is created'
+        required: false
+        type: string
+        default: '1'
+      harness:
+        description: 'Accepted for /test-nightly compatibility; no load harness is run'
+        required: false
+        type: string
+        default: 'inference-perf'
+      dry_run:
+        description: 'Accepted for /test-nightly compatibility; unused in this slice'
+        required: false
+        type: string
+        default: 'false'
+      update_badge:
+        description: 'Accepted for /test-nightly compatibility; no badge job exists'
+        required: false
+        type: string
+        default: 'false'
+      cleanup:
+        description: 'Set false to retain resources; inverse compatibility form of skip_cleanup'
+        required: false
+        type: string
+        default: 'true'
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+concurrency:
+  group: nightly-e2e-keda-epp-ocp
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    if: github.repository == 'llm-d/llm-d'
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift.yaml@main
+    with:
+      guide_name: workload-autoscaling
+      namespace: llm-d-nightly-keda-epp
+      gateway_host: optimized-baseline-epp
+      custom_deploy_script: |
+        bash guides/workload-autoscaling/scripts/nightly-deploy-keda-epp-ocp.sh
+      e2e_validate_args: '--extra-validate keda-epp'
+      required_gpus: 2
+      recommended_gpus: 4
+      pod_wait_timeout: '30m'
+      pod_readiness_delay: 180
+      allow_gpu_preemption: true
+      skip_cleanup: ${{ inputs.skip_cleanup || inputs.cleanup == 'false' }}
+      pr_number: ${{ inputs.pr_number }}
+      pr_repo: ${{ inputs.pr_repo }}
+    secrets: inherit
+
+  cleanup-cluster-rbac:
+    name: Cleanup direct KEDA+EPP cluster RBAC
+    needs: nightly
+    if: >-
+      ${{ always() &&
+          github.repository == 'llm-d/llm-d' &&
+          inputs.skip_cleanup != true &&
+          inputs.cleanup != 'false' }}
+    runs-on: [self-hosted, openshift, pok-prod]
+    steps:
+      - name: Checkout llm-d/llm-d
+        uses: actions/checkout@v7
+
+      - name: Ensure kubectl is available
+        run: |
+          if ! command -v kubectl >/dev/null 2>&1; then
+            ./helpers/client-setup/install-deps.sh
+          fi
+
+      - name: Delete direct KEDA+EPP authentication binding
+        env:
+          NAMESPACE: llm-d-nightly-keda-epp
+        run: |
+          set -euo pipefail
+          NS_HASH="$(printf '%s' "${NAMESPACE}" | sha256sum | cut -c1-8)"
+          AUTH_CRB="keda-epp-prometheus-cluster-monitoring-view-${NS_HASH}"
+          kubectl delete clusterrolebinding "${AUTH_CRB}" --ignore-not-found
+          if cleanup_result="$(kubectl get clusterrolebinding "${AUTH_CRB}" -o name --ignore-not-found)"; then
+            if [[ -z "${cleanup_result}" ]]; then
+              echo "ClusterRoleBinding/${AUTH_CRB} cleanup verified"
+              exit 0
+            fi
+            echo "ERROR: ClusterRoleBinding/${AUTH_CRB} still exists after cleanup" >&2
+            exit 1
+          fi
+          echo "ERROR: Could not verify ClusterRoleBinding/${AUTH_CRB} cleanup" >&2
+          exit 1

--- a/guides/workload-autoscaling/keda-epp/ocp/clusterrolebinding.yaml
+++ b/guides/workload-autoscaling/keda-epp/ocp/clusterrolebinding.yaml
@@ -1,0 +1,22 @@
+# Grants the dedicated KEDA+EPP Prometheus client read access to OpenShift's
+# Thanos Querier. This object is cluster-scoped and must be deleted explicitly;
+# deleting the workload namespace is not sufficient.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: keda-epp-prometheus-cluster-monitoring-view
+  labels:
+    app.kubernetes.io/name: keda-epp-prometheus
+    app.kubernetes.io/component: thanos-auth
+    app.kubernetes.io/managed-by: kustomize
+  annotations:
+    llm-d.ai/owner-namespace: llm-d-optimized-baseline
+    llm-d.ai/cleanup: explicit-cluster-scoped-cleanup-required
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+  - kind: ServiceAccount
+    name: keda-epp-prometheus
+    namespace: llm-d-optimized-baseline

--- a/guides/workload-autoscaling/keda-epp/ocp/kustomization.yaml
+++ b/guides/workload-autoscaling/keda-epp/ocp/kustomization.yaml
@@ -1,0 +1,49 @@
+# OpenShift adaptation for direct KEDA+EPP autoscaling. Thanos Querier's
+# authenticated :9091 endpoint is queried with a dedicated ServiceAccount token;
+# the service-account token Secret also supplies the OpenShift service CA.
+# This Component must be composed with the canonical keda-epp base; it is not a
+# standalone overlay.
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - serviceaccount.yaml
+  - serviceaccount-token-secret.yaml
+  - clusterrolebinding.yaml
+
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/secretTargetRef
+        value:
+          - parameter: bearerToken
+            name: keda-prometheus-auth
+            key: token
+          - parameter: ca
+            name: keda-prometheus-auth
+            key: service-ca.crt
+    target:
+      kind: TriggerAuthentication
+      name: keda-prometheus-auth
+  - patch: |-
+      - op: test
+        path: /spec/triggers/0/name
+        value: epp-queue-size
+      - op: replace
+        path: /spec/triggers/0/metadata/serverAddress
+        value: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
+      - op: add
+        path: /spec/triggers/0/metadata/authModes
+        value: bearer
+      - op: test
+        path: /spec/triggers/1/name
+        value: epp-running-requests
+      - op: replace
+        path: /spec/triggers/1/metadata/serverAddress
+        value: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
+      - op: add
+        path: /spec/triggers/1/metadata/authModes
+        value: bearer
+    target:
+      kind: ScaledObject
+      name: optimized-baseline-keda-epp

--- a/guides/workload-autoscaling/keda-epp/ocp/serviceaccount-token-secret.yaml
+++ b/guides/workload-autoscaling/keda-epp/ocp/serviceaccount-token-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keda-prometheus-auth
+  labels:
+    app.kubernetes.io/name: keda-epp-prometheus
+    app.kubernetes.io/component: thanos-auth
+    app.kubernetes.io/managed-by: kustomize
+  annotations:
+    kubernetes.io/service-account.name: keda-epp-prometheus
+type: kubernetes.io/service-account-token

--- a/guides/workload-autoscaling/keda-epp/ocp/serviceaccount.yaml
+++ b/guides/workload-autoscaling/keda-epp/ocp/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keda-epp-prometheus
+  labels:
+    app.kubernetes.io/name: keda-epp-prometheus
+    app.kubernetes.io/component: thanos-auth
+    app.kubernetes.io/managed-by: kustomize

--- a/guides/workload-autoscaling/scripts/nightly-deploy-keda-epp-ocp.sh
+++ b/guides/workload-autoscaling/scripts/nightly-deploy-keda-epp-ocp.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Deploy the direct KEDA+EPP optimized-baseline stack on OpenShift.
+# This path is deliberately independent of WVA; initial-state assertions live
+# in .github/scripts/e2e/e2e-validate-keda-epp.sh.
+#
+# Environment variables:
+#   NAMESPACE             target namespace
+#   OUTPUT_DIR            generated nightly overlay directory
+#   ROUTER_CHART_VERSION  EPP router chart version (default: guides/env.sh)
+#   RENDER_ONLY           generate and validate the overlay without cluster changes
+# The reusable nightly workflow creates the namespace and enables user-workload
+# monitoring before invoking this script.
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+# shellcheck source=guides/env.sh
+source "${REPO_ROOT}/guides/env.sh"
+
+NAMESPACE="${NAMESPACE:-keda-epp-nightly-optimized-baseline-$(printf '%04x' "$RANDOM")}"
+SCALEDOBJECT=optimized-baseline-keda-epp
+MODEL_DEPLOYMENT=optimized-baseline-nvidia-gpu-vllm-decode
+AUTH_CRB_BASE=keda-epp-prometheus-cluster-monitoring-view
+OUTPUT_DIR="${OUTPUT_DIR:-$(mktemp -d -t nightly-deploy-keda-epp-ocp.XXXXXX)}"
+RENDER_ONLY="${RENDER_ONLY:-false}"
+
+namespace_hash() {
+  if command -v sha256sum &>/dev/null; then
+    printf '%s' "$1" | sha256sum | cut -c1-8
+  else
+    printf '%s' "$1" | shasum -a 256 | cut -c1-8
+  fi
+}
+
+NS_HASH="$(namespace_hash "${NAMESPACE}")"
+AUTH_CRB="${AUTH_CRB_BASE}-${NS_HASH}"
+
+deployment_diagnostics() {
+  local status="$1" line="$2"
+  trap - ERR
+  set +e
+
+  echo "ERROR: direct KEDA+EPP deployment failed at line ${line} (status ${status})" >&2
+  echo "--- Namespaced resources ---" >&2
+  kubectl get deployment,replicaset,pod,service,endpoints,servicemonitor,podmonitor,scaledobject,triggerauthentication,hpa \
+    -n "${NAMESPACE}" -o wide >&2 2>/dev/null || true
+  echo "--- ScaledObject conditions ---" >&2
+  kubectl get scaledobject/${SCALEDOBJECT} -n "${NAMESPACE}" \
+    -o jsonpath='{range .status.conditions[*]}{.type}={.status} ({.reason}: {.message}){"\n"}{end}' \
+    >&2 2>/dev/null || true
+  echo "--- Authentication metadata (Secret data intentionally omitted) ---" >&2
+  kubectl get serviceaccount/keda-epp-prometheus triggerauthentication/keda-prometheus-auth \
+    -n "${NAMESPACE}" -o yaml >&2 2>/dev/null || true
+  kubectl get secret/keda-prometheus-auth -n "${NAMESPACE}" -o json 2>/dev/null \
+    | jq 'del(.data, .stringData)' >&2 || true
+  kubectl get "clusterrolebinding/${AUTH_CRB}" -o yaml >&2 2>/dev/null || true
+  echo "--- Namespace events ---" >&2
+  kubectl get events -n "${NAMESPACE}" --sort-by='.lastTimestamp' >&2 2>/dev/null || true
+  echo "--- KEDA operator messages for this deployment ---" >&2
+  kubectl logs -n openshift-keda -l app=keda-operator --all-containers --tail=200 2>/dev/null \
+    | grep -E "${NAMESPACE}|${SCALEDOBJECT}" >&2 || true
+
+  exit "${status}"
+}
+trap 'deployment_diagnostics "$?" "$LINENO"' ERR
+
+mkdir -p "${OUTPUT_DIR}"
+if ! command -v python3 &>/dev/null; then
+  echo "ERROR: python3 is required to construct the generated overlay paths" >&2
+  exit 1
+fi
+REL="$(python3 -c 'import os, sys; print(os.path.relpath(os.path.realpath(sys.argv[1]), os.path.realpath(sys.argv[2])))' \
+  "${REPO_ROOT}" "${OUTPUT_DIR}")"
+RENDERED_MANIFEST="${OUTPUT_DIR}/rendered.yaml"
+
+echo "Generating direct KEDA+EPP OpenShift overlay in ${OUTPUT_DIR}"
+echo "  NAMESPACE: ${NAMESPACE}"
+echo "  AUTH_CRB:  ${AUTH_CRB}"
+
+cat > "${OUTPUT_DIR}/kustomization.yaml" <<EOF
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ${NAMESPACE}
+resources:
+  - ${REL}/guides/optimized-baseline/modelserver/gpu/vllm/base/
+  - ${REL}/guides/workload-autoscaling/keda-epp/
+components:
+  - ${REL}/guides/recipes/modelserver/components/monitoring/
+  - ${REL}/guides/workload-autoscaling/keda-epp/ocp/
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+      - op: add
+        path: /spec/template/spec/priorityClassName
+        value: nightly-gpu-critical
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: ${MODEL_DEPLOYMENT}
+  - patch: |-
+      - op: replace
+        path: /spec/maxReplicaCount
+        value: 2
+      - op: add
+        path: /spec/fallback
+        value:
+          failureThreshold: 3
+          replicas: 1
+          behavior: currentReplicasIfHigher
+      - op: test
+        path: /spec/triggers/0/name
+        value: epp-queue-size
+      - op: replace
+        path: /spec/triggers/0/metadata/query
+        value: >-
+          sum(llm_d_epp_flow_control_queue_size{namespace="${NAMESPACE}",service="optimized-baseline-epp",model_name="Qwen/Qwen3-32B"})
+      - op: test
+        path: /spec/triggers/1/name
+        value: epp-running-requests
+      - op: replace
+        path: /spec/triggers/1/metadata/query
+        value: >-
+          sum(llm_d_epp_request_running{namespace="${NAMESPACE}",service="optimized-baseline-epp",model_name="Qwen/Qwen3-32B"})
+    target:
+      group: keda.sh
+      version: v1alpha1
+      kind: ScaledObject
+      name: ${SCALEDOBJECT}
+  - patch: |-
+      - op: replace
+        path: /metadata/name
+        value: ${AUTH_CRB}
+      - op: replace
+        path: /metadata/annotations/llm-d.ai~1owner-namespace
+        value: ${NAMESPACE}
+      - op: add
+        path: /metadata/labels/llm-d.ai~1nightly-namespace
+        value: ${NAMESPACE}
+      - op: replace
+        path: /subjects/0/namespace
+        value: ${NAMESPACE}
+    target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRoleBinding
+      name: ${AUTH_CRB_BASE}
+EOF
+
+echo "==> Validating generated kustomization"
+kubectl kustomize "${OUTPUT_DIR}" > "${RENDERED_MANIFEST}"
+
+if [[ "${RENDER_ONLY}" == "true" ]]; then
+  echo "Render-only validation complete: ${OUTPUT_DIR}"
+  trap - ERR
+  exit 0
+fi
+
+echo "==> Checking for KEDA"
+if ! kubectl get crd scaledobjects.keda.sh >/dev/null 2>&1; then
+  echo "ERROR: CRD scaledobjects.keda.sh not found." >&2
+  echo "       Install the OpenShift Custom Metrics Autoscaler operator before running this nightly." >&2
+  exit 1
+fi
+
+echo "==> Removing stale cluster-scoped authentication binding"
+kubectl delete clusterrolebinding "${AUTH_CRB}" --ignore-not-found
+
+echo "==> Installing EPP router via Helm"
+helm upgrade --install optimized-baseline \
+  "${ROUTER_STANDALONE_CHART}" \
+  -f "${REPO_ROOT}/guides/recipes/router/base.values.yaml" \
+  -f "${REPO_ROOT}/guides/optimized-baseline/router/optimized-baseline.values.yaml" \
+  -f "${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml" \
+  -f "${REPO_ROOT}/guides/workload-autoscaling/keda-epp/router.values.yaml" \
+  -n "${NAMESPACE}" --version "${ROUTER_CHART_VERSION}"
+
+echo "==> Applying model, monitoring, authentication, and direct ScaledObject"
+kubectl apply -f "${RENDERED_MANIFEST}"
+
+echo "==> Direct KEDA+EPP resources applied"
+kubectl get deployment/${MODEL_DEPLOYMENT} deployment/optimized-baseline-epp \
+  scaledobject/${SCALEDOBJECT} -n "${NAMESPACE}"
+echo "ClusterRoleBinding: ${AUTH_CRB}"
+
+trap - ERR


### PR DESCRIPTION
## Summary

This PR adds the first OpenShift validation slice toward nightly coverage for the direct KEDA+EPP autoscaling path tracked in [llm-d-workload-variant-autoscaler#1326](https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/1326).

The work follows the KEDA+EPP guide migration completed in [#1981](https://github.com/llm-d/llm-d/pull/1981). That PR introduced the reusable `keda-epp` guide assets and documented the intended path:

```text
EPP metrics
    ↓
Prometheus
    ↓
KEDA
    ↓
KEDA-managed HPA
    ↓
model Deployment
```

However it intentionally left dedicated nightly behavior coverage for a follow up.

This PR starts that follow up by adding the deployment and validation needed to verify the direct KEDA+EPP path on the OpenShift nightly environment. A real OCP workflow run is still required to confirm the live metric path and initial runtime state before load-induced scaling coverage is added.

This work is also related to the broader guide-evaluation context in [#1517](https://github.com/llm-d/llm-d/issues/1517). That issue notes that current guide testing focuses on installation and basic functionality and calls for guide specific performance benchmarks and accuracy testing. This PR does not address those performance or accuracy requirements; it adds feature-specific autoscaling-path validation toward [#1326](https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/1326).

## Why this is needed

[llm-d-workload-variant-autoscaler#1326](https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/1326) tracks promoting the KEDA+EPP queue size/running request guide from experimental to stable and explicitly requires adding the guide to nightly tests before promotion.

For this guide verifying only that the resources exist or that inference succeeds is not sufficient therefore meaningful path is:
```text
EPP emits queue/running request metrics
    ↓
OpenShift monitoring discovers them
    ↓
Thanos returns the expected series
    ↓
KEDA reads the metrics without fallback
    ↓
KEDA creates and updates the HPA
    ↓
the model Deployment remains in the expected state
```

This is particularly important because [#2039](https://github.com/llm-d/llm-d/pull/2039) addressed a case where the autoscaling nightly could appear healthy while the metric path was broken, fallback could preserve a runnable replica state even when Thanos authentication failed.

This PR therefore adds explicit metric path checks rather than treating resource liveness alone as evidence that autoscaling is functional.

## Commit 1: OpenShift adaptation for direct KEDA+EPP

### `feat(autoscaling): add direct KEDA+EPP OpenShift overlay`

The first commit adds a reusable OpenShift Component for the existing `guides/workload-autoscaling/keda-epp` assets.

it adds:
* a dedicated ServiceAccount for KEDA Prometheus queries
* a service account token Secret expected to receive the bearer token and OpenShift service CA at runtime
* a `cluster-monitoring-view` ClusterRoleBinding
* patches to the canonical TriggerAuthentication so it consumes the dedicated token and CA Secret
* OpenShift Thanos Querier configuration for both EPP triggers

both triggers are adapted to query:
```text
https://thanos-querier.openshift-monitoring.svc:9091
```
using bearer authentication.

The Component patches both canonical triggers:
```text
epp-queue-size
epp-running-requests
```

The patches include trigger name guards, so a future trigger reorder or rename fails during rendering instead of silently applying authentication to the wrong trigger. This commit is intentionally platform focused. It does not contain nightly specific namespace values, replica bounds, load generation or workflow logic.

## Commit 2: Initial-state deployment and validation

### `test(autoscaling): validate initial direct KEDA+EPP state on OpenShift`

The second commit adds the dedicated deployment script, guide specific validator and manual OpenShift workflow.

the deployment path installs:
* one optimized baseline model replica
* EPP with Flow Control enabled
* EPP monitoring through a ServiceMonitor
* model monitoring through a PodMonitor
* the direct KEDA+EPP ScaledObject
* the authenticated OpenShift metric path
* the KEDA generated HPA

the validation configuration uses:
```text
min replicas: 1
max replicas: 2
fallback failure threshold: 3
fallback replicas: 1
fallback behavior: currentReplicasIfHigher
```

Keeping fallback at one replica is important for this test. A broken metric path must not create two replicas and later resemble a successful scale up. The validator checks the system in layers.

### Resource and configuration checks

it verifies:
* the expected model, EPP, monitoring and KEDA resources exist
* the model starts with exactly one replica
* Flow Control and monitoring are enabled
* the ScaledObject contains both authenticated EPP triggers
* WVA and VariantAutoscaling resources are absent

This is a direct KEDA+EPP test and does not deploy the WVA controller or use `wva_desired_replicas`.

### Direct metric validation

The validator queries the EPP metrics endpoint directly:
```text
http://optimized-baseline-epp:9090/metrics
```

It requires real samples for:
```text
llm_d_epp_flow_control_queue_size
llm_d_epp_request_running
```

A value of zero is valid; a missing metric family or a metric with no sample is not.

### Thanos and KEDA validation

For each metric, the validator performs both raw and aggregate Thanos queries.

it verifies:
* authenticated Thanos access succeeds
* real source series exist
* namespace, service and model labels identify the intended EPP deployment
* the aggregate query returns exactly one result
* the selected series do not come from an unrelated deployment

It then requires:
* `ScaledObject Ready=True`
* `Fallback=False` across consecutive observations
* the generated HPA to be owned by the current ScaledObject
* exactly two external metrics in the HPA specification
* both metrics to appear in `status.currentMetrics`
* the HPA specification and current metric-name sets to match

Optional KEDA status fields are used as additional evidence when present but they are not treated as required API contracts.

### Stable initial state

Finally the validator repeatedly confirms:
* Deployment replicas remain one
* ready replicas remain one
* HPA current and desired replicas remain one
* exactly one non terminating model pod exists
* ReplicaSet totals do not hide a pending or terminating second replica

The existing generic inference smoke runs before this validator. It provides a basic inference check through EPP but it uses sequential requests and is not intended to generate autoscaling pressure.

## Relationship to [#2038](https://github.com/llm-d/llm-d/pull/2038) and [#2039](https://github.com/llm-d/llm-d/pull/2039)

This implementation reuses the accepted OpenShift/KEDA foundations introduced by:
* [#2038](https://github.com/llm-d/llm-d/pull/2038) which migrated the existing WVA nightly from Prometheus Adapter to KEDA
* [#2039](https://github.com/llm-d/llm-d/pull/2039) which added authenticated Thanos access and protections against fallback based false greens

The direct KEDA+EPP test reuses the relevant platform patterns:
* Thanos Querier on port `9091`
* bearer token authentication
* OpenShift service CA trust
* dedicated monitoring RBAC
* sustained fallback checks
* deterministic cleanup of cluster scoped RBAC

It does not copy the WVA specific controller, metrics or resources

## Scope of this PR

This PR intentionally adds only the first validation slice:
* deployment of the direct KEDA+EPP stack
* validation of EPP metric emission
* validation of authenticated OpenShift monitoring access
* validation that KEDA is not in fallback
* validation that the generated HPA receives both metrics
* validation of a stable one replica initial state

It does **not yet** add:
* bounded concurrent autoscaling load
* sustained queue or running request pressure
* HPA desired replicas greater than or equal to two
* Deployment scale up from one to two
* second-replica readiness
* inference validation after scale up
* scale down validation
* CKS coverage
* scheduled execution
* nightly badge or stable promotion changes

These behavior assertions should be added after the initial path is proven on the real OpenShift nightly environment.

## Local validation

The following checks pass locally:
* `git diff --check`
* `bash -n`
* ShellCheck
* actionlint, apart from the repository’s known custom runner label warnings
* YAML parsing
* restricted Kustomize rendering
* Helm rendering with the pinned router chart
* resource and selector assertions
* rendering of two bearer authenticated Thanos triggers
* one initial model replica
* fallback configured at one replica
* absence of rendered WVA resources

## Runtime validation required

**The workflow is manual only for this first slice and has not yet been run on the target OpenShift environment**

a real OpenShift run must still confirm:
* Custom Metrics Autoscaler/KEDA CRD availability
* the ServiceAccount Secret receives both `token` and `service-ca.crt`
* the model and EPP workloads become ready
* User Workload Monitoring discovers the EPP ServiceMonitor and model PodMonitor
* the direct EPP endpoint exposes both metric series
* authenticated Thanos queries return the intended EPP series
* KEDA reports sustained `Fallback=False`
* the generated HPA receives both external metrics
* the stack remains at one replica after the inference smoke
* the ClusterRoleBinding is removed after normal completion or failure
* cleanup behavior during workflow cancellation

## References

* First validation slice toward [llm-d-workload-variant-autoscaler#1326](https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/1326)
* Related broader guide evaluation context: [llm-d#1517](https://github.com/llm-d/llm-d/issues/1517)
* Builds on the KEDA+EPP guide assets from [#1981](https://github.com/llm-d/llm-d/pull/1981)
* Reuses the OpenShift KEDA nightly foundations from [#2038](https://github.com/llm-d/llm-d/pull/2038) and [#2039](https://github.com/llm-d/llm-d/pull/2039)