### PR TITLE
chore: remove explicit --vllm-port=8200 from sidecar configs

### DIFF
--- a/guides/agentic-serving/modelserver/gpu/vllm/nemotron-3-ultra/base/patch-decode.yaml
+++ b/guides/agentic-serving/modelserver/gpu/vllm/nemotron-3-ultra/base/patch-decode.yaml
@@ -11,7 +11,6 @@ spec:
           image: ghcr.io/llm-d/llm-d-router-disagg-sidecar:main
           args:
             - --port=8000
-            - --vllm-port=8200
             - --kv-connector=nixlv2
             - --zap-log-level=4
             - --secure-proxy=false

--- a/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/patch-decode.yaml
+++ b/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/patch-decode.yaml
@@ -10,7 +10,6 @@ spec:
         - name: routing-proxy
           args:
             - --port=8000
-            - --vllm-port=8200
             - --kv-connector=nixlv2
             - --ec-connector=ec-nixl
             - --zap-log-level=1

--- a/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-pd/base/patch-decode.yaml
+++ b/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-pd/base/patch-decode.yaml
@@ -11,7 +11,6 @@ spec:
           imagePullPolicy: Always
           args:
             - --port=8000
-            - --vllm-port=8200
             - --kv-connector=nixlv2
             - --ec-connector=ec-nixl
             - --zap-log-level=1

--- a/guides/pd-disaggregation/modelserver/gpu/vllm-ds/disaggregatedset.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm-ds/disaggregatedset.yaml
@@ -179,7 +179,6 @@ spec:
                   imagePullPolicy: Always
                   args:
                     - --port=8000
-                    - --vllm-port=8200
                     - --kv-connector=nixlv2
                     - --zap-log-level=1
                     - --secure-proxy=false

--- a/guides/recipes/modelserver/base/single-host/pd/sglang/patch-sidecar.yaml
+++ b/guides/recipes/modelserver/base/single-host/pd/sglang/patch-sidecar.yaml
@@ -9,7 +9,6 @@ spec:
         - name: routing-proxy
           args:
             - --port=8000
-            - --vllm-port=8200
             - --kv-connector=sglang
             - --zap-log-level=1
             - --secure-proxy=false

--- a/guides/recipes/modelserver/base/single-host/pd/vllm/patch-sidecar.yaml
+++ b/guides/recipes/modelserver/base/single-host/pd/vllm/patch-sidecar.yaml
@@ -9,7 +9,6 @@ spec:
         - name: routing-proxy
           args:
             - --port=8000
-            - --vllm-port=8200
             - --kv-connector=nixlv2
             - --zap-log-level=1
             - --secure-proxy=false

--- a/guides/wide-ep-lws/modelserver/gpu/vllm-deepseek-v4/base/decode.yaml
+++ b/guides/wide-ep-lws/modelserver/gpu/vllm-deepseek-v4/base/decode.yaml
@@ -24,7 +24,6 @@ spec:
           - name: routing-proxy
             args:
               - --port=8000
-              - --vllm-port=8200
               - --kv-connector=nixlv2
               - --zap-log-level=1
               - --secure-proxy=false

--- a/guides/wide-ep-lws/modelserver/gpu/vllm/base/decode.yaml
+++ b/guides/wide-ep-lws/modelserver/gpu/vllm/base/decode.yaml
@@ -27,11 +27,10 @@ spec:
         initContainers:
           - name: routing-proxy
             args:
-              # sidecar proxy is started with --port 8000, --vllm-port 8200, and --data-parallel-size 8,
+              # sidecar proxy is started with --port 8000 and --data-parallel-size 8,
               # so it listens on ports in the range [port:port+data-parallel-size-1] and forwards
               # requests each to the corresponding vllm port.
               - --port=8000
-              - --vllm-port=8200
               - --data-parallel-size=8
               - --kv-connector=nixlv2
               - --zap-log-level=1

--- a/guides/wide-ep-lws/modelserver/xpu/vllm/decode.yaml
+++ b/guides/wide-ep-lws/modelserver/xpu/vllm/decode.yaml
@@ -31,7 +31,6 @@ spec:
           - name: routing-proxy
             args:
               - --port=8000
-              - --vllm-port=8200
               - --kv-connector=nixlv2
               - --zap-log-level=1
               - --secure-proxy=false


### PR DESCRIPTION

## What

Remove the now-redundant `--vllm-port=8200` from all routing-sidecar configs.

## Why

- llm-d/llm-d-router#1723 changed the disagg sidecar's `--vllm-port` default  from 8001 to 8200 (`defaultVLLMPort` in `pkg/sidecar/proxy/options.go`), so  the explicit flag is a no-op.
- Across all guides, every decode server paired with a sidecar listens on 8200,  so the flag is not needed anywhere. 