### PR TITLE
Add guides for 1p1d dp=ep=8, tp=1 for DSV3, runs only MORI-IO and intra node Wide-EP

### DIFF
--- a/guides/pd-disaggregation/modelserver/amd/vllm/moriio/README.md
+++ b/guides/pd-disaggregation/modelserver/amd/vllm/moriio/README.md
@@ -1,0 +1,163 @@
+# AMD / vLLM / MoRI-IO P/D Disaggregation Overlay
+
+Single-pod **1P1D** P/D disaggregation overlay for **DeepSeek-V3** on AMD
+Instinct GPUs, using the **MoRI-IO** KV-transfer connector (RDMA WRITE) and
+the **MoRI-EP** Wide-EP all-to-all backend (**DP=8, EP=8, TP=1**).
+
+This is the MoRI-IO companion to the sibling NIXL overlay at `../base/`.
+Use this overlay when you want RDMA-Write KV transfer (MoRI-IO) instead of
+NIXL/UCX, and Wide-EP MoE expert parallelism inside a single pod instead of
+cross-pod TP.
+
+Validated on **AMD Instinct MI355X, ROCm 7.2.3** (Pensando/Ionic RDMA NICs
+exposed as `amd.com/vnic`), with the latest tested llm-d + vLLM stack.
+
+## Layout
+
+Follows the same `base/` + `amd-ci/` split as the sibling NIXL overlay:
+
+```
+moriio/
+├── base/        # the real, tested MoRI-IO config
+│   ├── kustomization.yaml
+│   ├── patch-prefill.yaml
+│   ├── patch-decode.yaml
+│   └── patch-sidecar.yaml
+└── amd-ci/      # thin CI/cluster overlay on ../base
+    └── kustomization.yaml
+```
+
+## Topology
+
+| Role    | Replicas | TP | DP | EP        | KV connector                    | all2all backend        |
+| ------- | -------- | -- | -- | --------- | ------------------------------- | ---------------------- |
+| Prefill | 1        | 1  | 8  | enabled   | `MoRIIOConnector` (kv_producer) | `mori_high_throughput` |
+| Decode  | 1        | 1  | 8  | enabled   | `MoRIIOConnector` (kv_consumer) | `mori_low_latency`     |
+
+Each pod consumes 8 GPUs on a single node; vLLM runs 8 data-parallel ranks
+locally with one OpenAI front-end per rank (`--api-server-count=8`). The
+routing sidecar in front of the decode pod hashes each request's UUID with
+blake2s and routes both the prefill and decode leg to the same DP rank, so a
+single conversation stays affinitised to one (P, D) rank pair.
+
+## Default configuration
+
+| Setting                     | Value                                                              |
+| --------------------------- | ----------------------------------------------------------------- |
+| Model                       | `deepseek-ai/DeepSeek-V3` served from local PVC `/models/DeepSeek-V3` |
+| Parallelism                 | TP=1, DP=8, EP enabled (Wide-EP)                                   |
+| KV connector                | `MoRIIOConnector`, WRITE mode (`VLLM_MORIIO_CONNECTOR_READ_MODE=0`) |
+| Networking                  | Pod networking (Calico) + Multus `amd-host-device-nad` ×8 + `amd.com/vnic: 8` |
+| cudagraph                   | prefill `PIECEWISE`, decode `FULL_DECODE_ONLY`                     |
+| AITER                       | MoE, RMSNorm, **MLA** enabled; paged-attn off                     |
+| Weights                     | offline, local PVC (`HF_HUB_OFFLINE=1`, no HF token)              |
+| ZMQ registration proxy      | not used (peer discovery via the routing sidecar)                 |
+
+Nothing about DP, TP, EP, or the model is hard-coded inside vLLM or
+`llm-d-router`; everything above is either a CLI flag or an env var, so this
+overlay can be cloned and re-tuned (e.g. DP=4 for half-pod runs) without
+touching binaries.
+
+## How it differs from `../base/` (NIXL)
+
+The sibling NIXL overlay runs Llama-3.3-70B-Instruct-FP8-KV with the upstream
+`NixlConnector` (`kv_role=kv_both`). This overlay adapts the recipe base to:
+
+1. **Model**: `deepseek-ai/DeepSeek-V3` (~700 GiB MoE) served offline from a PVC.
+2. **Connector**: `MoRIIOConnector` with split `kv_producer` / `kv_consumer`
+   roles (NIXL uses `kv_both`), WRITE mode.
+3. **Parallelism**: TP=1, DP=8, EP enabled, with a **role-specific MoRI
+   all-to-all backend** — prefill `mori_high_throughput` (`InterNodeV1`),
+   decode `mori_low_latency` (`InterNodeV1LL`). The legacy single-name `mori`
+   backend was split upstream; do **not** use it here.
+4. **Networking / RDMA**: **pod networking** (not `hostNetwork`). The RDMA NIC
+   is requested via `amd.com/vnic: 8` and the host RDMA netdevs are injected
+   into the pod netns with Multus (`default/amd-host-device-nad`, one per vnic).
+   This is what makes inter-node MoRI-IO RoCE work; `hostNetwork` + `rdma/ib`
+   is **not** required.
+5. **Routing sidecar**: extra CLI flags (`--moriio-write-mode`,
+   `--moriio-dp-size=8`, `--moriio-tp-size=1`, `--moriio-parallel-dispatch`,
+   `--moriio-local-pod-ip=$(POD_IP)`) plus a `POD_IP` downward-API env var. The
+   sidecar image must be a `llm-d-router` build that supports these flags and
+   the renamed `--kv-connector` flag.
+
+## Fixes baked into this overlay (validated during bring-up)
+
+- **RDMA netdevs via Multus** (`amd-host-device-nad` ×8): without them
+  `ibv_modify_qp(RTR)` fails with `No such device` on inter-node KV transfer.
+- **`VLLM_ROCM_USE_SKINNY_GEMM=0`**: the tested vLLM image overlays the MoRI-IO
+  Python (PR #45043) on a base `_rocm_C.abi3.so` that does not export
+  `wvSplitK`; disabling skinny-GEMM avoids an ABI ImportError (unquantized
+  layers fall back to torch `F.linear`; FP8 block-scale MoE still uses AITER).
+- **Sidecar `--kv-connector`**: the tested sidecar build renamed the old
+  `--connector` flag to `--kv-connector`.
+- **No ZMQ proxy**: `proxy_ip` is left unset, so the connector's heartbeat
+  thread never starts; peer discovery is done entirely by the routing sidecar.
+
+## Required overrides
+
+`base/kustomization.yaml` pins the two validated private image tags. Swap them
+for your own registry/tags via `kustomize edit set image`:
+
+| Image reference                 | Set to                                                                 |
+| ------------------------------- | ---------------------------------------------------------------------- |
+| `REPLACE_MODEL_SERVER_IMAGE`    | A vLLM ROCm image with MoRI-IO + MoRI-EP compiled in (see the vLLM PR adding MoRI-IO + MoRI-EP). |
+| `REPLACE_ROUTING_SIDECAR_IMAGE` | A `llm-d-router` build that accepts the `--moriio-*` and `--kv-connector` CLI flags. |
+
+```bash
+cd guides/pd-disaggregation/modelserver/amd/vllm/moriio/base
+kustomize edit set image \
+  REPLACE_MODEL_SERVER_IMAGE=<your-registry>/<vllm-rocm-moriio-image>:<tag> \
+  REPLACE_ROUTING_SIDECAR_IMAGE=<your-registry>/<llm-d-router-image>:<tag>
+```
+
+## Prerequisites on the cluster
+
+- AMD Instinct GPU nodes with 8 GPUs per node and an RDMA NIC exposed via the
+  `amd.com/vnic` device plugin, plus a Multus `NetworkAttachmentDefinition`
+  named `amd-host-device-nad` in the `default` namespace.
+- AMD GPU operator providing `amd.com/gpu`.
+- Pre-staged DeepSeek-V3 weights on an RWX PVC named `deepseek-v3-weights`,
+  mounted read-only at `/models/DeepSeek-V3` (this overlay runs fully offline;
+  no HF token is required).
+- If your MoRI-IO images live in a private registry, an image pull secret in
+  the target namespace attached to the model-server ServiceAccount. Add it in
+  a small per-cluster overlay on top of `base/` (see "Required overrides").
+
+See `../../../../prerequisites/` for cluster-bring-up details that apply to all
+P/D guides.
+
+## Quickstart
+
+```bash
+# Pin your images first (see "Required overrides"), then deploy the CI overlay:
+kustomize build guides/pd-disaggregation/modelserver/amd/vllm/moriio/amd-ci \
+  | kubectl apply -f -
+```
+
+Drive traffic at the decode pod's `Service` on port 8000 (the routing-proxy
+initContainer); it forwards to vLLM on 8200 after the MoRI-IO handshake
+completes.
+
+## Verifying the deployment
+
+```bash
+kubectl -n llm-d get pods
+# Expect: pd-disaggregation-rocm-moriio-vllm-prefill-* Running
+#         pd-disaggregation-rocm-moriio-vllm-decode-*  Running
+
+kubectl -n llm-d logs -l llm-d.ai/role=prefill --tail=50 \
+  | grep -E 'all2all-backend|MoRIIOConnector|engine ready'
+# Expect: --all2all-backend mori_high_throughput, kv_role=kv_producer
+
+kubectl -n llm-d logs -l llm-d.ai/role=decode --tail=50 \
+  | grep -E 'all2all-backend|MoRIIOConnector'
+# Expect: --all2all-backend mori_low_latency, kv_role=kv_consumer
+```
+
+## Tear down
+
+```bash
+kustomize build guides/pd-disaggregation/modelserver/amd/vllm/moriio/amd-ci \
+  | kubectl delete -f - --ignore-not-found
+```

