### PR TITLE
Fix: Bind In-Flight Token Accounting to the Precise Prefix Cache Producer

### DIFF
--- a/guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml
+++ b/guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml
@@ -61,6 +61,8 @@ router:
                 podDiscoveryConfig:
                   socketPort: 5556
           - type: inflight-load-producer
+            parameters:
+              prefixMatchInfoProducerName: precise-prefix-cache-producer
           - type: prefix-cache-affinity-filter
             parameters:
               # Exact resident-block fractions from KV-cache events, not the


### PR DESCRIPTION
The precise-prefix-cache-routing configuration enables only `precise-prefix-cache-producer`, which derives each endpoint’s cache residency from real KV-cache events. However, `inflight-load-producer` was configured without `prefixMatchInfoProducerName`. Its default data key targets `approx-prefix-cache-producer`, which is not enabled in this guide. As a result, the producer cannot find cache-match information and falls back to charging every routed request its full prompt token count, including the portion already present in the selected endpoint’s KV cache.

`inflight-load-producer` should explicitly set `prefixMatchInfoProducerName: precise-prefix-cache-producer`. This makes its cached-prefix discount consume the same exact KV-cache match data as the affinity filter, so in-flight token load reflects only tokens that still require prefill.
