### PR TITLE
Add speculative decoding well-lit path (EAGLE-3 / speculators)

### DIFF
--- a/docs/assets/spec-decoding.svg
+++ b/docs/assets/spec-decoding.svg
@@ -1,0 +1,54 @@
+<svg version="1.1" viewBox="0 0 576 260" fill="none" stroke="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Outer border -->
+  <rect x="2" y="2" width="572" height="256" rx="4" fill="#ffffff" stroke="#9f659f" stroke-width="3"/>
+
+  <!-- Title -->
+  <text x="288" y="28" text-anchor="middle" font-family="sans-serif" font-size="14" font-weight="bold" fill="#000000">Single vLLM Process</text>
+
+  <!-- Drafter box -->
+  <rect x="30" y="60" width="150" height="80" rx="4" fill="#f3f3f3" stroke="#9f659f" stroke-width="1"/>
+  <text x="105" y="95" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="bold" fill="#000000">Drafter</text>
+  <text x="105" y="115" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#666666">(small speculator)</text>
+
+  <!-- Arrow: Drafter -> Verifier -->
+  <line x1="180" y1="100" x2="246" y2="100" stroke="#000000" stroke-width="1.5"/>
+  <polygon points="246,96 254,100 246,104" fill="#000000"/>
+  <text x="218" y="88" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#666666">k candidate</text>
+  <text x="218" y="78" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#666666">tokens</text>
+
+  <!-- Verifier box -->
+  <rect x="256" y="48" width="170" height="104" rx="4" fill="#f3f3f3" stroke="#9f659f" stroke-width="1"/>
+  <text x="341" y="88" text-anchor="middle" font-family="sans-serif" font-size="13" font-weight="bold" fill="#000000">Verifier</text>
+  <text x="341" y="108" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#666666">(target model)</text>
+  <text x="341" y="126" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#666666">single forward pass</text>
+  <text x="341" y="140" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#666666">over all k candidates</text>
+
+  <!-- Arrow: Verifier -> Accept/Reject -->
+  <line x1="426" y1="100" x2="446" y2="100" stroke="#000000" stroke-width="1.5"/>
+  <polygon points="446,96 454,100 446,104" fill="#000000"/>
+
+  <!-- Accept/Reject box -->
+  <rect x="456" y="60" width="100" height="80" rx="4" fill="#f3f3f3" stroke="#9f659f" stroke-width="1"/>
+  <text x="506" y="92" text-anchor="middle" font-family="sans-serif" font-size="12" font-weight="bold" fill="#000000">Accept</text>
+  <text x="506" y="108" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#666666">up to first</text>
+  <text x="506" y="120" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#666666">mismatch</text>
+
+  <!-- Loop arrow: Accept -> Drafter (curved, below boxes) -->
+  <path d="M 506 140 L 506 200 Q 506 216 490 216 L 120 216 Q 105 216 105 200 L 105 140" stroke="#9f659f" stroke-width="1.5" fill="none" stroke-dasharray="6,3"/>
+  <polygon points="101,144 105,136 109,144" fill="#9f659f"/>
+  <text x="305" y="232" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#9f659f">resume from last accepted token</text>
+
+  <!-- Output arrow from Accept -->
+  <line x1="506" y1="60" x2="506" y2="44" stroke="#000000" stroke-width="1.5"/>
+  <polygon points="502,44 506,36 510,44" fill="#000000"/>
+  <text x="506" y="28" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#000000">Output tokens</text>
+
+  <!-- Input arrow to Drafter -->
+  <line x1="30" y1="100" x2="14" y2="100" stroke="#000000" stroke-width="1.5"/>
+  <polygon points="30,96 22,100 30,104" fill="#000000"/>
+  <text x="10" y="85" text-anchor="end" font-family="sans-serif" font-size="10" fill="#666666"> </text>
+
+  <!-- Lossless badge -->
+  <rect x="210" y="170" width="190" height="28" rx="12" fill="#9f659f" fill-opacity="0.12" stroke="#9f659f" stroke-width="1"/>
+  <text x="305" y="189" text-anchor="middle" font-family="sans-serif" font-size="11" font-weight="bold" fill="#9f659f">Lossless: output = target-only output</text>
+</svg>

