### PR TITLE
update(CI): convert wva dry-run job to do recursive find for kustomization

### DIFF
--- a/.github/workflows/ci-kustomize-dry-run.yaml
+++ b/.github/workflows/ci-kustomize-dry-run.yaml
@@ -386,9 +386,13 @@ jobs:
       - name: Kustomize build and dry-run all WVA platform overlays
         run: |
           failed=0
-          for kust_dir in guides/workload-autoscaling/wva-config/platform/*/; do
-            [ -f "${kust_dir}kustomization.yaml" ] || continue
-            name="${kust_dir#guides/workload-autoscaling/wva-config/platform/}"
+          base=guides/workload-autoscaling/wva-config/platform
+          # Recurse to any depth so every platform overlay is covered, matching
+          # the other dry-run jobs (today only platform/k8s/ and platform/ocp/
+          # exist, but nested overlays should be validated automatically too).
+          while IFS= read -r -d '' kustfile; do
+            kust_dir="${kustfile%kustomization.yaml}"
+            name="${kust_dir#"${base}"/}"
             name="${name%/}"
             echo ""
             echo "========================================"
@@ -414,5 +418,5 @@ jobs:
               echo "FAIL: workload-autoscaling / ${name}"
               failed=1
             fi
-          done
+          done < <(find "${base}" -name kustomization.yaml -print0 | sort -z)
           exit $failed


### PR DESCRIPTION
# Notes
The dry-run-workload-autoscaling job still used the old single-level loop (for kust_dir in .../platform/*/),
converge it onto the recursive pattern already used by dry-run-precise-prefix-cache-routing
so the whole workflow is consistent and nested overlays are validated automatically

ref  comments from https://github.com/llm-d/llm-d/pull/2035#pullrequestreview-4715414406

cc @diegocastanibm 

