### PR TITLE
refactor(e2e): extract shared validation library and clean up temp branches (#1494)

### DIFF
--- a/.github/scripts/e2e/e2e-validate-flow-control.sh
+++ b/.github/scripts/e2e/e2e-validate-flow-control.sh
@@ -63,90 +63,25 @@ done
 
 [[ "${VERBOSE}" == "true" ]] && set -x
 
+# ── Shared functions ───────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CURL_POD_NAME="curl-fc-${RANDOM}-$$"
-CURL_POD_TIMEOUT_SECONDS="${CURL_POD_TIMEOUT_SECONDS:-120}"
-
-setup_curl_pod() {
-  kubectl delete pod -n "$NAMESPACE" "$CURL_POD_NAME" --ignore-not-found >/dev/null 2>&1 || true
-  echo "Creating curl pod ${CURL_POD_NAME}..."
-  kubectl run "$CURL_POD_NAME" --namespace "$NAMESPACE" \
-    --image=curlimages/curl --restart=Never -- sleep 3600 >/dev/null
-  if ! kubectl wait --for=condition=Ready pod/"$CURL_POD_NAME" \
-       -n "$NAMESPACE" --timeout="${CURL_POD_TIMEOUT_SECONDS}s"; then
-    echo "Error: curl pod failed to become ready" >&2
-    kubectl describe pod -n "$NAMESPACE" "$CURL_POD_NAME" >&2 || true
-    exit 1
-  fi
-}
-
-cleanup_curl_pod() {
-  kubectl delete pod -n "$NAMESPACE" "$CURL_POD_NAME" --ignore-not-found >/dev/null 2>&1 || true
-}
+# shellcheck source=lib-e2e-common.sh
+source "${SCRIPT_DIR}/lib-e2e-common.sh"
 trap cleanup_curl_pod EXIT
 
-run_curl() {
-  CURL_OUTPUT=""; CURL_EXIT=0
-  CURL_OUTPUT=$(kubectl exec -n "$NAMESPACE" "$CURL_POD_NAME" -- "$@" 2>&1) || CURL_EXIT=$?
-}
-
-# ── Discover EPP service ────────────────────────────────────────────────────
-# Standalone mode has no Gateway resource: the EPP service serves both traffic
-# (:80) and metrics (:9090), so resolve straight to its ClusterIP.
-HOST="${GATEWAY_HOST:-}"
-if [[ -z "$HOST" ]]; then
-  EPP_SVC_NAME=$(kubectl get svc -n "$NAMESPACE" \
-      -o jsonpath='{.items[*].metadata.name}' 2>/dev/null \
-      | tr ' ' '\n' | grep -E -- '-epp$' | head -1 || true)
-  if [[ -n "$EPP_SVC_NAME" ]]; then
-    HOST=$(kubectl get svc "$EPP_SVC_NAME" -n "$NAMESPACE" \
-      -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)
-  fi
-fi
-if [[ -z "$HOST" ]]; then
-  echo "Error: could not discover EPP service in namespace '$NAMESPACE'." >&2
-  echo "       Set GATEWAY_HOST env var to the EPP service name or ClusterIP." >&2
-  exit 1
-fi
-SVC_HOST="${HOST}:80"
-EPP_HOST="${EPP_HOST_OVERRIDE:-$HOST}"
-EPP_METRICS_URL="http://${EPP_HOST}:${EPP_METRICS_PORT}/metrics"
-# NOTE: assumes a single EPP replica (base.values.yaml sets replicas: 1). With
-# more, /metrics load-balances per scrape and the gauges below go inconsistent.
-
+# ── Discover EPP service and model ─────────────────────────────────────────
+discover_epp_service
 setup_curl_pod
-
-# ── Discover model ──────────────────────────────────────────────────────────
-if [[ -n "$CLI_MODEL_ID" ]]; then
-  MODEL_ID="$CLI_MODEL_ID"
-elif [[ -n "${MODEL_ID-}" ]]; then
-  : # already set in env
-else
-  echo "Auto-discovering model from ${SVC_HOST}/v1/models..."
-  MODEL_ID=""
-  for _ in $(seq 1 10); do
-    run_curl curl -sS --max-time 15 "http://${SVC_HOST}/v1/models" || true
-    MODEL_ID=$(echo "${CURL_OUTPUT}" | grep -o '"id":"[^"]*"' | head -n 1 | cut -d '"' -f 4) || true
-    [[ -n "$MODEL_ID" ]] && break
-    sleep 10
-  done
-  if [[ -z "$MODEL_ID" ]]; then
-    echo "Error: could not auto-discover model after 10 attempts." >&2
-    exit 1
-  fi
-fi
+discover_model
 
 echo "Namespace=$NAMESPACE Gateway=${SVC_HOST} EPP=${EPP_METRICS_URL} Model=${MODEL_ID} Burst/band=${BURST} max_tokens=${MAX_TOKENS}"
 
 # ── Stage the request payload on the curl pod ───────────────────────────────
-# max_tokens is sized to keep each request in flight long enough to hold the
-# gate closed while the queue fills. Stage via `tee`: `kubectl exec` + redirect
-# silently writes a 0-byte file, sending empty request bodies.
 PAYLOAD=$(printf '{"model":"%s","prompt":"Write a long detailed story about a robot learning to paint.","max_tokens":%s}' "$MODEL_ID" "$MAX_TOKENS")
 printf '%s' "$PAYLOAD" | kubectl exec -i -n "$NAMESPACE" "$CURL_POD_NAME" -- tee /tmp/payload.json >/dev/null
 
 # ── Metric extraction helpers ───────────────────────────────────────────────
-# Sum a series' values across every label set carrying priority="<v>". Works
-# for the queue_size gauge and the queue_duration _sum/_count families alike.
 metric_sum_for_priority() {
   local series="$1" priority="$2"
   echo "$METRICS" \
@@ -169,7 +104,6 @@ gauge_max() {
       '
 }
 
-# Histogram mean = _sum / _count for a given priority; 0 when no samples.
 hist_mean_for_priority() {
   local series="$1" priority="$2" s c
   s=$(metric_sum_for_priority "${series}_sum" "$priority")
@@ -177,7 +111,6 @@ hist_mean_for_priority() {
   awk -v s="$s" -v c="$c" 'BEGIN { printf("%.4f\n", (c>0 ? s/c : 0)) }'
 }
 
-# float a > b
 fgt() { awk -v a="$1" -v b="$2" 'BEGIN{exit !(a>b)}'; }
 
 scrape_metrics() {
@@ -195,7 +128,6 @@ QSIZE=inference_extension_flow_control_queue_size
 SAT=inference_extension_flow_control_pool_saturation
 QD=inference_extension_flow_control_request_queue_duration_seconds
 
-# Background one band's burst; FlowKey = (fairness id, objective-derived priority).
 fire_band() {
   local objective="$1" priority="$2" tenant="$3"
   kubectl exec -n "$NAMESPACE" "$CURL_POD_NAME" -- sh -c "
@@ -211,8 +143,6 @@ fire_band() {
 }
 
 # ── Mixed-contention burst: all three bands at once ─────────────────────────
-# Firing every band simultaneously is what surfaces QoS: under a closed gate the
-# hardcoded strict-priority dispatcher must drain premium before best-effort.
 echo "── Firing ${BURST} requests into each band simultaneously (premium=100, standard=0, best-effort=-10) ──"
 PID_PREMIUM=$(fire_band premium-traffic     100 tenant-a)
 PID_STANDARD=$(fire_band standard-traffic   0   tenant-b)
@@ -233,7 +163,6 @@ for _ in $(seq 1 "$POLL_ATTEMPTS"); do
     (( total > peak_total_q )) && peak_total_q=$total
     fgt "$sat" "$peak_sat" && peak_sat=$sat
     fgt "$q100" 0 && seen_premium_queued=true
-    # Premium emptied while best-effort still waits == strict priority in action.
     if $seen_premium_queued && [[ "$q100" == "0" ]] && fgt "$qbe" 0; then
       drain_order_observed=true
     fi
@@ -257,21 +186,13 @@ scrape_metrics || { echo "Error: final metrics scrape failed." >&2; exit 1; }
 
 fail=false
 
-# priority -> human name. A case fn (not a bash-4 `declare -A`) keeps this
-# runnable on macOS bash 3.2 and avoids the negative-key subscript pitfall.
 band_name() { case "$1" in 100) echo premium ;; 0) echo standard ;; -10) echo best-effort ;; *) echo "band-$1" ;; esac; }
 
-# Backpressure signal — informational only. queue_size and pool_saturation are
-# gauges sampled mid-burst, so a fast drain can leave the peak between polls.
-# Backpressure is instead proven cumulatively by the QoS gap below: best-effort
-# could only out-wait premium if the queue actually held it back.
 echo "── Backpressure (peak gauges, informational) ──"
 echo "  peak total queue_size=${peak_total_q}  peak pool_saturation=${peak_sat}"
 $drain_order_observed && echo "  observed live drain order: premium emptied while best-effort still queued."
 
 # ── (1) Each band landed in its own queue ───────────────────────────────────
-# queue_duration_count is cumulative — unlike the gauges above it cannot be
-# missed by scrape timing, so it is the robust backbone assertion.
 echo "── Band classification (queue_duration_count) ──"
 for pri in 100 0 -10; do
   c=$(metric_sum_for_priority "${QD}_count" "$pri")
@@ -285,15 +206,11 @@ for pri in 100 0 -10; do
 done
 
 # ── (2) QoS: best-effort waits longer than premium under contention ─────────
-# Compare only the extremes — the premium/standard gap is small enough to be
-# noise when the pool drains fast, so asserting it would flake. A nonzero gap
-# also doubles as the cumulative proof that backpressure engaged at all.
 echo "── QoS differentiation (mean queue wait, seconds) ──"
 MEAN_PREMIUM=$(hist_mean_for_priority "$QD" 100)
 MEAN_STANDARD=$(hist_mean_for_priority "$QD" 0)
 MEAN_BEST=$(hist_mean_for_priority "$QD" -10)
 echo "  premium=${MEAN_PREMIUM}  standard=${MEAN_STANDARD}  best-effort=${MEAN_BEST}"
-# 50ms floor guards against asserting on float noise when waits are near zero.
 QOS_GAP=$(awk -v be="$MEAN_BEST" -v pr="$MEAN_PREMIUM" 'BEGIN{printf("%.4f", be-pr)}')
 if ! fgt "$QOS_GAP" 0.05; then
   echo "Error: no QoS differentiation — best-effort mean wait (${MEAN_BEST}s) did not exceed" >&2
@@ -302,7 +219,7 @@ if ! fgt "$QOS_GAP" 0.05; then
   echo "       priority is not ordering the bands." >&2
   fail=true
 else
-  echo "  ✓ best-effort waited ${QOS_GAP}s longer than premium (strict priority honored)."
+  echo "  best-effort waited ${QOS_GAP}s longer than premium (strict priority honored)."
 fi
 
 if $fail; then

--- a/.github/scripts/e2e/e2e-validate-predicted-latency.sh
+++ b/.github/scripts/e2e/e2e-validate-predicted-latency.sh
@@ -61,98 +61,25 @@ done
 
 [[ "${VERBOSE}" == "true" ]] && set -x
 
+# ── Shared functions ───────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CURL_POD_NAME="curl-pl-${RANDOM}-$$"
-CURL_POD_TIMEOUT_SECONDS="${CURL_POD_TIMEOUT_SECONDS:-120}"
-
-setup_curl_pod() {
-  kubectl delete pod -n "$NAMESPACE" "$CURL_POD_NAME" --ignore-not-found >/dev/null 2>&1 || true
-  echo "Creating curl pod ${CURL_POD_NAME}..."
-  kubectl run "$CURL_POD_NAME" --namespace "$NAMESPACE" \
-    --image=curlimages/curl --restart=Never -- sleep 3600 >/dev/null
-  if ! kubectl wait --for=condition=Ready pod/"$CURL_POD_NAME" \
-       -n "$NAMESPACE" --timeout="${CURL_POD_TIMEOUT_SECONDS}s"; then
-    echo "Error: curl pod failed to become ready" >&2
-    kubectl describe pod -n "$NAMESPACE" "$CURL_POD_NAME" >&2 || true
-    exit 1
-  fi
-}
-
-cleanup_curl_pod() {
-  kubectl delete pod -n "$NAMESPACE" "$CURL_POD_NAME" --ignore-not-found >/dev/null 2>&1 || true
-}
+# shellcheck source=lib-e2e-common.sh
+source "${SCRIPT_DIR}/lib-e2e-common.sh"
 trap cleanup_curl_pod EXIT
 
-run_curl() {
-  CURL_OUTPUT=""; CURL_EXIT=0
-  CURL_OUTPUT=$(kubectl exec -n "$NAMESPACE" "$CURL_POD_NAME" -- "$@" 2>&1) || CURL_EXIT=$?
-}
-
-# ── Discover EPP service ────────────────────────────────────────────────────
-# The predicted-latency guide deploys the llm-d Router in standalone mode —
-# there is no Gateway resource. Both the request flow (port 80, Envoy sidecar)
-# and the metrics endpoint (port 9090) are served by the EPP service itself,
-# so we resolve directly to the EPP service's ClusterIP.
-#
-# Multi-replica caveat: when more than one EPP pod is running, /metrics is
-# forwarded to one pod at random per scrape, so the histogram counts reflect
-# only that pod's view. base.values.yaml currently sets replicas: 1 so this
-# is fine; future scale-out will need per-pod scraping (port-forward or
-# headless service).
-HOST="${GATEWAY_HOST:-}"
-if [[ -z "$HOST" ]]; then
-  EPP_SVC_NAME=$(kubectl get svc -n "$NAMESPACE" \
-      -o jsonpath='{.items[*].metadata.name}' 2>/dev/null \
-      | tr ' ' '\n' | grep -E -- '-epp$' | head -1 || true)
-  if [[ -n "$EPP_SVC_NAME" ]]; then
-    HOST=$(kubectl get svc "$EPP_SVC_NAME" -n "$NAMESPACE" \
-      -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)
-  fi
-fi
-if [[ -z "$HOST" ]]; then
-  echo "Error: could not discover EPP service in namespace '$NAMESPACE'." >&2
-  echo "       Set GATEWAY_HOST env var to the EPP service name or ClusterIP." >&2
-  exit 1
-fi
-SVC_HOST="${HOST}:80"
-EPP_HOST="${EPP_HOST_OVERRIDE:-$HOST}"
-EPP_METRICS_URL="http://${EPP_HOST}:${EPP_METRICS_PORT}/metrics"
-
+# ── Discover EPP service and model ─────────────────────────────────────────
+discover_epp_service
 setup_curl_pod
-
-# ── Discover model ──────────────────────────────────────────────────────────
-if [[ -n "$CLI_MODEL_ID" ]]; then
-  MODEL_ID="$CLI_MODEL_ID"
-elif [[ -n "${MODEL_ID-}" ]]; then
-  : # already set in env
-else
-  echo "Auto-discovering model from ${SVC_HOST}/v1/models..."
-  MODEL_ID=""
-  for _ in $(seq 1 10); do
-    run_curl curl -sS --max-time 15 "http://${SVC_HOST}/v1/models" || true
-    MODEL_ID=$(echo "${CURL_OUTPUT}" | grep -o '"id":"[^"]*"' | head -n 1 | cut -d '"' -f 4) || true
-    [[ -n "$MODEL_ID" ]] && break
-    sleep 10
-  done
-  if [[ -z "$MODEL_ID" ]]; then
-    echo "Error: could not auto-discover model after 10 attempts." >&2
-    exit 1
-  fi
-fi
+discover_model
 
 echo "Namespace=$NAMESPACE Gateway=${SVC_HOST} EPP=${EPP_METRICS_URL} Model=${MODEL_ID} Iterations=${ITERATIONS} Concurrency=${CONCURRENCY}"
 
 # ── Warmup loop: feed the predictor's training window ───────────────────────
 PAYLOAD=$(printf '{"model":"%s","prompt":"Tell me a short story.","max_tokens":32}' "$MODEL_ID")
-# Pipe via tee so the payload actually lands in the file. `kubectl exec` +
-# `sh -c "cat > file"` silently produces a 0-byte file (cat's stdin never gets
-# the data through sh -c, even with -i), which would make every warmup curl
-# send an empty body and report ok=0 fail=N.
 printf '%s' "$PAYLOAD" | kubectl exec -i -n "$NAMESPACE" "$CURL_POD_NAME" -- tee /tmp/payload.json >/dev/null
 
 echo "Sending $ITERATIONS requests with concurrency $CONCURRENCY..."
-# Tolerate partial failures: a single curl that fails to connect would otherwise
-# propagate up through xargs/kubectl exec under `set -e` and abort the script
-# before we get to the ok/fail accounting and the metrics check below.
 status_log=$(kubectl exec -n "$NAMESPACE" "$CURL_POD_NAME" -- sh -c "
   seq 1 $ITERATIONS | xargs -I{} -P $CONCURRENCY \
     curl -sS --max-time 60 -o /dev/null -w '%{http_code}\n' \
@@ -179,7 +106,6 @@ if [[ "$CURL_EXIT" -ne 0 || -z "$metrics" ]]; then
   exit 1
 fi
 
-# Sum *_count samples across all label combinations for a histogram series.
 sum_histogram_count() {
   echo "$metrics" \
     | awk -v series="${1}_count" '

--- a/.github/scripts/e2e/e2e-validate.sh
+++ b/.github/scripts/e2e/e2e-validate.sh
@@ -43,52 +43,12 @@ if [[ "${VERBOSE}" == "true" ]]; then
   set -x
 fi
 
-# ── Persistent curl pod ─────────────────────────────────────────────────────
-# Use a single long-running curl pod for all requests instead of creating a new
-# pod per request. This avoids repeated pod scheduling, image pulls, and DNS
-# resolution — which previously caused intermittent "Could not resolve host"
-# failures (curl exit 6) under load.
+# ── Shared functions ───────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CURL_POD_NAME="curl-e2e-${RANDOM}-$$"
-CURL_POD_TIMEOUT_SECONDS="${CURL_POD_TIMEOUT_SECONDS:-120}"
-
-setup_curl_pod() {
-  # Delete any leftover pod with the same name (idempotent)
-  kubectl delete pod -n "$NAMESPACE" "$CURL_POD_NAME" \
-    --ignore-not-found >/dev/null 2>&1 || true
-
-  echo "Creating persistent curl pod ${CURL_POD_NAME}..."
-  kubectl run "$CURL_POD_NAME" \
-    --namespace "$NAMESPACE" \
-    --image=curlimages/curl \
-    --restart=Never \
-    -- sleep 3600 >/dev/null
-
-  # Wait for the pod to be ready
-  if ! kubectl wait --for=condition=Ready \
-       pod/"$CURL_POD_NAME" -n "$NAMESPACE" \
-       --timeout="${CURL_POD_TIMEOUT_SECONDS}s"; then
-    echo "Error: curl pod failed to become ready" >&2
-    kubectl describe pod -n "$NAMESPACE" "$CURL_POD_NAME" >&2 2>/dev/null || true
-    exit 1
-  fi
-  echo "Persistent curl pod is ready."
-}
-
-cleanup_curl_pod() {
-  kubectl delete pod -n "$NAMESPACE" "$CURL_POD_NAME" \
-    --ignore-not-found >/dev/null 2>&1 || true
-}
+# shellcheck source=lib-e2e-common.sh
+source "${SCRIPT_DIR}/lib-e2e-common.sh"
 trap cleanup_curl_pod EXIT
-
-# ── Run curl via kubectl exec on the persistent pod ─────────────────────────
-# Usage: run_curl <args…>
-# Sets:  CURL_OUTPUT  — captured stdout
-#        CURL_EXIT    — curl exit code (0 = success)
-run_curl() {
-  CURL_OUTPUT=""
-  CURL_EXIT=0
-  CURL_OUTPUT=$(kubectl exec -n "$NAMESPACE" "$CURL_POD_NAME" -- "$@" 2>&1) || CURL_EXIT=$?
-}
 
 # ── Discover Gateway address ────────────────────────────────────────────────
 HOST="${GATEWAY_HOST:-$(kubectl get gateway -n "$NAMESPACE" \
@@ -104,55 +64,7 @@ SVC_HOST="${HOST}:${PORT}"
 setup_curl_pod
 
 # ── Determine MODEL_ID ──────────────────────────────────────────────────────
-# Priority: command-line > env var > auto-discovery
-if [[ -n "$CLI_MODEL_ID" ]]; then
-  MODEL_ID="$CLI_MODEL_ID"
-elif [[ -n "${MODEL_ID-}" ]]; then
-  MODEL_ID="$MODEL_ID"
-else
-  echo "Attempting to auto-discover model ID from ${SVC_HOST}/v1/models..."
-
-  # Retry logic: wait for EPP to discover backends and gateway to be fully ready
-  MAX_RETRIES=10
-  RETRY_DELAY=10
-  MODEL_ID=""
-
-  for attempt in $(seq 1 $MAX_RETRIES); do
-    echo "Attempt $attempt of $MAX_RETRIES to discover model ID..."
-    run_curl curl -sS --max-time 15 "http://${SVC_HOST}/v1/models"
-    response="$CURL_OUTPUT"
-    ret="$CURL_EXIT"
-
-    # Try to extract model ID from response
-    MODEL_ID=$(echo "$response" | grep -o '"id":"[^"]*"' | head -n 1 | cut -d '"' -f 4) || true
-
-    if [[ -n "$MODEL_ID" ]]; then
-      echo "Successfully discovered model ID: $MODEL_ID"
-      break
-    fi
-
-    # Check if we got a specific error
-    if echo "$response" | grep -q "404\|No healthy upstream\|no endpoints"; then
-      echo "Gateway not ready yet (attempt $attempt): endpoints not available"
-    elif [[ $ret -ne 0 ]]; then
-      echo "Request failed (attempt $attempt, exit code $ret)"
-    else
-      echo "Empty or invalid response (attempt $attempt)"
-    fi
-
-    if [[ $attempt -lt $MAX_RETRIES ]]; then
-      echo "Waiting ${RETRY_DELAY}s before retry..."
-      sleep $RETRY_DELAY
-    fi
-  done
-
-  if [[ -z "$MODEL_ID" ]]; then
-    echo "Error: Failed to auto-discover model ID from gateway after $MAX_RETRIES attempts." >&2
-    echo "Last response: $response" >&2
-    echo "You can specify one using the -m flag or the MODEL_ID environment variable." >&2
-    exit 1
-  fi
-fi
+discover_model
 
 echo "Namespace: $NAMESPACE"
 echo "Inference Gateway:   ${SVC_HOST}"
@@ -209,12 +121,7 @@ done
 echo "✅ All 10 iterations succeeded."
 
 # ── Optional: hand off to a guide-specific validator ────────────────────────
-# When --extra-validate NAME is set, exec into ${SCRIPT_DIR}/e2e-validate-NAME.sh
-# so guides can layer their own checks on top of the standard smoke loop. We
-# release the smoke-test curl pod first (the dispatched script creates its
-# own) and clear the EXIT trap before exec'ing.
 if [[ -n "$EXTRA_VALIDATE" ]]; then
-  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   EXTRA_SCRIPT="${SCRIPT_DIR}/e2e-validate-${EXTRA_VALIDATE}.sh"
   if [[ ! -x "$EXTRA_SCRIPT" ]]; then
     echo "Error: --extra-validate '${EXTRA_VALIDATE}' but ${EXTRA_SCRIPT} is not executable" >&2

--- a/.github/scripts/e2e/lib-e2e-common.sh
+++ b/.github/scripts/e2e/lib-e2e-common.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Shared functions for E2E validation scripts.
+#
+# Callers must set NAMESPACE and CURL_POD_NAME before sourcing.
+# Callers own trap registration (call cleanup_curl_pod in their own trap).
+
+CURL_POD_TIMEOUT_SECONDS="${CURL_POD_TIMEOUT_SECONDS:-120}"
+
+setup_curl_pod() {
+  kubectl delete pod -n "$NAMESPACE" "$CURL_POD_NAME" \
+    --ignore-not-found >/dev/null 2>&1 || true
+
+  echo "Creating persistent curl pod ${CURL_POD_NAME}..."
+  kubectl run "$CURL_POD_NAME" \
+    --namespace "$NAMESPACE" \
+    --image=curlimages/curl \
+    --restart=Never \
+    -- sleep 3600 >/dev/null
+
+  if ! kubectl wait --for=condition=Ready \
+       pod/"$CURL_POD_NAME" -n "$NAMESPACE" \
+       --timeout="${CURL_POD_TIMEOUT_SECONDS}s"; then
+    echo "Error: curl pod failed to become ready" >&2
+    kubectl describe pod -n "$NAMESPACE" "$CURL_POD_NAME" >&2 2>/dev/null || true
+    exit 1
+  fi
+  echo "Persistent curl pod is ready."
+}
+
+cleanup_curl_pod() {
+  kubectl delete pod -n "$NAMESPACE" "$CURL_POD_NAME" \
+    --ignore-not-found >/dev/null 2>&1 || true
+}
+
+# Usage: run_curl <args...>
+# Sets:  CURL_OUTPUT  — captured stdout
+#        CURL_EXIT    — curl exit code (0 = success)
+run_curl() {
+  CURL_OUTPUT=""
+  CURL_EXIT=0
+  CURL_OUTPUT=$(kubectl exec -n "$NAMESPACE" "$CURL_POD_NAME" -- "$@" 2>&1) || CURL_EXIT=$?
+}
+
+# Discover the EPP service ClusterIP for standalone-mode guides.
+# Sets: HOST, SVC_HOST, EPP_HOST, EPP_METRICS_URL
+# Requires: NAMESPACE, EPP_METRICS_PORT, EPP_HOST_OVERRIDE (optional)
+discover_epp_service() {
+  HOST="${GATEWAY_HOST:-}"
+  if [[ -z "$HOST" ]]; then
+    local epp_svc_name
+    epp_svc_name=$(kubectl get svc -n "$NAMESPACE" \
+        -o jsonpath='{.items[*].metadata.name}' 2>/dev/null \
+        | tr ' ' '\n' | grep -E -- '-epp$' | head -1 || true)
+    if [[ -n "$epp_svc_name" ]]; then
+      HOST=$(kubectl get svc "$epp_svc_name" -n "$NAMESPACE" \
+        -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)
+    fi
+  fi
+  if [[ -z "$HOST" ]]; then
+    echo "Error: could not discover EPP service in namespace '$NAMESPACE'." >&2
+    echo "       Set GATEWAY_HOST env var to the EPP service name or ClusterIP." >&2
+    exit 1
+  fi
+  SVC_HOST="${HOST}:80"
+  EPP_HOST="${EPP_HOST_OVERRIDE:-$HOST}"
+  EPP_METRICS_URL="http://${EPP_HOST}:${EPP_METRICS_PORT}/metrics"
+}
+
+# Auto-discover model ID with retries.
+# Sets: MODEL_ID
+# Requires: SVC_HOST, CURL_POD_NAME, NAMESPACE
+# Respects: CLI_MODEL_ID (takes priority), MODEL_ID env var
+discover_model() {
+  if [[ -n "${CLI_MODEL_ID:-}" ]]; then
+    MODEL_ID="$CLI_MODEL_ID"
+    return
+  fi
+  if [[ -n "${MODEL_ID-}" ]]; then
+    return
+  fi
+  echo "Attempting to auto-discover model ID from ${SVC_HOST}/v1/models..."
+
+  local max_retries=10 retry_delay=10 attempt response ret
+  MODEL_ID=""
+
+  for attempt in $(seq 1 $max_retries); do
+    echo "Attempt $attempt of $max_retries to discover model ID..."
+    run_curl curl -sS --max-time 15 "http://${SVC_HOST}/v1/models"
+    response="$CURL_OUTPUT"
+    ret="$CURL_EXIT"
+
+    MODEL_ID=$(echo "$response" | grep -o '"id":"[^"]*"' | head -n 1 | cut -d '"' -f 4) || true
+
+    if [[ -n "$MODEL_ID" ]]; then
+      echo "Successfully discovered model ID: $MODEL_ID"
+      return
+    fi
+
+    if echo "$response" | grep -q "404\|No healthy upstream\|no endpoints"; then
+      echo "Gateway not ready yet (attempt $attempt): endpoints not available"
+    elif [[ $ret -ne 0 ]]; then
+      echo "Request failed (attempt $attempt, exit code $ret)"
+    else
+      echo "Empty or invalid response (attempt $attempt)"
+    fi
+
+    if [[ $attempt -lt $max_retries ]]; then
+      echo "Waiting ${retry_delay}s before retry..."
+      sleep $retry_delay
+    fi
+  done
+
+  echo "Error: Failed to auto-discover model ID after $max_retries attempts." >&2
+  echo "Last response: $response" >&2
+  echo "You can specify one using the -m flag or the MODEL_ID environment variable." >&2
+  exit 1
+}

--- a/.github/workflows/slash-test-nightly.yaml
+++ b/.github/workflows/slash-test-nightly.yaml
@@ -568,7 +568,7 @@ jobs:
             if (isTemp) {
               lines.push(
                 '',
-                '> Temp branch will be cleaned up automatically within 24 hours.',
+                '> Temp branch has been cleaned up.',
               );
             }
 
@@ -578,6 +578,25 @@ jobs:
               issue_number: prNumber,
               body: lines.join('\n'),
             });
+
+      - name: Delete temp branch
+        if: always() && steps.branch.outputs.is_temp == 'true'
+        uses: actions/github-script@v9
+        env:
+          BRANCH_REF: ${{ steps.branch.outputs.ref }}
+        with:
+          script: |
+            const ref = process.env.BRANCH_REF;
+            try {
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `heads/${ref}`,
+              });
+              console.log(`Deleted temp branch: ${ref}`);
+            } catch (e) {
+              console.log(`Warning: failed to delete temp branch ${ref}: ${e.message}`);
+            }
 
       - name: Post failure comment
         if: failure() && steps.parse.outputs.result == 'ok' && steps.perm.outputs.result == 'ok'


### PR DESCRIPTION
- Create lib-e2e-common.sh with shared curl-pod, EPP discovery, and model discovery functions used across all 3 validation scripts
- Refactor e2e-validate, predicted-latency, and flow-control scripts to source the shared library
- Delete temp branches immediately after /test-nightly dispatch instead of waiting for the daily cleanup cron