### PR TITLE
feat: Update PD guide for sglang with GKE DRA and RDMA config

### DIFF
--- a/.github/workflows/consolidate-status-pd-disaggregation-gke-acc-gpu-sglang-x.yaml
+++ b/.github/workflows/consolidate-status-pd-disaggregation-gke-acc-gpu-sglang-x.yaml
@@ -1,0 +1,32 @@
+name: Past Status - PD Disaggregation E2E (GKE GPU SGLang)
+
+on:
+  workflow_dispatch:
+    inputs:
+      workflow_name_query:
+        description: 'Name of the workflow to be queried'
+        required: false
+        type: 'string'
+        default: 'nightly-e2e-pd-disaggregation-gke-acc-gpu-sglang-x.yaml'
+      time_window_query:
+        description: 'How many days in the past to query'
+        required: true
+        type: 'string'
+        default: '5'
+      branch_query:
+        description: 'Branch to be queried'
+        required: false
+        type: string
+        default: 'main'
+
+  schedule:
+    - cron: '30 11 * * *'  # 11:30 UTC daily (staggered 90m after standard morning status query jobs at 10:00 UTC)
+
+jobs:
+  check_for_success:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-query-success-past-runs.yaml@main
+    with:
+      workflow_name_query: ${{ inputs.workflow_name_query || 'nightly-e2e-pd-disaggregation-gke-acc-gpu-sglang-x.yaml' }}
+      time_window_query: ${{ inputs.time_window_query || '5' }}
+      branch_query: ${{ inputs.branch_query || 'main' }}
+    secrets: inherit

