### PR TITLE
feat(precise): Serve render from the model server pods

### DIFF
--- a/.github/workflows/ci-kustomize-dry-run.yaml
+++ b/.github/workflows/ci-kustomize-dry-run.yaml
@@ -290,8 +290,8 @@ jobs:
         run: .github/scripts/install-gke-crds.sh
 
       - name: Dry-run router (active-active default)
-        # Tokenization runs as a standalone render Service (../render/), not a
-        # chart-injected sidecar (the chart's tokenizer sidecar is off by default).
+        # Tokenization runs as a separate render Service (guides/.../render/), not
+        # a chart-injected sidecar (the chart's tokenizer sidecar is off by default).
         run: |
           CHART_VERSION=v0
           echo ""
@@ -315,25 +315,34 @@ jobs:
             exit 1
           fi
 
-      - name: Dry-run render Service overlay
-        # Standalone `vllm launch render` Service that replaces the EPP sidecar.
+      - name: Dry-run render Service overlays
+        # Two mutually exclusive overlays, both publishing the same Service name:
+        # `render/` (default) is a Service over the model server pods, and
+        # `render/standalone/` a dedicated `vllm launch render` pool for backends
+        # without vLLM's render endpoints (SGLang).
         run: |
-          echo ""
-          echo "========================================"
-          echo "precise-prefix-cache-routing: render (vllm-render Service)"
-          echo "========================================"
-          echo "--- kustomize build ---"
-          if ! kustomize build guides/precise-prefix-cache-routing/render > /tmp/rendered.yaml; then
-            echo "FAIL: kustomize build failed for render"
-            exit 1
-          fi
-          echo "--- kubectl apply --dry-run=server ---"
-          if kubectl apply --dry-run=server -f /tmp/rendered.yaml; then
-            echo "PASS: precise-prefix-cache-routing / render (vllm-render Service)"
-          else
-            echo "FAIL: precise-prefix-cache-routing / render (vllm-render Service)"
-            exit 1
-          fi
+          failed=0
+          for overlay in render render/standalone; do
+            name="render (${overlay})"
+            echo ""
+            echo "========================================"
+            echo "precise-prefix-cache-routing: ${name}"
+            echo "========================================"
+            echo "--- kustomize build ---"
+            if ! kustomize build "guides/precise-prefix-cache-routing/${overlay}" > /tmp/rendered.yaml; then
+              echo "FAIL: kustomize build failed for ${overlay}"
+              failed=1
+              continue
+            fi
+            echo "--- kubectl apply --dry-run=server ---"
+            if kubectl apply --dry-run=server -f /tmp/rendered.yaml; then
+              echo "PASS: precise-prefix-cache-routing / ${name}"
+            else
+              echo "FAIL: precise-prefix-cache-routing / ${name}"
+              failed=1
+            fi
+          done
+          exit "${failed}"
 
       - name: Kustomize build and dry-run all model server overlays
         run: |

--- a/guides/precise-prefix-cache-routing/README.md
+++ b/guides/precise-prefix-cache-routing/README.md
@@ -30,7 +30,7 @@ The routing decision combines precise cache knowledge with token-based load bala
 | Backend              | Directory                  | Default model                           | Notes                                                    |
 | -------------------- | -------------------------- | --------------------------------------- | -------------------------------------------------------- |
 | NVIDIA GPU           | `modelserver/gpu/vllm/`    | Qwen/Qwen3-32B                          | Default configuration                                    |
-| NVIDIA GPU (SGLang)  | `modelserver/gpu/sglang/`  | Qwen/Qwen3-32B                          | SGLang; `--page-size=64` matches the producer's `blockSizeTokens`      |
+| NVIDIA GPU (SGLang)  | `modelserver/gpu/sglang/`  | Qwen/Qwen3-32B                          | SGLang; `--page-size=64` matches the producer's `blockSizeTokens`; requires `render/standalone/` |
 | AMD GPU              | `modelserver/amd/vllm/`    | Qwen/Qwen3-32B                          | AMD GPU                                                  |
 | Intel XPU            | `modelserver/xpu/vllm/`    | Qwen/Qwen3-0.6B                         | CI-sized; update router `modelName` for real use         |
 | Google TPU v6e       | `modelserver/tpu/v6/vllm/` | Qwen/Qwen3-32B                          | GKE TPU                                                  |
