### PR TITLE
ci: add Intel XPU wide-ep-lws nightly coverage

### DIFF
--- a/.github/workflows/consolidate-status-wide-ep-lws-intel-acc-xpu-vllm-x.yaml
+++ b/.github/workflows/consolidate-status-wide-ep-lws-intel-acc-xpu-vllm-x.yaml
@@ -1,0 +1,35 @@
+name: Past Status - Wide EP LWS E2E (Intel XPU)
+
+on:
+  workflow_dispatch:
+    inputs:
+      workflow_name_query:
+        description: 'Name of the workflow to be queried'
+        required: false
+        type: 'string'
+        default: 'nightly-e2e-wide-ep-lws-intel-acc-xpu-vllm-x.yaml'
+      time_window_query:
+        description: 'How many days in the past to query'
+        required: true
+        type: 'string'
+        default: '5'
+      branch_query:
+        description: 'Branch to be queried'
+        required: false
+        type: string
+        default: 'main'
+
+  workflow_run:
+    workflows:
+      - Nightly - Wide EP LWS E2E (Intel XPU)
+    types:
+      - completed
+
+jobs:
+  check_for_success:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-query-success-past-runs.yaml@main
+    with:
+      workflow_name_query: ${{ inputs.workflow_name_query || 'nightly-e2e-wide-ep-lws-intel-acc-xpu-vllm-x.yaml' }}
+      time_window_query: ${{ inputs.time_window_query || '5' }}
+      branch_query: ${{ inputs.branch_query || 'main' }}
+    secrets: inherit