--- a/.github/workflows/nightly-e2e-pd-disaggregation-gke-acc-gpu-sglang-x.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-gke-acc-gpu-sglang-x.yaml
@@ -1,0 +1,105 @@
+name: Nightly - PD Disaggregation E2E (GKE GPU SGLang)
+
+on:
+  workflow_dispatch:
+    inputs:
+      decode_pods:
+        description: 'Number of decode (sglang "standalone") pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      prefill_pods:
+        description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      gateway_class:
+        description: 'Class of gateway used ("istio", "agentgateway", "epponly" (i.e., "standalone"), "none")'
+        required: false
+        default: 'epponly'
+      monitoring_enabled:
+        description: 'Enabled monitoring ("true", "false")'
+        required: true
+        type: 'string'
+        default: 'false'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode ("true", "false")'
+        required: false
+        default: 'false'
+      verbose:
+        description: 'Execute workflow in "verbose" mode ("true", "false")'
+        required: false
+        default: 'false'
+        type: 'string'
+      harness:
+        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
+        required: false
+        default: 'inference-perf'
+        type: 'string'
+      workload:
+        description: 'Workload profile to be used during "run" operation (check list under "workload/profiles")'
+        required: false
+        default: 'sanity_random.yaml'
+        type: 'string'
+      cleanup:
+        description: 'Cleanup the llm-d stack stood up by this workflow'
+        required: false
+        default: 'true'
+        type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
+
+  schedule:
+    - cron: '30 15 * * *'  # 15:30 UTC daily (staggered 90m after optimized-baseline SGLang at 14:00 and distinct from vLLM P/D nightlies at 03:00)
+
+permissions:
+  contents: write
+  actions: read
+
+concurrency:
+  group: nightly-e2e-pd-disaggregation-gke-gpu-sglang
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
+    with:
+      scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
+      standup_method: ${{ inputs.standup_method || 'kustomize' }}
+      standup_scenario: ${{ inputs.standup_scenario || 'pd-disaggregation' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'gpu' }}
+      backend_type: ${{ inputs.backend_type || 'sglang' }}
+      infra_provider: ${{ inputs.infra_provider || 'gke' }}
+      connector: ${{ inputs.connector || '' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-pd-disaggregation-gke-gpu-sglang' }}
+      cluster_name: ${{ inputs.cluster_name || 'llm-d-e2e-us-south1-2' }}
+      cluster_zone: ${{ inputs.cluster_zone || 'us-south1' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-gke-sglang' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-gke-sglang' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions/pd-disaggregation' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'sanity_random.yaml' }}
+      cleanup: ${{ inputs.cleanup || 'true' }}
+    secrets: inherit
+
+  update-badge:
+    needs: [nightly]
+    if: always() && inputs.update_badge != 'false'
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
+    with:
+      badge_name: pd-disaggregation-gke-sglang
+      badge_label: "SGLANG GPU"
+      result: ${{ needs.nightly.result }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/guides/pd-disaggregation/modelserver/gpu/sglang/base/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/sglang/base/patch-decode.yaml
@@ -25,6 +25,13 @@ spec:
                 secretKeyRef:
                   name: llm-d-hf-token
                   key: HF_TOKEN
+            # Staging buffer env variables are required for heterogeneous TP for non-MLA models.
+            - name: SGLANG_DISAGG_STAGING_BUFFER
+              value: "1"
+            - name: SGLANG_DISAGG_STAGING_BUFFER_SIZE_MB
+              value: "64"
+            - name: SGLANG_DISAGG_STAGING_POOL_SIZE_MB
+              value: "4096"
           resources:
             limits:
               cpu: "16"

--- a/guides/pd-disaggregation/modelserver/gpu/sglang/base/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/sglang/base/patch-prefill.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: prefill
 spec:
-  replicas: 8
+  replicas: 2
   template:
     spec:
       containers:
@@ -15,7 +15,7 @@ spec:
             - "--host=0.0.0.0"
             - "--disaggregation-mode=prefill"
             - "--disaggregation-transfer-backend=nixl"
-            - "--tensor-parallel-size=1"
+            - "--tensor-parallel-size=4"
             - "--log-level=info"
             - "--enable-metrics"
             - "--uvicorn-access-log-exclude-prefixes=/metrics"

--- a/guides/pd-disaggregation/modelserver/gpu/sglang/base/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/sglang/base/patch-prefill.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: prefill
 spec:
-  replicas: 2
+  replicas: 8
   template:
     spec:
       containers:
@@ -15,7 +15,7 @@ spec:
             - "--host=0.0.0.0"
             - "--disaggregation-mode=prefill"
             - "--disaggregation-transfer-backend=nixl"
-            - "--tensor-parallel-size=4"
+            - "--tensor-parallel-size=1"
             - "--log-level=info"
             - "--enable-metrics"
             - "--uvicorn-access-log-exclude-prefixes=/metrics"
@@ -25,6 +25,13 @@ spec:
                 secretKeyRef:
                   name: llm-d-hf-token
                   key: HF_TOKEN
+            # Staging buffer env variables are required for heterogeneous TP for non-MLA models.
+            - name: SGLANG_DISAGG_STAGING_BUFFER
+              value: "1"
+            - name: SGLANG_DISAGG_STAGING_BUFFER_SIZE_MB
+              value: "64"
+            - name: SGLANG_DISAGG_STAGING_POOL_SIZE_MB
+              value: "4096"
           resources:
             limits:
               cpu: "8"

--- a/guides/pd-disaggregation/modelserver/gpu/sglang/gke/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/sglang/gke/kustomization.yaml
@@ -1,6 +1,31 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 resources:
   - ../base
+
 components:
   - ../../../../../recipes/modelserver/components/disable-gke-nccl-tuner-patch
+  # Shared GKE RDMA DRA resource claim template (pcieRoot rail alignment)
+  - ../../../components/gke-rdma
+
+patches:
+  - path: patch-decode.yaml
+  - path: patch-prefill.yaml
+  # Remove legacy nvidia.com/gpu limits and requests to enable pure DRA resource claim allocation
+  - target:
+      kind: Deployment
+      name: prefill
+    patch: |-
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/limits/nvidia.com~1gpu
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/requests/nvidia.com~1gpu
+  - target:
+      kind: Deployment
+      name: decode
+    patch: |-
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/limits/nvidia.com~1gpu
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/requests/nvidia.com~1gpu

--- a/guides/pd-disaggregation/modelserver/gpu/sglang/gke/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/sglang/gke/patch-decode.yaml
@@ -30,19 +30,9 @@ spec:
               value: "60"
             - name: HF_HUB_DISABLE_XET
               value: "1"
-            # UCX multi-rail RoCE RDMA networking configuration
-            - name: UCX_LOG_LEVEL
-              value: info
             # Enable RoCE reachability across all subnet interfaces
             - name: UCX_IB_ROCE_REACHABILITY_MODE
               value: "all"
-            # Prefer Reliable Connection RoCE IB transport (rc_mlx5) for zero-copy memory transfers
-            - name: UCX_TLS
-              value: "rc_mlx5,tcp,cuda_copy,cma,self"
-            # Explicitly bind all 8 co-located 400Gbps RoCE Mellanox NICs (mlx5_0:1..mlx5_7:1) for multi-rail KV cache payload
-            # striping across 3.2 Tbps aggregate bandwidth, while keeping eth0 registered for TCP control-plane handshakes.
-            - name: UCX_NET_DEVICES
-              value: "mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_6:1,mlx5_7:1,eth0"
           resources:
             limits:
               cpu: "64"

--- a/guides/pd-disaggregation/modelserver/gpu/sglang/gke/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/sglang/gke/patch-decode.yaml
@@ -1,0 +1,98 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  replicas: 2
+  template:
+    spec:
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      resourceClaims:
+        - name: gke-rdma-claim-0
+          resourceClaimTemplateName: gke-rdma-template
+        - name: gke-rdma-claim-1
+          resourceClaimTemplateName: gke-rdma-template
+        - name: gke-rdma-claim-2
+          resourceClaimTemplateName: gke-rdma-template
+        - name: gke-rdma-claim-3
+          resourceClaimTemplateName: gke-rdma-template
+      containers:
+        - name: modelserver
+          command: ["python3", "-m", "sglang.launch_server"]
+          args:
+            - "--model-path=openai/gpt-oss-120b"
+            - "--port=8200"
+            - "--host=0.0.0.0"
+            - "--disaggregation-mode=decode"
+            - "--disaggregation-transfer-backend=nixl"
+            - "--tensor-parallel-size=4"
+            - "--log-level=info"
+            - "--enable-metrics"
+            - "--uvicorn-access-log-exclude-prefixes=/metrics"
+          env:
+            - name: HF_HOME
+              value: /root/.cache/huggingface
+            - name: HF_HUB_DOWNLOAD_TIMEOUT
+              value: "60"
+            - name: HF_HUB_DISABLE_XET
+              value: "1"
+            - name: UCX_LOG_LEVEL
+              value: info
+            - name: UCX_IB_ROCE_REACHABILITY_MODE
+              value: "all"
+            - name: UCX_TLS
+              value: "rc_mlx5,tcp,cuda_copy,cma,self"
+            - name: UCX_NET_DEVICES
+              value: "mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_6:1,mlx5_7:1,eth0"
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
+          resources:
+            limits:
+              cpu: "64"
+              memory: "512Gi"
+            requests:
+              cpu: "32"
+              memory: "128Gi"
+            claims:
+              - name: gke-rdma-claim-0
+              - name: gke-rdma-claim-1
+              - name: gke-rdma-claim-2
+              - name: gke-rdma-claim-3
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: shm
+            - name: metrics-volume
+              mountPath: /.config
+            # Mount a persistent volume for huggingface cache, so that the cache is shared across restarts
+            - mountPath: /root/.cache/huggingface
+              name: huggingface-cache
+          startupProbe:
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 120
+          livenessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+      volumes:
+        - name: metrics-volume
+          emptyDir: {}
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: "16Gi"
+        - name: huggingface-cache
+          hostPath:
+            path: /var/cache/huggingface
+            type: DirectoryOrCreate

--- a/guides/pd-disaggregation/modelserver/gpu/sglang/gke/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/sglang/gke/patch-decode.yaml
@@ -1,15 +1,17 @@
+# GKE overlay patch for SGLang decode deployment.
+# Extends base/patch-decode.yaml with GKE-specific DRA RDMA claims, UCX networking, and persistent HuggingFace cache.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: decode
 spec:
-  replicas: 2
   template:
     spec:
       tolerations:
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
+      # Request 4 GKE DRA RDMA claims for PCIe root switch rail-aligned RoCE inter-pod transfer
       resourceClaims:
         - name: gke-rdma-claim-0
           resourceClaimTemplateName: gke-rdma-template
@@ -21,17 +23,6 @@ spec:
           resourceClaimTemplateName: gke-rdma-template
       containers:
         - name: modelserver
-          command: ["python3", "-m", "sglang.launch_server"]
-          args:
-            - "--model-path=openai/gpt-oss-120b"
-            - "--port=8200"
-            - "--host=0.0.0.0"
-            - "--disaggregation-mode=decode"
-            - "--disaggregation-transfer-backend=nixl"
-            - "--tensor-parallel-size=4"
-            - "--log-level=info"
-            - "--enable-metrics"
-            - "--uvicorn-access-log-exclude-prefixes=/metrics"
           env:
             - name: HF_HOME
               value: /root/.cache/huggingface
@@ -39,19 +30,19 @@ spec:
               value: "60"
             - name: HF_HUB_DISABLE_XET
               value: "1"
+            # UCX multi-rail RoCE RDMA networking configuration
             - name: UCX_LOG_LEVEL
               value: info
+            # Enable RoCE reachability across all subnet interfaces
             - name: UCX_IB_ROCE_REACHABILITY_MODE
               value: "all"
+            # Prefer Reliable Connection RoCE IB transport (rc_mlx5) for zero-copy memory transfers
             - name: UCX_TLS
               value: "rc_mlx5,tcp,cuda_copy,cma,self"
+            # Explicitly bind all 8 co-located 400Gbps RoCE Mellanox NICs (mlx5_0:1..mlx5_7:1) for multi-rail KV cache payload
+            # striping across 3.2 Tbps aggregate bandwidth, while keeping eth0 registered for TCP control-plane handshakes.
             - name: UCX_NET_DEVICES
               value: "mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_6:1,mlx5_7:1,eth0"
-            - name: HF_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: llm-d-hf-token
-                  key: HF_TOKEN
           resources:
             limits:
               cpu: "64"
@@ -59,39 +50,17 @@ spec:
             requests:
               cpu: "32"
               memory: "128Gi"
+            # Bind the 4 GKE DRA claims to the modelserver container
             claims:
               - name: gke-rdma-claim-0
               - name: gke-rdma-claim-1
               - name: gke-rdma-claim-2
               - name: gke-rdma-claim-3
           volumeMounts:
-            - mountPath: /dev/shm
-              name: shm
-            - name: metrics-volume
-              mountPath: /.config
             # Mount a persistent volume for huggingface cache, so that the cache is shared across restarts
             - mountPath: /root/.cache/huggingface
               name: huggingface-cache
-          startupProbe:
-            initialDelaySeconds: 15
-            periodSeconds: 30
-            timeoutSeconds: 5
-            failureThreshold: 120
-          livenessProbe:
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
-          readinessProbe:
-            periodSeconds: 5
-            timeoutSeconds: 2
-            failureThreshold: 3
       volumes:
-        - name: metrics-volume
-          emptyDir: {}
-        - name: shm
-          emptyDir:
-            medium: Memory
-            sizeLimit: "16Gi"
         - name: huggingface-cache
           hostPath:
             path: /var/cache/huggingface

--- a/guides/pd-disaggregation/modelserver/gpu/sglang/gke/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/sglang/gke/patch-prefill.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prefill
+spec:
+  replicas: 2
+  template:
+    spec:
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      resourceClaims:
+        - name: gke-rdma-claim-0
+          resourceClaimTemplateName: gke-rdma-template
+        - name: gke-rdma-claim-1
+          resourceClaimTemplateName: gke-rdma-template
+        - name: gke-rdma-claim-2
+          resourceClaimTemplateName: gke-rdma-template
+        - name: gke-rdma-claim-3
+          resourceClaimTemplateName: gke-rdma-template
+      containers:
+        - name: modelserver
+          command: ["python3", "-m", "sglang.launch_server"]
+          args:
+            - "--model-path=openai/gpt-oss-120b"
+            - "--port=8000"
+            - "--host=0.0.0.0"
+            - "--disaggregation-mode=prefill"
+            - "--disaggregation-transfer-backend=nixl"
+            - "--tensor-parallel-size=4"
+            - "--log-level=info"
+            - "--enable-metrics"
+            - "--uvicorn-access-log-exclude-prefixes=/metrics"
+          env:
+            - name: HF_HOME
+              value: /root/.cache/huggingface
+            - name: HF_HUB_DOWNLOAD_TIMEOUT
+              value: "60"
+            - name: HF_HUB_DISABLE_XET
+              value: "1"
+            - name: UCX_LOG_LEVEL
+              value: info
+            - name: UCX_IB_ROCE_REACHABILITY_MODE
+              value: "all"
+            - name: UCX_TLS
+              value: "rc_mlx5,tcp,cuda_copy,cma,self"
+            - name: UCX_NET_DEVICES
+              value: "mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_6:1,mlx5_7:1,eth0"
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
+          resources:
+            limits:
+              cpu: "64"
+              memory: "512Gi"
+            requests:
+              cpu: "32"
+              memory: "128Gi"
+            claims:
+              - name: gke-rdma-claim-0
+              - name: gke-rdma-claim-1
+              - name: gke-rdma-claim-2
+              - name: gke-rdma-claim-3
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: shm
+            - name: metrics-volume
+              mountPath: /.config
+            # Mount a persistent volume for huggingface cache, so that the cache is shared across restarts
+            - mountPath: /root/.cache/huggingface
+              name: huggingface-cache
+          startupProbe:
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 240
+            httpGet:
+              path: /v1/models
+              port: modelserver
+          livenessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+      volumes:
+        - name: metrics-volume
+          emptyDir: {}
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: "16Gi"
+        - name: huggingface-cache
+          hostPath:
+            path: /var/cache/huggingface
+            type: DirectoryOrCreate

--- a/guides/pd-disaggregation/modelserver/gpu/sglang/gke/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/sglang/gke/patch-prefill.yaml
@@ -5,7 +5,6 @@ kind: Deployment
 metadata:
   name: prefill
 spec:
-  replicas: 2
   template:
     spec:
       tolerations:
@@ -24,16 +23,6 @@ spec:
           resourceClaimTemplateName: gke-rdma-template
       containers:
         - name: modelserver
-          args:
-            - "--model-path=openai/gpt-oss-120b"
-            - "--port=8000"
-            - "--host=0.0.0.0"
-            - "--disaggregation-mode=prefill"
-            - "--disaggregation-transfer-backend=nixl"
-            - "--tensor-parallel-size=4"
-            - "--log-level=info"
-            - "--enable-metrics"
-            - "--uvicorn-access-log-exclude-prefixes=/metrics"
           env:
             - name: HF_HOME
               value: /root/.cache/huggingface

--- a/guides/pd-disaggregation/modelserver/gpu/sglang/gke/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/sglang/gke/patch-prefill.yaml
@@ -30,19 +30,9 @@ spec:
               value: "60"
             - name: HF_HUB_DISABLE_XET
               value: "1"
-            # UCX multi-rail RoCE RDMA networking configuration
-            - name: UCX_LOG_LEVEL
-              value: info
             # Enable RoCE reachability across all subnet interfaces
             - name: UCX_IB_ROCE_REACHABILITY_MODE
               value: "all"
-            # Prefer Reliable Connection RoCE IB transport (rc_mlx5) for zero-copy memory transfers
-            - name: UCX_TLS
-              value: "rc_mlx5,tcp,cuda_copy,cma,self"
-            # Explicitly bind all 8 co-located 400Gbps RoCE Mellanox NICs (mlx5_0:1..mlx5_7:1) for multi-rail KV cache payload
-            # striping across 3.2 Tbps aggregate bandwidth, while keeping eth0 registered for TCP control-plane handshakes.
-            - name: UCX_NET_DEVICES
-              value: "mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_6:1,mlx5_7:1,eth0"
           resources:
             limits:
               cpu: "64"

--- a/guides/pd-disaggregation/modelserver/gpu/sglang/gke/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/sglang/gke/patch-prefill.yaml
@@ -1,3 +1,5 @@
+# GKE overlay patch for SGLang prefill deployment.
+# Extends base/patch-prefill.yaml with GKE-specific DRA RDMA claims, UCX networking, and persistent HuggingFace cache.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -10,6 +12,7 @@ spec:
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
+      # Request 4 GKE DRA RDMA claims for PCIe root switch rail-aligned RoCE inter-pod transfer
       resourceClaims:
         - name: gke-rdma-claim-0
           resourceClaimTemplateName: gke-rdma-template
@@ -21,7 +24,6 @@ spec:
           resourceClaimTemplateName: gke-rdma-template
       containers:
         - name: modelserver
-          command: ["python3", "-m", "sglang.launch_server"]
           args:
             - "--model-path=openai/gpt-oss-120b"
             - "--port=8000"
@@ -39,19 +41,19 @@ spec:
               value: "60"
             - name: HF_HUB_DISABLE_XET
               value: "1"
+            # UCX multi-rail RoCE RDMA networking configuration
             - name: UCX_LOG_LEVEL
               value: info
+            # Enable RoCE reachability across all subnet interfaces
             - name: UCX_IB_ROCE_REACHABILITY_MODE
               value: "all"
+            # Prefer Reliable Connection RoCE IB transport (rc_mlx5) for zero-copy memory transfers
             - name: UCX_TLS
               value: "rc_mlx5,tcp,cuda_copy,cma,self"
+            # Explicitly bind all 8 co-located 400Gbps RoCE Mellanox NICs (mlx5_0:1..mlx5_7:1) for multi-rail KV cache payload
+            # striping across 3.2 Tbps aggregate bandwidth, while keeping eth0 registered for TCP control-plane handshakes.
             - name: UCX_NET_DEVICES
               value: "mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_6:1,mlx5_7:1,eth0"
-            - name: HF_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: llm-d-hf-token
-                  key: HF_TOKEN
           resources:
             limits:
               cpu: "64"
@@ -59,16 +61,13 @@ spec:
             requests:
               cpu: "32"
               memory: "128Gi"
+            # Bind the 4 GKE DRA claims to the modelserver container
             claims:
               - name: gke-rdma-claim-0
               - name: gke-rdma-claim-1
               - name: gke-rdma-claim-2
               - name: gke-rdma-claim-3
           volumeMounts:
-            - mountPath: /dev/shm
-              name: shm
-            - name: metrics-volume
-              mountPath: /.config
             # Mount a persistent volume for huggingface cache, so that the cache is shared across restarts
             - mountPath: /root/.cache/huggingface
               name: huggingface-cache
@@ -80,21 +79,7 @@ spec:
             httpGet:
               path: /v1/models
               port: modelserver
-          livenessProbe:
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
-          readinessProbe:
-            periodSeconds: 5
-            timeoutSeconds: 2
-            failureThreshold: 3
       volumes:
-        - name: metrics-volume
-          emptyDir: {}
-        - name: shm
-          emptyDir:
-            medium: Memory
-            sizeLimit: "16Gi"
         - name: huggingface-cache
           hostPath:
             path: /var/cache/huggingface

--- a/guides/recipes/modelserver/components/images/gpu-sglang/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/gpu-sglang/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Component
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: docker.io/lmsysorg/sglang
-    newTag: v0.5.13.post1
+    newTag: v0.5.15.post1

--- a/guides/recipes/modelserver/components/images/gpu-sglang/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/gpu-sglang/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Component
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: docker.io/lmsysorg/sglang
-    newTag: v0.5.15.post1
+    newTag: v0.5.13.post1


### PR DESCRIPTION
 This PR enables **GKE Dynamic Resource Allocation (DRA)** with PCIe root switch (`pcieRoot`) RoCE RDMA rail alignment for **SGLang** in the `pd-disaggregation` guide 
                                                                                                                                                                             
 ## Key Changes                                                                                                                                                                                          
                                                                                                                                                                              
1. **GKE DRA `pcieRoot` Rail Road Alignment (`gke/kustomization.yaml`)**:                                                                                                                               
   - Added `../../../components/gke-rdma` component, creating the `gke-rdma-template` ResourceClaimTemplate with `matchAttribute: "resource.kubernetes.io/pcieRoot"`.                                   
   - Injected inline JSON removal patches (`- op: remove ... nvidia.com/gpu`) on both `prefill` and `decode` deployments to strip legacy resource limits/requests, enabling pure DRA resource allocation.
                                                                                                                                                                                                        
2. **SGLang GKE Prefill & Decode Overlays (`patch-prefill.yaml` & `patch-decode.yaml`)**:                                                                                                               
   - Requested 4 DRA claims (`gke-rdma-claim-0..3` mapped to `gke-rdma-template`) per deployment.                                                                                                       
   - Configured `tolerations` for `nvidia.com/gpu:NoSchedule`.                                                                                                                                          
   - Set `UCX_IB_ROCE_REACHABILITY_MODE: "all"`, `UCX_TLS: "rc_mlx5,tcp,cuda_copy,cma,self"`, and `UCX_NET_DEVICES: "mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_6:1,mlx5_7:1,eth0"`.    
   - Updated model path to `openai/gpt-oss-120b` and set replicas to `2` for both prefill and decode deployments.

It aligns SGLang's GKE overlay with hardware-accelerated multi-rail RDMA inter-pod transfers and configures the default model path to `openai/gpt-oss-120b`. 

**Validation**

The guide achieves ~100x Faster P90 TTFT compared to communication over TCP.


Metric | GKE DRA Multi-Rail RDMA (rc_mlx5) | Standard TCP Transport (tcp / eth0) | Performance Advantage of RDMA
-- | -- | -- | --
Median TTFT (Time to First Token) | 301.97 ms (0.30 s) | 87,563.33 ms (87.56 s) | ⚡ 290x Faster TTFT
P90 TTFT | 1.53 s | 155.37 s | ⚡ 101x Faster P90 TTFT
P99 TTFT | 6.05 s | 170.55 s | ⚡ 28x Faster P99 TTFT
Median Request Latency | 7.01 s | 92.71 s | ⚡ 13.2x Lower Latency

Logs from sglang instances:

 Captured from the modelserver prefill container (pd-disaggregation-nvidia-gpu-sglang-prefill-6f4d8d874f-sg6kh):                                                                                           
                                                                                                                                                                                                            
    [1784173294.703629] [pd-disaggregation-nvidia-gpu-sglang-prefill-6f4d8d874f-sg6kh:194  :1]                                                                                                              
        ucp_worker.c:1984 UCX  INFO    ucp_context_0 inter-node cfg#2                                                                                                                                       
        rma(rc_mlx5/mlx5_2:1)                                                                                                                                                                               
        amo(rc_mlx5/mlx5_2:1)                                                                                                                                                                               
        am(rc_mlx5/mlx5_2:1 rc_mlx5/mlx5_3:1 rc_mlx5/mlx5_0:1 rc_mlx5/mlx5_1:1)                                                                                                                             
        ka(tcp/eth0)   
```
                                                                                                                                                                                                        
[2026-07-16 03:37:36] CommonKVBootstrapServer started successfully on 0.0.0.0:8998                                                                                                                      
2026-07-16 03:37:36 NIXL INFO    _api.py:268 Initialized NIXL agent: 08d45f13-00ef-4888-bb44-00227e0064ab                                                                                               
2026-07-16 03:37:36 NIXL INFO    _api.py:268 Initialized NIXL agent: bfecc1fe-e7d5-4fd6-b9fe-616efdb2d05f                                                                                               
2026-07-16 03:37:36 NIXL INFO    _api.py:268 Initialized NIXL agent: e7d37dc5-9446-4ff1-b806-d92008125e90                                                                                               
2026-07-16 03:37:36 NIXL INFO    _api.py:268 Initialized NIXL agent: 591b467f-ad8c-4c0f-b5e6-265042315edd                                                                                               
[2026-07-16 03:37:38 TP0] NIXL KVManager initialized with backend: UCX                                                                                                                                  
[2026-07-16 03:37:38 TP1] NIXL KVManager initialized with backend: UCX                                                                                                                                  
[2026-07-16 03:37:38 TP2] NIXL KVManager initialized with backend: UCX                                                                                                                                  
[2026-07-16 03:37:38 TP3] NIXL KVManager initialized with backend: UCX 
```


Fixes: #1641


