### PR TITLE
feat(autoscaling): add queue-based KEDA+EPP autoscaling nightly (OCP GPU)

### DIFF
--- a/.github/workflows/consolidate-status-workload-autoscaling-keda-epp-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/consolidate-status-workload-autoscaling-keda-epp-ibm-acc-gpu-vllm-x.yaml
@@ -1,0 +1,32 @@
+name: Past Status - Workload Autoscaling KEDA+EPP Queue E2E (OCP GPU)
+
+on:
+  workflow_dispatch:
+    inputs:
+      workflow_name_query:
+        description: 'Name of the workflow to be queried'
+        required: false
+        type: 'string'
+        default: 'nightly-e2e-workload-autoscaling-keda-epp-ibm-acc-gpu-vllm-x.yaml'
+      time_window_query:
+        description: 'How many days in the past to query'
+        required: true
+        type: 'string'
+        default: '5'
+      branch_query:
+        description: 'Branch to be queried'
+        required: false
+        type: string
+        default: 'main'
+
+  schedule:
+    - cron: '0 11 * * *'  # 11:00 UTC daily (after the WVA past-status at 10:00)
+
+jobs:
+  check_for_success:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-query-success-past-runs.yaml@main
+    with:
+      workflow_name_query: ${{ inputs.workflow_name_query || 'nightly-e2e-workload-autoscaling-keda-epp-ibm-acc-gpu-vllm-x.yaml' }}
+      time_window_query: ${{ inputs.time_window_query || '5' }}
+      branch_query: ${{ inputs.branch_query || 'main' }}
+    secrets: inherit