--- a/.github/workflows/nightly-e2e-wide-ep-lws-intel-acc-xpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-intel-acc-xpu-vllm-x.yaml
@@ -1,0 +1,143 @@
+name: Nightly - Wide EP LWS E2E (Intel XPU)
+
+on:
+  workflow_dispatch:
+    inputs:
+      decode_pods:
+        description: 'Number of decode (vllm "standalone") pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      prefill_pods:
+        description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      gateway_class:
+        description: 'Class of gateway used ("istio", "agentgateway", "epponly" (i.e., "standalone"), "none")'
+        required: false
+        default: 'epponly'
+      monitoring_enabled:
+        description: 'Enabled monitoring ("true", "false")'
+        required: true
+        type: 'string'
+        default: 'false'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode ("true", "false")'
+        required: false
+        default: 'false'
+      verbose:
+        description: 'Execute workflow in "verbose" mode ("true", "false")'
+        required: false
+        default: 'false'
+        type: 'string'
+      harness:
+        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
+        required: false
+        default: 'inference-perf'
+        type: 'string'
+      workload:
+        description: 'Workload profile to be used during "run" operation (check list under "workload/profiles")'
+        required: false
+        default: 'sanity_random.yaml'
+        type: 'string'
+      cleanup:
+        description: 'Cleanup the llm-d stack stood up by this workflow'
+        required: false
+        default: 'true'
+        type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
+
+  schedule:
+    - cron: '0 1 * * *'
+
+permissions:
+  contents: write
+  actions: read
+
+concurrency:
+  group: nightly-e2e-wide-ep-lws-intel-xpu
+  cancel-in-progress: true
+
+jobs:
+  xpu-kubernetes-preflight:
+    runs-on: [self-hosted, xpu]
+    timeout-minutes: 10
+    steps:
+      - name: Verify Wide EP XPU cluster prerequisites
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          kubectl get --raw='/readyz' >/dev/null
+          kubectl get deviceclass gpu.intel.com >/dev/null
+          kubectl get leaderworkersets --all-namespaces >/dev/null
+          kubectl get inferencepools --all-namespaces >/dev/null
+
+          disk_pressure_nodes="$(
+            kubectl get nodes -o json |
+              jq -r '.items[] |
+                select(any(.status.conditions[]?; .type == "DiskPressure" and .status == "True")) |
+                .metadata.name'
+          )"
+          if [[ -n "$disk_pressure_nodes" ]]; then
+            echo "::error::DiskPressure is active on: ${disk_pressure_nodes//$'\n'/, }"
+            exit 1
+          fi
+
+          xpu_count="$(
+            kubectl get nodes -o json |
+              jq '[.items[] |
+                select(.spec.unschedulable != true) |
+                (.status.allocatable["gpu.intel.com/xe"] // "0" | tonumber)] |
+                add // 0'
+          )"
+          if (( xpu_count < 4 )); then
+            echo "::error::Wide EP requires at least four schedulable gpu.intel.com/xe devices; found ${xpu_count}."
+            exit 1
+          fi
+
+  nightly:
+    needs: [xpu-kubernetes-preflight]
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
+    with:
+      scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
+      standup_method: ${{ inputs.standup_method || 'kustomize' }}
+      standup_scenario: ${{ inputs.standup_scenario || 'wide-ep-lws' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'xpu' }}
+      backend_type: ${{ inputs.backend_type || 'vllm' }}
+      infra_provider: ${{ inputs.infra_provider || '' }}
+      connector: ${{ inputs.connector || '' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-wide-ep-lws-intel-xpu' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-wide-ep-xpu' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-wide-ep-lws-xpu' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions/wide-ep-lws' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      # The XPU prefill/decode startup probes allow up to 60 minutes.
+      standup_timeout: '7200'
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'sanity_random.yaml' }}
+      cleanup: ${{ inputs.cleanup || 'true' }}
+    secrets: inherit
+
+  update-badge:
+    needs: [xpu-kubernetes-preflight, nightly]
+    if: always() && inputs.update_badge != 'false'
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
+    with:
+      badge_name: wide-ep-lws-xpu
+      badge_label: "VLLM XPU"
+      result: ${{ needs.xpu-kubernetes-preflight.result == 'success' && needs.nightly.result || needs.xpu-kubernetes-preflight.result }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/guides/wide-ep-lws/README.md
+++ b/guides/wide-ep-lws/README.md
@@ -3,6 +3,7 @@
 [![E2E (CKS GPU)](https://github.com/llm-d/llm-d/actions/workflows/consolidate-status-wide-ep-lws-cks-acc-gpu-vllm-x.yaml/badge.svg)](https://github.com/llm-d/llm-d/actions/workflows/consolidate-status-wide-ep-lws-cks-acc-gpu-vllm-x.yaml)
 [![E2E (GKE GPU)](https://github.com/llm-d/llm-d/actions/workflows/consolidate-status-wide-ep-lws-gke-acc-gpu-vllm-x.yaml/badge.svg)](https://github.com/llm-d/llm-d/actions/workflows/consolidate-status-wide-ep-lws-gke-acc-gpu-vllm-x.yaml)
 [![E2E (OCP GPU)](https://github.com/llm-d/llm-d/actions/workflows/consolidate-status-wide-ep-lws-ibm-acc-gpu-vllm-x.yaml/badge.svg)](https://github.com/llm-d/llm-d/actions/workflows/consolidate-status-wide-ep-lws-ibm-acc-gpu-vllm-x.yaml)
+[![E2E (Intel XPU)](https://github.com/llm-d/llm-d/actions/workflows/consolidate-status-wide-ep-lws-intel-acc-xpu-vllm-x.yaml/badge.svg)](https://github.com/llm-d/llm-d/actions/workflows/consolidate-status-wide-ep-lws-intel-acc-xpu-vllm-x.yaml)
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Adds nightly E2E coverage for the Intel XPU `wide-ep-lws` vLLM configuration.

- adds the XPU nightly workflow and status badge
- validates required cluster prerequisites before running the benchmark
- requires four schedulable XPUs: prefill TP=2 and decode TP=2

## Test plan

- [ ] Run the workflow on the self-hosted XPU cluster.