@@ -41,7 +41,7 @@ The routing decision combines precise cache knowledge with token-based load bala
 > Some hardware variants use reduced configurations (fewer replicas, smaller models) to enable CI testing for compatibility and regression checks.
 >
 > [!NOTE]
-> For precise prefix cache scoring to match reality, the `token-producer` `modelName` in [`router/precise-prefix-cache-routing.values.yaml`](router/precise-prefix-cache-routing.values.yaml) must match the model the overlay deploys.
+> The `token-producer` `modelName` in [`router/precise-prefix-cache-routing.values.yaml`](router/precise-prefix-cache-routing.values.yaml) must match the model the overlay deploys. With the default render overlay the render call lands on the model servers themselves, so a mismatch is rejected outright rather than silently scoring against the wrong tokenizer.
 >
 > [!NOTE]
 > The `gpu/vllm/` overlay defaults to 8 replicas to match the canonical 16×H100 benchmark. For smaller fleets (or quick smoke tests), reduce `replicas` in the deployment patch (`modelserver/gpu/vllm/patch-vllm.yaml`) before applying.
@@ -101,7 +101,7 @@ kubectl create secret generic llm-d-hf-token \
 
 This deploys the llm-d Router in the simple [Standalone Mode](../../docs/architecture/core/router/proxy.md). The release name `${GUIDE_NAME}` is mandatory — the inference pool selector matches a guide label that pairs with this release.
 
-Tokenization is served by a standalone render Service, not a chart-injected EPP sidecar — the chart's `router.tokenizer` sidecar is off by default, and the `token-producer` plugin points at that Service.
+Tokenization is served by a separate render Service, not a chart-injected EPP sidecar — the chart's `router.tokenizer` sidecar is off by default, and the `token-producer` plugin points at that Service.
 
 ```bash
 helm install ${GUIDE_NAME} \
@@ -113,16 +113,7 @@ helm install ${GUIDE_NAME} \
 
 The release name `${GUIDE_NAME}` is mandatory for standard deployments — the inference pool selector matches a guide label that pairs with this release.
 
-#### Deploy the Render (Tokenizer) Service
-
-The EPP `token-producer` plugin tokenizes prompts by calling vLLM's `/v1/completions/render` endpoint. This guide serves that endpoint from a dedicated, horizontally-scalable `vllm launch render` Service (3 replicas) instead of a per-EPP-pod sidecar, so render capacity scales independently of the EPP replica count and is shared across all EPP replicas. Deploy it with:
-
-```bash
-kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/render/
-```
-
-> [!NOTE]
-> The render pods deliberately do **not** carry the `llm-d.ai/guide` label — that label is the InferencePool / model-server selector, and the EPP would otherwise treat render pods as routable model servers (and try to subscribe to their nonexistent KV-event socket). Scale the pool with `kubectl scale -n ${NAMESPACE} deploy/${GUIDE_NAME}-render --replicas=<N>`.
+The render (tokenizer) Service the `token-producer` plugin calls is deployed separately, in [step 4](#4-deploy-the-render-tokenizer-service).
 
 <details>
 <summary><b>Gateway Mode</b></summary>
@@ -157,7 +148,41 @@ export INFRA_PROVIDER=base # base | gke
 kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/gpu/${MODEL_SERVER}/${INFRA_PROVIDER}/
 ```
 
