### PR TITLE
[quickstart guide] fix apply path - unable to find one of 'kustomization.yaml' error

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -64,7 +64,7 @@ helm install ${GUIDE_NAME} \
 Deploy the default model server (vLLM running on NVIDIA GPUs). This will deploy 8 replicas of `Qwen/Qwen3-32B` by default.
 
 ```bash
-kubectl apply -n ${NAMESPACE} -k guides/optimized-baseline/modelserver/gpu/vllm/
+kubectl apply -n ${NAMESPACE} -k guides/optimized-baseline/modelserver/gpu/vllm/base
 ```
 
 > [!TIP]


### PR DESCRIPTION
Issue: Following the quickstart guide here: https://llm-d.ai/docs/getting-started/quickstart (**v0.8 (latest)**)
 gives the following error when we apply the original command: `kubectl apply -n ${NAMESPACE} -k guides/optimized-baseline/modelserver/gpu/vllm/`

```
error: unable to find one of 'kustomization.yaml', 'kustomization.yml' or 'Kustomization' in directory '/Users/tayfun/projects/llm-inference-guidebook/repos/llm-d-fork/guides/optimized-baseline/modelserver/gpu/vllm'
```
Result when we apply the fixed command: `kubectl apply -n ${NAMESPACE} -k guides/optimized-baseline/modelserver/gpu/vllm/base`
```
serviceaccount/optimized-baseline-nvidia-gpu-vllm-sa created
deployment.apps/optimized-baseline-nvidia-gpu-vllm-decode created
```

Cause: probably at some point the k8s files were added to subfolders, to give a chance to people to try directly installing in other envs

First pull request here so let me know if any issues. thanks.