### PR TITLE
Fix: Prevent SGLang GKE Pods from Stalling on Missing PVCs

### DIFF
--- a/guides/tiered-prefix-cache/modelserver/gpu/sglang/native/fs/gke/patch-sglang.yaml
+++ b/guides/tiered-prefix-cache/modelserver/gpu/sglang/native/fs/gke/patch-sglang.yaml
@@ -15,4 +15,4 @@ spec:
       volumes:
         - name: files-storage
           persistentVolumeClaim:
-            claimName: preprov-pvc
+            claimName: llm-d-kv-cache-storage


### PR DESCRIPTION
No  PersistentVolumeClaim  named  `preprov-pvc`  is defined anywhere in the repository. 
Therefore, referencing  preprov-pvc  in  `guides/tiered-prefix-cache/modelserver/gpu/sglang/native/fs/gke/patch-sglang.yaml`  creates an invalid Deployment configuration.

The GKE patch should instead retain  `llm-d-kv-cache-storage` , the PVC defined in  `guides/tiered-prefix-cache/manifests/pvc.yaml` .

For comparison, the sibling base patch,  `guides/tiered-prefix-cache/modelserver/gpu/sglang/native/fs/base/patch-sglang.yaml` , correctly configures the same  files-storage  volume to use that PVC:

```
volumes:
  - name: files-storage
    persistentVolumeClaim:
      claimName: llm-d-kv-cache-storag
```