### PR TITLE
ci: add MoRI-IO 1P1D AMD ROCm nightly workflows

### DIFF
--- a/.github/workflows/consolidate-status-pd-disaggregation-moriio-1p1d-amd-ci-acc-rocm-vllm-x.yaml
+++ b/.github/workflows/consolidate-status-pd-disaggregation-moriio-1p1d-amd-ci-acc-rocm-vllm-x.yaml
@@ -1,0 +1,36 @@
+name: Past Status - PD Disaggregation MoRI-IO 1P1D E2E (AMD ROCM)
+
+on:
+  workflow_dispatch:
+    inputs:
+      workflow_name_query:
+        description: 'Name of the workflow to be queried'
+        required: false
+        type: 'string'
+        default: 'nightly-e2e-pd-disaggregation-moriio-1p1d-amd-ci-acc-rocm-vllm-x.yaml'
+      time_window_query:
+        description: 'How many days in the past to query'
+        required: true
+        type: 'string'
+        default: '5'
+      branch_query:
+        description: 'Branch to be queried'
+        required: false
+        type: string
+        default: 'main'
+
+#  push:
+#    branches:
+#      - main
+
+  schedule:
+    - cron: '0 22 * * *'  # 22:00 UTC daily
+
+jobs:
+  check_for_success:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-query-success-past-runs.yaml@main
+    with:
+      workflow_name_query: ${{ inputs.workflow_name_query || 'nightly-e2e-pd-disaggregation-moriio-1p1d-amd-ci-acc-rocm-vllm-x.yaml' }}
+      time_window_query: ${{ inputs.time_window_query || '5' }}
+      branch_query: ${{ inputs.branch_query || 'main' }}
+    secrets: inherit

--- a/.github/workflows/nightly-e2e-pd-disaggregation-moriio-1p1d-amd-ci-acc-rocm-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-moriio-1p1d-amd-ci-acc-rocm-vllm-x.yaml
@@ -1,0 +1,114 @@
+name: Nightly - PD Disaggregation MoRI-IO 1P1D E2E (AMD ROCM)
+
+on:
+  workflow_dispatch:
+    inputs:
+      decode_pods:
+        description: 'Number of decode (vllm "standalone") pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      prefill_pods:
+        description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      connector:
+        description: 'KV connector overlay to deploy ("moriio" for MoRI-IO RDMA-Write, "" for the sibling NIXL overlay)'
+        required: false
+        type: 'string'
+        default: 'moriio'
+      gateway_class:
+        description: 'Class of gateway used ("istio", "agentgateway", "epponly" (i.e., "standalone"), "none")'
+        required: false
+        default: 'epponly'
+      monitoring_enabled:
+        description: 'Enabled monitoring ("true", "false")'
+        required: true
+        type: 'string'
+        default: 'false'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode ("true", "false")'
+        required: false
+        default: 'false'
+      verbose:
+        description: 'Execute workflow in "verbose" mode ("true", "false")'
+        required: false
+        default: 'false'
+        type: 'string'
+      harness:
+        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
+        required: false
+        default: 'inference-perf'
+        type: 'string'
+      workload:
+        description: 'Workload profile to be used during "run" operation (check list under "workload/profiles")'
+        required: false
+        default: 'sanity_random.yaml'
+#        default: 'guide_pd-disaggregation_1.yaml'
+        type: 'string'
+      cleanup:
+        description: 'Cleanup the llm-d stack stood up by this workflow'
+        required: false
+        default: 'true'
+        type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
+
+#  push:
+#    branches:
+#      - main
+
+  schedule:
+    - cron: '0 15 * * *'
+
+permissions:
+  contents: write
+  actions: read
+
+concurrency:
+  group: nightly-e2e-pd-disaggregation-moriio-1p1d-amd
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
+    with:
+      scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
+      standup_method: ${{ inputs.standup_method || 'kustomize' }}
+      standup_scenario: ${{ inputs.standup_scenario || 'pd-disaggregation' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'amd' }}
+      backend_type: ${{ inputs.backend_type || 'vllm' }}
+      infra_provider: ${{ inputs.infra_provider || 'amd-ci' }}
+      connector: ${{ inputs.connector || 'moriio' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-pd-disaggregation-moriio-1p1d-amd-rocm' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-moriio-1p1d-amd' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-moriio-1p1d-amd' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions/pd-disaggregation-moriio-1p1d' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'sanity_random.yaml' }}
+#      workload: ${{ inputs.workload || 'guide_pd-disaggregation_1.yaml' }}
+      cleanup: ${{ inputs.cleanup || 'true' }}
+    secrets: inherit
+
+  update-badge:
+    needs: [nightly]
+    if: always() && inputs.update_badge != 'false'
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
+    with:
+      badge_name: pd-disaggregation-moriio-1p1d-amd
+      badge_label: "VLLM ROCM MoRI-IO 1P1D"
+      result: ${{ needs.nightly.result }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}


### PR DESCRIPTION
Add the nightly E2E and past-status query workflow pair for 1P1D Wide-EP MoRI-IO (DP=8/EP=8/TP=1) pd-disaggregation scenario on AMD MI355X (ROCM).

Crons at 15:00/22:00 UTC to avoid the existing AMD nightly slots.