### PR TITLE
docs: fix broken README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,17 @@ llm-d is a high-performance distributed inference serving stack optimized for pr
 
 llm-d is a [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io/) sandbox project, founded by Red Hat, Google Cloud, IBM Research, CoreWeave, and NVIDIA.
 
-
 ## What does llm-d offer to production inference?
 
 Model servers like [vLLM](https://docs.vllm.ai) and [SGLang](https://github.com/sgl-project/sglang) handle efficiently running large language models on accelerators. llm-d provides state-of-the-art orchestration and optimizations above model servers to serve high-scale real-world traffic efficiently and reliably. Our offerings are organized into four core themes:
 
-* **[Intelligent Routing:](https://llm-d.ai/docs/well-lit-paths/optimized-baseline)** Maximize performance with prefix-cache and load-aware balancing, including experimental predicted latency-based scheduling to decrease latency and increase throughput.
-* **[Advanced KV-Cache Management:](https://llm-d.ai/docs/well-lit-paths/tiered-prefix-cache)** Increase the effective "working set size" for multi-turn requests with tiered offloading to CPU or disk and precise global indexing of the KV cache state.
-* **[Serving Large Models:](https://llm-d.ai/docs/well-lit-paths/wide-expert-parallelism)** Optimize massive models (e.g., DeepSeek-R1, GPT-OSS) using prefill/decode disaggregation and wide expert-parallelism over fast accelerator interconnects.
-* **[Operational Excellence:](https://llm-d.ai/docs/resources/operations)** Ensure production stability with intelligent flow control for multi-tenant serving and proactive, SLO-aware autoscaling based on real-time inference signals.
-* **[Batch Processing:](https://llm-d.ai/docs/well-lit-paths/batch-serving)** Efficiently manage large-scale offline inference with OpenAI-compatible Batch APIs and asynchronous processing to maximize hardware utilization.
+* **[Intelligent Routing:](https://llm-d.ai/docs/well-lit-paths/foundations/optimized-baseline)** Maximize performance with prefix-cache and load-aware balancing, including experimental predicted latency-based scheduling to decrease latency and increase throughput.
+* **[Advanced KV-Cache Management:](https://llm-d.ai/docs/well-lit-paths/foundations/tiered-prefix-cache)** Increase the effective "working set size" for multi-turn requests with tiered offloading to CPU or disk and precise global indexing of the KV cache state.
+* **[Serving Large Models:](https://llm-d.ai/docs/well-lit-paths/foundations/wide-expert-parallelism)** Optimize massive models (e.g., DeepSeek-R1, GPT-OSS) using prefill/decode disaggregation and wide expert-parallelism over fast accelerator interconnects.
+* **[Operational Excellence:](https://llm-d.ai/docs/operations)** Ensure production stability with intelligent flow control for multi-tenant serving and proactive, SLO-aware autoscaling based on real-time inference signals.
+* **[Batch Processing:](https://llm-d.ai/docs/well-lit-paths/workloads/batch-serving)** Efficiently manage large-scale offline inference with OpenAI-compatible Batch APIs and asynchronous processing to maximize hardware utilization.
 
-For a complete list of tested recipes and architectural patterns, see our [well-lit path guides](https://llm-d.ai/docs/guides). These guides provide benchmarked recipes and Helm charts to start serving quickly with best practices common to production deployments. Our intent is to eliminate the heavy lifting common in tuning and deploying generative AI inference on modern accelerators.
+For a complete list of tested recipes and architectural patterns, see our [well-lit path guides](https://llm-d.ai/docs/well-lit-paths). These guides provide benchmarked recipes and Helm charts to start serving quickly with best practices common to production deployments. Our intent is to eliminate the heavy lifting common in tuning and deploying generative AI inference on modern accelerators.
 
 ## Performance Highlights
 
@@ -50,7 +49,7 @@ Explore detailed, reproducible benchmarks on [Prism](https://prism.llm-d.ai).
 Ready to achieve SOTA performance? Follow our [Quickstart Guide](https://llm-d.ai/docs/getting-started/quickstart) to deploy your first optimized inference service on Kubernetes. You'll learn how to set up the llm-d stack, configure the intelligent router, and validate performance with production-ready benchmarks.
 
 > [!TIP]
-> Most users begin with our [Optimized Baseline](https://llm-d.ai/docs/guides/optimized-baseline), which provides a high-performance foundation for a wide range of LLM serving use cases.
+> Most users begin with our [Optimized Baseline](https://llm-d.ai/docs/well-lit-paths/foundations/optimized-baseline), which provides a high-performance foundation for a wide range of LLM serving use cases.
 
 ## Latest News 🔥
 


### PR DESCRIPTION
## Summary

Update seven broken links in the root README to their current llm-d documentation locations.

## Problem

The documentation site reorganized well-lit paths into foundation and workload sections. As a result, few links are broken in the README file.

## Changes

- Point foundation topics to their current `well-lit-paths/foundations` pages.
- Point batch processing to the current workload page.
- Update Operational Excellence to the Operations index.
- Update the well-lit path guide index.
- Update the Optimized Baseline getting-started link.
