### PR TITLE
add benchmark results for P/D vllm 0.24

### DIFF
--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -342,7 +342,7 @@ kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/
 
 ## Benchmarking Report
 
-The benchmark is running on 16 H200 GPUs (with Infinband on CKS).
+The benchmark was run on 16 H200 GPUs (with InfiniBand on CKS).
 
 There is a report for each stage.
 
@@ -597,19 +597,49 @@ llmdbenchmark \
 
 (Drives the same `guide_pd-disaggregation_1.yaml` workload — rate=45 for 120s, 45 workers — against the aggregated baseline so the two result sets are directly comparable.)
 
-For this workload (20:1 ISL:OSL, 45 QPS), llm-d disaggregation improved mean and P90 request latency by ~50%!
+The following results were measured on **16 H200 GPUs with InfiniBand** (kermit cluster), running `openai/gpt-oss-120b` (MXFP4) at the guide workload: ISL=5000, OSL=250, rate=45 req/s, 45 workers, 120s.
 
-| Metric                   | aggregated | llm-d        | Δ% |
-| :----------------------- | :--------- | :----------- | :------- |
-| **E2E Latency (Mean)**   | **6.7s**   | **3.5s**     | **-47%** |
-| **E2E Latency (P95)**    | **10.2s**  | **5.08**     | **-50%** |
-| ITL (Mean)               | 25ms       | 8ms          | -67%     |
-| ITL (P95)                | 197ms      | 67ms         | -66%     |
-| TTFT (Mean)              | 532ms      | 1400ms       | +170%    |
-| TTFT (P95)               | 1574ms     | 2471ms       | +57%     |
+Two aggregated baselines enable a precise attribution of the P/D gains:
+- **baseline-2** — vLLM aggregated serving (8×TP=2) behind a **plain Kubernetes Service**, with no llm-d routing at all; this is the reference performance for vLLM alone.
+- **llm-d-baseline** — same 16 GPUs as baseline-2, with the full llm-d EPP and routing-proxy stack (prefix- and load-aware routing), but all pods running in aggregated mode; comparing llm-d p/d to llm-d-baseline cleanly attributes the remaining gains to P/D disaggregation itself.
+
+### All runs
+
+| Run | Config | Requests | Throughput | TTFT mean | TTFT p99 | TPOT mean | TPOT p99 | E2E mean | E2E p99 |
+| --- | ------ | -------- | ---------- | --------- | -------- | --------- | -------- | -------- | ------- |
+| baseline-1 | 16×TP=1, k8s Service | 3,477/5,400 ❌ | 29.0 req/s | 23,200ms | — | 184ms | — | 69.3s | — |
+| baseline-2 | 8×TP=2, k8s Service | 5,399/5,400 | 42.9 req/s | 1,333ms | 4,777ms | 68.7ms | 183ms | 18.5s | 47.5s |
+| llm-d-baseline | 8×TP=2, llm-d EPP | 5,400/5,400 | 41.3 req/s | 2,597ms | 4,812ms | 129ms | 165ms | 34.9s | 43.1s |
+| llm-d p/d | 8P(TP=1)+2D(TP=4), P/D | 5,400/5,400 | 42.9 req/s | 2,410ms | 7,990ms | 7.3ms | 9.2ms | 4.25s | 9.9s |
 
 > [!NOTE]
-> In aggregated setup, vLLM allocates all GPU resources to
-> processing prefills as they arrive. TTFT is elevated in the
-> disaggregated setup because less resources are allocated to
-> processing prefills.
+> Run baseline-1 (16×TP=1) failed to sustain the target rate: KV cache saturated quickly and only 64% of requests completed. The higher TPOT in llm-d-baseline vs baseline-2 is expected: the llm-d EPP Envoy sidecar uses a streaming ext_proc filter that intercepts every token in the response to enable token-aware routing decisions, adding per-token latency. In P/D disaggregation, the decode TPOT is so much lower that this overhead is negligible; for aggregated pods, it is more significant.
+
+### baseline-2 vs llm-d p/d — plain Kubernetes Service vs P/D disaggregation
+
+| Metric | baseline-2 (8×TP=2, k8s Service) | llm-d p/d (P/D disaggregation) | Δ% |
+| :----- | :-------------------------------- | :----------------------------- | :--- |
+| Throughput | 42.9 req/s | 42.9 req/s | ~0% |
+| TTFT mean | 1,333ms | 2,410ms | +81% |
+| TTFT p99 | 4,777ms | 7,990ms | +67% |
+| **TPOT mean** | **68.7ms** | **7.3ms** | **-89%** |
+| **TPOT p99** | **183ms** | **9.2ms** | **-95%** |
+| **E2E mean** | **18.5s** | **4.25s** | **-77%** |
+| **E2E p99** | **47.5s** | **9.9s** | **-79%** |
+
+### llm-d-baseline vs llm-d p/d — llm-d EPP (aggregated) vs P/D disaggregation
+
+Both runs route through the llm-d EPP, so this comparison isolates the P/D disaggregation gain from the routing-layer contribution.
+
+| Metric | llm-d-baseline (8×TP=2, llm-d EPP) | llm-d p/d (P/D disaggregation) | Δ% |
+| :----- | :---------------------------------- | :----------------------------- | :--- |
+| Throughput | 41.3 req/s | 42.9 req/s | +4% |
+| TTFT mean | 2,597ms | 2,410ms | -7% |
+| TTFT p99 | 4,812ms | 7,990ms | +66% |
+| **TPOT mean** | **129ms** | **7.3ms** | **-94%** |
+| **TPOT p99** | **165ms** | **9.2ms** | **-94%** |
+| **E2E mean** | **34.9s** | **4.25s** | **-88%** |
+| **E2E p99** | **43.1s** | **9.9s** | **-77%** |
+
+> [!NOTE]
+> TTFT is higher in the P/D setup because fewer GPU resources are dedicated to prefill processing at any instant; the improvement is in decode throughput (TPOT), which drives the large end-to-end latency reduction under sustained load.

