### PR TITLE
docs(menu): add Async Processor Operations Guide to the operations menu

### DIFF
--- a/docs/menu-config.json
+++ b/docs/menu-config.json
@@ -83,6 +83,7 @@
     "operations/rollouts/adapter-rollout": { "position": 1 },
     "operations/rollouts/blue-green-update": { "position": 2 },
     "operations/router": { "position": 4, "label": "Router Operations Guide" },
+    "operations/async-processor": { "position": 5, "label": "Async Processor Operations Guide" },
 
     "infrastructure/multi-node": { "position": 3, "label": "Kubernetes Multi-Node Orchestration" },
     "infrastructure/no-kubernetes-deployment": { "position": 4, "label": "Non-K8s & Bare-Metal Deployments" },


### PR DESCRIPTION
Follow-up to #1865. The operations guide it added (`docs/operations/async-processor.md`, indexed in `docs/operations/README.md`) was not wired into `docs/menu-config.json`, so it doesn't appear in the docs sidebar.

Adds it under **Operations & Monitoring** at position 5, right after the Router Operations Guide, matching the existing `operations/router` entry style. JSON validated.