--- a/guides/pd-disaggregation/modelserver/amd/vllm/moriio/amd-ci/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/vllm/moriio/amd-ci/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Thin CI/cluster overlay on top of ../base, mirroring the sibling
+# ../../amd-ci convention. The MoRI-IO base already carries the full
+# tested config (pod networking + Multus amd-host-device-nad + amd.com/vnic,
+# private image tags, offline PVC weights), so this overlay is a passthrough
+# by default. Add CI-only concerns here (runner nodeSelector/labels, a
+# storageClass pin for the RWX weights PVC, or `kustomize edit set image`
+# retags) without touching the base.
+resources:
+  - ../base

--- a/guides/pd-disaggregation/modelserver/amd/vllm/moriio/base/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/vllm/moriio/base/kustomization.yaml
@@ -1,0 +1,104 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# MoRI-IO + Wide-EP base overlay for the AMD/vLLM P/D disaggregation guide.
+#
+# Single-pod 1P1D DeepSeek-V3 deployment, validated on AMD Instinct
+# MI355X (ROCm 7.2.3) with:
+#   - Tensor-parallel  = 1
+#   - Data-parallel    = 8        (intra-pod, "Wide-EP")
+#   - Expert-parallel  = enabled  (DP * TP = 8)
+#   - vLLM kv_connector = MoRIIOConnector  (RDMA WRITE of KV blocks
+#     between prefill and decode pods, instead of NIXL).
+#   - Routing sidecar  = llm-d-router with the --moriio-* flags so the
+#     proxy emits MoRI-IO-shaped kv_transfer_params and pins both legs
+#     of every disagg pair to the same DP rank H = blake2s(uuid).
+#
+# Networking: pod networking (Calico), NOT hostNetwork. The Pensando/
+# Ionic RDMA NICs are exposed via the `amd.com/vnic` device plugin and
+# the host RDMA netdevs are injected into the pod netns via Multus
+# (default/amd-host-device-nad, one per vnic). This is the exact config
+# proven by the inter-node MoRI-IO RoCE bring-up; hostNetwork + rdma/ib
+# is NOT required.
+#
+# This is the connector-specific "real" config, analogous to the sibling
+# ../../base/ (NIXL). Cluster/CI-specific concerns (pull secrets, runner
+# pins, storage class) can layer on top via ../amd-ci/.
+
+resources:
+  - ../../../../../../recipes/modelserver/base/single-host/pd/vllm
+  # NOTE: no ZMQ registration proxy. The MoRIIOConnector only starts its
+  # heartbeat thread when `proxy_ip` is set (moriio_connector.py:
+  # `if self._rank==0 and proxy_ip`). In the llm-d P/D path, peer
+  # discovery is done by the routing sidecar (remote_host = decode POD_IP
+  # injected into kv_transfer_params), so `proxy_ip` is left unset and the
+  # proxy is not deployed.
+
+namePrefix: pd-disaggregation-rocm-moriio-vllm-
+
+# Image references come from the shared components (same pattern as the
+# sibling NIXL ../../base). These pin PUBLIC placeholder defaults:
+#   - amd-vllm       -> ghcr.io/llm-d/llm-d-rocm
+#   - routing-sidecar -> ghcr.io/llm-d/llm-d-router-disagg-sidecar
+# MoRI-IO requires a vLLM ROCm image with MoRI-IO + MoRI-EP compiled in and a
+# llm-d-router sidecar build that supports the --moriio-* / --kv-connector
+# flags, which the public defaults do NOT provide. Override both in a
+# per-cluster overlay or via `kustomize edit set image` before deploying
+# (see README "Required overrides").
+components:
+  - ../../../../../../recipes/modelserver/components/images/amd-vllm
+  - ../../../../../../recipes/modelserver/components/images/routing-sidecar
+
+labels:
+  - pairs:
+      llm-d.ai/model: DeepSeek-V3
+      llm-d.ai/guide: pd-disaggregation
+      llm-d.ai/accelerator-variant: gpu
+      llm-d.ai/accelerator-vendor: amd
+      llm-d.ai/kv-connector: moriio
+      inference.networking.k8s.io/engine-type: vllm
+    includeSelectors: true
+    includeTemplates: true
+    fields:
+      - version: v1
+        kind: ServiceAccount
+        path: metadata/labels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: metadata/labels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: spec/selector/matchLabels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: spec/template/metadata/labels
+        create: true
+      - group: monitoring.coreos.com
+        version: v1
+        kind: PodMonitor
+        path: metadata/labels
+        create: true
+      - group: monitoring.coreos.com
+        version: v1
+        kind: PodMonitor
+        path: spec/selector/matchLabels
+        create: true
+
+patches:
+  - path: patch-prefill.yaml
+  - path: patch-decode.yaml
+  # patch-sidecar overrides the recipe-default routing-proxy patch
+  # (recipes/.../vllm/patch-sidecar.yaml) with the MoRI-IO sidecar
+  # image and the additional --moriio-* CLI flags. Targets the decode
+  # Deployment by name (only decode runs the routing sidecar in P/D
+  # disagg).
+  - path: patch-sidecar.yaml
+    target:
+      kind: Deployment
+      name: decode

