### PR TITLE
[ROCM] add update_badge input to precise and predicted nightly

### DIFF
--- a/.github/workflows/nightly-e2e-precise-prefix-cache-routing-amd-ci-acc-rocm-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-routing-amd-ci-acc-rocm-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 
 #  push:
 #    branches:
@@ -94,7 +99,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: precise-prefix-cache-routing-rocm

--- a/.github/workflows/nightly-e2e-predicted-latency-routing-amd-ci-acc-rocm-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-routing-amd-ci-acc-rocm-vllm-x.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: 'true'
         type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
 
 #  push:
 #    branches:
@@ -94,7 +99,7 @@ jobs:
 
   update-badge:
     needs: [nightly]
-    if: always()
+    if: always() && inputs.update_badge != 'false'
     uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
     with:
       badge_name: predicted-latency-routing-rocm


### PR DESCRIPTION
Add missing update_badge workflow_dispatch input and guard the update-badge job condition