### PR TITLE
Update cron job to run at 3AM UTC daily

### DIFF
--- a/.github/workflows/consolidate-status-fast-model-actuation-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/consolidate-status-fast-model-actuation-ibm-acc-gpu-vllm-x.yaml
@@ -24,7 +24,7 @@ on:
 #      - main
 
   schedule:
-    - cron: '0 12 * * *'  # 12:00 UTC daily (aligned with the FMA nightly)
+    - cron: '0 3 * * *'  # 03:00 UTC daily
 
 jobs:
   check_for_success:

--- a/.github/workflows/consolidate-status-optimized-baseline-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/consolidate-status-optimized-baseline-ibm-acc-gpu-vllm-x.yaml
@@ -24,7 +24,7 @@ on:
 #      - main
 
   schedule:
-    - cron: '0 10 * * *'  # 10:00 UTC daily
+    - cron: '0 3 * * *'  # 03:00 UTC daily
 
 jobs:
   check_for_success:

--- a/.github/workflows/consolidate-status-pd-disaggregation-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/consolidate-status-pd-disaggregation-ibm-acc-gpu-vllm-x.yaml
@@ -24,7 +24,7 @@ on:
 #      - main
 
   schedule:
-    - cron: '0 10 * * *'  # 10:00 UTC daily
+    - cron: '0 3 * * *'  # 03:00 UTC daily
 
 jobs:
   check_for_success:

--- a/.github/workflows/consolidate-status-precise-prefix-cache-routing-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/consolidate-status-precise-prefix-cache-routing-ibm-acc-gpu-vllm-x.yaml
@@ -24,7 +24,7 @@ on:
 #      - main
 
   schedule:
-    - cron: '0 5 * * *'  # 05:00 UTC daily
+    - cron: '0 3 * * *'  # 03:00 UTC daily
 
 jobs:
   check_for_success:

--- a/.github/workflows/consolidate-status-predicted-latency-routing-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/consolidate-status-predicted-latency-routing-ibm-acc-gpu-vllm-x.yaml
@@ -24,7 +24,7 @@ on:
 #      - main
 
   schedule:
-    - cron: '0 10 * * *'  # 10:00 UTC daily
+    - cron: '0 3 * * *'  # 03:00 UTC daily
 
 jobs:
   check_for_success:

--- a/.github/workflows/consolidate-status-tiered-prefix-cache-ibm-cpu-gpu-vllm-native.yaml
+++ b/.github/workflows/consolidate-status-tiered-prefix-cache-ibm-cpu-gpu-vllm-native.yaml
@@ -24,7 +24,7 @@ on:
 #      - main
 
   schedule:
-    - cron: '0 13 * * *'  # 13:00 UTC daily
+    - cron: '0 3 * * *'  # 03:00 UTC daily
 
 jobs:
   check_for_success:

--- a/.github/workflows/consolidate-status-wide-ep-lws-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/consolidate-status-wide-ep-lws-ibm-acc-gpu-vllm-x.yaml
@@ -24,7 +24,7 @@ on:
 #      - main
 
   schedule:
-    - cron: '0 10 * * *'  # 10:00 UTC daily
+    - cron: '0 3 * * *'  # 03:00 UTC daily
 
 jobs:
   check_for_success:

--- a/.github/workflows/consolidate-status-workload-autoscaling-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/consolidate-status-workload-autoscaling-ibm-acc-gpu-vllm-x.yaml
@@ -24,7 +24,7 @@ on:
 #      - main
 
   schedule:
-    - cron: '0 10 * * *'  # 10:00 UTC daily
+    - cron: '0 3 * * *'  # 03:00 UTC daily
 
 jobs:
   check_for_success:

--- a/.github/workflows/nightly-e2e-fast-model-actuation-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-fast-model-actuation-ibm-acc-gpu-vllm-x.yaml
@@ -56,7 +56,7 @@ on:
 #      - main
 
   schedule:
-    - cron: '0 12 * * *'  # 12:00 UTC daily (staggered ~2h after the 10:00 guide nightlies)
+    - cron: '0 3 * * *'  # 03:00 UTC daily
 
 permissions:
   contents: write

--- a/.github/workflows/nightly-e2e-optimized-baseline-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-ibm-acc-gpu-vllm-x.yaml
@@ -57,7 +57,7 @@ on:
 #      - main
 
   schedule:
-    - cron: '0 10 * * *'  # 10:00 UTC daily
+    - cron: '0 3 * * *'  # 03:00 UTC daily
 
 permissions:
   contents: write

--- a/.github/workflows/nightly-e2e-pd-disaggregation-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-ibm-acc-gpu-vllm-x.yaml
@@ -57,7 +57,7 @@ on:
 #      - main
 
   schedule:
-    - cron: '0 3 * * *'
+    - cron: '0 3 * * *'  # 03:00 UTC daily
 
 permissions:
   contents: write

--- a/.github/workflows/nightly-e2e-precise-prefix-cache-routing-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-routing-ibm-acc-gpu-vllm-x.yaml
@@ -57,7 +57,7 @@ on:
 #      - main
 
   schedule:
-    - cron: '0 5 * * *'  # 05:00 UTC daily
+    - cron: '0 3 * * *'  # 03:00 UTC daily
 
 permissions:
   contents: write

--- a/.github/workflows/nightly-e2e-predicted-latency-routing-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-predicted-latency-routing-ibm-acc-gpu-vllm-x.yaml
@@ -57,7 +57,7 @@ on:
 #      - main
 
   schedule:
-    - cron: '0 10 * * *'  # 10:00 UTC daily
+    - cron: '0 3 * * *'  # 03:00 UTC daily
 
 permissions:
   contents: write

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-ibm-cpu-gpu-vllm-native.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-ibm-cpu-gpu-vllm-native.yaml
@@ -57,7 +57,7 @@ on:
 #      - main
 
   schedule:
-    - cron: '0 12 * * *'  # 10:00 UTC daily
+    - cron: '0 3 * * *'  # 03:00 UTC daily
 
 permissions:
   contents: write

--- a/.github/workflows/nightly-e2e-wide-ep-lws-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-ibm-acc-gpu-vllm-x.yaml
@@ -57,7 +57,7 @@ on:
 #      - main
 
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '0 3 * * *'  # 03:00 UTC daily
 
 permissions:
   contents: write

--- a/.github/workflows/nightly-e2e-workload-autoscaling-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-workload-autoscaling-ibm-acc-gpu-vllm-x.yaml
@@ -9,7 +9,7 @@ name: Nightly - Workload Autoscaling E2E (OCP GPU)
 
 on:
   schedule:
-    - cron: '0 3 * * *'  # 03:00 UTC daily (staggered from tiered-prefix-cache)
+    - cron: '0 3 * * *'  # 03:00 UTC daily
   workflow_dispatch:
     inputs:
       image_tag:


### PR DESCRIPTION
Update cron job to run at 3AM UTC (11PM in NYC and 6AM in Israel) daily in IBM nightlies and consolidates