--- a/guides/pd-disaggregation/modelserver/amd/vllm/moriio/base/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/vllm/moriio/base/patch-decode.yaml
@@ -1,0 +1,142 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        # Multus: attach 8 host RDMA netdevs into the pod netns (one per vnic).
+        # REQUIRED for inter-node MoRI-IO RoCE (see prefill patch).
+        k8s.v1.cni.cncf.io/networks: >-
+          default/amd-host-device-nad,
+          default/amd-host-device-nad,
+          default/amd-host-device-nad,
+          default/amd-host-device-nad,
+          default/amd-host-device-nad,
+          default/amd-host-device-nad,
+          default/amd-host-device-nad,
+          default/amd-host-device-nad
+    spec:
+      # Pod networking (Calico) + amd.com/vnic RDMA, as on prefill.
+      containers:
+        - name: modelserver
+          command: ["vllm", "serve"]
+          args:
+            - "/models/DeepSeek-V3"
+            - "--served-model-name=deepseek-ai/DeepSeek-V3"
+            - "--disable-uvicorn-access-log"
+            - "--tensor-parallel-size=1"
+            - "--data-parallel-size=8"
+            - "--data-parallel-size-local=8"
+            - "--api-server-count=8"
+            - "--enable-expert-parallel"
+            # Decode is latency-bound: MoRI low-latency InterNodeV1LL.
+            - "--all2all-backend=mori_low_latency"
+            - "--block-size=16"
+            - "--gpu-memory-utilization=0.75"
+            - "--kv-cache-memory-bytes=20000000000"
+            - "--no-enable-prefix-caching"
+            - "--max-model-len=32768"
+            - "--compilation-config"
+            # Full cudagraph for pure-decode batches -> biggest TPOT win.
+            - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
+            - "--kv-transfer-config"
+            # WRITE-mode consumer. proxy_ip omitted (no ZMQ proxy).
+            - '{"kv_connector":"MoRIIOConnector","kv_role":"kv_consumer","kv_connector_extra_config":{"http_port":"8200","handshake_port":"6301","notify_port":"61005"}}'
+            # vLLM listens on 8200; the routing-proxy initContainer fronts 8000.
+            - "--port=8200"
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HF_HUB_OFFLINE
+              value: "1"
+            - name: TRANSFORMERS_OFFLINE
+              value: "1"
+            - name: VLLM_MORIIO_CONNECTOR_READ_MODE
+              value: "0"
+            - name: VLLM_ENGINE_READY_TIMEOUT_S
+              value: "7200"
+            - name: VLLM_ROCM_USE_AITER
+              value: "1"
+            - name: VLLM_ROCM_USE_AITER_MOE
+              value: "1"
+            - name: VLLM_ROCM_USE_AITER_PAGED_ATTN
+              value: "0"
+            - name: VLLM_ROCM_USE_AITER_RMSNORM
+              value: "1"
+            # AITER MLA enabled (faster DeepSeek MLA attention kernel).
+            - name: VLLM_ROCM_USE_AITER_MLA
+              value: "1"
+            # See prefill patch: base image _rocm_C.so lacks wvSplitK; disable
+            # skinny-GEMM so unquantized layers use torch F.linear.
+            - name: VLLM_ROCM_USE_SKINNY_GEMM
+              value: "0"
+            - name: MORI_SHMEM_HEAP_SIZE
+              value: "17179869184"
+            - name: HSA_ENABLE_SDMA
+              value: "1"
+            - name: HSA_FORCE_FINE_GRAIN_PCIE
+              value: "1"
+          ports:
+            - containerPort: 8200
+              name: vllm
+              protocol: TCP
+            - containerPort: 6301
+              name: mori-handshake
+              protocol: TCP
+            - containerPort: 61005
+              name: mori-notify
+              protocol: TCP
+          resources:
+            limits:
+              cpu: "200"
+              memory: 1500Gi
+              amd.com/gpu: "8"
+              amd.com/vnic: "8"
+            requests:
+              cpu: "200"
+              memory: 1500Gi
+              amd.com/gpu: "8"
+              amd.com/vnic: "8"
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["IPC_LOCK", "SYS_PTRACE", "NET_RAW"]
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /.cache
+              name: torch-compile-cache
+            - mountPath: /models
+              name: weights
+              readOnly: true
+          startupProbe:
+            httpGet: { path: /v1/models, port: 8200 }
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 240
+          livenessProbe:
+            httpGet: { path: /health, port: 8200 }
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet: { path: /v1/models, port: 8200 }
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 12
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Gi
+        - name: torch-compile-cache
+          emptyDir: {}
+        - name: weights
+          persistentVolumeClaim:
+            claimName: deepseek-v3-weights

