### PR TITLE
Inject HF_TOKEN into optimized-baseline trtllm decode pods

### DIFF
--- a/guides/optimized-baseline/modelserver/gpu/trtllm/base/patch-trtllm.yaml
+++ b/guides/optimized-baseline/modelserver/gpu/trtllm/base/patch-trtllm.yaml
@@ -22,6 +22,11 @@ spec:
             # reads. See extra-llm-api-options-configmap.yaml for the contents.
             - "--extra_llm_api_options=/etc/trtllm/llm_api_options.yaml"
           env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
             - name: HF_HOME
               value: /hf-cache
             # Overriding the container command (above) bypasses the image entrypoint


### PR DESCRIPTION
The trtllm variant is the only optimized-baseline modelserver patch that doesn't mount the llm-d-hf-token secret, so decode pods were making unauthenticated HF requests and intermittently died to rate limiting before trtllm-serve could bind :8000. This makes it the same as the vllm and sglang patch.

Fixes #2123