### PR TITLE
docs(guides): point async-processing guide at the llm-d org

### DIFF
--- a/guides/asynchronous-processing/README.md
+++ b/guides/asynchronous-processing/README.md
@@ -1,6 +1,6 @@
 # [Experimental] Asynchronous Processing with Async Processor
 
-The [Async Processor](https://github.com/llm-d-incubation/llm-d-async) provides a way to process inference requests asynchronously using a queue-based architecture. This is ideal for latency-insensitive workloads or for filling "slack" capacity in your inference pool.
+The [Async Processor](https://github.com/llm-d/llm-d-async) provides a way to process inference requests asynchronously using a queue-based architecture. This is ideal for latency-insensitive workloads or for filling "slack" capacity in your inference pool.
 
 ## Overview
 
@@ -56,10 +56,10 @@ Deploy the Async Processor using the selected queue implementation's configurati
 ```bash
 export NAMESPACE=llm-d-async
 export MQ_PROVIDER=gcp-pubsub # options are gcp-pubsub or redis
-export ASYNC_VERSION=0.6.1
+export ASYNC_VERSION=0.7.4
 
 helm install async-processor \
-    oci://ghcr.io/llm-d-incubation/charts/async-processor \
+    oci://ghcr.io/llm-d/charts/async-processor \
     -f ${REPO_ROOT}/guides/asynchronous-processing/${MQ_PROVIDER}/values.yaml \
     --set ap.igwBaseURL=http://${IP}:80 \
     -n ${NAMESPACE} --create-namespace --version ${ASYNC_VERSION}

--- a/guides/asynchronous-processing/gcp-pubsub/README.md
+++ b/guides/asynchronous-processing/gcp-pubsub/README.md
@@ -65,6 +65,7 @@ Edit the `values.yaml` file with your specific GCP project and resources:
 ```yaml
 ap:
   gcpPubSub:
+    projectId: "<your-project>"
     requestSubscriberId: "projects/<your-project>/subscriptions/async-proc-requests-sub"
     resultTopicId: "projects/<your-project>/topics/async-proc-results"
 ```

--- a/guides/asynchronous-processing/gcp-pubsub/values.yaml
+++ b/guides/asynchronous-processing/gcp-pubsub/values.yaml
@@ -3,6 +3,7 @@ ap:
   gcpPubSub:
     enabled: true
     # Replace with your GCP project and resources
+    projectId: "REPLACE_WITH_YOUR_PROJECT"
     requestSubscriberId: "projects/REPLACE_WITH_YOUR_PROJECT/subscriptions/async-proc-requests-sub"
     resultTopicId: "projects/REPLACE_WITH_YOUR_PROJECT/topics/async-proc-results"
     requestPathURL: "/v1/completions"

--- a/guides/asynchronous-processing/redis/README.md
+++ b/guides/asynchronous-processing/redis/README.md
@@ -20,21 +20,26 @@ This implementation uses Redis Sorted Sets as the backend for the request queue.
      export REDIS_PASSWORD=your-secure-password
      helm install redis bitnami/redis -n redis --create-namespace --set auth.enabled=true --set auth.password=$REDIS_PASSWORD
 
-     # Create a secret for the Async Processor to use
-     kubectl create secret generic redis-creds -n llm-d-async --from-literal=password=$REDIS_PASSWORD
+     # Create a secret holding the full connection URL for the Async Processor
+     # (referenced via ap.redis.secretName / ap.redis.secretKey in values.yaml):
+     kubectl create secret generic redis-creds -n llm-d-async \
+       --from-literal=url="redis://:$REDIS_PASSWORD@redis-master.redis.svc.cluster.local:6379"
      ```
 
 ## Configuration and Deployment
 
 We provide a `values.yaml` for this implementation in `guides/asynchronous-processing/redis/values.yaml`.
 
-Edit the `values.yaml` file with your specific Redis configuration:
+Edit the `values.yaml` file with your specific Redis connection:
 
 ```yaml
 ap:
   redis:
-    host: "redis-master.redis.svc.cluster.local"
-    port: 6379
+    # No auth: the connection URL directly (the chart creates the Secret).
+    url: "redis://redis-master.redis.svc.cluster.local:6379"
+    # With auth: reference the Secret created above instead of `url`.
+    # secretName: "redis-creds"
+    # secretKey: "url"
 ```
 
 For deployment instructions, please refer to the [main README](../README.md#installation).

--- a/guides/asynchronous-processing/redis/values.yaml
+++ b/guides/asynchronous-processing/redis/values.yaml
@@ -2,13 +2,12 @@ ap:
   messageQueueImpl: "redis-sortedset"
   redis:
     enabled: true
-    host: "redis-master.redis.svc.cluster.local"
-    port: 6379
+    # Option 1 (no auth): the connection URL directly. The chart creates the Secret.
+    url: "redis://redis-master.redis.svc.cluster.local:6379"
+    # Option 2 (auth): reference a pre-existing Secret holding the full redis URL
+    # (see the "With Authentication" prerequisite). When set, `url` is ignored.
+    # secretName: "redis-creds"
+    # secretKey: "url"
     requestPathURL: "/v1/completions"
     requestQueueName: "request-sortedset"
     resultQueueName: "result-list"
-    auth:
-       enabled: false
-       secretName: "redis-creds"
-       # usernameKey: "username" # Optional: key in the secret for the username
-       # passwordKey: "password" # Optional: key in the secret for the password


### PR DESCRIPTION
The `llm-d-async` project moved to the **llm-d org** and its chart now publishes to `ghcr.io/llm-d/charts/async-processor` (v0.7.4). This updates the asynchronous-processing guide, and fixes two stale config-schema bugs found while validating it against the current chart.

## Changes
- **Org/version:** chart install URL → `oci://ghcr.io/llm-d/charts/async-processor`; project link → `github.com/llm-d/llm-d-async`; `ASYNC_VERSION` example → `0.7.4`.
- **Fix redis config schema:** guide used `ap.redis.host`/`port` (+ nested `auth`); the chart requires `ap.redis.url` (or `secretName`/`secretKey`) and fail-fast rejects otherwise. Switched `redis/values.yaml` + README to `url` (no-auth) / `secretName`+`secretKey` (auth).
- **Fix gcp-pubsub missing projectId:** chart fail-fast requires `ap.gcpPubSub.projectId`, but the guide's `gcp-pubsub/values.yaml` omitted it, so the documented install failed. Added the placeholder to values + README.

## Validation
- **Redis path — full kind e2e (passed):** baseline router+EPP+CPU-vLLM → redis → async-processor **v0.7.4 pulled from `ghcr.io/llm-d`** → publish → `status_code:200` result. (First run caught the redis-schema bug; re-run with the fix passed.)

Out of scope: the `batch-gateway` guide's chart URL (separate project).