### PR TITLE
chore(typos): clear nightly typo-scan false positives

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -5,3 +5,4 @@ AKS = "AKS"     # Azure Kubernetes Service
 aks = "aks"      # Azure Kubernetes Service (lowercase)
 IST = "IST"      # Indian Standard Time (used in benchmark timestamps)
 ND = "ND"        # Azure VM SKU prefix (e.g., Standard_ND96asr_v4)
+ahd = "ahd"      # SVG arrowhead marker id in diagram HTML

--- a/guides/pd-disaggregation/router/pd-disaggregation.values.yaml
+++ b/guides/pd-disaggregation/router/pd-disaggregation.values.yaml
@@ -9,7 +9,7 @@ router:
     # Single EPP replica: the inflight-load-producer's in-flight token accounting
     # (which the token-load-scorer and affinity filter consume) is local to each
     # EPP process, so multiple replicas would each see only a fraction of the
-    # per-endpoint load and mis-gate the affinity filter.
+    # per-endpoint load and incorrectly gate the affinity filter.
     replicas: 1
     pluginsConfigFile: "pd-config.yaml"
     pluginsCustomConfig:


### PR DESCRIPTION
# Notes
- 'mis-gate' in pd-disaggregation.values.yaml: intentional prefix use; reword to 'incorrectly gate' so the comment reads plainly.
- 'ahd' in the async-processing multitenant diagram: an SVG arrowhead marker id, not prose; add it to _typos.toml.

fix https://github.com/llm-d/llm-d/issues/2095

cc @clubanderson
