### PR TITLE
[Observability][Feature]: Add TPU metrics PodMonitor

### DIFF
--- a/guides/recipes/observability/tpu/README.md
+++ b/guides/recipes/observability/tpu/README.md
@@ -1,0 +1,28 @@
+# GKE TPU Metrics
+
+This recipe configures the Prometheus Operator to scrape the existing GKE TPU
+device-plugin metrics exporter. It does not install or configure the exporter.
+
+It is intended for llm-d's central `kube-prometheus-stack` monitoring setup.
+Apply it after the TPU node pool and the monitoring stack are available:
+
+```bash
+kubectl apply -k ${REPO_ROOT}/guides/recipes/observability/tpu
+```
+
+Verify that the exporter pods and the PodMonitor are present:
+
+```bash
+kubectl get pods -n kube-system -l k8s-app=tpu-device-plugin
+kubectl get podmonitor -n kube-system tpu-metrics-exporter
+```
+
+The monitor selects the documented GKE device-plugin label and scrapes
+`/metrics` on port `2112`.
+
+The PodMonitor is labeled
+`app.kubernetes.io/name: tpu-metrics-exporter`. When using a non-empty
+`podMonitorSelector`, configure it to match this label. The
+`podMonitorNamespaceSelector` must also include the `kube-system` namespace.
+Otherwise, the PodMonitor may be created successfully without being discovered
+by Prometheus.

--- a/guides/recipes/observability/tpu/kustomization.yaml
+++ b/guides/recipes/observability/tpu/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - tpu-metrics-exporter-podmonitor.yaml

--- a/guides/recipes/observability/tpu/tpu-metrics-exporter-podmonitor.yaml
+++ b/guides/recipes/observability/tpu/tpu-metrics-exporter-podmonitor.yaml
@@ -1,0 +1,17 @@
+# Scrape the GKE TPU device-plugin metrics exporter with the Prometheus Operator.
+# The exporter is provided by the GKE TPU runtime.
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: tpu-metrics-exporter
+  labels:
+    app.kubernetes.io/name: tpu-metrics-exporter
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: tpu-device-plugin
+  podMetricsEndpoints:
+    - portNumber: 2112
+      path: /metrics
+      interval: 15s


### PR DESCRIPTION
## What changed

Add a Prometheus Operator `PodMonitor` recipe for the existing GKE TPU device-plugin metrics exporter.

The recipe:

- selects exporter pods with `k8s-app: tpu-device-plugin` in `kube-system`;
- scrapes port `2112` every 15 seconds;
- includes a Kustomize entry point and short usage instructions.

This is the monitoring integration requested in #2157. The exporter itself is provided by the GKE TPU runtime and is not installed here.

## Scope

This change intentionally does not add a TPU exporter, Grafana dashboard, recording rules, or alerts. Those pieces can be added separately once the production exporter metric names and labels are confirmed.

Refs #2157

## Validation

- YAML structure and whitespace checks passed.
- Applied the PodMonitor in a disposable Kind cluster with `kube-prometheus-stack` 88.1.5.
- A synthetic exporter with the documented label and port was discovered by Prometheus and reported `up`.
- PromQL queries returned synthetic `tpu_mxu_duty_cycle` and `tpu_hbm_memory_used_bytes` samples.

No TPU hardware or GKE runtime validation was available.
