### PR TITLE
fix(ci): correct workflow name queried by precise-prefix-cache GKE TPU status job

### DIFF
--- a/.github/workflows/consolidate-status-precise-prefix-cache-routing-gke-acc-tpu-vllm-x.yaml
+++ b/.github/workflows/consolidate-status-precise-prefix-cache-routing-gke-acc-tpu-vllm-x.yaml
@@ -7,7 +7,7 @@ on:
         description: 'Name of the workflow to be queried'
         required: false
         type: 'string'
-        default: 'nightly-e2e-precise-prefix-cache-routing-gke-acc-tpu-vllm-x.yaml'
+        default: 'nightly-e2e-precise-prefix-cache-gke-acc-tpu-vllm-x.yaml'
       time_window_query:
         description: 'How many days in the past to query'
         required: true
@@ -30,7 +30,7 @@ jobs:
   check_for_success:
     uses: llm-d/llm-d-infra/.github/workflows/reusable-query-success-past-runs.yaml@main
     with:
-      workflow_name_query: ${{ inputs.workflow_name_query || 'nightly-e2e-precise-prefix-cache-routing-gke-acc-tpu-vllm-x.yaml' }}
+      workflow_name_query: ${{ inputs.workflow_name_query || 'nightly-e2e-precise-prefix-cache-gke-acc-tpu-vllm-x.yaml' }}
       time_window_query: ${{ inputs.time_window_query || '5' }}
       branch_query: ${{ inputs.branch_query || 'main' }}
     secrets: inherit


### PR DESCRIPTION
the past status job for the precise prefix cache GKE TPU lane queries nightly-e2e-precise-prefix-cache-routing-gke-acc-tpu-vllm-x.yaml but there is no workflow by that name. its nightly-e2e-precise-prefix-cache-gke-acc-tpu-vllm-x.yaml, without the -routing.

its wrong in both spots, the workflow_dispatch default and the fallback in the with: block. scheduled runs dont pass inputs so they hit the fallback, which means that job has been querying a name that doesnt exist on every 05:00 UTC run and the past status for that lane is meaningless.

@nourey mentioned finding a couple of consolidate-status filename reference issues while looking at #1517, this is one of them. the other one (the .yamll typo on the wide-ep lane) is already fixed on main.