--- a/docs/menu-config.json
+++ b/docs/menu-config.json
@@ -48,6 +48,7 @@
     "well-lit-paths/foundations/flow-control": { "position": 7, "label": "Apply Flow Control and Fairness" },
     "well-lit-paths/foundations/workload-autoscaling": { "position": 8, "label": "Autoscale your Inference Pool" },
     "well-lit-paths/foundations/multi-model-routing": { "position": 9 },
+    "well-lit-paths/foundations/spec-decoding": { "position": 10, "label": "Accelerate Decoding with Speculative Drafters" },
 
     "well-lit-paths/workloads/agentic-serving": { "position": 1, "label": "Serve Agentic Workloads" },
     "well-lit-paths/workloads/multimodal-serving": { "position": 2, "label": "Serve Multimodal Workloads" },

--- a/docs/well-lit-paths/foundations/README.md
+++ b/docs/well-lit-paths/foundations/README.md
@@ -20,6 +20,10 @@ These guides teach single architectural capabilities that you can configure inde
 - **[Prefill/Decode Disaggregation](pd-disaggregation.md)**: Separating prefill (compute-bound) and decode (memory-bandwidth-bound) phases for optimized performance.
 - **[Wide Expert-Parallelism](wide-expert-parallelism.md)**: Scaling KV cache space for massive MoE models like DeepSeek-R1 using DP/EP deployment patterns.
 
+### Inference Acceleration
+
+- **[Speculative Decoding](spec-decoding.md)**: Pairing a target model with a speculators-trained drafter to cut inter-token latency in the low-QPS, memory-bound regime — losslessly.
+
 ### Traffic Control & Autoscaling
 
 - **[Flow Control](flow-control.md)**: Intelligent request queuing for multi-tenant deployments and managing traffic spikes.

