### PR TITLE
fix(flow-control): repair user-facing guide breakages

### DIFF
--- a/guides/env.sh
+++ b/guides/env.sh
@@ -7,6 +7,10 @@ export REPO_ROOT=${REPO_ROOT:-$(realpath $(git rev-parse --show-toplevel 2>/dev/
 export GAIE_VERSION=v1.5.0
 export ROUTER_CHART_VERSION=v0
 export ROUTER_EPP_VERSION=main
+# GitHub release tag for CRD manifests. Distinct from ROUTER_CHART_VERSION:
+# the chart channel (v0) floats on the OCI registry and has no matching
+# GitHub release, so release-asset URLs must use a real release tag.
+export ROUTER_RELEASE_VERSION=v0.9.0
 export ROUTER_STANDALONE_CHART=oci://ghcr.io/llm-d/charts/llm-d-router-standalone
 export ROUTER_GATEWAY_CHART=oci://ghcr.io/llm-d/charts/llm-d-router-gateway
 export ROUTER_EPP_IMAGE=ghcr.io/llm-d/llm-d-router-endpoint-picker

--- a/guides/flow-control/README.md
+++ b/guides/flow-control/README.md
@@ -89,7 +89,7 @@ Flow Control is a software-level scheduling feature at the EPP layer and is enti
 
   ```bash
   kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
-  kubectl apply -f https://github.com/llm-d/llm-d-router/releases/download/${ROUTER_CHART_VERSION}/manifests.yaml
+  kubectl apply -f https://github.com/llm-d/llm-d-router/releases/download/${ROUTER_RELEASE_VERSION}/manifests.yaml
   ```
 
 * Create a target namespace for the installation:
@@ -161,8 +161,11 @@ kubectl kustomize ${REPO_ROOT}/guides/optimized-baseline/modelserver/gpu/vllm/${
 
 ### 3. Enable monitoring (optional)
 
-* Install the [Monitoring stack](../../docs/operations/observability/setup.md).
-* To enable Prometheus monitoring on the llm-d router, add `-f ${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml` during the [router installation step](#1-deploy-the-router).
+If you want monitoring, decide before step 1: the monitoring values create a
+ServiceMonitor, whose CRD only exists after the monitoring stack is installed.
+
+* Install the [Monitoring stack](../../docs/operations/observability/setup.md) **before deploying the router**.
+* Add `-f ${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml` to the [router installation command](#1-deploy-the-router). If you already installed without it, re-run the same `helm upgrade --install` command with the extra `-f` appended.
 * Deploy the monitoring resources for model servers:
 
 ```bash
@@ -193,8 +196,13 @@ export IP=$(kubectl get gateway llm-d-inference-gateway -n ${NAMESPACE} -o jsonp
 Check EPP logs for feature gate activation:
 
 ```bash
-kubectl logs deploy/${GUIDE_NAME}-epp -n ${NAMESPACE} | grep "Flow Control enabled"
+kubectl logs deploy/${GUIDE_NAME}-epp -n ${NAMESPACE} | grep "Initializing Flow Control layer"
 ```
+
+Expected: one line, `Initializing Flow Control layer`. No output means the gate is off for
+this deployment (the EPP then logs `Flow Control layer is disabled` instead) or the log
+format changed; the stronger check is that `llm_d_epp_flow_control_*` series exist on the
+metrics endpoint (next section).
 
 ### 3. Proof of Queuing
 
@@ -411,7 +419,8 @@ To remove the deployed components:
 ```bash
 helm uninstall ${GUIDE_NAME} -n ${NAMESPACE}
 kubectl delete -f ${REPO_ROOT}/guides/${GUIDE_NAME}/objectives.yaml -n ${NAMESPACE}
-kubectl kustomize ${REPO_ROOT}/guides/optimized-baseline/modelserver/gpu/vllm/ \
+export INFRA_PROVIDER=base # match the value used at deploy time
+kubectl kustomize ${REPO_ROOT}/guides/optimized-baseline/modelserver/gpu/vllm/${INFRA_PROVIDER}/ \
   | sed "s/optimized-baseline/${GUIDE_NAME}/g" \
   | kubectl delete -n ${NAMESPACE} -f -
 ```

--- a/guides/flow-control/objectives.yaml
+++ b/guides/flow-control/objectives.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   priority: 100
   poolRef:
-    name: default-pool
+    name: flow-control
 ---
 apiVersion: llm-d.ai/v1alpha2
 kind: InferenceObjective
@@ -22,7 +22,7 @@ metadata:
 spec:
   priority: 0
   poolRef:
-    name: default-pool
+    name: flow-control
 ---
 apiVersion: llm-d.ai/v1alpha2
 kind: InferenceObjective
@@ -35,4 +35,4 @@ metadata:
 spec:
   priority: -10
   poolRef:
-    name: default-pool
+    name: flow-control

--- a/guides/flow-control/router/flow-control.values.yaml
+++ b/guides/flow-control/router/flow-control.values.yaml
@@ -4,10 +4,9 @@ router:
       port: 80
       protocol: TCP
       targetPort: 8081
-    - name: metrics
-      port: 9090
-      protocol: TCP
-      targetPort: 9090
+    # No metrics entry here: the chart always exposes http-metrics:9090 on the
+    # EPP Service, so declaring it again produces a duplicate-port conflict
+    # that fails the install.
   epp:
     pluginsConfigFile: "custom-plugins.yaml"
     pluginsCustomConfig:


### PR DESCRIPTION
1. **`objectives.yaml` binds to a pool that does not exist.** All three InferenceObjectives hardcode `poolRef.name: default-pool`; this guide's InferencePool is `flow-control`. Priority and fairness headers resolve to nothing and every request lands in band `priority="0"` (observed: 450/450 burst requests dispatched at priority 0 despite `best-effort-traffic` headers), so Use Case 1 silently no-ops. After the fix, a premium request lands in `priority="100"`.

2. **The CRD manifests URL 404s.** The command interpolates `ROUTER_CHART_VERSION` (`v0`), a floating OCI chart channel with no matching GitHub release. `env.sh` gains a distinct `ROUTER_RELEASE_VERSION=v0.9.0` and the README prerequisite uses it.

3. **The verification grep matches nothing.** `grep "Flow Control enabled"` has no counterpart in the EPP. Current `main` logs `Initializing Flow Control layer` (the `experimental` qualifier was dropped at GA graduation), and the disabled path logs `Flow Control layer is disabled...`. The doc now greps the init line and names the disabled-path line, so no output stays diagnosable.

4. **Monitoring ordering is backwards.** Step 3 ("Enable monitoring") tells the reader to add values during the step 1 install, two sections after they installed, and the ServiceMonitor CRD requires the monitoring stack first. The README now states the ordering up front and gives the re-run path for readers who already installed.

5. **Duplicate metrics port fails the install.** `flow-control.values.yaml` declares a 9090 `extraServicePort` the chart already templates unconditionally on the EPP Service, so the install fails with `INSTALLATION FAILED ... duplicate entries for key [port=9090,protocol="TCP"]` regardless of whether `monitoring.values.yaml` is layered (that file never touches `extraServicePorts`). With the entry removed, the chart's own 9090 port remains, so the README's no-monitoring `curl :9090/metrics` check still works.

6. **Cleanup path drifted from the deploy path.** The deploy step renders `modelserver/gpu/vllm/${INFRA_PROVIDER}/`; cleanup rendered `modelserver/gpu/vllm/`, which no longer resolves the same manifests. Cleanup now matches, with a reminder to set `INFRA_PROVIDER` to the deploy-time value.
