### PR TITLE
docs/guides: replace deprecated maxPrefixBlocksToMatch and blockSize with supported token alternatives

### DIFF
--- a/docs/architecture/core/router/epp/configuration.md
+++ b/docs/architecture/core/router/epp/configuration.md
@@ -110,7 +110,7 @@ spec:
           - type: approx-prefix-cache-producer
             parameters:
               blockSizeTokens: 5
-              maxPrefixBlocksToMatch: 256
+              maxPrefixTokensToMatch: 131072
               lruCapacityPerServer: 31250
           schedulingProfiles:
           - name: default
@@ -379,7 +379,7 @@ plugins:
 - type: approx-prefix-cache-producer
   parameters:
     blockSizeTokens: 64
-    maxPrefixBlocksToMatch: 256 # Default
+    maxPrefixTokensToMatch: 131072 # Default
     lruCapacityPerServer: 31250 # Default
 
 # ...

--- a/docs/architecture/core/router/epp/configuration.md
+++ b/docs/architecture/core/router/epp/configuration.md
@@ -110,7 +110,7 @@ spec:
           - type: approx-prefix-cache-producer
             parameters:
               blockSizeTokens: 5
-              maxPrefixTokensToMatch: 131072
+              maxPrefixTokensToMatch: 1280
               lruCapacityPerServer: 31250
           schedulingProfiles:
           - name: default
@@ -379,7 +379,7 @@ plugins:
 - type: approx-prefix-cache-producer
   parameters:
     blockSizeTokens: 64
-    maxPrefixTokensToMatch: 131072 # Default
+    maxPrefixTokensToMatch: 16384 # 256 blocks * 64 tokens/block
     lruCapacityPerServer: 31250 # Default
 
 # ...

--- a/docs/operations/router.md
+++ b/docs/operations/router.md
@@ -42,7 +42,7 @@ router:
 
 #### CPU Allocation
 - **Rule of Thumb**: Allocate **0.5 to 1.0 CPU cores per request/second** of expected throughput for large agentic workloads (~100k input / 1k output tokens).
-- **Prefix Matching Overhead**: Increasing `maxPrefixTokensToMatch` increases CPU consumption. At lower throughputs, a limit of 6250 blocks can increase CPU consumption by over 100% compared to 256 blocks due to block search overhead.
+- **Prefix Matching Overhead**: Increasing `maxPrefixTokensToMatch` increases CPU consumption. At lower throughputs, a large prefix limit (such as 100,000 tokens / 6,250 blocks with `blockSizeTokens: 16`) can increase CPU consumption by over 100% compared to a small limit (4,096 tokens / 256 blocks) due to block search overhead.
 - **Idle Scraping Overhead**: Idle CPU consumption scales with total model-serving pods due to background Prometheus scraping. In a cluster with 100 pods, EPP idle consumption reaches approximately **7.5 cores**.
 
 #### Memory Allocation

--- a/docs/operations/router.md
+++ b/docs/operations/router.md
@@ -42,7 +42,7 @@ router:
 
 #### CPU Allocation
 - **Rule of Thumb**: Allocate **0.5 to 1.0 CPU cores per request/second** of expected throughput for large agentic workloads (~100k input / 1k output tokens).
-- **Prefix Matching Overhead**: Increasing `maxPrefixBlocksToMatch` (deprecated; use `maxPrefixTokensToMatch` instead) increases CPU consumption. At lower throughputs, a limit of 6250 blocks can increase CPU consumption by over 100% compared to 256 blocks due to block search overhead.
+- **Prefix Matching Overhead**: Increasing `maxPrefixTokensToMatch` increases CPU consumption. At lower throughputs, a limit of 6250 blocks can increase CPU consumption by over 100% compared to 256 blocks due to block search overhead.
 - **Idle Scraping Overhead**: Idle CPU consumption scales with total model-serving pods due to background Prometheus scraping. In a cluster with 100 pods, EPP idle consumption reaches approximately **7.5 cores**.
 
 #### Memory Allocation

--- a/docs/operations/router.md
+++ b/docs/operations/router.md
@@ -42,7 +42,7 @@ router:
 
 #### CPU Allocation
 - **Rule of Thumb**: Allocate **0.5 to 1.0 CPU cores per request/second** of expected throughput for large agentic workloads (~100k input / 1k output tokens).