--- a/docs/well-lit-paths/foundations/spec-decoding.md
+++ b/docs/well-lit-paths/foundations/spec-decoding.md
@@ -1,0 +1,50 @@
+# Speculative Decoding
+
+Speculative decoding accelerates decode by pairing a full-size **target (verifier)** model with a
+small, fast **drafter (speculator)** that proposes several tokens ahead; the target verifies them
+in a single forward pass. It is **lossless** — every accepted token is exactly what the target
+would have generated — so it buys latency without touching output quality.
+
+> [!IMPORTANT]
+> Speculative decoding trades **compute for latency**. At low concurrency the GPU has spare
+> compute to spend drafting, so inter-token latency (ITL/TPOT) drops sharply. As load rises the
+> benefit erodes and aggregate throughput can regress. This path targets **latency-sensitive,
+> lightly-loaded** workloads — the guide's benchmark locates the crossover point.
+
+## Deploy
+
+See the [speculative decoding guide](../../../guides/spec-decoding/README.md) for manifests and
+step-by-step deployment.
+
+## Architecture
+
+The drafter and verifier run inside a single vLLM process — no separate service or sidecar.
+Speculative decoding is a **model-server** capability, orthogonal to routing: it reuses the
+[Optimized Baseline](optimized-baseline.md) EPP configuration unchanged and composes cleanly
+with prefix-cache routing, P/D disaggregation, and tiered cache.
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)">
+    <img src="../../assets/spec-decoding.svg" alt="Speculative Decoding">
+  </picture>
+</p>
+
+Each step:
+
+1. **Draft** — the drafter proposes *k* candidate tokens autoregressively.
+2. **Verify** — the verifier runs a single forward pass over all *k* candidates, producing
+   *k*+1 logits.
+3. **Accept / reject** — tokens are accepted sequentially until the first mismatch. One
+   verifier-sampled token is appended after the last accepted position.
+4. **Loop** — generation resumes from the last accepted token.
+
+When acceptance is high, multiple tokens are emitted per verifier forward pass, cutting
+inter-token latency.
+
+## Further Reading
+
+- [speculators](https://github.com/vllm-project/speculators) — training library for speculator models
+- [EAGLE-3 paper](https://arxiv.org/abs/2503.01840) — the algorithm behind the default drafter
+- [vLLM speculative decoding docs](https://docs.vllm.ai/en/latest/features/spec_decode.html) — configuration reference and supported methods
+- [RedHatAI speculator models](https://huggingface.co/collections/RedHatAI/speculator-models-68c39684ac2649111619f068) — pretrained drafters for popular models

--- a/guides/README.md
+++ b/guides/README.md
@@ -22,6 +22,10 @@ We currently offer the following:
 * [Prefill/Decode Disaggregation](./pd-disaggregation/README.md) - Split inference into specialized prefill and decode instances, improving throughput and quality of service stability for medium and large models like `openai/gpt-oss-120b`.
 * [Wide Expert-Parallelism](./wide-ep-lws/README.md) - Deploy large Mixture-of-Experts (MoE) models like `deepseek-ai/DeepSeek-R1` over multiple nodes via DP/EP configuration, increasing available KV cache space and throughput.
 
+### Inference Acceleration
+
+* [Speculative Decoding](./spec-decoding/README.md) - Pair a target model with a [speculators](https://github.com/vllm-project/speculators)-trained drafter to cut inter-token latency in the low-QPS, memory-bound regime, losslessly. Reuses the optimized-baseline router unchanged.
+
 ### Operational Excellence
 
 * [Flow Control](./flow-control/README.md) - Intelligent request queuing for multi-tenant deployments and managing traffic spikes.

--- a/guides/spec-decoding/OWNERS
+++ b/guides/spec-decoding/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- Rahul-Tuli
+reviewers:
+- Rahul-Tuli

--- a/guides/spec-decoding/README.md
+++ b/guides/spec-decoding/README.md
@@ -1,0 +1,200 @@
+# Speculative Decoding
+
+## Overview
+
+This guide deploys a target model together with a
+[speculators](https://github.com/vllm-project/speculators)-trained **drafter** and serves them
+with llm-d. See the [speculative decoding foundation](../../docs/well-lit-paths/foundations/spec-decoding.md)
+for the conceptual background. Speculative decoding is a **lossless** latency optimization: the small drafter
+proposes several tokens ahead and the target (verifier) checks them in a single forward pass, so
+accepted tokens skip decode steps. Every accepted token is exactly what the target would have
+produced on its own — output quality is unchanged.
+
+Speculative decoding is a property of **how vLLM is launched** — it is orthogonal to routing.
+This guide therefore reuses the [Optimized Baseline](../optimized-baseline/README.md) EPP/router
+configuration unchanged; the only spec-decoding-specific file is the model server's
+`patch-vllm.yaml`, which adds `--speculative-config`.
+
+> [!IMPORTANT]
+> Speculative decoding wins in the **memory-bound, low-QPS regime** — vLLM's docs note it reduces
+> "inter-token latency under medium-to-low QPS, memory-bound workloads." It trades spare compute
+> for lower latency, so the benefit is largest at low concurrency and **erodes (aggregate
+> throughput can regress) as load rises and the verifier becomes compute-bound.** Benchmark on
+> your own traffic and find the crossover before enabling it in production. See
+> [Benchmarking](#benchmarking).
+
+## Configuration
+
+| Parameter               | Default                                                                 |
+| ----------------------- | ----------------------------------------------------------------------- |
+| Target (verifier) model | [Qwen/Qwen3-32B](https://huggingface.co/Qwen/Qwen3-32B)               |
+| Drafter (speculator)    | [RedHatAI/Qwen3-32B-speculator.eagle3](https://huggingface.co/RedHatAI/Qwen3-32B-speculator.eagle3) |
+| Method                  | `eagle3`                                                                |
+| `num_speculative_tokens`| `3`                                                                     |
+| Replicas                | 1                                                                       |
+| Tensor Parallelism      | 2                                                                       |
+| GPUs per replica        | 2                                                                       |
+
+This guide currently targets **NVIDIA GPU** only. The manifests are tested on H200; adapt
+resource requests for other GPU SKUs.
+
+Token acceptance rates are workload-dependent: code and math workloads see ~**2.5–3.0** accepted
+tokens per step with EAGLE-3 on Qwen3-32B; chat/summarization workloads see lower rates (~**2.1–2.3**).
+To try a different speculator, swap the drafter and `method`/`num_speculative_tokens` in
+[`modelserver/gpu/vllm/eagle3/patch-vllm.yaml`](./modelserver/gpu/vllm/eagle3/patch-vllm.yaml).
+
+> [!NOTE]
+> **Choosing a speculator:** This guide uses EAGLE-3, which is in mainline vLLM. Alternative
+> methods include DFlash and DSpark — see the
+> [RedHatAI speculators collection](https://huggingface.co/collections/RedHatAI/speculator-models-68c39684ac2649111619f068)
+> for compatible drafters and their published acceptance rates.
+
+## Prerequisites
+
+- The [proper client tools installed](../../helpers/client-setup/README.md).
+- A Kubernetes cluster with NVIDIA GPU scheduling.
+- Checkout llm-d and set environment variables:
+
+  ```bash
+  export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
+  source ${REPO_ROOT}/guides/env.sh
+  export GUIDE_NAME="spec-decoding"
+  export NAMESPACE=llm-d-spec-decoding
+  ```
+
+- Install the Gateway API Inference Extension CRDs:
+
+  ```bash
+  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
+  ```
+
+- Create the namespace and the HuggingFace token secret:
+
+  ```bash
+  kubectl create namespace ${NAMESPACE} --dry-run=client -o yaml | kubectl apply -f -
+  ```
+<!-- llm-d-cicd:skip start -->
+  ```bash
+  export HF_TOKEN=<your HuggingFace token>
+  kubectl create secret generic llm-d-hf-token \
+    --from-literal="HF_TOKEN=${HF_TOKEN}" \
+    --namespace "${NAMESPACE}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+  ```
+<!-- llm-d-cicd:skip end -->
+
+## Installation Instructions
+
+### 1. Deploy the llm-d Router (Standalone Mode)
+
+```bash
+helm install ${GUIDE_NAME} \
+    ${ROUTER_STANDALONE_CHART} \
+    -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
+    -f ${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
+    -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
+```
+
+### 2. Deploy the Model Server (target + EAGLE-3 drafter)
+
+```bash
+kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/gpu/vllm/eagle3/
+```
+
+### 3. (Optional but recommended) Enable monitoring
+
+The acceptance metrics reported below come from vLLM's Prometheus counters, so enable monitoring
+if you intend to benchmark:
+
+- Install the [Monitoring stack](../../docs/operations/observability/setup.md).
+- Add `-f ${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml` to the router
+  install above, and deploy the model-server monitoring resources:
+
+  ```bash
+  kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/recipes/modelserver/components/monitoring
+  ```
+
+## Verification
+
+### 1. Get the endpoint IP
+
+```bash
+export IP=$(kubectl get service ${GUIDE_NAME}-epp -n ${NAMESPACE} -o jsonpath='{.spec.clusterIP}')
+```
+
+### 2. Send a test request
+
+```bash
+kubectl run curl-debug --rm -it \
+    --image=cfmanteiga/alpine-bash-curl-jq \
+    --namespace="$NAMESPACE" --env="IP=$IP" -- /bin/bash
+
+curl -X POST http://${IP}/v1/completions \
+    -H 'Content-Type: application/json' \
+    -d '{"model": "Qwen/Qwen3-32B", "prompt": "Write a Python function to reverse a linked list."}' | jq
+```
+
+### 3. Confirm speculative decoding is active
+
+Check the model server's spec-decode Prometheus metrics:
+
+```bash
+POD=$(kubectl get pod -n ${NAMESPACE} -l llm-d.ai/guide=spec-decoding -o jsonpath='{.items[0].metadata.name}')
+kubectl exec -n ${NAMESPACE} ${POD} -c modelserver -- \
+  sh -c 'curl -s localhost:8000/metrics | grep vllm:spec_decode'
+```
+
+You should see `vllm:spec_decode_num_accepted_tokens_total`,
+`vllm:spec_decode_num_draft_tokens_total`, and `vllm:spec_decode_num_drafts` climbing.
+
+## Benchmarking
+
+The point of this guide is not "does it serve" — it is "**does spec decoding help, and until what
+load?**" That is a two-arm experiment run **through the deployed llm-d stack** with
+[`llmdbenchmark`](../../helpers/benchmark.md), not raw vLLM.
+
+**Arms** (identical hardware and router/EPP values; only the model-server overlay differs):
+
+| Arm | Model server overlay | Spec decoding |
+| --- | -------------------- | ------------- |
+| A (baseline) | `optimized-baseline/modelserver/gpu/vllm/base` (Qwen3-32B, replicas 1, TP 2) | off |
+| B (spec) | `spec-decoding/modelserver/gpu/vllm/eagle3` | on |
+
+**Metrics** (all captured by the harness per [`helpers/benchmark.md`](../../helpers/benchmark.md)),
+plus acceptance from the Prometheus counters above:
+
+- **ITL / TPOT** — the headline win (accepted drafts skip decode steps).
+- **Token acceptance length** = `spec_decode_num_accepted_tokens_total / spec_decode_num_drafts + 1`
+  (per-position from `..._per_pos`). The quality signal that explains the ITL win.
+- **TTFT** — expected unchanged (prefill metric); report to prove no regression.
+- **Aggregate throughput** — watch for the **crossover** where the win erodes.
+
+**Run** the benchmark — a low-QPS-emphasis ladder that sweeps the crossover region:
+
+```bash
+export ENDPOINT_URL="http://$(kubectl get service ${GUIDE_NAME}-epp -n ${NAMESPACE} -o jsonpath='{.spec.clusterIP}')"
+export GATEWAY_CLASS=epponly
+
+llmdbenchmark \
+    --spec          guides/spec-decoding \
+    run \
+    --endpoint-url  "${ENDPOINT_URL}" \
+    --gateway-class "${GATEWAY_CLASS}" \
+    --model         "Qwen/Qwen3-32B" \
+    --namespace     "${NAMESPACE}" \
+    --harness       inference-perf \
+    --workload      guide_spec-decoding_1.yaml \
+    --analyze
+```
+
+Repeat against Arm A (baseline) and overlay the results. See the
+[benchmark report](./benchmark-results/vllm-qwen3-32b-eagle3/README.md) for the full
+comparison (TPOT-vs-QPS, throughput-vs-QPS, crossover analysis).
+
+## Cleanup
+
+```bash
+helm uninstall ${GUIDE_NAME} -n ${NAMESPACE}
+kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/gpu/vllm/eagle3
+kubectl delete namespace ${NAMESPACE}
+```

--- a/guides/spec-decoding/benchmark-results/vllm-qwen3-32b-eagle3/README.md
+++ b/guides/spec-decoding/benchmark-results/vllm-qwen3-32b-eagle3/README.md
@@ -1,0 +1,82 @@
+# Benchmark Report — Speculative Decoding (Qwen3-32B + EAGLE-3)
+
+The benchmark runs **through the llm-d stack** (EPP router + vLLM model server), driven by
+`inference-perf`. Two arms on identical hardware and identical router/EPP config — only the
+model-server overlay differs — so any delta is attributable to the drafter.
+
+- **Hardware:** 2 × H200 GPU (TP=2, replicas=1)
+- **Target / verifier:** `Qwen/Qwen3-32B`
+- **Drafter:** `RedHatAI/Qwen3-32B-speculator.eagle3` (`method=eagle3`, `num_speculative_tokens=3`)
+- **Arm A (baseline):** `optimized-baseline` overlay, spec decoding off
+- **Arm B (spec):** `spec-decoding` overlay, spec decoding on
+- **Harness / profile:** `inference-perf` v0.6.0 · `guide_spec-decoding_1.yaml`
+- **Load:** 5-stage constant-rate ladder (1 → 2 → 4 → 8 → 16 QPS), 120 s per stage
+- **Data:** random tokens, input ~2048 (normal, σ=1024, 10–4096), output ~256 (normal, σ=128, 10–512)
+
+## Headline: the latency win at low QPS
+
+Speculative decoding is a decode-phase optimization; the win shows in **ITL/TPOT**, not TTFT.
+At 1 QPS (single-user latency), EAGLE-3 cuts per-token decode time by **27%** and request
+latency by **31%**.
+
+| Metric (at 1 QPS)           | Arm A (baseline) | Arm B (spec) | Δ vs baseline |
+| :-------------------------- | ---------------: | -----------: | :------------ |
+| **TPOT p50 (ms)**           | 13.2             | 9.7          | **−27%**      |
+| **ITL mean (ms)**           | 13.3             | 10.3         | **−22%**      |
+| Request latency p50 (s)     | 3.60             | 2.50         | **−31%**      |
+| Output tokens/s             | 265              | 244          | −8%           |
+| TTFT p50 (ms)               | 167              | 160          | −4%           |
+
+> [!NOTE]
+> Output throughput is slightly lower at 1 QPS because the system is lightly loaded — per-request
+> speed improved but fewer total tokens were in flight. At 2–4 QPS, throughput is equivalent or
+> slightly higher with spec decoding.
+
+## Crossover: where the win erodes
+
+As load rises, the drafter's compute overhead competes with real decode work. The benefit erodes
+around **4–8 QPS** on this hardware — beyond 8 QPS, the baseline delivers higher throughput and
+lower latency.
+
+| QPS | Arm A TPOT p50 (ms) | Arm B TPOT p50 (ms) | Δ TPOT | Arm A tok/s | Arm B tok/s | Δ tok/s |
+| --: | ------------------: | ------------------: | -----: | ----------: | ----------: | ------: |
+|   1 |                13.2 |                 9.7 |   −27% |         265 |         244 |     −8% |
+|   2 |                15.1 |                11.7 |   −22% |         525 |         538 |     +3% |
+|   4 |                24.6 |                21.4 |   −13% |       1,006 |       1,032 |     +3% |
+|   8 |               209.7 |               210.1 |     0% |       1,649 |       1,442 |    −13% |
+|  16 |               222.5 |               220.7 |    −1% |       1,645 |       1,473 |    −10% |
+
+**Crossover QPS: ~4–8** &nbsp;·&nbsp; EAGLE-3 delivers clear per-token wins at ≤4 QPS. At 8 QPS
+both arms are saturated and TPOT converges; the baseline pulls ahead on throughput (−13%) because
+the drafter consumes GPU resources that could otherwise serve concurrent decodes.
+
+<details>
+<summary><b><i>Click</i></b> to view the full per-stage latency breakdown</summary>
+
+| QPS | Arm A ITL mean (ms) | Arm B ITL mean (ms) | Arm A TTFT p50 (s) | Arm B TTFT p50 (s) | Arm A Req Lat p50 (s) | Arm B Req Lat p50 (s) |
+| --: | ------------------: | ------------------: | -----------------: | -----------------: | --------------------: | --------------------: |
+|   1 |                13.3 |                10.3 |              0.167 |              0.160 |                  3.60 |                  2.50 |
+|   2 |                14.1 |                10.3 |              0.166 |              0.191 |                  4.02 |                  3.04 |
+|   4 |                23.4 |                21.2 |              0.210 |              0.240 |                  6.29 |                  5.53 |
+|   8 |               168.5 |               180.2 |              9.774 |             19.243 |                 55.08 |                 68.83 |
+|  16 |               189.8 |               199.9 |             85.730 |            108.233 |                141.83 |                166.64 |
+
+At 8+ QPS, TTFT degrades significantly with spec decoding (19.2 s vs 9.8 s at 8 QPS) — the
+drafter's memory footprint reduces available KV cache capacity, causing more prefill queueing.
+
+</details>
+
+## Observations
+
+- **TPOT improvement at low load is the primary win.** At 1–4 QPS, EAGLE-3 reduces TPOT p50 by
+  13–27%, translating to proportional request latency reductions.
+- **Throughput ceiling is lower.** The baseline peaks at ~1,649 output tok/s; EAGLE-3 peaks at
+  ~1,473 tok/s — the drafter's forward passes are overhead at saturation.
+- **TTFT regresses under load.** At 8 QPS, TTFT p50 nearly doubles (19.2 s vs 9.8 s). The
+  drafter model's memory footprint reduces KV cache headroom, increasing prefill queue depth.
+- **At saturation, TPOT converges.** Both arms show ~210–222 ms TPOT p50 at 8–16 QPS — the
+  spec decode advantage vanishes when the GPU is compute-bound.
+
+**Recommendation:** enable speculative decoding for latency-sensitive, low-concurrency workloads
+(interactive chat, coding assistants) where per-user TPOT matters more than aggregate throughput.
+Disable (or scale out instead) above the crossover.

--- a/guides/spec-decoding/modelserver/gpu/vllm/eagle3/kustomization.yaml
+++ b/guides/spec-decoding/modelserver/gpu/vllm/eagle3/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../../recipes/modelserver/base/single-host/default
+
+namePrefix: spec-decoding-nvidia-gpu-vllm-
+
+components:
+  - ../../../../../recipes/modelserver/components/images/gpu-vllm
+
+labels:
+  - pairs:
+      llm-d.ai/model: Qwen3-32B
+      llm-d.ai/guide: spec-decoding
+      llm-d.ai/accelerator-variant: gpu
+      llm-d.ai/accelerator-vendor: nvidia
+    includeSelectors: true
+    includeTemplates: true
+patches:
+  - path: patch-vllm.yaml

--- a/guides/spec-decoding/modelserver/gpu/vllm/eagle3/patch-vllm.yaml
+++ b/guides/spec-decoding/modelserver/gpu/vllm/eagle3/patch-vllm.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  # Single replica: this is a latency-focused Foundation. Speculative decoding is orthogonal to
+  # routing (the EPP config is inherited from optimized-baseline), so one replica keeps the
+  # two-arm benchmark clean. Scale replicas up to compose with load-aware routing — the drafter
+  # behaves identically per replica.
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: modelserver
+          command: ["vllm", "serve"]
+          # Include all args in overlay patch for consistency.
+          # Speculative decoding is enabled by the --speculative-config flag below.
+          # The rest matches a normal vLLM launch except PYTORCH_ALLOC_CONF (see env).
+          args:
+            - "Qwen/Qwen3-32B"
+            - "--served-model-name=Qwen/Qwen3-32B"
+            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+            - "--tensor-parallel-size=2"
+            - "--speculative-config"
+            - '{"model": "RedHatAI/Qwen3-32B-speculator.eagle3", "method": "eagle3", "num_speculative_tokens": 3}'
+            # Uncomment for distributed tracing
+            # - "--otlp-traces-endpoint=http://otel-collector:4317"
+            # - "--collect-detailed-traces=all"
+          env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
+            # Drafter weights share the target's GPU memory; expandable segments
+            # reduces fragmentation from the two-model allocation pattern.
+            - name: PYTORCH_ALLOC_CONF
+              value: "expandable_segments:True"
+          resources:
+            limits:
+              cpu: '16'
+              memory: 128Gi
+              nvidia.com/gpu: 2
+            requests:
+              cpu: '8'
+              memory: 96Gi
+              nvidia.com/gpu: 2
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /.cache
+              name: torch-compile-cache
+            - mountPath: /.triton
+              name: triton-cache
+            - mountPath: /.config
+              name: vllm-config
+          startupProbe:
+            # Loading target + drafter and compiling can take a while on first boot.
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 120
+          livenessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 20Gi
+        - name: torch-compile-cache
+          emptyDir: {}
+        - name: triton-cache
+          emptyDir: {}
+        - name: vllm-config
+          emptyDir: {}

--- a/guides/spec-decoding/router/spec-decoding.values.yaml
+++ b/guides/spec-decoding/router/spec-decoding.values.yaml
@@ -1,0 +1,40 @@
+## spec-decoding guide overrides for the llm-d router.
+## Layer on top of: recipes/router/base.values.yaml
+##
+## Speculative decoding is a model-server property, NOT a routing property — the EPP does not
+## change. These values are intentionally the optimized-baseline EPP config, with the guide
+## label switched to `spec-decoding` so the router selects this guide's model servers.
+
+router:
+  extraServicePorts:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8081
+
+  epp:
+    pluginsConfigFile: "spec-decoding-plugins.yaml"
+    pluginsCustomConfig:
+      spec-decoding-plugins.yaml: |
+        apiVersion: llm-d.ai/v1alpha1
+        kind: EndpointPickerConfig
+        plugins:
+        - type: queue-scorer
+        - type: kv-cache-utilization-scorer
+        - type: prefix-cache-scorer
+        - type: no-hit-lru-scorer
+        schedulingProfiles:
+        - name: default
+          plugins:
+          - pluginRef: queue-scorer
+            weight: 2
+          - pluginRef: kv-cache-utilization-scorer
+            weight: 2
+          - pluginRef: prefix-cache-scorer
+            weight: 3
+          - pluginRef: no-hit-lru-scorer
+            weight: 2
+
+  modelServers:
+    matchLabels:
+      llm-d.ai/guide: "spec-decoding"


### PR DESCRIPTION
## Summary

Adds a new **Speculative Decoding** Foundation to the well-lit paths, covering end-to-end deployment of a [speculators](https://github.com/vllm-project/speculators)-trained EAGLE-3 drafter alongside Qwen3-32B on llm-d.

- **Foundation doc** (`docs/well-lit-paths/foundations/spec-decoding.md`) — conceptual overview: draft-verify-accept loop, trade-off framing (compute for latency), composability with existing Foundations, and SVG architecture diagram matching the visual style of peer docs.
- **Deployment guide** (`guides/spec-decoding/README.md`) — full walkthrough: Kustomize overlay for vLLM with `--speculative-config`, Helm-based EPP router (reuses optimized-baseline plugin config unchanged), verification steps including Prometheus spec-decode metrics, and benchmarking instructions.
- **Benchmark report** (`guides/spec-decoding/benchmark-results/vllm-qwen3-32b-eagle3/README.md`) — real data from a 5-stage QPS ladder (1→2→4→8→16) on 2×H200 with Qwen3-32B, comparing baseline vs EAGLE-3 through the llm-d EPP stack. Key findings:
  - **TPOT p50 reduced 27%** at 1 QPS (13.2 ms → 9.7 ms), **request latency down 31%**
  - Throughput parity at 2–4 QPS, with per-token latency still 13–22% lower
  - **Crossover at ~4–8 QPS** — beyond this, baseline wins on throughput (−13%) and TTFT as the drafter's memory footprint reduces KV cache headroom
- **Kubernetes manifests** — model server Kustomize overlay (`patch-vllm.yaml`) and router Helm values, with the router config intentionally identical to optimized-baseline (spec decoding is orthogonal to routing)
- **Sidebar integration** — `menu-config.json` entry added at position 10

### Design decisions

| Decision | Rationale |
|----------|-----------|
| Foundation doc is 50 lines (matching peer density) | Trade-off analysis, acceptance tables, and speculator comparison live in the guide README, not the foundation — keeps the conceptual layer lean |
| Router config duplicates optimized-baseline | Spec decoding is a model-server property; the EPP doesn't know or care. Duplicating (vs. symlink) keeps the guide self-contained and avoids cross-guide coupling |
| `PYTORCH_ALLOC_CONF=expandable_segments:True` | Drafter + target share GPU memory; expandable segments reduces fragmentation from the two-model allocation pattern (diverges from baseline, documented in comment) |
| SVG diagram instead of ASCII art | Matches all other foundation docs which use `docs/assets/*.svg` |
| Single replica in manifests | Latency-focused Foundation; keeps the two-arm benchmark clean. Comment explains how to scale |

## Test plan

- [ ] `kustomize build guides/spec-decoding/modelserver/gpu/vllm/eagle3/` renders without errors
- [ ] Helm template with `guides/spec-decoding/router/spec-decoding.values.yaml` renders without errors
- [ ] All internal doc links resolve (verified by automated link checker)
- [ ] All external URLs return 200 (HuggingFace model cards, arxiv, vLLM docs, speculators repo)
- [ ] SVG renders correctly in GitHub markdown preview
- [ ] Benchmark numbers match the raw `inference-perf` v0.2 stage reports
- [ ] Deploy on a 2×GPU cluster and verify spec-decode Prometheus metrics are emitted
- [ ] `menu-config.json` entry renders spec-decoding in the docs sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)