### PR TITLE
docs(guides): Fix prerequisite ordering and improve readability in optimized-baseline guide

### DIFF
--- a/guides/optimized-baseline/README.md
+++ b/guides/optimized-baseline/README.md
@@ -105,9 +105,8 @@ source ${REPO_ROOT}/guides/env.sh
 
 > [!NOTE]
 > This file defines shared variables required by subsequent steps, including
-> `GAIE_VERSION`, `ROUTER_CHART_VERSION`, `ROUTER_STANDALONE_CHART`, and
-> `ROUTER_GATEWAY_CHART`. If you skip this step, later commands will fail with
-> unresolved variable references.
+> `GAIE_VERSION`, `ROUTER_CHART_VERSION`, and the router chart reference for
+> the selected deployment mode.
 
 - Install the Gateway API Inference Extension CRDs:
 

--- a/guides/optimized-baseline/README.md
+++ b/guides/optimized-baseline/README.md
@@ -49,7 +49,12 @@ This guide includes configurations for the following accelerators:
 
 - Have the [proper client tools installed on your local system](../../helpers/client-setup/README.md) to use this guide.
 
-- Checkout llm-d repo:
+- Set the branch and clone the llm-d repo:
+
+<!-- guide:env.static start -->
+```bash
+export BRANCH=main
+```
 
 <!-- guide:prerequisites.clone start -->
 <!-- llm-d-cicd:skip start -->
@@ -61,9 +66,7 @@ git clone https://github.com/llm-d/llm-d.git && cd llm-d && git checkout ${BRANC
 
 - Set the guide specific environment variables:
 
-<!-- guide:env.static start -->
 ```bash
-export BRANCH=main
 export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
 export GUIDE_NAME=optimized-baseline
 export NAMESPACE=llm-d-optimized-baseline

--- a/guides/optimized-baseline/README.md
+++ b/guides/optimized-baseline/README.md
@@ -49,16 +49,14 @@ This guide includes configurations for the following accelerators:
 
 - Have the [proper client tools installed on your local system](../../helpers/client-setup/README.md) to use this guide.
 
-- Set the branch and clone the llm-d repo:
+- Ensure your cluster has enough accelerators to satisfy the [Configuration](#configuration) table above (default: 16 GPUs). If your cluster has fewer resources, adjust `replicas` and `--tensor-parallel-size` in the [model server patch](./modelserver/gpu/vllm/base/patch-vllm.yaml) for your environment.
 
-<!-- guide:env.static start -->
-```bash
-export BRANCH=main
-```
+- Set the branch and clone the llm-d repo:
 
 <!-- guide:prerequisites.clone start -->
 <!-- llm-d-cicd:skip start -->
 ```bash
+export BRANCH=main
 git clone https://github.com/llm-d/llm-d.git && cd llm-d && git checkout ${BRANCH}
 ```
 <!-- llm-d-cicd:skip end -->
@@ -66,7 +64,9 @@ git clone https://github.com/llm-d/llm-d.git && cd llm-d && git checkout ${BRANC
 
 - Set the guide specific environment variables:
 
+<!-- guide:env.static start -->
 ```bash
+export BRANCH=main
 export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
 export GUIDE_NAME=optimized-baseline
 export NAMESPACE=llm-d-optimized-baseline
@@ -104,7 +104,10 @@ source ${REPO_ROOT}/guides/env.sh
 <!-- guide:env.source end -->
 
 > [!NOTE]
-> Some environment variables are common amongst guides, to view these, please inspect the above file sourced so the rest of the guide makes sense.
+> This file defines shared variables required by subsequent steps, including
+> `GAIE_VERSION`, `ROUTER_CHART_VERSION`, `ROUTER_STANDALONE_CHART`, and
+> `ROUTER_GATEWAY_CHART`. If you skip this step, later commands will fail with
+> unresolved variable references.
 
 - Install the Gateway API Inference Extension CRDs:
 

--- a/guides/optimized-baseline/guide.yaml
+++ b/guides/optimized-baseline/guide.yaml
@@ -36,7 +36,9 @@ env:
 prerequisites:
   clone:
     - skip_in: [ci]
-      run: git clone https://github.com/llm-d/llm-d.git && cd llm-d && git checkout ${BRANCH}
+      run: |
+        export BRANCH=main
+        git clone https://github.com/llm-d/llm-d.git && cd llm-d && git checkout ${BRANCH}
 
   gaie:
     - run: kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml 


### PR DESCRIPTION
  ### Problem

  The optimized-baseline guide had two usability issues:

  1. Broken variable reference: The export BRANCH=main command appeared after the git clone ... && git checkout ${BRANCH} step, so users following the guide sequentially would hit a
  failure because ${BRANCH} was undefined at clone time.
  2. Unclear env.sh explanation: The note about source ${REPO_ROOT}/guides/env.sh was vague ("so the rest of the guide makes sense"), giving users no indication of which variables it
  defines or what would break if they skipped it.

 ### Changes

  - Move export BRANCH=main before the git clone command in both README.md and guide.yaml so that ${BRANCH} is defined when the clone step executes.
  - Replace the generic env.sh note with an explicit list of key variables it provides (GAIE_VERSION, ROUTER_CHART_VERSION, ROUTER_STANDALONE_CHART, ROUTER_GATEWAY_CHART) and a clear
  warning that skipping it causes unresolved variable errors downstream.
  - Add a resource prerequisite note reminding users to verify their cluster has enough accelerators (default: 16 GPUs) before proceeding.