### PR TITLE
fix: FMA guide fixes for benchmark nightly errors

### DIFF
--- a/guides/fast-model-actuation/README.md
+++ b/guides/fast-model-actuation/README.md
@@ -132,7 +132,8 @@ kubectl apply -n ${NAMESPACE} -f ${REPO_ROOT}/guides/${GUIDE_NAME}/rbac/role.yam
 kubectl create rolebinding fma-launcher-pod-reader \
   --role=fma-launcher-pod-reader \
   --serviceaccount=${NAMESPACE}:default \
-  -n ${NAMESPACE}
+  -n ${NAMESPACE} \
+  --dry-run=client -o yaml | kubectl apply -f -
 ```
 <!-- guide:deploy.rbac end -->
 
@@ -176,7 +177,7 @@ Apply the FMA custom resources — `InferenceServerConfig`, `LauncherConfig`, an
 ```bash
 kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/
 
-kubectl wait --for=condition=ready pod -l app=fma-requester -n ${NAMESPACE} --timeout=300s
+kubectl rollout status deployment/fma-requester -n ${NAMESPACE} --timeout=300s
 ```
 <!-- guide:deploy.modelserver end -->
 
@@ -233,7 +234,7 @@ kubectl scale deployment fma-requester -n ${NAMESPACE} --replicas=0
 
 kubectl scale deployment fma-requester -n ${NAMESPACE} --replicas=2
 
-kubectl wait --for=condition=ready pod -l app=fma-requester -n ${NAMESPACE} --timeout=120s
+kubectl rollout status deployment/fma-requester -n ${NAMESPACE} --timeout=120s
 ```
 <!-- guide:verify.tests.sleep_wake end -->
 
@@ -290,20 +291,31 @@ llmdbenchmark \
 
 ## Cleanup
 
-To remove all deployed components:
+To remove all deployed components. **Order matters:** delete the model-server
+CRs and the requester Deployment first, then wait for the requester and launcher
+pods to drain while the dual-pods controller is still running to strip their
+finalizers, and only then remove the controllers. Removing the controller before
+the pods drain leaves finalizer-bound pods stuck in `Terminating` forever.
 
 <!-- guide:cleanup start -->
 ```bash
 kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/ --ignore-not-found=true
 
-helm uninstall ${GUIDE_NAME} -n ${NAMESPACE}
+kubectl wait --for=delete pod -l app=fma-requester -n ${NAMESPACE} --timeout=120s
+
+kubectl wait --for=delete pod -l app.kubernetes.io/component=launcher -n ${NAMESPACE} --timeout=120s
 
 helm uninstall ${FMA_CHART_INSTANCE_NAME} -n ${NAMESPACE}
 
-kubectl delete -f ${REPO_ROOT}/guides/${GUIDE_NAME}/rbac/clusterrole.yaml --ignore-not-found=true
+helm uninstall ${GUIDE_NAME} -n ${NAMESPACE}
 
+kubectl delete -f ${REPO_ROOT}/guides/${GUIDE_NAME}/rbac/clusterrole.yaml --ignore-not-found=true
+```
+<!-- llm-d-cicd:skip start -->
+```bash
 kubectl delete namespace ${NAMESPACE}
 
 kubectl delete crd inferenceserverconfigs.fma.llm-d.ai launcherconfigs.fma.llm-d.ai launcherpopulationpolicies.fma.llm-d.ai
 ```
+<!-- llm-d-cicd:skip end -->
 <!-- guide:cleanup end -->

--- a/guides/fast-model-actuation/guide.yaml
+++ b/guides/fast-model-actuation/guide.yaml
@@ -61,7 +61,8 @@ deploy:
         kubectl create rolebinding fma-launcher-pod-reader \
           --role=fma-launcher-pod-reader \
           --serviceaccount=${NAMESPACE}:default \
-          -n ${NAMESPACE}
+          -n ${NAMESPACE} \
+          --dry-run=client -o yaml | kubectl apply -f -
 
   fma_controllers:
     - run: |
@@ -90,7 +91,7 @@ deploy:
     - run: |
         kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/
 
-        kubectl wait --for=condition=ready pod -l app=fma-requester -n ${NAMESPACE} --timeout=300s
+        kubectl rollout status deployment/fma-requester -n ${NAMESPACE} --timeout=300s
 
 verify:
   endpoint:
@@ -108,7 +109,7 @@ verify:
     sleep_wake:
       - run: kubectl scale deployment fma-requester -n ${NAMESPACE} --replicas=0
       - run: kubectl scale deployment fma-requester -n ${NAMESPACE} --replicas=2
-      - run: kubectl wait --for=condition=ready pod -l app=fma-requester -n ${NAMESPACE} --timeout=120s
+      - run: kubectl rollout status deployment/fma-requester -n ${NAMESPACE} --timeout=120s
 
 benchmark:
   setup:
@@ -134,10 +135,23 @@ benchmark:
           --analyze
 
 cleanup:
-  # Removes the model-server CRs AND the requester Deployment (both are part of modelserver/).
+  # Order matters. Delete the model-server CRs and the requester Deployment
+  # FIRST (both live in modelserver/): this unbinds the requester/provider
+  # pairs and tells the dual-pods controller to tear down the launcher pods.
   - run: kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/ --ignore-not-found=true
-  - run: helm uninstall ${GUIDE_NAME} -n ${NAMESPACE}
+  # Then wait for the requester and launcher pods to fully drain while the
+  # controller is still running to strip their finalizers. If the controller
+  # is removed first, finalizer-bound pods get stuck in Terminating forever.
+  - run: kubectl wait --for=delete pod -l app=fma-requester -n ${NAMESPACE} --timeout=120s
+  - run: kubectl wait --for=delete pod -l app.kubernetes.io/component=launcher -n ${NAMESPACE} --timeout=120s
+  # Only after the pods have drained, remove the controllers (dual-pods
+  # controller + launcher populator), then the router and the cluster-scoped RBAC.
   - run: helm uninstall ${FMA_CHART_INSTANCE_NAME} -n ${NAMESPACE}
+  - run: helm uninstall ${GUIDE_NAME} -n ${NAMESPACE}
   - run: kubectl delete -f ${REPO_ROOT}/guides/${GUIDE_NAME}/rbac/clusterrole.yaml --ignore-not-found=true
-  - run: kubectl delete namespace ${NAMESPACE}
-  - run: kubectl delete crd inferenceserverconfigs.fma.llm-d.ai launcherconfigs.fma.llm-d.ai launcherpopulationpolicies.fma.llm-d.ai
+  # Destructive / cluster-wide -- skipped in CI, where the namespace is reused
+  # and the FMA CRDs are shared across deployments. Run only on a cluster you own.
+  - skip_in: [ci]
+    run: kubectl delete namespace ${NAMESPACE}
+  - skip_in: [ci]
+    run: kubectl delete crd inferenceserverconfigs.fma.llm-d.ai launcherconfigs.fma.llm-d.ai launcherpopulationpolicies.fma.llm-d.ai

--- a/guides/fast-model-actuation/modelserver/gpu/vllm/base/kustomization.yaml
+++ b/guides/fast-model-actuation/modelserver/gpu/vllm/base/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# DETECTION-ONLY overlay -- NOT part of the FMA standup.
+#
+# The llm-d-benchmark CI ("Apply overrides to kustomize manifests" step) runs
+#   kubectl kustomize modelserver/<accelerator>/<backend>/.../base
+# and reads the served model from a Deployment's container args. FMA's real
+# model is declared in an InferenceServerConfig (../../../inferenceserverconfig.yaml),
+# which has no container args, so that step cannot detect it and fails.
+#
+# This overlay exists ONLY to satisfy that model auto-detection: it emits a
+# tiny, never-scheduled Deployment (replicas: 0) whose args carry the served
+# model name. The flat modelserver/kustomization.yaml does NOT reference this
+# directory, so `kubectl apply -k modelserver/` (the actual standup) never
+# applies it. Keep the model here in sync with inferenceserverconfig.yaml.
+resources:
+  - model-detect.yaml

--- a/guides/fast-model-actuation/modelserver/gpu/vllm/base/model-detect.yaml
+++ b/guides/fast-model-actuation/modelserver/gpu/vllm/base/model-detect.yaml
@@ -1,0 +1,20 @@
+# DETECTION-ONLY stub -- see kustomization.yaml.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fma-model-detect
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: fma-model-detect
+  template:
+    metadata:
+      labels:
+        app: fma-model-detect
+    spec:
+      containers:
+        - name: model-detect
+          image: registry.k8s.io/pause:3.10
+          args:
+            - Qwen/Qwen3-0.6B


### PR DESCRIPTION
Four small fixes to the FMA guide so it (hopefully) passes the benchmark nightly.

- Cleanup ordering: delete the CRs + requester Deployment first, wait for the requester/launcher pods to drain while the dual-pods controller is still up to strip their finalizers, then uninstall the controllers.
- Requester readiness: standupnow use `kubectl rollout status deployment/fma-requester` instead of `kubectl wait --for=condition=ready pod -l app=fma-requester`. The label-based wait times out when a flaky GPU leaves an admission-failed ghost pod behind...rollout status tracks the Deployment, so it's immune to that.
- `kubectl delete namespace / kubectl delete crd` are wrapped in `<!-- llm-d-cicd:skip -->` so the benchmark CI (shared cluster) skips the destructive/cluster-wide deletes.
- RBAC: `fma-launcher-pod-reader` RoleBinding is now created via `kubectl create … --dry-run=client -o yaml | kubectl apply -f -`, so a re-run no longer fails with "already exists".
- CI model detection: adds a `modelserver/gpu/vllm/base/` overlay so the benchmark's kustomize-based model auto-detection succeeds for FMA (whose model lives in an InferenceServerConfig, not a vLLM Deployment).

- [x] README is regenerated from guide.yaml via `guide-render.py`
- [x] guide-check-yaml, guide-check-readme, and guide-render checks

🤖 Generated with Claude Code (https://claude.com/claude-code)