### PR TITLE
docs: remove monitoring values from default router install commands

### DIFF
--- a/guides/optimized-baseline/README.md
+++ b/guides/optimized-baseline/README.md
@@ -171,6 +171,15 @@ export ROUTER_VALUES="-f ${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.
 > [!NOTE]
 > When following the guide from top to bottom, we already have `export MONITORING_VALUES=""` by default. This means that `monitoring` is disabled by default.
 
+> [!WARNING]
+> Enabling monitoring here requires the monitoring stack to be installed first. The
+> `monitoring.values.yaml` file creates a `ServiceMonitor`, which needs the Prometheus
+> Operator CRDs. Deploying the router with this file before the monitoring stack is ready
+> (see [Step 3: Enable monitoring](#3-optional-enable-monitoring)) will fail with a Helm
+> validation error. If you want monitoring enabled from the start, install the monitoring
+> stack before the router, or leave `MONITORING_VALUES` empty and `helm upgrade` with the
+> monitoring values after Step 3.
+
 #### Standalone Mode
 
 This deploys the llm-d Router in [Standalone Mode](../../docs/architecture/core/router/proxy.md):

--- a/guides/recipes/router/README.md
+++ b/guides/recipes/router/README.md
@@ -12,7 +12,6 @@ Use this when you **do not** want to deploy a proxy via Kubernetes Gateway APIs.
 helm install <release-name> \
   ${ROUTER_STANDALONE_CHART} \
   -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
-  -f ${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml \
   -f ${REPO_ROOT}/guides/<your-guide>/router/<your-guide>.values.yaml \
   --set provider.name=<gke|istio|none> \
   -n ${NAMESPACE} \
@@ -33,12 +32,37 @@ Use this when you want to route traffic through a proxy managed by the Kubernete
 helm install <release-name> \
   ${ROUTER_GATEWAY_CHART} \
   -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
+  -f ${REPO_ROOT}/guides/<your-guide>/router/<your-guide>.values.yaml \
+  --set provider.name=<gke|istio|none> \
+  -n ${NAMESPACE} \
+  --version ${ROUTER_CHART_VERSION}
+```
+
+## Enable Prometheus Monitoring (Optional)
+
+The Router's monitoring values file (`features/monitoring.values.yaml`) renders a
+`ServiceMonitor` CR, which requires the **Prometheus Operator** CRDs to be present in the
+cluster. On a fresh cluster without those CRDs, layering this file onto the initial install
+will fail Helm validation.
+
+To enable monitoring, deploy the monitoring stack first (see the
+[Observability guide](../../../docs/operations/observability/setup.md)) and then layer the
+monitoring values file on top of an existing release:
+
+```bash
+helm upgrade <release-name> \
+  ${ROUTER_STANDALONE_CHART} \
+  -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
   -f ${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml \
   -f ${REPO_ROOT}/guides/<your-guide>/router/<your-guide>.values.yaml \
   --set provider.name=<gke|istio|none> \
   -n ${NAMESPACE} \
   --version ${ROUTER_CHART_VERSION}
 ```
+
+If your cluster already has the Prometheus Operator CRDs installed, you can also add
+`-f ${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml` to the initial
+`helm install` command above instead.
 
 ## Calibration
 


### PR DESCRIPTION
Fixes #2134

The Router README's default install commands layer `features/monitoring.values.yaml`
unconditionally. That values file enables a `ServiceMonitor`, which requires
Prometheus Operator CRDs. On a clean cluster without those CRDs, Helm client-side
validation aborts with:

```text
Error: unable to build kubernetes objects from release manifest: ...
no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
```

Changes:
- Removed the monitoring values file from both default `helm install` commands in
  `guides/recipes/router/README.md`.
- Added an optional "Enable Prometheus Monitoring" section that shows how to
  `helm upgrade` with the monitoring values after the monitoring stack is in place.
- Added a warning in `guides/optimized-baseline/README.md` that enabling
  `MONITORING_VALUES` in Step 1 before Step 3 installs the monitoring stack will
  hit the same validation error.