### PR TITLE
Fix Stale Kustomize Reference Left Behind by AMD vLLM Base Directory Relocation

### DIFF
--- a/guides/predicted-latency-routing/modelserver/amd/vllm/kustomization.yaml
+++ b/guides/predicted-latency-routing/modelserver/amd/vllm/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../../../optimized-baseline/modelserver/amd/vllm
+  - ../../../../optimized-baseline/modelserver/amd/vllm/base
 
 labels:
   - pairs:


### PR DESCRIPTION
PR #2153 moved `guides/optimized-baseline/modelserver/amd/vllm/kustomization.yaml` to `guides/optimized-baseline/modelserver/amd/vllm/base/kustomization.yaml`. 

`guides/predicted-latency-routing/modelserver/amd/vllm/kustomization.yaml` still references old location, so its resource path must be updated accordingly.
