### PR TITLE
Mooncake tiered offloading router values

### DIFF
--- a/guides/tiered-prefix-cache/modelserver/gpu/vllm/mooncake-store/fs/kustomization.yaml
+++ b/guides/tiered-prefix-cache/modelserver/gpu/vllm/mooncake-store/fs/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - base
+  - mooncake-client

--- a/guides/tiered-prefix-cache/router/mooncake-offloading.values.yaml
+++ b/guides/tiered-prefix-cache/router/mooncake-offloading.values.yaml
@@ -1,0 +1,75 @@
+## Mooncake Store tiered-offload router overrides (non-PD mode).
+## Layer on top of:
+##   guides/recipes/router/base.values.yaml
+##
+## Mooncake Store manages the shared CPU DRAM and SSD/NVMe tiers.
+## The router treats every prefix match the Mooncake transfer engine
+## reports as a single signal and trusts Mooncake to decide which tier
+## to pull from. The router owns the load-based routing signals (queue
+## depth, KV-cache utilization) and mixes them with prefix affinity.
+##
+## A single approximate prefix-cache producer and scorer are used
+## because MooncakeStoreConnector hardcodes medium="cpu" on all
+## BlockStored events regardless of actual backing tier (memory vs
+## disk). The EPP cannot distinguish offload tiers until vLLM exposes
+## the real storage medium:
+##   https://github.com/vllm-project/vllm/blob/8f158d0e/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py#L896
+## When per-tier mediums are available, switch to
+## precise-prefix-cache-producer with per-tier kvCacheBackendConfigs
+## weights to score memory and disk hits differently.
+
+router:
+  extraServicePorts:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8081
+
+  epp:
+    pluginsConfigFile: tiered-prefix-cache-mooncake-plugins.yaml
+
+    pluginsCustomConfig:
+      tiered-prefix-cache-mooncake-plugins.yaml: |
+        apiVersion: llm-d.ai/v1alpha1
+        kind: EndpointPickerConfig
+
+        plugins:
+          # Prefix affinity from Mooncake engine cache matches.
+          # All tiers are scored equally since Mooncake reports a
+          # single medium today.
+          - type: approx-prefix-cache-producer
+            name: mooncake-prefix-cache-producer
+
+          - type: prefix-cache-scorer
+            name: mooncake-prefix-cache-scorer
+            parameters:
+              prefixMatchInfoProducerName: mooncake-prefix-cache-producer
+
+          # Prefer endpoints with less queued work.
+          - type: queue-scorer
+
+          # Prefer endpoints with lower local GPU KV-cache pressure.
+          - type: kv-cache-utilization-scorer
+
+          # Spread cold requests across endpoints so new cache entries
+          # are not concentrated on one model server.
+          - type: no-hit-lru-scorer
+            name: mooncake-no-hit-lru-scorer
+            parameters:
+              prefixPluginType: prefix-cache-scorer
+              prefixPluginName: mooncake-prefix-cache-scorer
+
+        schedulingProfiles:
+          - name: default
+            plugins:
+              - pluginRef: queue-scorer
+              - pluginRef: kv-cache-utilization-scorer
+              - pluginRef: mooncake-prefix-cache-scorer
+              - pluginRef: mooncake-no-hit-lru-scorer
+
+  modelServers:
+    type: vllm
+    targetPorts:
+      - number: 8000
+    matchLabels:
+      llm-d.ai/guide: tiered-prefix-cache

--- a/guides/tiered-prefix-cache/router/mooncake-offloading.values.yaml
+++ b/guides/tiered-prefix-cache/router/mooncake-offloading.values.yaml
@@ -40,32 +40,25 @@ router:
           - type: approx-prefix-cache-producer
             name: mooncake-prefix-cache-producer
 
-          - type: prefix-cache-scorer
-            name: mooncake-prefix-cache-scorer
+          # In-flight load feeds the affinity filter's TTFT estimation.
+          - type: inflight-load-producer
+
+          # Narrow to endpoints with high prefix cache scores, but
+          # break stickiness when sticky endpoints are too loaded.
+          # peakPrefillThroughput default (15928) is calibrated for
+          # Qwen3-32B on H100 80GB TP=2; adjust for your hardware.
+          - type: prefix-cache-affinity-filter
             parameters:
               prefixMatchInfoProducerName: mooncake-prefix-cache-producer
 
-          # Prefer endpoints with less queued work.
-          - type: queue-scorer
-
-          # Prefer endpoints with lower local GPU KV-cache pressure.
-          - type: kv-cache-utilization-scorer
-
-          # Spread cold requests across endpoints so new cache entries
-          # are not concentrated on one model server.
-          - type: no-hit-lru-scorer
-            name: mooncake-no-hit-lru-scorer
-            parameters:
-              prefixPluginType: prefix-cache-scorer
-              prefixPluginName: mooncake-prefix-cache-scorer
+          # Load-balanced scoring across remaining candidates.
+          - type: token-load-scorer
 
         schedulingProfiles:
           - name: default
             plugins:
-              - pluginRef: queue-scorer
-              - pluginRef: kv-cache-utilization-scorer
-              - pluginRef: mooncake-prefix-cache-scorer
-              - pluginRef: mooncake-no-hit-lru-scorer
+              - pluginRef: prefix-cache-affinity-filter
+              - pluginRef: token-load-scorer
 
   modelServers:
     type: vllm

--- a/helpers/mooncake-client/base/daemonset.yaml
+++ b/helpers/mooncake-client/base/daemonset.yaml
@@ -5,6 +5,12 @@ metadata:
 spec:
   template:
     spec:
+      ## To target some subset of CPU nodes instead of every node in the cluster,
+      ## simply labe your CPU nodes with the following kubectl command:
+      ## `kubectl label node cpu-node-{1,2,3,4} llm-d.ai/cpu-offloading-node=true`
+      ## and then uncomment the yaml `nodeSelector` below:
+      # nodeSelector:
+      #   llm-d.ai/cpu-offloading-node: "true"
       containers:
         - name: mooncake-client
           image: mooncake-client

--- a/helpers/mooncake-client/base/kustomization.yaml
+++ b/helpers/mooncake-client/base/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: mooncake
 resources:
   - daemonset.yaml
   - service.yaml


### PR DESCRIPTION

fixes:
- Deployment / operational: the mooncake client doesnt need to be in the mooncake namespace it can be wherever and should be treated as an application not infrastructure level component.
- Show comments on how to target a subset of nodes and not every node for offloading
- add mooncake tiered offloading values. As described currently the vLLM mooncake connector hardcodes every `medium="cpu"`, so basically llm-d controlls load signals and mooncake tent figures out cache hit wherever it may live
cc @vMaroon @ykwd @zdtsw @ahg-g @liu-cong 

I tested this succesfully. Logs attached, but we eventually see the prefix-cache-affinity-filter consider it a sticky endpoint, ie bubling up routing for cache hits to the router:
```
{"level":"debug","ts":1785963823.8774176,"caller":"prefixcacheaffinity/plugin.go:208","msg":"PrefixCacheAffinityFilter: narrowed to sticky","x-request-id":"ff3f3fa5-c641-46cf-a100-2b8f86228b3f","objectiveKey":"","incomingModelName":"Qwen/Qwen3-32B","targetModelName":"Qwen/Qwen3-32B","priority":0,"affinityThreshold":0.8,"sticky":1,"total":4}
```


[epp-log-mooncake-tiered-offload.log](https://github.com/user-attachments/files/30762742/epp-log-mooncake-tiered-offload.log)