### PR TITLE
docs(guides): make the multitenant publish() helper burst

### DIFF
--- a/guides/asynchronous-processing/multitenant/README.md
+++ b/guides/asynchronous-processing/multitenant/README.md
@@ -173,16 +173,23 @@ to the **`(team, model)`** queue; the helper takes a team and a model (`a`|`b`).
 
 ```bash
 publish() {                                   # publish <team> <a|b> [count]
-  local team=$1 model=$2 n=${3:-1} now dl member name
+  local team=$1 model=$2 n=${3:-1} ttl=${PUBLISH_TTL:-300} now dl run name i pairs=()
   [ "$model" = a ] && name="$MODEL_A" || name="$MODEL_B"
+  now=$(date +%s); dl=$((now+ttl)); run="${now}-${RANDOM}"
+  # The whole batch goes in one exec — ZADD takes any number of score/member pairs. One exec
+  # per request trickled `publish batch a 100` in over minutes, and the workers drained it as
+  # fast as it arrived: no backlog to classify as overflow. The batch shares a score, so
+  # ZPopMin breaks ties on the member string — the zero-padded index makes that publish order.
   for i in $(seq 1 "$n"); do
-    now=$(date +%s); dl=$((now+300))
-    member=$(printf '{"internal":{},"request_kind":"plain","data":{"id":"%s-%s-%s-%s","created":%s,"deadline":%s,"payload":{"model":"%s","prompt":"summarize this","max_tokens":64},"metadata":{"team":"%s"}}}' \
-      "$team" "$model" "$now" "$i" "$now" "$dl" "$name" "$team")
-    kubectl -n ${NAMESPACE} exec -i deploy/redis -- redis-cli ZADD "team-${team}-${model}" "$dl" "$member" >/dev/null
+    pairs+=("$dl" "$(printf '{"internal":{},"request_kind":"plain","data":{"id":"%s-%s-%s-%04d","created":%s,"deadline":%s,"payload":{"model":"%s","prompt":"summarize this","max_tokens":64},"metadata":{"team":"%s"}}}' \
+      "$team" "$model" "$run" "$i" "$now" "$dl" "$name" "$team")")
   done
+  kubectl -n ${NAMESPACE} exec -i deploy/redis -- redis-cli ZADD "team-${team}-${model}" "${pairs[@]}"
 }
-# e.g.  publish premium a 5    # premium team, model A
+# e.g.  publish premium a 5    # premium team, model A; prints the number enqueued.
+#   PUBLISH_TTL=900 publish batch a 400   # one deadline covers the batch — raise it if a
+#                                         # saturated pool will not drain within 300s.
+# Keep the count in the low thousands: every pair travels in the one exec's argv.
 ```
 
 <details>
