### PR TITLE
Update docs to reflect 60s default metrics polling interval

### DIFF
--- a/docs/well-lit-paths/foundations/optimized-baseline.md
+++ b/docs/well-lit-paths/foundations/optimized-baseline.md
@@ -32,7 +32,7 @@ EPP maintains a view of each endpoints' prefix-cache state in memory. When a req
 
 ### Load-Aware Scheduling
 
-EPP continuously probes each endpoints' metrics by scraping `/metrics` at a regular interval (50ms default). It scores endpoints on queue depth, running requests, and KV-cache utilization to schedule requests to the endpoint with the lowest load, avoiding hotspots caused by heterogeneous request patterns.
+EPP continuously probes each endpoints' metrics by scraping `/metrics` at a regular interval (60s default). It scores endpoints on queue depth, running requests, and KV-cache utilization to schedule requests to the endpoint with the lowest load, avoiding hotspots caused by heterogeneous request patterns.
 
 <p align="center">
   <picture>

--- a/docs/well-lit-paths/workloads/multimodal-serving.md
+++ b/docs/well-lit-paths/workloads/multimodal-serving.md
@@ -65,7 +65,7 @@ For incoming requests the router breaks the tokenized input into blocks and matc
 
 ### Load-Aware Routing
 
-EPP continuously probes each endpoints' metrics by scraping `/metrics` at a regular interval (50ms default). It scores endpoints on queue depth, running requests, and KV-cache utilization to schedule requests to the endpoint with the lowest load, avoiding hotspots caused by heterogeneous request patterns.
+EPP continuously probes each endpoints' metrics by scraping `/metrics` at a regular interval (60s default). It scores endpoints on queue depth, running requests, and KV-cache utilization to schedule requests to the endpoint with the lowest load, avoiding hotspots caused by heterogeneous request patterns.
 
 ---
 

--- a/guides/flow-control/tuning.md
+++ b/guides/flow-control/tuning.md
@@ -151,7 +151,7 @@ The `headroom` parameter allows the scheduler to temporarily bypass the strict c
 
 The EPP provides two saturation detectors, each optimized for different traffic profiles.
 
-* **`utilization-detector` (Default / Closed-Loop):** Reacts to the true physical state of the hardware (KV cache utilization, engine queue depth). Because it measures actual memory footprint rather than just request counts, it is highly accurate and the best choice for heterogeneous hardware pools or workloads with highly variable context lengths. It relies on a periodic (50ms) telemetry scrape interval and is optimized for sustained, organic traffic.
+* **`utilization-detector` (Default / Closed-Loop):** Reacts to the true physical state of the hardware (KV cache utilization, engine queue depth). Because it measures actual memory footprint rather than just request counts, it is highly accurate and the best choice for heterogeneous hardware pools or workloads with highly variable context lengths. It relies on a periodic (60s) telemetry scrape interval and is optimized for sustained, organic traffic.
 * **`concurrency-detector` (Open-Loop):** Evaluates capacity using zero-latency optimistic accounting of in-flight requests. Because it does not wait for engine telemetry, its instantaneous reaction time makes it a great choice for workloads that experience sudden, massive traffic bursts.
 
 ## ⚠️ Operational Notes


### PR DESCRIPTION
The 50ms default causes excessive memory allocations from the Prometheus TextParser on every scrape cycle, leading to potentail OOM errors. By default, none of the plugins recommended in the [optimized baseline](https://github.com/llm-d/llm-d/tree/main/guides/optimized-baseline) use the scraped metrics, with the exception of `KVCacheBlockSize`, which is constant. Therefore, it makes sense to increase the polling interval to 60s, to prevent memory strains.

This PR only updates documentation, whereas [this](https://github.com/llm-d/llm-d-router/pull/2195) PR on`llm-d-router` updates defaults.