### PR TITLE
docs(async): fix unconsumable quickstart payload in the async guides

### DIFF
--- a/guides/asynchronous-processing/gcp-pubsub/README.md
+++ b/guides/asynchronous-processing/gcp-pubsub/README.md
@@ -76,8 +76,13 @@ For deployment instructions, please refer to the [main README](../README.md#inst
 
 1. **Publish a message**:
 
+   Requests are consumed as an `InternalRequest` envelope: a `request_kind` tag
+   (`pubsub` for Pub/Sub) wrapping the caller-visible request under `data`. Note
+   that `deadline` and `created` are Unix-seconds **numbers**, not strings — a
+   quoted `deadline` fails to decode.
+
    ```bash
-   gcloud pubsub topics publish $REQUEST_TOPIC_NAME --message='{"id" : "testmsg", "payload":{ "model":"your-model", "prompt":"Hi, good morning "}, "deadline" :"1999999999" }'
+   gcloud pubsub topics publish $REQUEST_TOPIC_NAME --message='{"request_kind":"pubsub","internal":{},"data":{"id":"testmsg","created":1700000000,"deadline":1999999999,"payload":{"model":"your-model","prompt":"Hi, good morning"}}}'
    ```
 
 2. **Pull from results subscription**:

--- a/guides/asynchronous-processing/redis/README.md
+++ b/guides/asynchronous-processing/redis/README.md
@@ -54,12 +54,17 @@ For deployment instructions, please refer to the [main README](../README.md#inst
 
 2. **Publish a message using Redis CLI**:
 
+   Requests are consumed as an `InternalRequest` envelope: a `request_kind` tag
+   (`redis` for the sorted-set queue) wrapping the caller-visible request under
+   `data`. Note that `deadline` and `created` are Unix-seconds **numbers**, not
+   strings — a quoted `deadline` fails to decode.
+
    ```bash
    export REDIS_IP=$(kubectl get svc -n redis redis-master -o jsonpath='{.spec.clusterIP}')
    # If you used authentication, pass the password using -a
-   # kubectl run --rm -i -t publishmsgbox --image=redis --restart=Never -- /usr/local/bin/redis-cli -h $REDIS_IP -a $REDIS_PASSWORD ZADD request-sortedset 1999999999 '{"id" : "testmsg", "payload":{ "model":"your-model", "prompt":"Hi, good morning "}, "deadline" :"1999999999" }'
+   # kubectl run --rm -i -t publishmsgbox --image=redis --restart=Never -- /usr/local/bin/redis-cli -h $REDIS_IP -a $REDIS_PASSWORD ZADD request-sortedset 1999999999 '{"request_kind":"redis","internal":{},"data":{"id":"testmsg","created":1700000000,"deadline":1999999999,"payload":{"model":"your-model","prompt":"Hi, good morning"}}}'
    # Otherwise:
-   kubectl run --rm -i -t publishmsgbox --image=redis --restart=Never -- /usr/local/bin/redis-cli -h $REDIS_IP ZADD request-sortedset 1999999999 '{"id" : "testmsg", "payload":{ "model":"your-model", "prompt":"Hi, good morning "}, "deadline" :"1999999999" }'
+   kubectl run --rm -i -t publishmsgbox --image=redis --restart=Never -- /usr/local/bin/redis-cli -h $REDIS_IP ZADD request-sortedset 1999999999 '{"request_kind":"redis","internal":{},"data":{"id":"testmsg","created":1700000000,"deadline":1999999999,"payload":{"model":"your-model","prompt":"Hi, good morning"}}}'
    ```
 
 3. **Check for results**:


### PR DESCRIPTION
## What

Fixes the test payload in both asynchronous-processing quickstarts (`redis/README.md` and `gcp-pubsub/README.md`) so it can actually be consumed by `llm-d-async`.

## Why

The documented message is the first command a new user runs after installing from the guide, and it always fails. Worse, it fails as a *consumer-side* unmarshal error, so the publisher sees a successful `ZADD` / `gcloud pubsub publish` and no indication anything went wrong.

There are two independent decode failures against `llm-d-async` v0.8.0+:

1. **Missing envelope.** `InternalRequest.UnmarshalJSON` decodes a tagged wire format (`internal` / `request_kind` / `data`) and hard-errors with `api: missing required field request_kind` when the tag is absent. The documented payload had no envelope at all.
2. **`deadline` typed as a string.** `api.RequestMessage` declares `Deadline int64`, but the guides quoted `"deadline": "1999999999"`, which fails `json.Unmarshal` even once the envelope is added.

## Change

Both payloads now use the working envelope form — `request_kind: "redis"` for the sorted-set queue, `"pubsub"` for Pub/Sub — matching the shape already exercised by `guides/asynchronous-processing/test/kind-e2e.sh` and by `docs/guides/e2e-deploy.md` in llm-d-async. Each guide also gets a short note that `deadline` and `created` are Unix-seconds numbers rather than strings, since that was the second, non-obvious trap.

Docs-only; no code or manifest changes.

Fixes llm-d/llm-d-async#353
