### PR TITLE
docs(async/multitenant): render prometheusURL, drop the MODEL_A/MODEL_B placeholders

### DIFF
--- a/guides/asynchronous-processing/multitenant/README.md
+++ b/guides/asynchronous-processing/multitenant/README.md
@@ -98,20 +98,30 @@ This guide layers on the base [asynchronous-processing](../README.md) guide — 
   export IP=$(kubectl get service optimized-baseline-epp -n llm-d-optimized-baseline -o jsonpath='{.spec.clusterIP}')
   export POOL_A=<pool-a> POOL_B=<pool-b>       # InferencePool names (saturation-gate scope)
   export MODEL_A=<model-a> MODEL_B=<model-b>   # served model names (go in payload.model)
+
+  # Scenario C only: the base URL the saturation gates read PromQL from. The default
+  # matches the kube-prometheus-stack install in Observability below; override it if
+  # your Prometheus lives somewhere else.
+  export PROM_URL=http://kps-kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
   ```
 
 ## Configuration and Deployment
 
 The value overlays live in [`values/`](values/) with literal placeholders (`NAMESPACE`, `IGW_HOST`,
-`POOL_A`, `POOL_B`, and — Pub/Sub only — `PROJECT_ID`). Render one for your environment before
-installing:
+`POOL_A`, `POOL_B`, `PROM_URL` on the self-hosted-Prometheus saturation overlays, and — Pub/Sub only —
+`PROJECT_ID`). Render one for your environment before installing:
 
 ```bash
 render() {   # render <overlay-path> -> stdout
   sed -e "s/NAMESPACE/${NAMESPACE}/g" -e "s#IGW_HOST#${IP}#g" \
-      -e "s/POOL_A/${POOL_A}/g" -e "s/POOL_B/${POOL_B}/g" "$1"
+      -e "s/POOL_A/${POOL_A}/g" -e "s/POOL_B/${POOL_B}/g" \
+      -e "s#PROM_URL#${PROM_URL:-http://kps-kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090}#g" "$1"
 }
 ```
+
+`MODEL_A` / `MODEL_B` are **not** overlay placeholders — they never appear in a value, only in
+comments. The served model names reach the system through `payload.model`, which the `publish()`
+helper below fills in from `${MODEL_A}` / `${MODEL_B}`.
 
 ### Redis SortedSet (default)
 
@@ -252,10 +262,36 @@ bringing up [self-hosted Prometheus](#observability), then drive sustained load:
 
 ```bash
 render ${MT}/values/redis/saturation-prometheus.yaml > /tmp/mt-redis-sat.yaml
+grep prometheusURL /tmp/mt-redis-sat.yaml    # must be your Prometheus, not the literal PROM_URL
 helm upgrade async-processor \
     oci://ghcr.io/llm-d/charts/async-processor \
     -f /tmp/mt-redis-sat.yaml -n ${NAMESPACE} --version ${ASYNC_VERSION}
