### PR TITLE
docs(guides): remove IPP image tag workaround

### DIFF
--- a/guides/multi-model-routing/README.md
+++ b/guides/multi-model-routing/README.md
@@ -65,7 +65,6 @@ git clone https://github.com/llm-d/llm-d-inference-payload-processor.git /tmp/ip
 helm install ipp /tmp/ipp/config/charts/payload-processor \
     --set provider.name=istio \
     --set inferenceGateway.name=llm-d-inference-gateway \
-    --set payloadProcessor.image.tag=v0.1.0-rc.4 \
     -n ${NAMESPACE}
 ```
 


### PR DESCRIPTION
## Summary

- Remove the `--set payloadProcessor.image.tag=v0.1.0-rc.4` workaround from the multi-model routing guide's `helm install` command.
- IPP `v0.1.0` (stable) was released on July 12, 2026 and is available on GHCR.
- The chart's default image tag (`main`) is not yet published — tracked in [llm-d-inference-payload-processor#XX](https://github.com/llm-d/llm-d-inference-payload-processor/issues/XX) to update `values.yaml` to use a stable default tag.

> **Note:** This PR depends on [llm-d/llm-d-inference-payload-processor#254](https://github.com/llm-d/llm-d-inference-payload-processor/issues/254) merging first.

Closes #2001

## Test plan

- [x] Verify `ghcr.io/llm-d/llm-d-inference-payload-processor:v0.1.0` is pullable
- [x] Confirm IPP chart default tag fix is tracked in the IPP repo