-- **Prefix Matching Overhead**: Increasing `maxPrefixBlocksToMatch` increases CPU consumption. At lower throughputs, a limit of 6250 blocks can increase CPU consumption by over 100% compared to 256 blocks due to block search overhead.
+- **Prefix Matching Overhead**: Increasing `maxPrefixBlocksToMatch` (deprecated; use `maxPrefixTokensToMatch` instead) increases CPU consumption. At lower throughputs, a limit of 6250 blocks can increase CPU consumption by over 100% compared to 256 blocks due to block search overhead.
 - **Idle Scraping Overhead**: Idle CPU consumption scales with total model-serving pods due to background Prometheus scraping. In a cluster with 100 pods, EPP idle consumption reaches approximately **7.5 cores**.
 
 #### Memory Allocation

--- a/docs/operations/router.md
+++ b/docs/operations/router.md
@@ -57,23 +57,23 @@ Empirical benchmark reference data for Qwen/Qwen3-8B simulation across 100 servi
 
 #### Throughput and Prefix Block Sizing (100k Input / 1k Output Tokens)
 
-| Configuration | Request Rate (Req/s) | maxPrefixBlocksToMatch | Peak CPU (Cores) | Peak Memory (GiB) | Scheduler P50 Latency (s) |
+| Configuration | Request Rate (Req/s) | maxPrefixTokensToMatch | Peak CPU (Cores) | Peak Memory (GiB) | Scheduler P50 Latency (s) |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| Small Prefix Match | 5.0 | 256 | 1.19 | 0.26 | 0.00010 |
-| Large Prefix Match | 5.0 | 6250 | 3.82 | 0.65 | 0.00010 |
-| Small Prefix Match | 98.7 | 256 | 35.17 | 2.46 | 0.00014 |
-| Large Prefix Match | 98.8 | 6250 | 46.50 | 3.41 | 0.00020 |
+| Small Prefix Match | 5.0 | 4096 | 1.19 | 0.26 | 0.00010 |
+| Large Prefix Match | 5.0 | 100000 | 3.82 | 0.65 | 0.00010 |
+| Small Prefix Match | 98.7 | 4096 | 35.17 | 2.46 | 0.00014 |
+| Large Prefix Match | 98.8 | 100000 | 46.50 | 3.41 | 0.00020 |
 
 #### Output Length Variation (50 Req/s Constant Throughput)
 
-| Input Tokens | Output Tokens | maxPrefixBlocksToMatch | Peak CPU (Cores) | Peak Memory (GiB) |
+| Input Tokens | Output Tokens | maxPrefixTokensToMatch | Peak CPU (Cores) | Peak Memory (GiB) |
 | :--- | :--- | :--- | :--- | :--- |
-| 100k | 500 | 256 | 15.13 | 2.27 |
-| 100k | 500 | 2048 | 17.14 | 3.76 |
-| 100k | 1000 | 256 | 17.51 | 3.66 |
-| 100k | 1000 | 2048 | 20.28 | 5.23 |
-| 100k | 5000 | 1024 | 30.95 | 12.54 |
-| 100k | 10000 | 512 | 32.53 | 12.54 |
+| 100k | 500 | 4096 | 15.13 | 2.27 |
+| 100k | 500 | 32768 | 17.14 | 3.76 |
+| 100k | 1000 | 4096 | 17.51 | 3.66 |
+| 100k | 1000 | 32768 | 20.28 | 5.23 |
+| 100k | 5000 | 16384 | 30.95 | 12.54 |
+| 100k | 10000 | 8192 | 32.53 | 12.54 |
 
 ---
 

--- a/guides/precise-prefix-cache-routing/README.md
+++ b/guides/precise-prefix-cache-routing/README.md
@@ -22,14 +22,14 @@ Two scorers make up the routing decision alongside the load-aware stack:
 | Tensor Parallelism  | 2                                                       |
 | GPUs per replica    | 2                                                       |
 | Total GPUs          | 16                                                      |
