### PR TITLE
docs(optimized-baseline): quote helm values file arguments

### DIFF
--- a/guides/optimized-baseline/README.md
+++ b/guides/optimized-baseline/README.md
@@ -180,11 +180,11 @@ This deploys the llm-d Router in [Standalone Mode](../../docs/architecture/core/
 # Assuming base-directory is the root of the llm-d repo
 helm_values=(
   -f "${ROUTER_BASE_VALUES}"
-  -f "${ROUTER_VALUES}"
 )
 if [[ -n "${MONITORING_VALUES:-}" ]]; then
   helm_values+=( -f "${MONITORING_VALUES}" )
 fi
+helm_values+=( -f "${ROUTER_VALUES}" )
 helm install ${GUIDE_NAME} \
   ${ROUTER_STANDALONE_CHART} \
   "${helm_values[@]}" \
@@ -204,11 +204,11 @@ To use a Kubernetes Gateway managed proxy rather than the standalone version, fo
 ```bash
 helm_values=(
   -f "${ROUTER_BASE_VALUES}"
-  -f "${ROUTER_VALUES}"
 )
 if [[ -n "${MONITORING_VALUES:-}" ]]; then
   helm_values+=( -f "${MONITORING_VALUES}" )
 fi
+helm_values+=( -f "${ROUTER_VALUES}" )
 helm install ${GUIDE_NAME} \
   ${ROUTER_GATEWAY_CHART} \
   "${helm_values[@]}" \

--- a/guides/optimized-baseline/README.md
+++ b/guides/optimized-baseline/README.md
@@ -136,11 +136,10 @@ kubectl create secret generic llm-d-hf-token \
 
 ### 1. Deploy the llm-d Router
 
-- Prepare the paths to the `helm` values files for `llm-d` router (used in the deployment commands below):
+- Define the `helm` values files for `llm-d` router:
 
 <!-- guide:deploy.router_values start -->
 ```bash
-# Paths to values files
 export ROUTER_BASE_VALUES="${REPO_ROOT}/guides/recipes/router/base.values.yaml"
 
 # only when MODEL_SERVER=vllm or sglang:
@@ -165,7 +164,7 @@ export ROUTER_VALUES="${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.val
 # 
 # Uncomment the below to enable Prometheus monitoring on the llm-d router
 # 
-# export MONITORING_VALUES="-f ${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml"
+# export MONITORING_VALUES="${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml"
 ```
 <!-- guide:deploy.monitoring_values end -->
 
@@ -176,17 +175,19 @@ export ROUTER_VALUES="${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.val
 
 This deploys the llm-d Router in [Standalone Mode](../../docs/architecture/core/router/proxy.md):
 
-> [!IMPORTANT]
-> Before running the command below, execute the path setup commands from the previous section: the `export ROUTER_BASE_VALUES=...` and `export ROUTER_VALUES=...` commands above.
-
 <!-- guide:deploy.standalone start -->
 ```bash
 # Assuming base-directory is the root of the llm-d repo
+helm_values=(
+  -f "${ROUTER_BASE_VALUES}"
+  -f "${ROUTER_VALUES}"
+)
+if [[ -n "${MONITORING_VALUES:-}" ]]; then
+  helm_values+=( -f "${MONITORING_VALUES}" )
+fi
 helm install ${GUIDE_NAME} \
   ${ROUTER_STANDALONE_CHART} \
-  -f ${ROUTER_BASE_VALUES} \
-  ${MONITORING_VALUES} \
-  -f ${ROUTER_VALUES} \
+  "${helm_values[@]}" \
   -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
 ```
 <!-- guide:deploy.standalone end -->
@@ -199,16 +200,18 @@ To use a Kubernetes Gateway managed proxy rather than the standalone version, fo
 1. _Deploy a Kubernetes Gateway_ named by following one of [the gateway guides](../../docs/infrastructure/gateway).
 2. _Deploy the llm-d router and an HTTPRoute_ that connects it to the Gateway as follows:
 
-> [!IMPORTANT]
-> Before running the command below, execute the path setup commands from the previous section: the `export ROUTER_BASE_VALUES=...` and `export ROUTER_VALUES=...` commands above.
-
 <!-- guide:deploy.gateway start -->
 ```bash
+helm_values=(
+  -f "${ROUTER_BASE_VALUES}"
+  -f "${ROUTER_VALUES}"
+)
+if [[ -n "${MONITORING_VALUES:-}" ]]; then
+  helm_values+=( -f "${MONITORING_VALUES}" )
+fi
 helm install ${GUIDE_NAME} \
   ${ROUTER_GATEWAY_CHART} \
-  -f ${ROUTER_BASE_VALUES} \
-  ${MONITORING_VALUES} \
-  -f ${ROUTER_VALUES} \
+  "${helm_values[@]}" \
   --set provider.name=${PROVIDER_NAME} \
   --set httpRoute.create=true \
   --set httpRoute.inferenceGatewayName=llm-d-inference-gateway \

--- a/guides/optimized-baseline/guide.yaml
+++ b/guides/optimized-baseline/guide.yaml
@@ -52,42 +52,52 @@ prerequisites:
 deploy:
 
   router_values:
-    - run: export ROUTER_BASE_VALUES="-f ${REPO_ROOT}/guides/recipes/router/base.values.yaml"
+    - run: export ROUTER_BASE_VALUES="${REPO_ROOT}/guides/recipes/router/base.values.yaml"
 
     - when: { MODEL_SERVER: [vllm, sglang] }
-      run: export ROUTER_VALUES="-f ${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml"
+      run: export ROUTER_VALUES="${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml"
     
     - when: { MODEL_SERVER: [trtllm] }
       run: |
         #
         # Comment out the above `ROUTER_VALUES` and uncomment the below for TensorRT-LLM (trtllm-serve)
         #
-        # export ROUTER_VALUES="-f ${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}-trtllm.values.yaml"
+        # export ROUTER_VALUES="${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}-trtllm.values.yaml"
 
   monitoring_values:
     - run: |
         # 
         # Uncomment the below to enable Prometheus monitoring on the llm-d router
         # 
-        # export MONITORING_VALUES="-f ${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml"
+        # export MONITORING_VALUES="${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml"
 
   standalone:
     - run: |
         # Assuming base-directory is the root of the llm-d repo
+        helm_values=(
+          -f "${ROUTER_BASE_VALUES}"
+          -f "${ROUTER_VALUES}"
+        )
+        if [[ -n "${MONITORING_VALUES:-}" ]]; then
+          helm_values+=( -f "${MONITORING_VALUES}" )
+        fi
         helm install ${GUIDE_NAME} \
           ${ROUTER_STANDALONE_CHART} \
-          ${ROUTER_BASE_VALUES} \
-          ${MONITORING_VALUES} \
-          ${ROUTER_VALUES} \
+          "${helm_values[@]}" \
           -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
 
   gateway:
     - run: |
+        helm_values=(
+          -f "${ROUTER_BASE_VALUES}"
+          -f "${ROUTER_VALUES}"
+        )
+        if [[ -n "${MONITORING_VALUES:-}" ]]; then
+          helm_values+=( -f "${MONITORING_VALUES}" )
+        fi
         helm install ${GUIDE_NAME} \
           ${ROUTER_GATEWAY_CHART} \
-          ${ROUTER_BASE_VALUES} \
-          ${MONITORING_VALUES} \
-          ${ROUTER_VALUES} \
+          "${helm_values[@]}" \
           --set provider.name=${PROVIDER_NAME} \
           --set httpRoute.create=true \
           --set httpRoute.inferenceGatewayName=llm-d-inference-gateway \

--- a/guides/optimized-baseline/guide.yaml
+++ b/guides/optimized-baseline/guide.yaml
@@ -76,11 +76,11 @@ deploy:
         # Assuming base-directory is the root of the llm-d repo
         helm_values=(
           -f "${ROUTER_BASE_VALUES}"
-          -f "${ROUTER_VALUES}"
         )
         if [[ -n "${MONITORING_VALUES:-}" ]]; then
           helm_values+=( -f "${MONITORING_VALUES}" )
         fi
+        helm_values+=( -f "${ROUTER_VALUES}" )
         helm install ${GUIDE_NAME} \
           ${ROUTER_STANDALONE_CHART} \
           "${helm_values[@]}" \
@@ -90,11 +90,11 @@ deploy:
     - run: |
         helm_values=(
           -f "${ROUTER_BASE_VALUES}"
-          -f "${ROUTER_VALUES}"
         )
         if [[ -n "${MONITORING_VALUES:-}" ]]; then
           helm_values+=( -f "${MONITORING_VALUES}" )
         fi
+        helm_values+=( -f "${ROUTER_VALUES}" )
         helm install ${GUIDE_NAME} \
           ${ROUTER_GATEWAY_CHART} \
           "${helm_values[@]}" \


### PR DESCRIPTION
## Summary

The optimized-baseline guide stored Helm values-file variables with the `-f` flag embedded in the variable value, then expanded those variables unquoted in `helm install`. This breaks argument parsing and is especially fragile when optional values are empty.

## Changes

- Store values variables as paths only.
- Build the Helm values arguments as a quoted Bash array.
- Add the optional monitoring values file only when `MONITORING_VALUES` is non-empty.
- Keep `guide.yaml` as the source of truth and regenerate the corresponding README blocks.
- Apply the same argument handling to standalone and gateway installs.

## Verification

- `python scripts/guide.py render guides/optimized-baseline --check`
- `python scripts/guide.py check guides/optimized-baseline`
- `pre-commit run check-yaml --files guides/optimized-baseline/guide.yaml`
- `pre-commit run end-of-file-fixer --files guides/optimized-baseline/guide.yaml guides/optimized-baseline/README.md`
- `bash -n` on both rendered Helm snippets
- `shellcheck` on both rendered Helm snippets with repository-variable checks excluded
- Quoted-array simulation verified with empty and non-empty monitoring paths
- `git diff --check`

Fixes #2176
