### PR TITLE
docs(e-disaggregation): rebalance E/P/D worker counts and TP, add TP=2 to encode workers

### DIFF
--- a/guides/multimodal-serving/e-disaggregation/README.md
+++ b/guides/multimodal-serving/e-disaggregation/README.md
@@ -21,16 +21,16 @@ llm-d supports two encode-disaggregated topologies:
 
 In E/PD, dedicated encode workers handle multimodal processing while a single worker type handles both prefill and decode. Multiple encode workers enable parallel processing of multimodal entries within a single request:
 
-* 2 Encode Workers (multimodal encoding, parallelized across entries)
+* 2 TP=2 Encode Workers (multimodal encoding, parallelized across entries)
 * 8 TP=2 Decode Workers (prefill + decode combined)
 
 ### E/P/D Configuration
 
 E/P/D extends P/D disaggregation by adding a dedicated encode stage. This provides maximum specialization, with multiple encode workers processing multimodal content in parallel:
 
-* 2 Encode Workers (multimodal encoding, parallelized across entries)
-* 2 TP=4 Prefill Workers
-* 2 TP=4 Decode Workers
+* 2 TP=2 Encode Workers (multimodal encoding, parallelized across entries)
+* 4 TP=2 Prefill Workers
+* 4 TP=2 Decode Workers
 
 ### Best Practices
 

--- a/guides/multimodal-serving/e-disaggregation/README.md
+++ b/guides/multimodal-serving/e-disaggregation/README.md
@@ -81,7 +81,6 @@ export GUIDE_PATH="multimodal-serving/e-disaggregation"
 export TOPOLOGY="e-p-d"
 export NAMESPACE="llm-d-e-p-d-disaggregation"
 export MODEL_NAME="Qwen/Qwen3-VL-32B-Instruct"
-export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
 ```
 
 - Install the Gateway API Inference Extension CRDs:

--- a/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/patch-decode.yaml
+++ b/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/patch-decode.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: decode
 spec:
-  replicas: 3
+  replicas: 4
   template:
     spec:
       initContainers:

--- a/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/patch-prefill.yaml
+++ b/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/patch-prefill.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: prefill
 spec:
-  replicas: 3
+  replicas: 4
   template:
     spec:
       containers:


### PR DESCRIPTION
## Summary
- Change E/P/D Prefill and Decode workers from 3 replicas to 4 replicas(`patch-prefill.yaml`, `patch-decode.yaml`)
- Add tensor-parallel-size=2 to the Encode workers (shared by E/PD and E/P/D) in the `README` file 
-  Update `README` worker-count tables for both topologies to match (also fixes a pre-existing mismatch where the `README` said "2 TP=4 Prefill/Decode Workers" while the manifests deployed 3 workers with TP=2)