-| vLLM `--block-size` | 64 (must match scorer `tokenProcessorConfig.blockSize`) |
+| vLLM `--block-size` | 64 (must match scorer `tokenProcessorConfig.blockSizeTokens`) |
 
 ### Supported Hardware Backends
 
 | Backend              | Directory                  | Default model                           | Notes                                                    |
 | -------------------- | -------------------------- | --------------------------------------- | -------------------------------------------------------- |
 | NVIDIA GPU           | `modelserver/gpu/vllm/`    | Qwen/Qwen3-32B                          | Default configuration                                    |
-| NVIDIA GPU (SGLang)  | `modelserver/gpu/sglang/`  | Qwen/Qwen3-32B                          | SGLang; `--page-size=64` matches scorer `blockSize`      |
+| NVIDIA GPU (SGLang)  | `modelserver/gpu/sglang/`  | Qwen/Qwen3-32B                          | SGLang; `--page-size=64` matches scorer `blockSizeTokens`      |
 | AMD GPU              | `modelserver/amd/vllm/`    | Qwen/Qwen3-32B                          | AMD GPU                                                  |
 | Intel XPU            | `modelserver/xpu/vllm/`    | Qwen/Qwen3-0.6B                         | CI-sized; update router `modelName` for real use         |
 | Google TPU v6e       | `modelserver/tpu/v6/vllm/` | Qwen/Qwen3-32B                          | GKE TPU                                                  |

--- a/guides/precise-prefix-cache-routing/modelserver/gpu/sglang/patch-sglang.yaml
+++ b/guides/precise-prefix-cache-routing/modelserver/gpu/sglang/patch-sglang.yaml
@@ -16,7 +16,7 @@ spec:
             - "--tensor-parallel-size=2"
             - "--mem-fraction-static=0.9"
             # KV-block granularity. Must match the router scorer's
-            # tokenProcessorConfig.blockSize (default 64); SGLang's knob is
+            # tokenProcessorConfig.blockSizeTokens (default 64); SGLang's knob is
             # --page-size, where vLLM uses --block-size.
             - "--page-size=64"
             - "--enable-metrics"

--- a/guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml
+++ b/guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml
@@ -46,7 +46,7 @@ router:
           - type: precise-prefix-cache-producer # `precise-prefix-cache-scorer` is deprecated
             parameters:
               tokenProcessorConfig:
-                blockSize: 64
+                blockSizeTokens: 64
               speculativeIndexing: true
               indexerConfig:
                 kvBlockIndexConfig:

--- a/guides/tiered-prefix-cache/modelserver/gpu/sglang/base/patch-sglang.yaml
+++ b/guides/tiered-prefix-cache/modelserver/gpu/sglang/base/patch-sglang.yaml
@@ -15,7 +15,7 @@ spec:
             - "--port=8000"
             - "--tensor-parallel-size=2"
             # KV-block granularity. Must match the router scorer's
-            # tokenProcessorConfig.blockSize (default 64); SGLang's knob is
+            # tokenProcessorConfig.blockSizeTokens (default 64); SGLang's knob is
             # --page-size, where vLLM uses --block-size.
             - "--page-size=64"
             - "--enable-metrics"

--- a/guides/tiered-prefix-cache/modelserver/gpu/sglang/native/cpu/base/patch-sglang.yaml
+++ b/guides/tiered-prefix-cache/modelserver/gpu/sglang/native/cpu/base/patch-sglang.yaml
@@ -13,7 +13,7 @@ spec:
             - "--port=8000"
             - "--tensor-parallel-size=2"
             # KV-block granularity. Must match the router scorer's
-            # tokenProcessorConfig.blockSize (default 64); SGLang's knob is
+            # tokenProcessorConfig.blockSizeTokens (default 64); SGLang's knob is
             # --page-size, where vLLM uses --block-size.
             - "--page-size=64"
             - "--mem-fraction-static=0.9"


### PR DESCRIPTION
## Summary
Replace remaining usages of deprecated fields `maxPrefixBlocksToMatch` and `blockSize` with their supported token-based equivalents (`maxPrefixTokensToMatch` and `blockSizeTokens`) across documentation, guides, and example values files in the llm-d repository.