### PR TITLE
Add .editorconfig for consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Markdown files allow trailing double spaces for line breaks
+[*.md]
+trim_trailing_whitespace = false
+
+# Makefiles require tabs
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Summary

Adds .editorconfig to enforce consistent indent style, charset, and newline settings across editors and contributors.

## Changes

- Add .editorconfig file with:
  - Default 2-space indentation for all files
  - UTF-8 charset and LF line endings
  - Final newline insertion and trailing whitespace trimming
  - Tabs for Makefiles (as required)
  - Preserved trailing spaces in Markdown (for line breaks)

## Testing

N/A — verified by grep.