@@ -191,15 +198,20 @@ publish() {                                   # publish <team> <a|b> [count]
 <!-- llm-d-cicd:skip start -->
 ```bash
 publish() {                                   # publish <team> <a|b> [count]
-  local team=$1 model=$2 n=${3:-1} now name
+  local team=$1 model=$2 n=${3:-1} ttl=${PUBLISH_TTL:-300} par=${PUBLISH_PAR:-8} now dl run name i
   [ "$model" = a ] && name="$MODEL_A" || name="$MODEL_B"
+  now=$(date +%s); dl=$((now+ttl)); run="${now}-${RANDOM}"
+  # gcloud publishes one message per invocation, so keep `par` of them in flight: serially,
+  # `publish batch a 100` takes minutes and never builds the backlog the scenarios need.
+  # Each invocation is a fresh Python process — lower PUBLISH_PAR if memory is tight.
   for i in $(seq 1 "$n"); do
-    now=$(date +%s)
     gcloud pubsub topics publish "team-${team}-${model}-requests" --project "$PROJECT_ID" \
       --attribute "team=${team}" \
-      --message "$(printf '{"id":"%s-%s-%s-%s","created":%s,"deadline":%s,"payload":{"model":"%s","prompt":"summarize this","max_tokens":64},"metadata":{"team":"%s"}}' \
-        "$team" "$model" "$now" "$i" "$now" "$((now+300))" "$name" "$team")"
+      --message "$(printf '{"id":"%s-%s-%s-%04d","created":%s,"deadline":%s,"payload":{"model":"%s","prompt":"summarize this","max_tokens":64},"metadata":{"team":"%s"}}' \
+        "$team" "$model" "$run" "$i" "$now" "$dl" "$name" "$team")" >/dev/null &
+    (( i % par )) || wait
   done
+  wait
 }
 ```
 <!-- llm-d-cicd:skip end -->


### PR DESCRIPTION
Fixes the defect reported in llm-d/llm-d-async#366 (filed there for triage; the code is here).

`guides/asynchronous-processing/multitenant/README.md` publishes one request per round trip — one `kubectl exec` on Redis, one `gcloud` invocation on Pub/Sub. The scenarios that follow call `publish batch a 100` (Scenario B) and `publish premium a 200 & publish batch a 200` (Scenario C). At roughly a second apiece that is several minutes of enqueue per scenario, and the cost is not just patience:

- **The burst is not a burst.** Scenario B's premise is that batch's flood exceeds its reserved quota of 1 while premium runs within quota. Spread over minutes, the workers drain the queue as fast as the loop fills it, so the backlog the classification is supposed to act on may never form. Scenario C's saturation has the same problem.
- **Concurrent `publish ... &` calls interleave their round trips**, so relative arrival rates are set by exec latency rather than by the counts the scenario asks for.

## Redis — one `ZADD` for the whole batch

`ZADD` takes any number of score/member pairs, so the pairs are built first and sent in one exec:

```bash
pairs+=("$dl" "$(printf '...' ...)")
...
kubectl -n ${NAMESPACE} exec -i deploy/redis -- redis-cli ZADD "team-${team}-${model}" "${pairs[@]}"
```

Same envelope, same key, same score — one round trip instead of *n*. The `>/dev/null` is dropped: the count `ZADD` returns is now one line instead of *n*, and it is the only confirmation the burst landed.

## Pub/Sub — bounded parallelism

`gcloud pubsub topics publish` has no multi-message form, so the invocations run concurrently with `PUBLISH_PAR` (default 8) in flight. Each invocation is a fresh Python process, hence the cap rather than backgrounding all *n*.

The issue only proposed the Redis fix, but the scenarios are backend-agnostic and a reader on the Pub/Sub path hits the identical defect, so fixing one and not the other would leave Scenarios B and C unreproducible on Pub/Sub.

## Two consequences of batching, handled

1. **Shared score.** All members of a batch now carry the same score, so `ZPopMin` breaks ties on the member string rather than on arrival. Zero-padding the index (`%04d`) makes that lexicographic tie-break equal to publish order — previously it was FIFO only by accident, because the loop was slow enough for `date +%s` to tick over.
2. **Shared deadline.** Every request in a batch expires at the same instant instead of getting its own `now+300` as the loop crawled. `PUBLISH_TTL` (default 300 — unchanged) is documented next to the helper so a long Scenario C run can raise it rather than watch the tail return `DEADLINE_EXCEEDED`.

Message ids also gain a per-call `${RANDOM}` token. Without it, two bursts to the same queue within the same second would produce identical members, and the second `ZADD` would silently re-score the first instead of enqueuing anything.

## Verification

No cluster here, so both helpers were extracted from the README and run against stub `kubectl`/`gcloud` binaries that record their argv.

Redis, `publish batch a 200`:

- **1** exec (was 200), 400 pair-args, 49 KB of argv,
- all 200 members parse as JSON, are unique, and sort lexicographically into publish order,
- `deadline` in the payload matches the score; `PUBLISH_TTL=900` propagates.

Scenario B (`publish batch a 100 & publish premium a 20 & publish premium b 20 &`): 3 execs for 140 requests, correct key/team/model on each, globally unique members. Scenario C (`PUBLISH_TTL=900 publish premium a 200 & publish batch a 200 &`): 2 execs for 400 requests. Two back-to-back `publish batch a 3` calls in the same second produce disjoint member sets.

Pub/Sub, with the stub sleeping 300 ms per invocation to stand in for gcloud's startup:

| `PUBLISH_PAR` | wall clock, n=16 | peak concurrent processes |
| --- | --- | --- |
| 1 (serial, old behaviour) | 7s | 1 |
| 4 | 1s | 4 |
| 8 (default) | 1s | 8 |

100 messages: all valid JSON, unique ids, correct topic and `team` attribute.

Both blocks pass `bash -n`, and the array/`local` syntax works on bash 3.2 (macOS) as well as bash 5.

## Note for reviewers

This touches the same README as #2145 (`PROM_URL` in `render()`), though different sections — #2145 edits the env block, `render()`, Scenario C and Notes & gotchas, this one only the two `publish()` blocks. Whichever merges second may need a trivial rebase; happy to do it.
