### PR TITLE
feat(a4xmax): add GKE A4X Max / GB300 optimized DRA recipe for vLLM m…

### DIFF
--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -150,10 +150,10 @@ Choose the overlay matching your infrastructure provider:
 - **CoreWeave**: Deploys on CoreWeave.
 
 > [!TIP]
-> Check subdirectories under your provider folder (e.g. `modelserver/gpu/vllm/gke/a4x` for GKE A4X / GB200 platforms) for platform-specific overlays. If your target hardware has specialized driver, memory, or network interconnect requirements, default provider settings may not adapt to your platform, and you should select the corresponding platform sub-overlay (for example, `export INFRA_PROVIDER=gke/a4x`).
+> Check subdirectories under your provider folder (e.g. `modelserver/gpu/vllm/gke/a4x` and `modelserver/gpu/vllm/gke/a4xmax` for GKE A4X/A4X Max / GB200/GB300 platforms) for platform-specific overlays. If your target hardware has specialized driver, memory, or network interconnect requirements, default provider settings may not adapt to your platform, and you should select the corresponding platform sub-overlay (for example, `export INFRA_PROVIDER=gke/a4xmax`).
 
 ```bash
-export INFRA_PROVIDER=base # base | coreweave | gke/base | gke/a4x | aws
+export INFRA_PROVIDER=base # base | coreweave | gke/base | gke/a4x | gke/a4xmax | aws
 
 kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}
 ```

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/gke/a4xmax/gke-rdma-claim-gb300.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/gke/a4xmax/gke-rdma-claim-gb300.yaml
@@ -1,0 +1,38 @@
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: gke-rdma-claim-gb300
+spec:
+  spec:
+    devices:
+      requests:
+      - name: nic
+        firstAvailable:
+        - name: nic-group-0
+          deviceClassName: mrdma.google.com
+          count: 2
+          allocationMode: ExactCount
+          selectors:
+          - cel:
+              expression: device.attributes["dra.net"].ifName.startsWith("gpu0")
+        - name: nic-group-1
+          deviceClassName: mrdma.google.com
+          count: 2
+          allocationMode: ExactCount
+          selectors:
+          - cel:
+              expression: device.attributes["dra.net"].ifName.startsWith("gpu1")
+        - name: nic-group-2
+          deviceClassName: mrdma.google.com
+          count: 2
+          allocationMode: ExactCount
+          selectors:
+          - cel:
+              expression: device.attributes["dra.net"].ifName.startsWith("gpu2")
+        - name: nic-group-3
+          deviceClassName: mrdma.google.com
+          count: 2
+          allocationMode: ExactCount
+          selectors:
+          - cel:
+              expression: device.attributes["dra.net"].ifName.startsWith("gpu3")

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/gke/a4xmax/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/gke/a4xmax/kustomization.yaml
@@ -47,13 +47,6 @@ patches:
                 securityContext:
                   capabilities:
                     add: ["IPC_LOCK", "NET_ADMIN"]
-            tolerations:
-              - effect: NoSchedule
-                key: nvidia.com/gpu
-                operator: Exists
-              - key: kubernetes.io/arch
-                operator: Exists
-                effect: NoSchedule
   # Configure decode deployment with DRANet resourceClaims (gke-rdma-claim-gb300), A4X Max GPU resources, env, and capabilities
   - patch: |-
       apiVersion: apps/v1
@@ -103,10 +96,3 @@ patches:
                 securityContext:
                   capabilities:
                     add: ["IPC_LOCK", "NET_ADMIN"]