+```
 
+**Confirm the gates can reach Prometheus before you read anything into the result.** The gates are
+`wait-on-refuse(prometheus-query)` with `"fallback":"1"` — a budget of 1 is a wide-open gate, so an
+unreachable Prometheus produces a run that looks perfect and demonstrates nothing.
+
+```bash
+# 1. The URL the gates use resolves and answers, from inside the cluster:
+kubectl run --rm -i promcheck --image=curlimages/curl --restart=Never -n ${NAMESPACE} -- \
+    curl -sS --max-time 5 "${PROM_URL}/api/v1/query?query=up" | head -c 120
+# -> {"status":"success",...}   anything else means the gates are blind
+
+# 2. vLLM is actually being scraped (the metric the gates read):
+kubectl run --rm -i promcheck-vllm --image=curlimages/curl --restart=Never -n ${NAMESPACE} -- \
+    curl -sS --max-time 5 --data-urlencode "query=sum(vllm:num_requests_running{inference_pool=\"${POOL_A}\"})" \
+    "${PROM_URL}/api/v1/query" | head -c 200
+# -> a result with a value; an empty "result":[] means the PodMonitor is not matching
+
+# 3. The processor is not silently falling back:
+kubectl logs -n ${NAMESPACE} deploy/async-processor --tail=200 | grep -i "using fallback value" \
+    && echo ">>> gates are on the fallback budget (1 = wide open), not on live metrics"
+```
+
+Then drive sustained load:
+
+```bash
 publish premium a 200 & publish batch a 200 &   # heavy on model A; keep model B light
 wait
 ```
@@ -266,6 +302,8 @@ keeps dispatching at full rate** (its own gate reads only `POOL_B`). As `model-a
 merge policy drains the highest lanes first. Query each model's budget independently:
 
 ```bash
+# Assumes the kube-prometheus-stack install from Observability below; point this at
+# whatever ${PROM_URL} resolves to if your Prometheus lives elsewhere.
 kubectl port-forward -n monitoring svc/kps-kube-prometheus-stack-prometheus 9090:9090 &
 curl -s localhost:9090/api/v1/query --data-urlencode \
   "query=clamp(1 - sum(vllm:num_requests_running{inference_pool=\"${POOL_A}\"})/20, 0, 1)"   # model-a budget
@@ -333,6 +371,10 @@ Prometheus path reacts within one scrape.
 - **Saturation gate.** These overlays use `prometheus-query` over `vllm:num_requests_running`. The
   `prometheus-saturation` gate instead expects the EPP metric
   `inference_extension_flow_control_pool_saturation`.
+- **An unreachable Prometheus fails open, not closed.** The saturation gates set `"fallback":"1"`, and
+  a budget of 1 is a fully open gate. If `PROM_URL` is wrong, or the vLLM `PodMonitor` matches nothing,
+  Scenario C completes cleanly and demonstrates nothing — no error, no parked pool. Run the three
+  checks in [Scenario C](#scenario-c--priority-under-saturation) before drawing conclusions from a run.
 
 ## Cleanup
 

--- a/guides/asynchronous-processing/multitenant/values/pubsub/quota-only.yaml
+++ b/guides/asynchronous-processing/multitenant/values/pubsub/quota-only.yaml
@@ -1,9 +1,13 @@
 # Values for the multi-tenant Pub/Sub demo — team × tier × MODEL (Scenarios A + B).
 #
 # Replace: PROJECT_ID, NAMESPACE, IGW_HOST (one gateway routing by payload.model to
-# two InferencePools), MODEL_A / MODEL_B, POOL_A / POOL_B (used by the saturation
-# overlay). 6 topics = 3 teams × 2 models; the publisher sends model-a traffic to
-# the *-a subscriptions (payload.model = MODEL_A) and model-b to *-b.
+# two InferencePools), POOL_A / POOL_B (used by the saturation overlay). 6 topics =
+# 3 teams × 2 models; the publisher sends model-a traffic to the *-a subscriptions
+# (payload.model = MODEL_A) and model-b to *-b.
+#
+# MODEL_A / MODEL_B below are the guide's ${MODEL_A} / ${MODEL_B} shell variables,
+# not placeholders in this file: the served model names reach the system through
+# payload.model in the publisher, never through these values.
 #
 #   - MODEL -> its own worker pool (model-a / model-b): independent concurrency and
 #     (saturation overlay) saturation back-off.

--- a/guides/asynchronous-processing/multitenant/values/pubsub/saturation-gmp.yaml
+++ b/guides/asynchronous-processing/multitenant/values/pubsub/saturation-gmp.yaml
@@ -5,8 +5,10 @@
 #  - TEAM quota (redis-quota, classifying, per-model prefix): reserved vs overflow.
 #  - TIER: per-topic label; tier-priority merge policy orders each pool's lanes.
 #
-# PromQL endpoint = the GMP query frontend (manifests/gmp-frontend.yaml).
-# NOTE: GMP/Monarch lags real time ~1-2 min. Replace MODEL_A/MODEL_B, POOL_A/POOL_B.
+# PromQL endpoint = the GMP query frontend (manifests/gmp-frontend.yaml), already
+# scoped to NAMESPACE — no PROM_URL here, unlike the self-hosted Prometheus overlays.
+# NOTE: GMP/Monarch lags real time ~1-2 min.
+# Replace: PROJECT_ID, NAMESPACE, IGW_HOST, POOL_A/POOL_B.
 ap:
 
   messageQueueImpl: "gcp-pubsub-gated"

--- a/guides/asynchronous-processing/multitenant/values/pubsub/saturation-prometheus.yaml
+++ b/guides/asynchronous-processing/multitenant/values/pubsub/saturation-prometheus.yaml
@@ -6,15 +6,18 @@
 #  - TEAM quota (redis-quota, classifying, per-model prefix): reserved vs overflow.
 #  - TIER: per-topic label; tier-priority merge policy orders each pool's lanes.
 #
-# prometheusURL points at the in-cluster kube-prometheus-stack Prometheus; vLLM is
-# scraped by manifests/prometheus-vllm-podmonitor.yaml. Replace MODEL_A/MODEL_B,
-# POOL_A/POOL_B.
+# Replace: PROJECT_ID, NAMESPACE, IGW_HOST, POOL_A/POOL_B, PROM_URL.
+# PROM_URL is the base URL the gates read PromQL from — the in-cluster
+# kube-prometheus-stack Prometheus if you followed the guide's Observability
+# section. Get it wrong and the gates fall back to a budget of 1 (wide open), so
+# the demo runs clean and proves nothing: verify it after the upgrade.
+# vLLM is scraped by manifests/prometheus-vllm-podmonitor.yaml.
 ap:
 
   messageQueueImpl: "gcp-pubsub-gated"
   igwBaseURL: "http://IGW_HOST:80"
 
-  prometheusURL: "http://kps-kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090"
+  prometheusURL: "PROM_URL"
   prometheusCacheTTL: "5s"
 
   requestMergePolicyConfig:

--- a/guides/asynchronous-processing/multitenant/values/redis/quota-only.yaml
+++ b/guides/asynchronous-processing/multitenant/values/redis/quota-only.yaml
@@ -2,9 +2,12 @@
 # Redis SortedSet queue backend.
 #
 # Replace the placeholders: NAMESPACE, IGW_HOST (one inference gateway that routes
-# by payload.model to two InferencePools), MODEL_A / MODEL_B (the two served model
-# names), POOL_A / POOL_B (their InferencePool names — used by the saturation
-# overlay).
+# by payload.model to two InferencePools), POOL_A / POOL_B (the two InferencePool
+# names — used by the saturation overlay).
+#
+# MODEL_A / MODEL_B below are the guide's ${MODEL_A} / ${MODEL_B} shell variables,
+# not placeholders in this file: the served model names reach the system through
+# payload.model in the publisher, never through these values.
 #
 # Three dimensions:
 #   - MODEL  -> its own worker pool (model-a / model-b): independent concurrency

--- a/guides/asynchronous-processing/multitenant/values/redis/saturation-prometheus.yaml
+++ b/guides/asynchronous-processing/multitenant/values/redis/saturation-prometheus.yaml
@@ -9,15 +9,18 @@
 #  - TIER: per-queue label; the tier-priority merge policy orders each pool's
 #    reserved/overflow × tier lanes and stamps x-gateway-priority.
 #
-# Replace: NAMESPACE, IGW_HOST, MODEL_A/MODEL_B, POOL_A/POOL_B (InferencePool names).
-# prometheusURL points at the in-cluster kube-prometheus-stack Prometheus; vLLM is
-# scraped by manifests/prometheus-vllm-podmonitor.yaml.
+# Replace: NAMESPACE, IGW_HOST, POOL_A/POOL_B (InferencePool names), PROM_URL.
+# PROM_URL is the base URL the gates read PromQL from — the in-cluster
+# kube-prometheus-stack Prometheus if you followed the guide's Observability
+# section. Get it wrong and the gates fall back to a budget of 1 (wide open), so
+# the demo runs clean and proves nothing: verify it after the upgrade.
+# vLLM is scraped by manifests/prometheus-vllm-podmonitor.yaml.
 ap:
 
   messageQueueImpl: "redis-sortedset"
   igwBaseURL: "http://IGW_HOST:80"
 
-  prometheusURL: "http://kps-kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090"
+  prometheusURL: "PROM_URL"
   prometheusCacheTTL: "5s"
 
   requestMergePolicyConfig:


### PR DESCRIPTION
Fixes the defect reported in llm-d/llm-d-async#364 (filed there for triage; the code is here).

The multitenant guide's `render()` helper does not cover everything the overlays need, and it lists two placeholders that do not exist.

## 1. `prometheusURL` was hardcoded to the `monitoring` namespace

`values/{redis,pubsub}/saturation-prometheus.yaml` both set:

```yaml
prometheusURL: "http://kps-kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090"
```

with no placeholder, and `render()` did not touch it. The guide's own Observability section installs kube-prometheus-stack into `monitoring`, so the happy path works — but a reader whose Prometheus lives anywhere else gets a URL that resolves to nothing.

**And it fails open, not closed.** The Scenario C gates are `wait-on-refuse(prometheus-query)` with `"fallback":"1"`, and a budget of 1 is a wide-open gate. So an unreachable Prometheus produces a run that completes cleanly, parks nothing, logs no error, and demonstrates nothing.

Now:

```yaml
prometheusURL: "PROM_URL"
```

rendered by `render()`, with the previously-hardcoded URL as the default:

```bash
-e "s#PROM_URL#${PROM_URL:-http://kps-kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090}#g"
```

so **an unset `PROM_URL` reproduces today's behaviour byte-for-byte** — no new failure mode for readers following the guide verbatim. `PROM_URL` is exported in the environment block with that same default.

`values/pubsub/saturation-gmp.yaml` keeps its own URL: it points at the GMP query frontend in `NAMESPACE`, which is already rendered. Its header now says so.

## 2. Make the silent case visible

Scenario C now grep-checks the rendered `prometheusURL`, and after the `helm upgrade` runs three checks before any conclusion is drawn from a run:

1. the URL answers from inside the cluster (`/api/v1/query?query=up`),
2. `vllm:num_requests_running{inference_pool="${POOL_A}"}` is actually present — an empty result means the PodMonitor is not matching,
3. the processor is not logging `using fallback value`.

`Notes & gotchas` gains an entry recording that an unreachable Prometheus fails open.

## 3. `MODEL_A` / `MODEL_B` are not placeholders

All four overlays listed them under `Replace:`. They are not substitutable anywhere:

| overlay | `MODEL_` occurrences | what they are |
| --- | --- | --- |
| `redis/saturation-prometheus.yaml` | 1 | the `Replace:` line itself |
| `pubsub/saturation-prometheus.yaml` | 1 | the `Replace:` line itself |
| `pubsub/saturation-gmp.yaml` | 1 | the `Replace:` line itself |
| `redis/quota-only.yaml` | 4 | `Replace:` line + prose (`payload.model = MODEL_A`) |
| `pubsub/quota-only.yaml` | 4 | `Replace:` line + prose |

Model names reach the system through `payload.model`, which the guide's `publish()` helper fills in from `${MODEL_A}` / `${MODEL_B}`. Dropped from every `Replace:` list; the two quota-only headers and the README now say plainly that they are the guide's shell variables, not overlay placeholders. The explanatory prose is kept.

## Verification

Ran the new `render()` over all four overlays with `PROM_URL` pointed at a different namespace (`llm-d-monitoring`):

- every placeholder resolves — zero occurrences of `PROM_URL`, `POOL_A`, `POOL_B`, `IGW_HOST` remain in any rendered output,
- all four render to valid YAML,
- `ap.prometheusURL` comes out as the overridden URL on both self-hosted overlays, `http://gmp-frontend.llm-d-async.svc.cluster.local:9090` on the GMP overlay, and absent on quota-only,
- with `PROM_URL` unset, `redis/saturation-prometheus.yaml` renders the original hardcoded URL unchanged.

## Note for reviewers

`values/pubsub/saturation-prometheus.yaml` is not referenced anywhere in the README — only `redis/saturation-prometheus.yaml` and `pubsub/saturation-gmp.yaml` are. Pre-existing, out of scope here, but worth a follow-up.

This overlaps #2135, which edits the same `Replace:` header lines in the three saturation overlays to add `SAT_CAP`. Whichever merges second needs a small rebase; happy to do it.
