### PR TITLE
fix(guides): add HF_TOKEN to the optimized-baseline trtllm decode pods

### DIFF
--- a/guides/optimized-baseline/modelserver/gpu/trtllm/base/patch-trtllm.yaml
+++ b/guides/optimized-baseline/modelserver/gpu/trtllm/base/patch-trtllm.yaml
@@ -22,6 +22,13 @@ spec:
             # reads. See extra-llm-api-options-configmap.yaml for the contents.
             - "--extra_llm_api_options=/etc/trtllm/llm_api_options.yaml"
           env:
+            # Mirrors the vLLM/SGLang variants. Without it the container makes
+            # unauthenticated Hub requests, which are rate limited.
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
             - name: HF_HOME
               value: /hf-cache
             # Overriding the container command (above) bypasses the image entrypoint


### PR DESCRIPTION
checked the first next step on #2123, HF_TOKEN doesnt reach the trtllm pod.

patch-trtllm.yaml only sets HF_HOME and LD_LIBRARY_PATH. every other optimized-baseline variant pulls HF_TOKEN off the llm-d-hf-token secret and trtllm is the only one that doesnt, and nothing in guides/recipes injects it either. so the token the job sets stays on the runner, which matches the unauthenticated Hub warning in the container output.

this adds the same env block sglang uses.

not sure its the fatal cause though. Qwen3-32B is public so unauth pulls still work, just rate limited. worth a manual dispatch of the lane to see if it gets past the startup probe.

Part of #2123