--- a/guides/pd-disaggregation/modelserver/amd/vllm/moriio/base/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/vllm/moriio/base/patch-prefill.yaml
@@ -1,0 +1,160 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prefill
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        # Multus: attach the 8 host RDMA netdevs (Pensando/Ionic) into the pod
+        # netns via the amd-host-device NAD, one per amd.com/vnic. REQUIRED for
+        # inter-node MoRI-IO RoCE: without it the RDMA device has no netdev/GID
+        # in the pod and ibv_modify_qp(RTR) fails with "No such device". This is
+        # the exact config proven by the mori-io-0/1 inter-node bring-up.
+        k8s.v1.cni.cncf.io/networks: >-
+          default/amd-host-device-nad,
+          default/amd-host-device-nad,
+          default/amd-host-device-nad,
+          default/amd-host-device-nad,
+          default/amd-host-device-nad,
+          default/amd-host-device-nad,
+          default/amd-host-device-nad,
+          default/amd-host-device-nad
+    spec:
+      # Pod networking (Calico). This cluster exposes the Pensando/Ionic RDMA
+      # NICs via the `amd.com/vnic` device plugin (NOT `rdma/ib` + hostNetwork),
+      # exactly like the proven mori-io-0/1 bring-up. The KV handshake/notify
+      # control channels ride pod IPs; the KV data path rides the vnic RDMA.
+      containers:
+        - name: modelserver
+          command: ["vllm", "serve"]
+          args:
+            # Weights are pre-staged on the deepseek-v3-weights PVC, mounted at
+            # /models. Serve locally (no HF Hub); keep the advertised model id.
+            - "/models/DeepSeek-V3"
+            - "--served-model-name=deepseek-ai/DeepSeek-V3"
+            - "--disable-uvicorn-access-log"
+            - "--tensor-parallel-size=1"
+            # Wide-EP: 8 DP ranks all local to this single pod, one OAI
+            # front-end per rank.
+            - "--data-parallel-size=8"
+            - "--data-parallel-size-local=8"
+            - "--api-server-count=8"
+            - "--enable-expert-parallel"
+            # Prefill is throughput-bound: MoRI high-throughput InterNodeV1.
+            - "--all2all-backend=mori_high_throughput"
+            - "--block-size=16"
+            - "--gpu-memory-utilization=0.75"
+            - "--kv-cache-memory-bytes=20000000000"
+            - "--no-enable-prefix-caching"
+            - "--max-model-len=32768"
+            - "--compilation-config"
+            # cudagraph enabled. Prefill has variable seqlens -> PIECEWISE
+            # (captures around attention); decode uses FULL_DECODE_ONLY.
+            - '{"cudagraph_mode":"PIECEWISE"}'
+            - "--kv-transfer-config"
+            # WRITE-mode producer. proxy_ip intentionally omitted (no ZMQ proxy);
+            # peer discovery is via the routing sidecar on the request path.
+            - '{"kv_connector":"MoRIIOConnector","kv_role":"kv_producer","kv_connector_extra_config":{"http_port":"8000","handshake_port":"6301","notify_port":"61005"}}'
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            # Fully offline: weights are local, no HF Hub calls, no token needed.
+            - name: HF_HUB_OFFLINE
+              value: "1"
+            - name: TRANSFORMERS_OFFLINE
+              value: "1"
+            # MoRIIOConnector WRITE mode ("0" == not READ).
+            - name: VLLM_MORIIO_CONNECTOR_READ_MODE
+              value: "0"
+            # DP=8 AITER JIT warm-up + weight load headroom.
+            - name: VLLM_ENGINE_READY_TIMEOUT_S
+              value: "7200"
+            - name: VLLM_ROCM_USE_AITER
+              value: "1"
+            - name: VLLM_ROCM_USE_AITER_MOE
+              value: "1"
+            - name: VLLM_ROCM_USE_AITER_PAGED_ATTN
+              value: "0"
+            - name: VLLM_ROCM_USE_AITER_RMSNORM
+              value: "1"
+            # AITER MLA enabled (faster DeepSeek MLA attention kernel).
+            - name: VLLM_ROCM_USE_AITER_MLA
+              value: "1"
+            # Disable the ROCm skinny-GEMM custom ops (wvSplitK/wvSplitKrc).
+            # Our vLLM image overlays PR#45043 Python source on top of the base
+            # image's compiled _rocm_C.abi3.so, which does NOT export wvSplitK.
+            # Skinny-GEMM off => rocm_unquantized_gemm falls back to torch
+            # F.linear (unquantized layers only; FP8 block-scale MoE still uses
+            # the JIT-compiled AITER a8w8 blockscale path).
+            - name: VLLM_ROCM_USE_SKINNY_GEMM
+              value: "0"
+            - name: HSA_ENABLE_SDMA
+              value: "1"
+            - name: HSA_FORCE_FINE_GRAIN_PCIE
+              value: "1"
+            # MoRI symmetric shmem heap (16 GiB) for the EP all2all path.
+            - name: MORI_SHMEM_HEAP_SIZE
+              value: "17179869184"
+          ports:
+            - containerPort: 8000
+              name: vllm
+              protocol: TCP
+            - containerPort: 6301
+              name: mori-handshake
+              protocol: TCP
+            - containerPort: 61005
+              name: mori-notify
+              protocol: TCP
+          resources:
+            limits:
+              cpu: "200"
+              memory: 1500Gi
+              amd.com/gpu: "8"
+              amd.com/vnic: "8"
+            requests:
+              cpu: "200"
+              memory: 1500Gi
+              amd.com/gpu: "8"
+              amd.com/vnic: "8"
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["IPC_LOCK", "SYS_PTRACE", "NET_RAW"]
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /.cache
+              name: torch-compile-cache
+            - mountPath: /models
+              name: weights
+              readOnly: true
+          startupProbe:
+            httpGet: { path: /v1/models, port: 8000 }
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 240
+          livenessProbe:
+            httpGet: { path: /health, port: 8000 }
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet: { path: /v1/models, port: 8000 }
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 12
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Gi
+        - name: torch-compile-cache
+          emptyDir: {}
+        - name: weights
+          persistentVolumeClaim:
+            claimName: deepseek-v3-weights

