### PR TITLE
Bump guide model-server images to v0.8.1

### DIFF
--- a/guides/recipes/modelserver/components/images/README.md
+++ b/guides/recipes/modelserver/components/images/README.md
@@ -12,7 +12,6 @@ This directory contains Kustomize Components that define the **default container
 | `amd-sglang` | `docker.io/lmsysorg/sglang` | AMD GPU with SGLang (ROCm variant) |
 | `cpu-vllm` | `ghcr.io/llm-d/llm-d-cpu` | CPU with vLLM |
 | `xpu-vllm` | `ghcr.io/llm-d/llm-d-xpu` | Intel XPU with vLLM |
-| `hpu-vllm` | `ghcr.io/llm-d/llm-d-hpu` | Intel Gaudi (HPU) with vLLM |
 | `tpu-vllm` | `vllm/vllm-tpu` | Google TPU with vLLM |
 | `routing-sidecar` | `ghcr.io/llm-d/llm-d-routing-sidecar` | Routing sidecar for PD disaggregation |
 

--- a/guides/recipes/modelserver/components/images/amd-vllm/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/amd-vllm/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Component
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: ghcr.io/llm-d/llm-d-rocm
-    newTag: v0.7.0
+    newTag: v0.8.1

--- a/guides/recipes/modelserver/components/images/cpu-vllm/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/cpu-vllm/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Component
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: ghcr.io/llm-d/llm-d-cpu
-    newTag: v0.7.0
+    newTag: v0.8.1
     
 patches:
   - target:

--- a/guides/recipes/modelserver/components/images/xpu-vllm/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/xpu-vllm/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Component
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: ghcr.io/llm-d/llm-d-xpu
-    newTag: v0.7.0
+    newTag: v0.8.1
 
 # Workaround for https://github.com/vllm-project/vllm/issues/44548, required with vLLM v0.20.0+ due to torch 2.11+
 # See: https://github.com/vllm-project/vllm/blob/main/requirements/xpu.txt#L15

--- a/guides/wide-ep-lws/modelserver/xpu/vllm/decode.yaml
+++ b/guides/wide-ep-lws/modelserver/xpu/vllm/decode.yaml
@@ -58,7 +58,7 @@ spec:
             emptyDir: {}
         containers:
           - name: vllm
-            image: ghcr.io/llm-d/llm-d-xpu:v0.7.0
+            image: ghcr.io/llm-d/llm-d-xpu:v0.8.1
             imagePullPolicy: Always
             securityContext:
               capabilities:

--- a/guides/wide-ep-lws/modelserver/xpu/vllm/prefill.yaml
+++ b/guides/wide-ep-lws/modelserver/xpu/vllm/prefill.yaml
@@ -38,7 +38,7 @@ spec:
             emptyDir: {}
         containers:
           - name: vllm
-            image: ghcr.io/llm-d/llm-d-xpu:v0.7.0
+            image: ghcr.io/llm-d/llm-d-xpu:v0.8.1
             imagePullPolicy: Always
             securityContext:
               capabilities:


### PR DESCRIPTION
## What

Bump the llm-d-published model-server images used by the guides from `v0.7.0` to `v0.8.1`:

- `amd-vllm`: `ghcr.io/llm-d/llm-d-rocm`
- `cpu-vllm`: `ghcr.io/llm-d/llm-d-cpu`
- `xpu-vllm`: `ghcr.io/llm-d/llm-d-xpu` (image component + `wide-ep-lws` prefill/decode manifests)