-### 4. (Optional) Enable Monitoring
+### 4. Deploy the Render (Tokenizer) Service
+
+The EPP `token-producer` plugin tokenizes prompts by calling vLLM's `/v1/completions/render` endpoint. This guide serves that endpoint from a Service rather than a per-EPP-pod sidecar, so a single render pool is shared across EPP replicas and render capacity is decoupled from the EPP replica count.
+
+`vllm serve` already exposes `/v1/completions/render` and `/v1/chat/completions/render`, so the default overlay is a **Service with no pods of its own**: it selects the model server pods you just deployed and tokenizes on them.
+
+```bash
+kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/render/
+```
+
+Why this over a separate renderer pool: a dedicated pool is scheduled independently of the model servers, so as QPS climbs it saturates before they do and render latency — which sits inside TTFT, since every request is tokenized before it is routed — starts to dominate. Fronting the model servers instead makes render capacity scale with the fleet, which keeps latency more contained at higher QPS.
+
+The trade-offs to weigh:
+
+- Tokenization CPU competes with serving on the same pods. The GPU overlay requests 8 CPU / limits 16 per replica; raise that if render latency climbs under load.
+- The render call is a synchronous hop to a GPU serving pod on the request path.
+- Only `Ready` endpoints receive traffic, so render calls are never sent to a pod still loading weights. Until the first model server is `Ready` the Service has no endpoints and `token-producer` calls fail — apply this after [step 3](#3-deploy-the-model-server), as ordered here.
+
+<details>
+<summary><b>Dedicated renderer pool (required for SGLang)</b></summary>
+
+SGLang does not implement vLLM's render endpoints, so the SGLang overlay must instead run a dedicated, GPU-less `vllm launch render` pool (3 replicas). The same applies to any deployment where you would rather not spend model server CPU on tokenization. Apply this **instead of** the default overlay above — both publish the same Service name, so the router's `vllm.url` is unchanged either way:
+
+```bash
+kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/render/standalone/
+```
+
+Because this pool is GPU-less and engine-agnostic, it tokenizes with vLLM's tokenizer no matter which engine serves inference. It is configured for `Qwen/Qwen3-32B`; for another model, change the model argument in [`render/standalone/deployment.yaml`](render/standalone/deployment.yaml) and the router `token-producer` `modelName` together. Scale it with `kubectl scale -n ${NAMESPACE} deploy/${GUIDE_NAME}-render --replicas=<N>`.
+
+> [!NOTE]
+> These render pods deliberately do **not** carry the `llm-d.ai/guide` label — that label is the InferencePool / model-server selector, and the EPP would otherwise treat render pods as routable model servers (and try to subscribe to their nonexistent KV-event socket).
+
+</details>
+
+### 5. (Optional) Enable Monitoring
 
 - Install the [Monitoring stack](../../docs/operations/observability/setup.md).
 - To enable Prometheus monitoring on the llm-d router, add `-f ${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml` during the [router installation step](#2-deploy-the-llm-d-router).
@@ -297,8 +322,9 @@ llmdbenchmark \
 
 ```bash
 helm uninstall ${GUIDE_NAME} -n ${NAMESPACE}
-# Render (tokenizer) Service:
-kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/render/
+# Render (tokenizer) Service. Set this to the overlay you applied:
+export RENDER_OVERLAY=render # render | render/standalone
+kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/${RENDER_OVERLAY}/
 # For vLLM (default):
 kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/gpu/vllm/${INFRA_PROVIDER}/
 # For SGLang:
@@ -309,7 +335,8 @@ kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/
 
 1. **Model server pods publish KV-cache events** — each pod (vLLM or SGLang) runs with `--kv-events-config '{...,"publisher":"zmq","endpoint":"$(KV_EVENTS_ENDPOINT)","topic":"kv@$(POD_IP):$(POD_PORT)@<model>"}'` and `KV_EVENTS_ENDPOINT=tcp://*:5556`, binding its own ZMQ socket. On every KV block allocation/eviction, the server emits a ZMQ message.
 2. **Router subscribes per pod** — pod-discovery (`kvEventsConfig.discoverPods: true`) registers the `precise-prefix-cache-producer` as an extractor on the data-layer `endpoint-notification-source`, so each router replica installs a ZMQ subscriber per model server pod independently. All replicas converge to the same index.
-3. **Filter + score** — the `prefix-cache-affinity-filter` narrows candidates to the pods where the request's prefix blocks are resident (falling back to the least-loaded pods when the cache-warm set is saturated past `peakPrefillThroughput`), and the `token-load-scorer` picks the endpoint with the least in-flight token load among them.
+3. **Router tokenizes the prompt** — before it can look the prefix up in that index, the `token-producer` plugin POSTs the prompt to the render Service to get exact token IDs. By default that Service fronts the model server pods themselves (`vllm serve` exposes `/v1/completions/render`), so no separate renderer pool sits on the request path.
+4. **Filter + score** — the `prefix-cache-affinity-filter` narrows candidates to the pods where the request's prefix blocks are resident (falling back to the least-loaded pods when the cache-warm set is saturated past `peakPrefillThroughput`), and the `token-load-scorer` picks the endpoint with the least in-flight token load among them.
 
 ## Benchmarking Reports
 

--- a/guides/precise-prefix-cache-routing/README.md
+++ b/guides/precise-prefix-cache-routing/README.md
@@ -171,9 +171,11 @@ The trade-offs to weigh:
 
 SGLang does not implement vLLM's render endpoints, so the SGLang overlay must instead run a dedicated, GPU-less `vllm launch render` pool (3 replicas). The same applies to any deployment where you would rather not spend model server CPU on tokenization. Apply this **instead of** the default overlay above — both publish the same Service name, so the router's `vllm.url` is unchanged either way:
 
+<!-- llm-d-cicd:skip start -->
 ```bash
 kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/render/standalone/
 ```
+<!-- llm-d-cicd:skip end -->
 
 Because this pool is GPU-less and engine-agnostic, it tokenizes with vLLM's tokenizer no matter which engine serves inference. It is configured for `Qwen/Qwen3-32B`; for another model, change the model argument in [`render/standalone/deployment.yaml`](render/standalone/deployment.yaml) and the router `token-producer` `modelName` together. Scale it with `kubectl scale -n ${NAMESPACE} deploy/${GUIDE_NAME}-render --replicas=<N>`.
 

--- a/guides/precise-prefix-cache-routing/README.md
+++ b/guides/precise-prefix-cache-routing/README.md
@@ -150,7 +150,7 @@ kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/g
 
 ### 4. Deploy the Render (Tokenizer) Service
 
-The EPP `token-producer` plugin tokenizes prompts by calling vLLM's `/v1/completions/render` endpoint. This guide serves that endpoint from a Service rather than a per-EPP-pod sidecar, so a single render pool is shared across EPP replicas and render capacity is decoupled from the EPP replica count.
+The EPP `token-producer` plugin tokenizes prompts by calling vLLM's `/v1/*/render` endpoints. This guide serves that endpoint from a Service rather than a per-EPP-pod sidecar, so a single render pool is shared across EPP replicas and render capacity is decoupled from the EPP replica count.
 
 `vllm serve` already exposes `/v1/completions/render` and `/v1/chat/completions/render`, so the default overlay is a **Service with no pods of its own**: it selects the model server pods you just deployed and tokenizes on them.
 

--- a/guides/precise-prefix-cache-routing/README.md
+++ b/guides/precise-prefix-cache-routing/README.md
@@ -152,7 +152,7 @@ kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/g
 
 The EPP `token-producer` plugin tokenizes prompts by calling vLLM's `/v1/*/render` endpoints. This guide serves that endpoint from a Service rather than a per-EPP-pod sidecar, so a single render pool is shared across EPP replicas and render capacity is decoupled from the EPP replica count.
 
-`vllm serve` already exposes `/v1/completions/render` and `/v1/chat/completions/render`, so the default overlay is a **Service with no pods of its own**: it selects the model server pods you just deployed and tokenizes on them.
+`vllm serve` already exposes `/v1/*/render`, so the default overlay is a **Service with no pods of its own**: it selects the model server pods you just deployed and tokenizes on them.
 
 ```bash
 kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/render/
@@ -337,7 +337,7 @@ kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/
 
 1. **Model server pods publish KV-cache events** — each pod (vLLM or SGLang) runs with `--kv-events-config '{...,"publisher":"zmq","endpoint":"$(KV_EVENTS_ENDPOINT)","topic":"kv@$(POD_IP):$(POD_PORT)@<model>"}'` and `KV_EVENTS_ENDPOINT=tcp://*:5556`, binding its own ZMQ socket. On every KV block allocation/eviction, the server emits a ZMQ message.
 2. **Router subscribes per pod** — pod-discovery (`kvEventsConfig.discoverPods: true`) registers the `precise-prefix-cache-producer` as an extractor on the data-layer `endpoint-notification-source`, so each router replica installs a ZMQ subscriber per model server pod independently. All replicas converge to the same index.
-3. **Router tokenizes the prompt** — before it can look the prefix up in that index, the `token-producer` plugin POSTs the prompt to the render Service to get exact token IDs. By default that Service fronts the model server pods themselves (`vllm serve` exposes `/v1/completions/render`), so no separate renderer pool sits on the request path.
+3. **Router tokenizes the prompt** — before it can look the prefix up in that index, the `token-producer` plugin POSTs the prompt to the render Service to get exact token IDs. By default that Service fronts the model server pods themselves (`vllm serve` exposes `/v1/*/render`), so no separate renderer pool sits on the request path.
 4. **Filter + score** — the `prefix-cache-affinity-filter` narrows candidates to the pods where the request's prefix blocks are resident (falling back to the least-loaded pods when the cache-warm set is saturated past `peakPrefillThroughput`), and the `token-load-scorer` picks the endpoint with the least in-flight token load among them.
 
 ## Benchmarking Reports

--- a/guides/precise-prefix-cache-routing/modelserver/amd/vllm/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-routing/modelserver/amd/vllm/patch-vllm.yaml
@@ -11,7 +11,7 @@ spec:
           command: ["vllm", "serve"]
           args:
             - "Qwen/Qwen3-32B"
-            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models,/v1/completions/render,/v1/chat/completions/render"
             - "--tensor-parallel-size=2"
             - "--block-size=64"
             - "--kv-events-config"

--- a/guides/precise-prefix-cache-routing/modelserver/cpu/vllm/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-routing/modelserver/cpu/vllm/patch-vllm.yaml
@@ -15,7 +15,7 @@ spec:
           # to match `meta-llama/Llama-3.2-3B-Instruct`.
           args:
             - "meta-llama/Llama-3.2-3B-Instruct"
-            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models,/v1/completions/render,/v1/chat/completions/render"
             - "--disable-hybrid-kv-cache-manager"
             - "--max_model_len=8192"
             - "--block-size=64"

--- a/guides/precise-prefix-cache-routing/modelserver/gpu/vllm/base/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-routing/modelserver/gpu/vllm/base/patch-vllm.yaml
@@ -11,7 +11,7 @@ spec:
           command: ["vllm", "serve"]
           args:
             - "Qwen/Qwen3-32B"
-            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models,/v1/completions/render,/v1/chat/completions/render"
             - "--tensor-parallel-size=2"
             - "--block-size=64"
             - "--kv-events-config"

--- a/guides/precise-prefix-cache-routing/modelserver/tpu/v6/vllm/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-routing/modelserver/tpu/v6/vllm/patch-vllm.yaml
@@ -16,6 +16,7 @@ spec:
             - "--max-model-len=4096"
             - "--tensor-parallel-size=8"
             - "--block-size=64"
+            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models,/v1/completions/render,/v1/chat/completions/render"
             - "--kv-events-config"
             - '{"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"$(KV_EVENTS_ENDPOINT)","topic":"kv@$(POD_IP):$(POD_PORT)@Qwen/Qwen3-32B"}'
           resources:

--- a/guides/precise-prefix-cache-routing/modelserver/tpu/v7/vllm/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-routing/modelserver/tpu/v7/vllm/patch-vllm.yaml
@@ -19,7 +19,7 @@ spec:
             - "--max-num-seqs=128"
             - "--kv-cache-dtype=fp8"
             - "--async-scheduling"
-            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models,/v1/completions/render,/v1/chat/completions/render"
             - "--tensor-parallel-size=8"
             - "--block-size=64"
             - "--kv-events-config"

--- a/guides/precise-prefix-cache-routing/modelserver/xpu/vllm/patch-vllm.yaml
+++ b/guides/precise-prefix-cache-routing/modelserver/xpu/vllm/patch-vllm.yaml
@@ -21,7 +21,7 @@ spec:
             - "--port=$(POD_PORT)"
             - "--dtype=float16"
             - "--disable-sliding-window"
-            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models,/v1/completions/render,/v1/chat/completions/render"
             - "--block-size=64"
             - "--kv-events-config"
             - '{"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"$(KV_EVENTS_ENDPOINT)","topic":"kv@$(POD_IP):$(POD_PORT)@Qwen/Qwen3-0.6B"}'

--- a/guides/precise-prefix-cache-routing/render/kustomization.yaml
+++ b/guides/precise-prefix-cache-routing/render/kustomization.yaml
@@ -1,22 +1,30 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-# Standalone render (tokenizer) Service for precise-prefix-cache-routing.
-# Replaces the chart-injected `vllm-render` EPP sidecar (off by chart default)
-# with a shared, independently-scalable pool. Pairs with the token-producer
-# `vllm.url` in router/precise-prefix-cache-routing.values.yaml.
+# Render (tokenizer) endpoint for precise-prefix-cache-routing.
+#
+# The chart-injected `vllm-render` EPP sidecar is off by chart default; the EPP
+# `token-producer` reaches this Service instead (see the `vllm.url` in
+# router/precise-prefix-cache-routing.values.yaml).
+#
+# This overlay deploys a Service ONLY — it fronts the vLLM model server pods
+# from ../modelserver/, which already serve /v1/completions/render. Under load
+# this keeps render latency lower than a separate CPU renderer pool, because the
+# EPP no longer contends for a small, independently-scheduled set of replicas.
+#
+# Backends that do NOT serve vLLM's render endpoints (notably SGLang) must use
+# `standalone/` instead, which deploys a dedicated `vllm launch render` pool.
+# Both overlays produce the same Service name, so `vllm.url` never changes —
+# apply exactly one of them.
 namePrefix: precise-prefix-cache-routing-
 
 resources:
-  - deployment.yaml
   - service.yaml
 
-# NOTE: the guide label lands on resource metadata ONLY, never on the pod
-# template or selectors (kustomize `labels` defaults to includeSelectors:false /
-# includeTemplates:false). `llm-d.ai/guide: precise-prefix-cache-routing` is the
-# InferencePool / model-server selector (router modelServers.matchLabels); if
-# render pods carried it the EPP would treat them as routable model servers and
-# try to ZMQ-subscribe to their (nonexistent) :5556 KV-event socket.
+# NOTE: this lands on resource metadata ONLY, never on `spec.selector` (kustomize
+# `labels` defaults to includeSelectors:false). The selector in service.yaml is
+# written out literally because it must match the model server pods, not this
+# Service's own (nonexistent) pods.
 labels:
   - pairs:
       llm-d.ai/guide: precise-prefix-cache-routing

--- a/guides/precise-prefix-cache-routing/render/kustomization.yaml
+++ b/guides/precise-prefix-cache-routing/render/kustomization.yaml
@@ -8,7 +8,7 @@ kind: Kustomization
 # router/precise-prefix-cache-routing.values.yaml).
 #
 # This overlay deploys a Service ONLY — it fronts the vLLM model server pods
-# from ../modelserver/, which already serve /v1/completions/render. Under load
+# from ../modelserver/, which already serve /v1/*/render. Under load
 # this keeps render latency lower than a separate CPU renderer pool, because the
 # EPP no longer contends for a small, independently-scheduled set of replicas.
 #

--- a/guides/precise-prefix-cache-routing/render/service.yaml
+++ b/guides/precise-prefix-cache-routing/render/service.yaml
@@ -7,9 +7,8 @@ metadata:
 spec:
   # This Service owns no pods of its own: it fronts the model server pods
   # deployed by ../modelserver/, so the EPP `token-producer` tokenizes prompts
-  # on the same vLLM pods that serve inference. `vllm serve` already exposes
-  # /v1/completions/render and /v1/chat/completions/render, so no model-server
-  # flag is needed to turn them on.
+  # on the same vLLM pods that serve inference. `vllm serve` already exposes the
+  # /v1/*/render endpoints, so no model-server flag is needed to turn them on.
   #
   # Only Ready endpoints receive traffic, so render calls are never sent to a
   # pod that is still loading weights.

--- a/guides/precise-prefix-cache-routing/render/service.yaml
+++ b/guides/precise-prefix-cache-routing/render/service.yaml
@@ -2,15 +2,27 @@ apiVersion: v1
 kind: Service
 metadata:
   name: render
-spec:
-  # ClusterIP fronting the render replicas. EPP token-producer dials this name;
-  # kube-proxy load-balances across the pods so any EPP replica can tokenize via
-  # any render pod.
-  selector:
+  labels:
     app.kubernetes.io/component: vllm-render
-    app.kubernetes.io/part-of: precise-prefix-cache-routing
+spec:
+  # This Service owns no pods of its own: it fronts the model server pods
+  # deployed by ../modelserver/, so the EPP `token-producer` tokenizes prompts
+  # on the same vLLM pods that serve inference. `vllm serve` already exposes
+  # /v1/completions/render and /v1/chat/completions/render, so no model-server
+  # flag is needed to turn them on.
+  #
+  # Only Ready endpoints receive traffic, so render calls are never sent to a
+  # pod that is still loading weights.
+  selector:
+    # Matches every decode pod of this guide, across all modelserver overlays
+    # (each one stamps `llm-d.ai/guide` onto its pod template and selector, and
+    # `llm-d.ai/role: decode` comes from the shared base deployment). Deliberately
+    # not narrowed further so a single Service works for every backend overlay.
+    llm-d.ai/guide: precise-prefix-cache-routing
+    llm-d.ai/role: decode
   ports:
     - name: render-http
       port: 8000
-      targetPort: render-http
+      # Named container port on the model server pods (containerPort 8000).
+      targetPort: modelserver
       protocol: TCP

--- a/guides/precise-prefix-cache-routing/render/standalone/deployment.yaml
+++ b/guides/precise-prefix-cache-routing/render/standalone/deployment.yaml
@@ -7,6 +7,11 @@ spec:
   # EPP sidecar (the chart's tokenizer sidecar is off by default). EPP replicas
   # share this pool via the token-producer `vllm.url`, decoupling render
   # capacity from EPP replica count.
+  #
+  # This pool is scheduled independently of the model servers, so under a rising
+  # QPS ladder it becomes the render bottleneck before the model servers do —
+  # which is why the default overlay (../) serves render from the model server
+  # pods instead. Size this up if you stay on this overlay (e.g. for SGLang).
   replicas: 3
   selector:
     matchLabels:

--- a/guides/precise-prefix-cache-routing/render/standalone/kustomization.yaml
+++ b/guides/precise-prefix-cache-routing/render/standalone/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 # Dedicated render (tokenizer) pool for precise-prefix-cache-routing.
 #
-# Fallback for backends that do not serve vLLM's /v1/completions/render — most
+# Fallback for backends that do not serve vLLM's /v1/*/render endpoints — most
 # notably SGLang — and for anyone who would rather not spend model-server CPU on
 # tokenization. It runs a GPU-less `vllm launch render` Deployment fronted by a
 # Service, so the tokenizer is always vLLM's regardless of which engine serves

--- a/guides/precise-prefix-cache-routing/render/standalone/kustomization.yaml
+++ b/guides/precise-prefix-cache-routing/render/standalone/kustomization.yaml
@@ -1,0 +1,32 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Dedicated render (tokenizer) pool for precise-prefix-cache-routing.
+#
+# Fallback for backends that do not serve vLLM's /v1/completions/render — most
+# notably SGLang — and for anyone who would rather not spend model-server CPU on
+# tokenization. It runs a GPU-less `vllm launch render` Deployment fronted by a
+# Service, so the tokenizer is always vLLM's regardless of which engine serves
+# inference.
+#
+# The default (../) fronts the model server pods with a Service instead and is
+# the preferred choice for vLLM backends: at higher QPS it keeps render latency
+# more contained than this separately-scheduled pool. Both overlays produce the
+# same Service name, so `vllm.url` in
+# router/precise-prefix-cache-routing.values.yaml never changes — apply exactly
+# one of them.
+namePrefix: precise-prefix-cache-routing-
+
+resources:
+  - deployment.yaml
+  - service.yaml
+
+# NOTE: the guide label lands on resource metadata ONLY, never on the pod
+# template or selectors (kustomize `labels` defaults to includeSelectors:false /
+# includeTemplates:false). `llm-d.ai/guide: precise-prefix-cache-routing` is the
+# InferencePool / model-server selector (router modelServers.matchLabels); if
+# render pods carried it the EPP would treat them as routable model servers and
+# try to ZMQ-subscribe to their (nonexistent) :5556 KV-event socket.
+labels:
+  - pairs:
+      llm-d.ai/guide: precise-prefix-cache-routing

--- a/guides/precise-prefix-cache-routing/render/standalone/service.yaml
+++ b/guides/precise-prefix-cache-routing/render/standalone/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: render
+spec:
+  # ClusterIP fronting the render replicas. EPP token-producer dials this name;
+  # kube-proxy load-balances across the pods so any EPP replica can tokenize via
+  # any render pod.
+  selector:
+    app.kubernetes.io/component: vllm-render
+    app.kubernetes.io/part-of: precise-prefix-cache-routing
+  ports:
+    - name: render-http
+      port: 8000
+      targetPort: render-http
+      protocol: TCP

--- a/guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml
+++ b/guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml
@@ -7,7 +7,7 @@
 ## over HTTP against that Service (see its `vllm.url` below).
 ##
 ## That Service has no pods of its own — it fronts the vLLM model servers, which
-## already expose `/v1/completions/render`. Render capacity therefore scales with
+## already expose `/v1/*/render`. Render capacity therefore scales with
 ## the model server fleet rather than with a separately-scheduled renderer pool,
 ## which keeps render latency more contained at higher QPS. Backends without
 ## vLLM's render endpoints (SGLang) apply `../render/standalone/` instead; it

--- a/guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml
+++ b/guides/precise-prefix-cache-routing/router/precise-prefix-cache-routing.values.yaml
@@ -1,12 +1,17 @@
 ## precise-prefix-cache-routing guide overrides for the router.
 ## Layer on top of: recipes/router/base.values.yaml
 ##
-## Tokenization is served by a standalone `vllm launch render` Service deployed
-## from `../render/` (3 replicas), NOT the chart-injected EPP sidecar. The
-## chart's `router.tokenizer` sidecar is off by default, so no override is
-## needed here; the EPP `token-producer` plugin tokenizes prompts over HTTP
-## against that Service (see its `vllm.url` below). This decouples render
-## capacity from EPP replica count and lets the render pool scale independently.
+## Tokenization is served by the `../render/` Service, NOT the chart-injected
+## EPP sidecar. The chart's `router.tokenizer` sidecar is off by default, so no
+## override is needed here; the EPP `token-producer` plugin tokenizes prompts
+## over HTTP against that Service (see its `vllm.url` below).
+##
+## That Service has no pods of its own — it fronts the vLLM model servers, which
+## already expose `/v1/completions/render`. Render capacity therefore scales with
+## the model server fleet rather than with a separately-scheduled renderer pool,
+## which keeps render latency more contained at higher QPS. Backends without
+## vLLM's render endpoints (SGLang) apply `../render/standalone/` instead; it
+## publishes the same Service name, so this `vllm.url` is unchanged either way.
 ##
 ## Single EPP replica: the token-load-scorer's in-flight token accounting is
 ## local to each EPP process, so active-active HA (replicas: 2) would halve the
@@ -40,9 +45,13 @@ router:
         plugins:
           - type: token-producer
             parameters:
-              modelName: Qwen/Qwen3-32B # Must match the render Service model (../render/) and the deployed model server
+              # Must match the model the overlay deploys: with the default
+              # `../render/` overlay the render call lands on the model servers
+              # themselves, so a mismatch is rejected rather than silently
+              # producing token IDs from the wrong tokenizer.
+              modelName: Qwen/Qwen3-32B
               vllm:
-                # Standalone render Service (../render/), not a loopback sidecar.
+                # Guide render Service (../render/), not a loopback sidecar.
                 # `precise-prefix-cache-routing-` namePrefix + Service name `render`.
                 url: "http://precise-prefix-cache-routing-render:8000"
           - type: endpoint-notification-source


### PR DESCRIPTION
## Summary

In the `precise-prefix-cache-routing` guide, the render (tokenizer) Service no longer has pods of its own by default. Instead of three GPU-less `vllm launch render` replicas, it selects the vLLM model server pods the guide already deploys, since `vllm serve` exposes `/v1/completions/render` and `/v1/chat/completions/render` out of the box.

The old renderer pool moves to `render/standalone/`, still required for SGLang (it doesn't implement vLLM's render endpoints). Both overlays publish the same Service name, so the router's `vllm.url` is unchanged. Apply exactly one.

### Why

Every request is tokenized before it's routed, so the render call sits inside TTFT. A separately-scheduled pool saturates before the model servers do as QPS climbs; fronting the model servers makes render capacity scale with the serving fleet.

At higher RPS, latency is more contained with this approach than with the CPU renderers. See below the benchmarking data for `Qwen3-32B` and [this workload](https://github.com/albertoperdomo2/benchflow/blob/main/profiles/benchmark/x-70r-6kSys.yaml). 

<img width="1524" height="343" alt="image" src="https://github.com/user-attachments/assets/7821d704-bb4e-4d27-8d6f-ccc44998c1e6" />

<img width="1538" height="827" alt="image" src="https://github.com/user-attachments/assets/1ea69b7f-23d2-49fb-8bd1-c31900f25b80" />

## Notes

- `modelName` **mismatches now fail loudly** instead of silently scoring against the wrong tokenizer.
- Added the render paths to `--disable-access-log-for-endpoints`, otherwise each model server logs a line per routed request.
- Unaffected by standalone vs. gateway mode, verified by templating both charts: identical `token-producer` params and InferencePool selectors.