### PR TITLE
docs(guides): fix prerequisite ordering and add pod readiness check in quickstart

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -7,19 +7,20 @@ For this quickstart, we will use the **Standalone Mode** deployment, which is th
 ## Prerequisites
 
 - Installed proper client tools (kubectl, helm).
+
+- Checkout llm-d repo:
+
+  ```bash
+  export branch="main"
+  git clone https://github.com/llm-d/llm-d.git && cd llm-d && git checkout ${branch}
+  ```
+
 - Set the following environment variables:
   ```bash
   export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
   source ${REPO_ROOT}/guides/env.sh
   export GUIDE_NAME="quickstart"
   export NAMESPACE=llm-d-quickstart
-  ```
-
-- Checkout llm-d repo:
-
-  ```bash
-    export branch="main"
-    git clone https://github.com/llm-d/llm-d.git && cd llm-d && git checkout ${branch}
   ```
 
 - Install the Gateway API Inference Extension CRDs:
@@ -64,11 +65,20 @@ helm install ${GUIDE_NAME} \
 Deploy the default model server (vLLM running on NVIDIA GPUs). This will deploy 8 replicas of `Qwen/Qwen3-32B` by default.
 
 ```bash
-kubectl apply -n ${NAMESPACE} -k guides/optimized-baseline/modelserver/gpu/vllm/
+kubectl apply -n ${NAMESPACE} -k guides/optimized-baseline/modelserver/gpu/vllm/base/
 ```
 
 > [!TIP]
 > If you are using different hardware (AMD, Intel, TPU, or CPU), you can find alternative configurations in the `guides/optimized-baseline/modelserver/` directory.
+
+Wait for all model server pods to be running and ready before proceeding:
+
+```bash
+bash ${REPO_ROOT}/guides/scripts/wait-for-pods-ready.sh -l llm-d.ai/guide=optimized-baseline -n ${NAMESPACE}
+```
+
+> [!NOTE]
+> Model server pods may take several minutes to start as they need to download the model weights.
 
 ## Verification
 

--- a/guides/scripts/wait-for-pods-ready.sh
+++ b/guides/scripts/wait-for-pods-ready.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Wait for all pods matching a label selector to be Running and Ready.
+# Usage: bash wait-for-pods-ready.sh -l <label-selector> -n <namespace> [-t <timeout-seconds>]
+
+set -euo pipefail
+
+LABEL=""
+NAMESPACE=""
+TIMEOUT=600
+INTERVAL=5
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -l) LABEL="$2"; shift 2 ;;
+    -n) NAMESPACE="$2"; shift 2 ;;
+    -t) TIMEOUT="$2"; shift 2 ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+if [[ -z "${LABEL}" || -z "${NAMESPACE}" ]]; then
+  echo "Usage: $0 -l <label-selector> -n <namespace> [-t <timeout-seconds>]"
+  exit 1
+fi
+
+elapsed=0
+while true; do
+  echo "--- Checking pods (elapsed: ${elapsed}s, timeout: ${TIMEOUT}s) ---"
+  kubectl get pods -l "${LABEL}" -n "${NAMESPACE}"
+
+  total=$(kubectl get pods -l "${LABEL}" -n "${NAMESPACE}" --no-headers 2>/dev/null | wc -l | tr -d '[:space:]')
+  ready=$(kubectl get pods -l "${LABEL}" -n "${NAMESPACE}" -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null | grep -c "True" || true)
+  ready=$(echo "${ready}" | tr -d '[:space:]')
+
+  echo "----> Ready: ${ready}/${total}"
+
+  if [[ "${total}" -gt 0 && "${ready}" -eq "${total}" ]]; then
+    echo "All pods are ready!"
+    exit 0
+  fi
+
+  if [[ "${elapsed}" -ge "${TIMEOUT}" ]]; then
+    echo "ERROR: Timed out waiting for pods to be ready."
+    exit 1
+  fi
+
+  sleep "${INTERVAL}"
+  elapsed=$((elapsed + INTERVAL))
+done


### PR DESCRIPTION
### Problem

The quickstart guide has several issues that prevent new users from successfully following it:

1. It instructs users to `source guides/env.sh` (which sets `GAIE_VERSION`, `ROUTER_CHART_VERSION`, etc.) **before** cloning the repo — but the file doesn't exist until the repo is cloned.
2. The kustomize path `guides/optimized-baseline/modelserver/gpu/vllm/` is missing the `base/` subdirectory where `kustomization.yaml` actually lives, causing `kubectl apply -k` to fail.
3. There is no guidance on waiting for model server pods to become ready before proceeding to verification, which leads to failed requests.

### Changes

- **Reorder prerequisites**: move "Checkout llm-d repo" before "Set environment variables" so `env.sh` exists when sourced.
- **Fix kustomize path**: `gpu/vllm/` → `gpu/vllm/base/`.
- **Add pod readiness check**: introduce a reusable `guides/scripts/wait-for-pods-ready.sh` script that polls pod status every 5 seconds and exits when all pods are Ready (or on timeout). Reference it in the quickstart guide between deploy and verification steps.
