### PR TITLE
fix: quote variable expansion and remove broken link in guides/

### DIFF
--- a/guides/README.md
+++ b/guides/README.md
@@ -26,7 +26,6 @@ We currently offer the following:
 
 * [Flow Control](./flow-control/README.md) - Intelligent request queuing for multi-tenant deployments and managing traffic spikes.
 * [Workload Autoscaling](./workload-autoscaling/README.md) - autoscale the LLM service via proactive, SLO-aware signals that reflect the true state of the inference system — queue depth, in-flight request counts, and KV cache pressure — so that capacity can be added before end-user latency is impacted.
-* [Rollouts](./rollouts/README.md) - perform incremental rollout operations for LoRA adapters, base models, and model server versions with minimal service disruption using traffic splitting and gradual deployment strategies.
 * [Fast Model Actuation](./fast-model-actuation/README.md) - rapidly load, switch, and wake models on shared GPUs using vLLM sleep/wake and a "dual pod" technique that decouples GPU reservation from the vLLM process, avoiding cold starts.
 
 ### Workloads

--- a/guides/env.sh
+++ b/guides/env.sh
@@ -3,7 +3,7 @@
 # Source this file in your shell before running guide commands:
 #   source ${REPO_ROOT}/guides/env.sh
 
-export REPO_ROOT=${REPO_ROOT:-$(realpath $(git rev-parse --show-toplevel 2>/dev/null) 2>/dev/null)}
+export REPO_ROOT=${REPO_ROOT:-$(realpath "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null)}
 export GAIE_VERSION=v1.5.0
 export ROUTER_CHART_VERSION=v0
 export ROUTER_EPP_VERSION=main


### PR DESCRIPTION
## Summary

Fixes shell quoting in guides/env.sh to prevent word splitting and removes a broken link to a non-existent Rollouts guide.

## Changes

- Quote `git rev-parse` output in `guides/env.sh` to handle repository paths with spaces
- Remove broken link to `./rollouts/README.md` which was never created

## Testing

Verified by grep that no rollouts directory exists and tested the env.sh change with paths containing spaces.