### PR TITLE
ci: collapse duplicated platform-parsing steps in build-image

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -63,12 +63,12 @@ jobs:
   detect-changes:
     runs-on: ubuntu-latest
     outputs:
-      cuda: ${{ steps.force.outputs.cuda || steps.platforms-input.outputs.cuda || steps.filter.outputs.cuda || steps.dispatch.outputs.cuda }}
-      aws: ${{ steps.force.outputs.aws || steps.platforms-input.outputs.aws || steps.filter.outputs.aws || steps.dispatch.outputs.aws }}
-      gb200: ${{ steps.force.outputs.gb200 || steps.platforms-input.outputs.gb200 || steps.filter.outputs.gb200 || steps.dispatch.outputs.gb200 }}
-      rocm: ${{ steps.force.outputs.rocm || steps.platforms-input.outputs.rocm || steps.filter.outputs.rocm || steps.dispatch.outputs.rocm }}
-      xpu: ${{ steps.force.outputs.xpu || steps.platforms-input.outputs.xpu || steps.filter.outputs.xpu || steps.dispatch.outputs.xpu }}
-      cpu: ${{ steps.force.outputs.cpu || steps.platforms-input.outputs.cpu || steps.filter.outputs.cpu || steps.dispatch.outputs.cpu }}
+      cuda: ${{ steps.force.outputs.cuda || steps.platforms-input.outputs.cuda || steps.filter.outputs.cuda }}
+      aws: ${{ steps.force.outputs.aws || steps.platforms-input.outputs.aws || steps.filter.outputs.aws }}
+      gb200: ${{ steps.force.outputs.gb200 || steps.platforms-input.outputs.gb200 || steps.filter.outputs.gb200 }}
+      rocm: ${{ steps.force.outputs.rocm || steps.platforms-input.outputs.rocm || steps.filter.outputs.rocm }}
+      xpu: ${{ steps.force.outputs.xpu || steps.platforms-input.outputs.xpu || steps.filter.outputs.xpu }}
+      cpu: ${{ steps.force.outputs.cpu || steps.platforms-input.outputs.cpu || steps.filter.outputs.cpu }}
       rdma-tools: ${{ steps.filter.outputs.rdma-tools }}
     steps:
       - name: Force all platforms
@@ -81,8 +81,10 @@ jobs:
           echo "rocm=true" >> $GITHUB_OUTPUT
           echo "xpu=true" >> $GITHUB_OUTPUT
           echo "cpu=true" >> $GITHUB_OUTPUT
-      - name: Parse platforms input (from workflow_call)
-        if: inputs.force_build != true && inputs.platforms != ''
+      # shim to convert comma-separated platforms input into same boolean outputs as path filter
+      # covers both the workflow_call override and workflow_dispatch
+      - name: Parse platforms input
+        if: inputs.force_build != true && (inputs.platforms != '' || github.event_name == 'workflow_dispatch')
         id: platforms-input
         run: |
           platforms="${{ inputs.platforms }}"
@@ -146,18 +148,6 @@ jobs:
             rdma-tools:
               - 'docker/Dockerfile.rdma-tools'
               - 'docker/common-versions'
-      # shim to convert comma-separated platforms input into same boolean outputs as path filter
-      - name: Parse dispatch platforms
-        if: github.event_name == 'workflow_dispatch'
-        id: dispatch
-        run: |
-          platforms="${{ inputs.platforms }}"
-          echo "cuda=$(echo $platforms | grep -q cuda && echo true || echo false)" >> $GITHUB_OUTPUT
-          echo "aws=$(echo $platforms | grep -q aws && echo true || echo false)" >> $GITHUB_OUTPUT
-          echo "gb200=$(echo $platforms | grep -q gb200 && echo true || echo false)" >> $GITHUB_OUTPUT
-          echo "rocm=$(echo $platforms | grep -q rocm && echo true || echo false)" >> $GITHUB_OUTPUT
-          echo "xpu=$(echo $platforms | grep -q xpu && echo true || echo false)" >> $GITHUB_OUTPUT
-          echo "cpu=$(echo $platforms | grep -q cpu && echo true || echo false)" >> $GITHUB_OUTPUT
 
   cuda-build-llm-d-debug:
     needs: [detect-changes]


### PR DESCRIPTION
## Summary

The `detect-changes` job in `.github/workflows/build-image.yaml` parsed
`inputs.platforms` **twice**, with byte-identical logic, in two separate steps:

| Step | Guard |
| --- | --- |
| `platforms-input` | `inputs.force_build != true && inputs.platforms != ''` |
| `dispatch` | `github.event_name == 'workflow_dispatch'` |

This PR merges them into a single `platforms-input` step and removes the
now-unused `steps.dispatch.outputs.*` references from the job outputs.

Net **-10 lines**, single file touched. No behavior change on any trigger path.

## Why

- **Drift risk.** Adding a new build platform required editing both blocks; it
  was easy to update one and forget the other.
- **Redundant execution.** On a `workflow_dispatch` run both steps executed and
  computed identical values — `platforms-input` simply won `||` precedence in
  the job `outputs:` block. The `dispatch` copy was only ever *decisive* in a
  single case (dispatch with `platforms` cleared to empty), which the merged
  guard covers.

A bash function can't be shared across `run:` steps (each is a fresh shell), so
collapsing the two steps is the way to remove the duplication without adding a
new script file.

## What changed

1. Merged the two steps into one, widening the guard to cover both entry points:

   ```yaml
   if: inputs.force_build != true && (inputs.platforms != '' || github.event_name == 'workflow_dispatch')
   ```

2. Deleted the `dispatch` step; moved its explanatory shim comment onto the
   surviving step.
3. Dropped `|| steps.dispatch.outputs.*` from the six `detect-changes` outputs.

The `grep -q` parsing body is **byte-for-byte unchanged** — this PR is purely
structural, deliberately not folding in any parsing-logic changes.