### PR TITLE
Update router images and manifests to point to main

### DIFF
--- a/.github/workflows/ci-kustomize-dry-run.yaml
+++ b/.github/workflows/ci-kustomize-dry-run.yaml
@@ -102,7 +102,7 @@ jobs:
         run: |
           CHART_VERSION=v0
           failed=0
-          for chart in llm-d-router-standalone-dev llm-d-router-gateway-dev; do
+          for chart in llm-d-router-standalone llm-d-router-gateway; do
             echo ""
             echo "========================================"
             echo "optimized-baseline: router (${chart})"
@@ -193,7 +193,7 @@ jobs:
         run: |
           CHART_VERSION=v0
           failed=0
-          for chart in llm-d-router-standalone-dev llm-d-router-gateway-dev; do
+          for chart in llm-d-router-standalone llm-d-router-gateway; do
             echo ""
             echo "========================================"
             echo "pd-disaggregation: router (${chart})"
@@ -290,7 +290,7 @@ jobs:
           echo "========================================"
           echo "--- helm template ---"
           if ! helm template precise-prefix-cache-routing \
-            "oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev" \
+            "oci://ghcr.io/llm-d/charts/llm-d-router-standalone" \
             -f guides/recipes/router/base.values.yaml \
             -f guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml \
             --version "${CHART_VERSION}" > /tmp/rendered.yaml; then

--- a/docs/api-reference/artifacts.md
+++ b/docs/api-reference/artifacts.md
@@ -36,8 +36,8 @@ llm-d Router is deployed via Helm. We offer a chart both Standalone and Gateway 
 
 | Chart | Version | OCI Registry | Description |
 |-------|---------|--------------|-------------|
-| **Standalone Mode** | v0 | `oci://ghcr.io/llm-d/charts/llm-d-router-standalone-dev` | Deploys an InferencePool and EPP with a standalone Envoy proxy as sidecar in EPP pod  |
-| **Gateway Mode** | v0 | `oci://ghcr.io/llm-d/charts/llm-d-router-gateway-dev` | Deploys an InferencePool and EPP for use with an existing Kubernetes Gateway (e.g. Istio, AgentGateway, Envoy AI Gateway, GKE) |
+| **Standalone Mode** | v0 | `oci://ghcr.io/llm-d/charts/llm-d-router-standalone` | Deploys an InferencePool and EPP with a standalone Envoy proxy as sidecar in EPP pod  |
+| **Gateway Mode** | v0 | `oci://ghcr.io/llm-d/charts/llm-d-router-gateway` | Deploys an InferencePool and EPP for use with an existing Kubernetes Gateway (e.g. Istio, AgentGateway, Envoy AI Gateway, GKE) |
 
 The charts are currently published by the Gateway API Inference Extension (GAIE) project (see [standalone mode source](https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/config/charts/standalone) and [gateway mode source](https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/config/charts/inferencepool)). Each well-lit path guides provides values files on top of the chart defaults to enable the functionality implemented in EPP.
 

--- a/guides/agentic-serving/modelserver/gpu/vllm/nemotron-3-ultra/patch-decode.yaml
+++ b/guides/agentic-serving/modelserver/gpu/vllm/nemotron-3-ultra/patch-decode.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       initContainers:
         - name: routing-proxy
-          image: ghcr.io/llm-d/llm-d-router-disagg-sidecar-dev:main
+          image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:main
           args:
             - --port=8000
             - --vllm-port=8200

--- a/guides/env.sh
+++ b/guides/env.sh
@@ -5,8 +5,8 @@
 
 export REPO_ROOT=${REPO_ROOT:-$(realpath $(git rev-parse --show-toplevel 2>/dev/null) 2>/dev/null)}
 export GAIE_VERSION=v1.5.0
-export ROUTER_CHART_VERSION=v0.9.0
-export ROUTER_EPP_VERSION=v0.9.0
+export ROUTER_CHART_VERSION=v0
+export ROUTER_EPP_VERSION=main
 export ROUTER_STANDALONE_CHART=oci://ghcr.io/llm-d/charts/llm-d-router-standalone
 export ROUTER_GATEWAY_CHART=oci://ghcr.io/llm-d/charts/llm-d-router-gateway
 export ROUTER_EPP_IMAGE=ghcr.io/llm-d/llm-d-router-endpoint-picker

--- a/guides/recipes/modelserver/components/images/routing-sidecar/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/routing-sidecar/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Component
 images:
   - name: REPLACE_ROUTING_SIDECAR_IMAGE
     newName: ghcr.io/llm-d/llm-d-router-disagg-sidecar
-    newTag: v0.9.0
+    newTag: main

--- a/guides/wide-ep-lws/modelserver/gpu/vllm-deepseek-v4/base/decode.yaml
+++ b/guides/wide-ep-lws/modelserver/gpu/vllm-deepseek-v4/base/decode.yaml
@@ -29,7 +29,7 @@ spec:
               - --zap-log-level=1
               - --secure-proxy=false
               - --enable-prefiller-sampling
-            image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0
+            image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:main
             imagePullPolicy: Always
             ports:
               - containerPort: 8000

--- a/guides/wide-ep-lws/modelserver/gpu/vllm/base/decode.yaml
+++ b/guides/wide-ep-lws/modelserver/gpu/vllm/base/decode.yaml
@@ -37,7 +37,7 @@ spec:
               - --zap-log-level=1
               - --secure-proxy=false
               - --enable-prefiller-sampling
-            image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.0
+            image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:main
             imagePullPolicy: Always
             ports:
               - containerPort: 8000

--- a/guides/wide-ep-lws/modelserver/xpu/vllm/decode.yaml
+++ b/guides/wide-ep-lws/modelserver/xpu/vllm/decode.yaml
@@ -36,7 +36,7 @@ spec:
               - --zap-log-level=1
               - --secure-proxy=false
               - --enable-prefiller-sampling
-            image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:v0.9.1
+            image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:main
             imagePullPolicy: Always
             ports:
               - containerPort: 8000


### PR DESCRIPTION
https://github.com/llm-d/llm-d-router/pull/2048 consolidated the router artifacts (images and charts) to drop the `-dev` suffixed ones. The canonical artifacts are:

The latest version built from the head of the main branch of the https://github.com/llm-d/llm-d-router repo
- Charts:
  - oci://ghcr.io/llm-d/charts/llm-d-router-standalone
  - oci://ghcr.io/llm-d/charts/llm-d-router-gateway
- Images:
  - ghcr.io/llm-d/llm-d-router-endpoint-picker
  - ghcr.io/llm-d/llm-d-router-disagg-sidecar