--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -597,7 +597,7 @@ llmdbenchmark \
 
 (Drives the same `guide_pd-disaggregation_1.yaml` workload — rate=45 for 120s, 45 workers — against the aggregated baseline so the two result sets are directly comparable.)
 
-The following results were measured on **16 H200 GPUs with InfiniBand** (kermit cluster), running `openai/gpt-oss-120b` (MXFP4) at the guide workload: ISL=5000, OSL=250, rate=45 req/s, 45 workers, 120s.
+The following results were measured on **16 H200 GPUs with InfiniBand**, running `openai/gpt-oss-120b` (MXFP4) at the guide workload: ISL=5000, OSL=250, rate=45 req/s, 45 workers, 120s.
 
 Two aggregated baselines enable a precise attribution of the P/D gains:
 - **baseline-2** — vLLM aggregated serving (8×TP=2) behind a **plain Kubernetes Service**, with no llm-d routing at all; this is the reference performance for vLLM alone.

--- a/guides/pd-disaggregation/baseline/manifest.yaml
+++ b/guides/pd-disaggregation/baseline/manifest.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: vllm
-          image: docker.io/vllm/vllm-openai:v0.23.0
+          image: docker.io/vllm/vllm-openai:v0.24.0
           imagePullPolicy: IfNotPresent
           command: ["vllm", "serve"]
           args:

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/base/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/base/patch-decode.yaml
@@ -17,6 +17,7 @@ spec:
             - "--kv-transfer-config"
             - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
             - "--no-disable-hybrid-kv-cache-manager"
+            - "--max-model-len=8192"
             - "--port=8200"
           env:
             - name: HF_TOKEN
@@ -28,11 +29,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: UCX_MAX_RMA_RAILS
+              value: "1"
             # NOTE: vLLM 0.19.X and 0.20.X images ship both nixl-cu13 and nixl-cu12;
             # NIXL can pick the wrong UCX libraries. Uncomment UCX_MODULE_DIR only
             # if you are running a cu129 version of vLLM.
             # - name: UCX_MODULE_DIR
             #   value: /usr/local/lib/python3.12/dist-packages/nixl_cu12.libs/ucx
+            # Default vLLM keep-alive (5s) is shorter than llm-d-routing-sidecar's default idle
+            # conn timeout (90s, from Go http.Transport), causing TCP RSTs on reuse.
+            # Server keep-alive must be >= sidecar idle timeout; configured to 120s.
+            - name: VLLM_HTTP_TIMEOUT_KEEP_ALIVE
+              value: "120"
           resources:
             limits:
               cpu: "16"

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/base/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/base/patch-prefill.yaml
@@ -17,6 +17,7 @@ spec:
             - "--kv-transfer-config"
             - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
             - "--no-disable-hybrid-kv-cache-manager"
+            - "--max-model-len=8192"
           env:
             - name: HF_TOKEN
               valueFrom:
@@ -27,6 +28,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: UCX_MAX_RMA_RAILS
+              value: "1"
             # NOTE: vLLM 0.19.X and 0.20.X images ship both nixl-cu13 and nixl-cu12;
             # NIXL can pick the wrong UCX libraries. Uncomment UCX_MODULE_DIR only
             # if you are running a cu129 version of vLLM.
@@ -37,6 +40,8 @@ spec:
             # Server keep-alive must be >= sidecar idle timeout; configured to 120s.
             - name: VLLM_HTTP_TIMEOUT_KEEP_ALIVE
               value: "120"
+            # PYTORCH_ALLOC_CONF=expandable_segments:True must NOT be set on prefill:
+            # causes NIXL RDMA memory region fragmentation, delaying peer discovery by 30+ min.
           resources:
             limits:
               cpu: "8"

--- a/guides/recipes/modelserver/components/images/gpu-vllm/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/gpu-vllm/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Component
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: vllm/vllm-openai
-    newTag: v0.23.0
+    newTag: v0.24.0
 
 # Workaround for https://github.com/vllm-project/vllm/issues/44548, required with vLLM v0.20.0+ due to torch 2.11
 patches:


### PR DESCRIPTION
Added benchmark results to the P/D disaggregation guide with benchmark results from llm-d main and vLLM v0.24.0, run on H200 cluster.
Added an llm-d-baseline measurement (same 16 GPUs with the full llm-d EPP and routing stack, but in aggregated mode) alongside the plain Kubernetes Service baseline, so the results cleanly attribute the gains to P/D disaggregation itself. 
The guide YAMLs have also been updated to match the tested configuration.