-            tolerations:
-              - effect: NoSchedule
-                key: nvidia.com/gpu
-                operator: Exists
-              - key: kubernetes.io/arch
-                operator: Exists
-                effect: NoSchedule

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/gke/a4xmax/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/gke/a4xmax/kustomization.yaml
@@ -1,0 +1,112 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+  - gke-rdma-claim-gb300.yaml
+
+patches:
+  # Configure prefill deployment with DRANet resourceClaims (gke-rdma-claim-gb300), A4X Max GPU resources, env, and capabilities
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: prefill
+      spec:
+        template:
+          spec:
+            resourceClaims:
+              - name: gke-rdma-claim
+                resourceClaimTemplateName: gke-rdma-claim-gb300
+            containers:
+              - name: modelserver
+                # A4X Max requires "kv_buffer_device":"cuda" in kv-transfer-config, gpu-memory-utilization=0.9, and disabling flashinfer autotune
+                args:
+                  - openai/gpt-oss-120b
+                  - --disable-access-log-for-endpoints=/health,/metrics,/v1/models
+                  - --tensor-parallel-size=1
+                  - --block-size=128
+                  - --kv-transfer-config
+                  - '{"kv_connector":"NixlConnector", "kv_role":"kv_both", "kv_buffer_device":"cuda"}'
+                  - --no-disable-hybrid-kv-cache-manager
+                  - --gpu-memory-utilization=0.9
+                  - --no-enable-flashinfer-autotune
+                # Re-add GPU requests & limits (managed via NVIDIA Device Plugin on A4X Max)
+                resources:
+                  claims:
+                    - name: gke-rdma-claim
+                  limits:
+                    nvidia.com/gpu: "1"
+                  requests:
+                    nvidia.com/gpu: "1"
+                env:
+                  - name: UCX_TLS
+                    value: "rc_mlx5,rc,cuda_copy,cuda_ipc,sm,shm,self"
+                  - name: UCX_IB_ROCE_REACHABILITY_MODE
+                    value: "all"
+                securityContext:
+                  capabilities:
+                    add: ["IPC_LOCK", "NET_ADMIN"]
+            tolerations:
+              - effect: NoSchedule
+                key: nvidia.com/gpu
+                operator: Exists
+              - key: kubernetes.io/arch
+                operator: Exists
+                effect: NoSchedule
+  # Configure decode deployment with DRANet resourceClaims (gke-rdma-claim-gb300), A4X Max GPU resources, env, and capabilities
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: decode
+      spec:
+        template:
+          spec:
+            resourceClaims:
+              - name: gke-rdma-claim-0
+                resourceClaimTemplateName: gke-rdma-claim-gb300
+              - name: gke-rdma-claim-1
+                resourceClaimTemplateName: gke-rdma-claim-gb300
+              - name: gke-rdma-claim-2
+                resourceClaimTemplateName: gke-rdma-claim-gb300
+              - name: gke-rdma-claim-3
+                resourceClaimTemplateName: gke-rdma-claim-gb300
+            containers:
+              - name: modelserver
+                # A4X Max requires "kv_buffer_device":"cuda" in kv-transfer-config
+                args:
+                  - openai/gpt-oss-120b
+                  - --disable-access-log-for-endpoints=/health,/metrics,/v1/models
+                  - --tensor-parallel-size=4
+                  - --block-size=128
+                  - --kv-transfer-config
+                  - '{"kv_connector":"NixlConnector", "kv_role":"kv_both", "kv_buffer_device":"cuda"}'
+                  - --no-disable-hybrid-kv-cache-manager
+                  - --port=8200
+                # Re-add GPU requests & limits (managed via NVIDIA Device Plugin on A4X Max)
+                resources:
+                  claims:
+                    - name: gke-rdma-claim-0
+                    - name: gke-rdma-claim-1
+                    - name: gke-rdma-claim-2
+                    - name: gke-rdma-claim-3
+                  limits:
+                    nvidia.com/gpu: "4"
+                  requests:
+                    nvidia.com/gpu: "4"
+                env:
+                  - name: UCX_TLS
+                    value: "rc_mlx5,rc,cuda_copy,cuda_ipc,sm,shm,self"
+                  - name: UCX_IB_ROCE_REACHABILITY_MODE
+                    value: "all"
+                securityContext:
+                  capabilities:
+                    add: ["IPC_LOCK", "NET_ADMIN"]
+            tolerations:
+              - effect: NoSchedule
+                key: nvidia.com/gpu
+                operator: Exists
+              - key: kubernetes.io/arch
+                operator: Exists
+                effect: NoSchedule


### PR DESCRIPTION
This PR introduces the official modelserver recipe for GKE A4X Max / GB300 instances under the pd-disaggregation guide.

Unlike previous generations, GB300's architectures expose 2 logical NICs per 1 physical NIC (e.g., gpu0ipvlan0 and gpu0ipvlan1 both map to physical gpu0). However, the current DRANet driver doesn't offer any information, such as PCIe root topologies from the logical interfaces, meaning the K8s Scheduler's matchAttribute cannot be used natively to group them. 

To fix this, we introduce the gke-rdma-claim-gb300 template.

### What this PR does
- Introduced `gke/a4xmax` platform overlay under `guides/pd-disaggregation`.
- Implemented `gke-rdma-claim-gb300` ResourceClaimTemplate utilizing K8s v1.31 DRA `firstAvailable` and CEL matching with NIC's prefix.
- Guaranteed logical-to-physical NIC alignment (e.g., matching gpu0ipvlan0 and gpu0ipvlan1) by using fallback sequences (`nic-group-0` to `nic-group-3`) to overcome the lack of physical PCIe root properties in DRANet's mrdma driver.