### PR TITLE
fix(ci): stop tiered-prefix-cache GKE GPU nightly lanes from cancelling each other

### DIFF
--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-lmcache.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-lmcache.yaml
@@ -58,15 +58,17 @@ on:
 #      - main
 
   schedule:
-    - cron: '0 12 * * *'
+    - cron: '0 14 * * *'  # 14:00 UTC daily (staggered after the "native" lane, same namespace)
 
 permissions:
   contents: write
   actions: read
 
 concurrency:
+  # Shared with the "native" lane: both stand up in the same namespace and helm release,
+  # so they must not overlap. Queue the second run instead of cancelling the first.
   group: nightly-e2e-tiered-prefix-cache-gke-gpu
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   nightly:

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-native.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-native.yaml
@@ -58,15 +58,17 @@ on:
 #      - main
 
   schedule:
-    - cron: '0 12 * * *'
+    - cron: '0 12 * * *'  # 12:00 UTC daily (the "lmcache" lane follows at 14:00, same namespace)
 
 permissions:
   contents: write
   actions: read
 
 concurrency:
+  # Shared with the "lmcache" lane: both stand up in the same namespace and helm release,
+  # so they must not overlap. Queue the second run instead of cancelling the first.
   group: nightly-e2e-tiered-prefix-cache-gke-gpu
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   nightly:


### PR DESCRIPTION
#2125 flagged tiered-prefix-cache-gke-cpu-gpu-vllm-native for having 6 of its last 7 scheduled runs cancelled. i think the cause is just in the workflow files.

the native and the lmcache lane both declare concurrency group nightly-e2e-tiered-prefix-cache-gke-gpu with cancel-in-progress: true, and both sit on cron '0 12 * * *'. so they fire together every night and whichever starts second kills the other. its the only duplicated concurrency group in the whole nightly fleet, every other lane has its own.

the shared group looks intentional though. both lanes use the same cluster_namespace, helm_release and workspace_dir and only differ by connector, so they really cant run side by side. so instead of splitting them up i set cancel-in-progress: false on both so the second one queues, and moved lmcache to 14:00 UTC so theyre not racing in the first place. 12:00 already has 5 lanes on it and 14:00 has 1. also left a comment on both files so the shared group doesnt look like a leftover to whoever reads it next.

one thing i didnt touch. both lanes pass the same badge_name (tiered-prefix-cache-gke-cpu-llmcache), so the native lane has no badge of its own and its result ends up on the lmcache one. thats probably the other half of the not producing verdicts thing here, but renaming it makes a badge nothing points at yet so i left it alone. can add it to this PR if you want.


Part of #2125