--- a/.github/workflows/nightly-e2e-workload-autoscaling-keda-epp-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-workload-autoscaling-keda-epp-ibm-acc-gpu-vllm-x.yaml
@@ -1,0 +1,108 @@
+name: Nightly - Workload Autoscaling KEDA+EPP Queue E2E (OCP GPU)
+
+# Nightly regression test for the queue-based KEDA + EPP autoscaling path
+# (guides/workload-autoscaling/README.hpa-epp.md) on OpenShift. Deploys the
+# optimized-baseline modelserver + EPP router and scales the decode Deployment
+# directly from EPP queue metrics via KEDA (keda-epp-queue/ocp) — there is NO
+# WVA controller on this path.
+#
+# Runs ALONGSIDE nightly-e2e-workload-autoscaling-ibm-acc-gpu-vllm-x.yaml (the
+# WVA path); the two test different autoscalers and must not replace each other.
+
+on:
+  schedule:
+    - cron: '0 5 * * *'  # 05:00 UTC daily (staggered from the WVA path at 03:00)
+  workflow_dispatch:
+    inputs:
+      # decode_pods/prefill_pods/harness/workload are accepted only for
+      # /test-nightly compatibility: that command classifies any nightly-e2e-*
+      # not containing "-wva-" as a benchmark nightly and always passes these.
+      # This path runs no benchmark (metric-pipeline validation only), so they are
+      # accepted-and-ignored; only cleanup/dry_run/update_badge take effect.
+      decode_pods:
+        description: 'Unused on this path (accepted for /test-nightly compatibility)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      prefill_pods:
+        description: 'Unused on this path (accepted for /test-nightly compatibility)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      harness:
+        description: 'Unused on this path (accepted for /test-nightly compatibility)'
+        required: false
+        type: 'string'
+        default: 'inference-perf'
+      workload:
+        description: 'Unused on this path (accepted for /test-nightly compatibility)'
+        required: false
+        type: 'string'
+        default: 'sanity_random.yaml'
+      cleanup:
+        description: 'Cleanup the llm-d stack stood up by this workflow'
+        required: false
+        default: 'true'
+        type: string
+      pr_number:
+        description: 'PR number for comment-back (set by /test-nightly)'
+        required: false
+        default: ''
+      pr_repo:
+        description: 'Repo for PR comment-back'
+        required: false
+        default: 'llm-d/llm-d'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode ("true", "false")'
+        required: false
+        default: 'true'
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
+
+permissions:
+  contents: write
+  actions: read
+  packages: write
+
+concurrency:
+  group: nightly-e2e-keda-epp-queue-ocp
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    if: github.repository == 'llm-d/llm-d'
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-openshift.yaml@main
+    with:
+      guide_name: workload-autoscaling
+      namespace: llm-d-nightly-keda-epp-queue
+      # EPP Service name for helm release `optimized-baseline` (matches the guide),
+      # confirmed via `helm template`. The deploy script also discovers this at
+      # runtime for the ScaledObject queries; this input is used by the gateway
+      # smoke test.
+      gateway_host: 'optimized-baseline-epp'
+      custom_deploy_script: |
+        bash guides/workload-autoscaling/scripts/nightly-deploy-ocp-keda-epp.sh
+      required_gpus: 2
+      recommended_gpus: 4
+      pod_wait_timeout: '30m'
+      pod_readiness_delay: 180
+      image_override: 'ghcr.io/llm-d/llm-d-cuda-dev:latest'
+      allow_gpu_preemption: true
+      skip_cleanup: ${{ inputs.cleanup == 'false' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_repo: ${{ github.event.inputs.pr_repo }}
+    secrets: inherit
+
+  update-badge:
+    needs: [nightly]
+    if: always() && inputs.update_badge != 'false'
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
+    with:
+      badge_name: keda-epp-queue-ocp
+      badge_label: "VLLM GPU Queue"
+      result: ${{ needs.nightly.result }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/guides/workload-autoscaling/README.md
+++ b/guides/workload-autoscaling/README.md
@@ -1,6 +1,7 @@
 # Workload Autoscaling
 
-[![E2E (OCP GPU)](https://github.com/llm-d/llm-d/actions/workflows/consolidate-status-workload-autoscaling-ibm-acc-gpu-vllm-x.yaml/badge.svg)](https://github.com/llm-d/llm-d/actions/workflows/consolidate-status-workload-autoscaling-ibm-acc-gpu-vllm-x.yaml)
+[![WVA E2E (OCP GPU)](https://github.com/llm-d/llm-d/actions/workflows/consolidate-status-workload-autoscaling-ibm-acc-gpu-vllm-x.yaml/badge.svg)](https://github.com/llm-d/llm-d/actions/workflows/consolidate-status-workload-autoscaling-ibm-acc-gpu-vllm-x.yaml)
+[![KEDA+EPP Queue E2E (OCP GPU)](https://github.com/llm-d/llm-d/actions/workflows/consolidate-status-workload-autoscaling-keda-epp-ibm-acc-gpu-vllm-x.yaml/badge.svg)](https://github.com/llm-d/llm-d/actions/workflows/consolidate-status-workload-autoscaling-keda-epp-ibm-acc-gpu-vllm-x.yaml)
 
 Traditional autoscaling indicators like resource utilization metrics (CPU/GPU) are often lagging indicators — they only reflect saturation after it has already occurred, by which point latency has spiked and requests may be failing. For LLM inference, this problem is compounded by the fact that GPU utilization is often pegged near 100% during active batching regardless of actual load, making it an entirely unreliable signal.
 

--- a/guides/workload-autoscaling/scripts/nightly-deploy-ocp-keda-epp.sh
+++ b/guides/workload-autoscaling/scripts/nightly-deploy-ocp-keda-epp.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# Deploy the queue-based KEDA + EPP autoscaling path (README.hpa-epp.md) on
+# OpenShift in a single namespace. Same code path for CI nightly runs and local
+# development.
+#
+# This is the EPP-direct sibling of nightly-deploy-ocp.sh (the WVA path). It
+# deploys the SAME optimized-baseline modelserver + EPP router, but drives
+# autoscaling directly from EPP queue metrics via KEDA — there is NO WVA
+# controller on this path. KEDA reads `llm_d_epp_flow_control_queue_size` (and
+# `llm_d_epp_request_running`) from Thanos and scales the decode Deployment.
+#
+# Environment variables:
+#   NAMESPACE     target namespace for ALL resources (default: keda-epp-queue-nightly-XXXX)
+#   OUTPUT_DIR    where to write the generated overlay (default: mktemp -d)
+#   EPP_SERVICE   override the EPP service name in the trigger queries
+#                 (default: auto-discovered from the namespace after the router install)
+#   MODEL_NAME    model_name label in the trigger queries (default: Qwen/Qwen3-32B)
+#   ROUTER_CHART_VERSION  EPP router chart version (default: set by guides/env.sh)
+
+set -euo pipefail
+
+if command -v grealpath &>/dev/null; then
+  _realpath=grealpath          # macOS: brew install coreutils
+elif realpath --version &>/dev/null 2>&1; then
+  _realpath=realpath           # Linux GNU coreutils
+else
+  echo "ERROR: GNU realpath not found. On macOS install it with: brew install coreutils" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+source "${REPO_ROOT}/guides/env.sh"
+
+NAMESPACE="${NAMESPACE:-keda-epp-queue-nightly-$(printf '%04x' $RANDOM)}"
+SCALEDOBJECT=optimized-baseline-keda-epp
+DECODE_DEPLOYMENT=optimized-baseline-nvidia-gpu-vllm-decode
+MODEL_NAME="${MODEL_NAME:-Qwen/Qwen3-32B}"
+# EPP router Helm release. Matches the guide (README.hpa-epp.md step 4), which
+# installs the router as `optimized-baseline` and expects the EPP named
+# `optimized-baseline-epp` — the same `service` label the guide's checked-in
+# ScaledObject query uses. The Service name is release-derived, so we still
+# discover it at runtime rather than hardcoding it.
+ROUTER_RELEASE=optimized-baseline
+# Short hash used as a suffix on the ClusterRoleBinding to make it unique per namespace.
+NS_HASH="$(printf '%s' "${NAMESPACE}" | sha256sum | cut -c1-8)"
+OUTPUT_DIR="${OUTPUT_DIR:-$(mktemp -d -t nightly-deploy-ocp-keda-epp.XXXXXX)}"
+ROUTER_CHART_VERSION="${ROUTER_CHART_VERSION}"
+
+mkdir -p "${OUTPUT_DIR}"
+REL="$("${_realpath}" --relative-to="${OUTPUT_DIR}" "${REPO_ROOT}")"
+
+echo "==> Deploying queue-based KEDA+EPP path"
+echo "  NAMESPACE: ${NAMESPACE}"
+
+# KEDA is the external metrics provider. On OpenShift it is operator-managed
+# (Custom Metrics Autoscaler); this path never installs it.
+echo "==> Checking for KEDA"
+if ! kubectl get crd scaledobjects.keda.sh >/dev/null 2>&1; then
+  echo "ERROR: CRD scaledobjects.keda.sh not found." >&2
+  echo "       KEDA must be installed on the cluster (Custom Metrics Autoscaler operator on OpenShift)." >&2
+  exit 1
+fi
+
+echo "==> Ensuring namespace ${NAMESPACE} exists"
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+# Enable user-workload-monitoring to scrape this namespace's ServiceMonitors so
+# the EPP metrics reach Thanos (matches the WVA path's OpenShift setup).
+kubectl label namespace "${NAMESPACE}" openshift.io/user-monitoring=true --overwrite
+
+echo "==> Installing EPP router via Helm (release: ${ROUTER_RELEASE})"
+# Values are layered: base -> optimized-baseline -> monitoring -> keda-epp-queue.
+#   monitoring.values.yaml     enables the router's Prometheus ServiceMonitor.
+#   keda-epp-queue router.values.yaml enables the flowControl feature gate — the
+#     source of llm_d_epp_flow_control_queue_size — plus the queue-scoring EPP
+#     plugins. Without these two the queue metric is never emitted or scraped.
+helm install "${ROUTER_RELEASE}" \
+  "${ROUTER_STANDALONE_CHART}" \
+  -f "${REPO_ROOT}/guides/recipes/router/base.values.yaml" \
+  -f "${REPO_ROOT}/guides/optimized-baseline/router/optimized-baseline.values.yaml" \
+  -f "${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml" \
+  -f "${REPO_ROOT}/guides/workload-autoscaling/optimized-baseline-autoscaling/keda-epp-queue/router.values.yaml" \
+  -n "${NAMESPACE}" --version "${ROUTER_CHART_VERSION}"
+
+# Discover the EPP Service name the chart created (release-derived; release
+# `optimized-baseline` yields Service `optimized-baseline-epp`). The queue metric is
+# labelled by this `service` value, so the ScaledObject query must match it exactly.
+# We discover rather than hardcode so the nightly still works if the release name or
+# chart naming changes.
+if [[ -z "${EPP_SERVICE:-}" ]]; then
+  echo "==> Discovering EPP Service name"
+  EPP_SERVICE="$(kubectl get svc -n "${NAMESPACE}" -o name \
+    | sed 's#^service/##' | grep -E -- '-epp$' | head -1 || true)"
+fi
+if [[ -z "${EPP_SERVICE:-}" ]]; then
+  echo "ERROR: could not find an EPP Service (name ending in -epp) in ${NAMESPACE}." >&2
+  echo "       Set EPP_SERVICE explicitly, or check the router install." >&2
+  kubectl get svc -n "${NAMESPACE}" >&2 || true
+  exit 1
+fi
+echo "  EPP_SERVICE: ${EPP_SERVICE}"
+echo "  MODEL_NAME:  ${MODEL_NAME}"
+
+# Nightly patch for the decode Deployment: GPU scheduling priority + triton cache,
+# and start at 1 replica (the ScaledObject floor) so load — not a pinned count —
+# drives scale-up, and there is no idle scale-down race during the ~6 min vLLM
+# startup. maxReplicaCount is capped at the GPU budget the nightly reserves (2).
+cat > "${OUTPUT_DIR}/patch-vllm.yaml" <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${DECODE_DEPLOYMENT}
+spec:
+  replicas: 1
+  template:
+    spec:
+      priorityClassName: nightly-gpu-critical
+      volumes:
+        - name: triton-cache
+          emptyDir: {}
+      containers:
+        - name: modelserver
+          volumeMounts:
+            - mountPath: /.triton
+              name: triton-cache
+EOF
+
+echo "==> Generating overlay in ${OUTPUT_DIR}"
+cat > "${OUTPUT_DIR}/kustomization.yaml" <<EOF
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ${NAMESPACE}
+resources:
+  - ${REL}/guides/optimized-baseline/modelserver/gpu/vllm/base/
+  - ${REL}/guides/workload-autoscaling/optimized-baseline-autoscaling/keda-epp-queue/ocp/
+patches:
+  # The namespace/service/model_name live inside opaque PromQL strings that the
+  # kustomize namespace transformer cannot reach — rewrite both trigger queries
+  # explicitly to match the deployed EPP. maxReplicaCount is capped at the GPU
+  # budget the nightly reserves (2), rather than the guide's default of 8.
+  - patch: |-
+      - op: replace
+        path: /spec/triggers/0/metadata/query
+        value: >-
+          sum(llm_d_epp_flow_control_queue_size{namespace="${NAMESPACE}",service="${EPP_SERVICE}",model_name="${MODEL_NAME}"})
+      - op: replace
+        path: /spec/triggers/1/metadata/query
+        value: >-
+          sum(llm_d_epp_request_running{namespace="${NAMESPACE}",service="${EPP_SERVICE}",model_name="${MODEL_NAME}"})
+      - op: replace
+        path: /spec/maxReplicaCount
+        value: 2
+    target:
+      kind: ScaledObject
+      name: ${SCALEDOBJECT}
+  # ClusterRoleBindings are cluster-scoped; suffix a namespace hash so concurrent
+  # deployments to different namespaces do not collide on the same CRB name.
+  - patch: |-
+      - op: replace
+        path: /metadata/name
+        value: keda-epp-metrics-reader-monitoring-view-${NS_HASH}
+    target:
+      kind: ClusterRoleBinding
+      name: keda-epp-metrics-reader-monitoring-view
+  - path: patch-vllm.yaml
+    target:
+      kind: Deployment
+      name: ${DECODE_DEPLOYMENT}
+EOF
+
+echo "==> Validating kustomization"
+kubectl kustomize "${OUTPUT_DIR}" >/dev/null
+
+echo "==> Applying kustomize overlay"
+kubectl apply -k "${OUTPUT_DIR}"
+
+# llm_d_epp_flow_control_queue_size is a PER-MODEL series that only exists once the
+# EPP has a ready backend endpoint — i.e. the decode modelserver is up (verified on
+# pokprod: an idle pool with ready_endpoints=1 and zero traffic still reports
+# queue_size=0, but a pool with no ready endpoint reports no series at all). So wait
+# for the modelserver before the Fallback check below, or KEDA would query an empty
+# series and the gate would fail before the stack is even ready. vLLM startup (image
+# pull + model load) commonly takes several minutes.
+echo "==> Waiting for the decode modelserver to become ready (vLLM startup)"
+kubectl rollout status deployment/"${DECODE_DEPLOYMENT}" \
+  -n "${NAMESPACE}" --timeout=20m
+
+echo "==> Waiting for the ScaledObject to be Ready"
+# Ready only means KEDA accepted the trigger and created its HPA. It does NOT mean
+# the metric pipeline works — see the Fallback check below.
+kubectl wait scaledobject/"${SCALEDOBJECT}" \
+  -n "${NAMESPACE}" --for=condition=Ready --timeout=300s
+
+# Assert the metric pipeline is live: EPP -> user-workload-monitoring -> Thanos ->
+# KEDA -> HPA. If KEDA cannot query Thanos (401, wrong label, no such series) it
+# suppresses the error and serves `fallback: replicas`, so the ScaledObject still
+# reports Ready=True while autoscaling is dead. The only signal that any of it is
+# real is Fallback=False. Require it to HOLD: it reads False before KEDA's first
+# poll, so a single early reading is meaningless.
+echo "==> Verifying KEDA is scaling on the real metric (not fallback)"
+streak=0
+for _ in $(seq 1 30); do
+  fallback="$(kubectl get scaledobject/"${SCALEDOBJECT}" -n "${NAMESPACE}" \
+    -o jsonpath='{.status.conditions[?(@.type=="Fallback")].status}' 2>/dev/null || true)"
+  if [[ "${fallback}" == "False" ]]; then
+    streak=$((streak + 1))
+    [[ "${streak}" -ge 3 ]] && break
+  else
+    streak=0
+  fi
+  sleep 10
+done
+
+if [[ "${streak}" -lt 3 ]]; then
+  echo "ERROR: ScaledObject is in fallback (Fallback=${fallback:-unknown}) — KEDA is NOT reading" >&2
+  echo "       the EPP queue metric. Replica count is coming from spec.fallback." >&2
+  kubectl get scaledobject/"${SCALEDOBJECT}" -n "${NAMESPACE}" \
+    -o jsonpath='{range .status.conditions[*]}  {.type}={.status} ({.reason}: {.message}){"\n"}{end}' >&2
+  echo "--- KEDA operator errors for this namespace ---" >&2
+  kubectl logs -n openshift-keda -l app=keda-operator --tail=200 2>/dev/null \
+    | grep -i "${NAMESPACE}" | tail -10 >&2 || true
+  exit 1
+fi
+
+echo "==> Listing autoscaling resources"
+# KEDA owns the HPA (keda-hpa-*); we do not create one ourselves.
+kubectl get scaledobject,hpa -n "${NAMESPACE}"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds a nightly test lane for the **queue-based KEDA + EPP** autoscaling guide (`guides/workload-autoscaling/README.hpa-epp.md`), which has no CI today. The existing `workload-autoscaling` nightly tests the legacy WVA path (`wva_desired_replicas`); this lane tests the EPP-direct path. KEDA scales the decode Deployment straight from `llm_d_epp_flow_control_queue_size`, with **no WVA controller**.

This is the "wiring / signal-liveness" gate: it validates that the guide deploys, the EPP emits the queue metric with the right labels, user-workload-monitoring scrapes it into Thanos, KEDA authenticates to Thanos, and the HPA is driven by the real signal (`Fallback=False`) the silent-failure class (401 / wrong CA / label drift / missing metric) that breaks autoscaling invisibly. Load-driven scale-up actuation is a planned follow-up as V2.

Files:

- **`scripts/nightly-deploy-ocp-keda-epp.sh`** — the EPP-direct sibling of `nightly-deploy-ocp.sh`. Installs the EPP router as helm release `optimized-baseline` (matching the guide → EPP Service `optimized-baseline-epp`) with the `monitoring` + `keda-epp-queue/router.values.yaml` values (the latter enables `featureGates: [flowControl]`, the source of the queue metric), applies `keda-epp-queue/ocp`, discovers the EPP Service name at runtime and templates both trigger queries' `namespace`/`service`/`model_name` to it, labels the namespace for UWM scraping, starts the decode Deployment at 1 replica, waits for it to be ready (the queue metric is per-model and only exists once the EPP has a ready backend endpoint), then gates on `Fallback=False`. `maxReplicaCount` is capped at the GPU budget (2).
- **`nightly-e2e-workload-autoscaling-keda-epp-ibm-acc-gpu-vllm-x.yaml`** — the nightly workflow, calling `reusable-nightly-e2e-openshift.yaml@main` with the deploy script as `custom_deploy_script` (no WVA image-build job). Distinct namespace (`llm-d-nightly-keda-epp-queue`), concurrency group, badge (`keda-epp-queue-ocp`), and schedule (`0 5 * * *`) from the WVA lane. Declares the inputs `/test-nightly` passes so it can be triggered by comment.
- **`consolidate-status-workload-autoscaling-keda-epp-ibm-acc-gpu-vllm-x.yaml`** — the companion past-status query (flake-tolerant "green ≥1× in 5 days").
- **`guides/workload-autoscaling/README.md`** — adds the status badge for the new lane; relabels the existing badge "WVA" so the two are distinguishable.

**Verification:**
- `kubectl kustomize` builds the generated overlay; both trigger queries are templated to the deployed EPP's `namespace`/`service`/`model_name`; the Thanos endpoint, `authModes: bearer`, and SA-token auth are inherited from `keda-epp-queue/ocp`; the decode Deployment is patched to 1 replica with the nightly GPU priority class. `bash -n` clean; all referenced value files resolve; both workflow YAMLs parse; the consolidate-status file and README badge reference the nightly by filename.
- Validated on a live OpenShift cluster (EPP router only): the helm install succeeds and the EPP pod runs; the Service (`optimized-baseline-epp`) and ServiceMonitor are created; the `flowControl` gate is active; and UWM scrapes such ServiceMonitors into Thanos by default on this cluster. Confirmed against live cluster state that `llm_d_epp_flow_control_queue_size` is a per-model series present at `0` once `flowControl` is enabled AND the EPP has a ready endpoint (no traffic needed) — hence the deploy waits for the modelserver before the `Fallback=False` gate.
- End-to-end behavior (metric flows → `Fallback=False`) requires the GPU modelserver; recommend a `/test-nightly workload-autoscaling-keda-epp-ibm-acc-gpu-vllm-x` run before relying on the schedule.

**Which issue(s) this PR fixes**:

N/A — adds nightly CI for the queue-based KEDA+EPP autoscaling guide.

**Release note**:

```release-note
NONE
```