--- a/guides/pd-disaggregation/modelserver/amd/vllm/moriio/base/patch-sidecar.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/vllm/moriio/base/patch-sidecar.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: routing-proxy
+          # The sidecar image comes from the routing-sidecar component
+          # (REPLACE_ROUTING_SIDECAR_IMAGE). MoRI-IO needs a llm-d-router
+          # build that supports the --moriio-* / --kv-connector flags below,
+          # which the public default does NOT provide - override the image in
+          # a per-cluster overlay or via `kustomize edit set image`.
+          imagePullPolicy: IfNotPresent
+          # Strategic-merge replaces (does not append to) the args
+          # list, so re-emit the recipe defaults plus the MoRI-IO
+          # flags. Keep in sync with
+          # recipes/modelserver/base/single-host/pd/vllm/patch-sidecar.yaml.
+          args:
+            - --port=8000
+            - --vllm-port=8200
+            # NOTE: our sidecar build (llm-d-router llmd_leader_worker_clean_2p2d
+            # branch) renamed --connector -> --kv-connector.
+            - --kv-connector=nixlv2
+            - --zap-log-level=1
+            - --secure-proxy=false
+            # MoRI-IO WRITE-mode toggle. When set, the prefill leg of
+            # buildKVTransferParamsForPrefill emits the full
+            # remote_host / remote_notify_port / remote_dp_rank /
+            # remote_handshake_port / "tx"-prefixed transfer_id tuple
+            # that vLLM's MoRIIOConnector WRITE branch requires.
+            - --moriio-write-mode
+            # Wide-EP shape: blake2s(uuid) -> rank in [0, dp-size) and
+            # both legs of every disagg pair pin to that rank. dp-size
+            # MUST match the vLLM --data-parallel-size on prefill and
+            # decode (8 in this overlay).
+            - --moriio-dp-size=8
+            - --moriio-tp-size=1
+            # Concurrent prefill/decode dispatch: fire both legs in
+            # parallel goroutines so decode block-allocation overlaps
+            # with prefill compute. Off-by-default in the sidecar;
+            # opt in here because WRITE-mode does not depend on
+            # prefill-supplied kv_transfer_params and is safe to
+            # parallelise.
+            - --moriio-parallel-dispatch
+            # Pod IP that prefill should RDMA-write KV blocks back
+            # to. Read at startup from the POD_IP env var below; if
+            # left empty / 127.0.0.1 the prefill engine would
+            # handshake with itself and hang.
+            - --moriio-local-pod-ip=$(POD_IP)
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          ports:
+            - containerPort: 8000
+              name: sidecar
+              protocol: TCP
+          resources: {}
+          restartPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true


### PR DESCRIPTION
Single-pod 1P1D P/D disaggregation overlay for DeepSeek-V3 on AMD Instinct using the MoRI-IO KV connector (RDMA WRITE) and MoRI-EP Wide-EP backend (intra node ep) (DP=8, EP=8, TP=1). Follows the sibling NIXL overlay's base/ + amd-ci/ split.