### PR TITLE
Exclude non-serving requester pods from the InferencePool

### DIFF
--- a/guides/fast-model-actuation/README.md
+++ b/guides/fast-model-actuation/README.md
@@ -191,6 +191,9 @@ kubectl rollout status deployment/fma-requester -n ${NAMESPACE} --timeout=300s
 > The launcher pod does **not** request GPU resources from the Kubernetes scheduler or device plugin. Instead, the FMA controller sets `CUDA_VISIBLE_DEVICES` to point to the GPU reserved by the corresponding requesting pod, giving the launcher direct access to that GPU via the CUDA runtime. The `runtimeClassName: nvidia` is required on platforms (e.g., OpenShift) where GPU driver libraries are injected via the runtime class rather than the device plugin resource request.
 
 > [!NOTE]
+> Only **bound launcher** pods serve inference on `:8000`. Requester pods reserve the GPU and hold the pod identity, but never listen on that port. Both halves carry the `llm-d.ai/guide: fast-model-actuation` label, so the router's `InferencePool` selector in `router/fast-model-actuation.values.yaml` also matches on `app.kubernetes.io/component: launcher` (set by the FMA chart) to keep requesters out of the pool. Without that second label the EPP load-balances across endpoints that refuse the connection, and requests intermittently fail with `upstream connect error ... Connection refused`. Unbound launchers need no special handling — FMA stamps the `InferenceServerConfig` labels onto a launcher only once it is bound.
+
+> [!NOTE]
 > `launcherCount` is **per matching node**. Setting `launcherCount: 1` creates one launcher pod on each node that has `nvidia.com/gpu.present: "true"`. Only launchers that get bound to a requesting pod will actually start a vLLM instance.
 
 You should see:

--- a/guides/fast-model-actuation/README.md
+++ b/guides/fast-model-actuation/README.md
@@ -191,9 +191,6 @@ kubectl rollout status deployment/fma-requester -n ${NAMESPACE} --timeout=300s
 > The launcher pod does **not** request GPU resources from the Kubernetes scheduler or device plugin. Instead, the FMA controller sets `CUDA_VISIBLE_DEVICES` to point to the GPU reserved by the corresponding requesting pod, giving the launcher direct access to that GPU via the CUDA runtime. The `runtimeClassName: nvidia` is required on platforms (e.g., OpenShift) where GPU driver libraries are injected via the runtime class rather than the device plugin resource request.
 
 > [!NOTE]
-> Only **bound launcher** pods serve inference on `:8000`. Requester pods reserve the GPU and hold the pod identity, but never listen on that port. Both halves carry the `llm-d.ai/guide: fast-model-actuation` label, so the router's `InferencePool` selector in `router/fast-model-actuation.values.yaml` also matches on `app.kubernetes.io/component: launcher` (set by the FMA chart) to keep requesters out of the pool. Without that second label the EPP load-balances across endpoints that refuse the connection, and requests intermittently fail with `upstream connect error ... Connection refused`. Unbound launchers need no special handling — FMA stamps the `InferenceServerConfig` labels onto a launcher only once it is bound.
-
-> [!NOTE]
 > `launcherCount` is **per matching node**. Setting `launcherCount: 1` creates one launcher pod on each node that has `nvidia.com/gpu.present: "true"`. Only launchers that get bound to a requesting pod will actually start a vLLM instance.
 
 You should see:

--- a/guides/fast-model-actuation/router/fast-model-actuation.values.yaml
+++ b/guides/fast-model-actuation/router/fast-model-actuation.values.yaml
@@ -26,5 +26,14 @@ router:
             weight: 1
 
   modelServers:
+    # Select bound launchers ONLY. Both halves of FMA's dual-pods design carry
+    # llm-d.ai/guide, but requester pods never listen on :8000 -- they reserve the
+    # GPU and hold the pod identity while the bound launcher runs vLLM. Selecting
+    # on the guide label alone admits requesters to the pool, and the EPP then
+    # routes a share of traffic to endpoints that refuse the connection. The
+    # component label is set by the FMA chart on launcher pods; unbound launchers
+    # are already excluded because FMA stamps the ISC labels onto a launcher only
+    # once it is bound to a requester.
     matchLabels:
       llm-d.ai/guide: "fast-model-actuation"
+      app.kubernetes.io/component: "launcher"

--- a/guides/fast-model-actuation/router/fast-model-actuation.values.yaml
+++ b/guides/fast-model-actuation/router/fast-model-actuation.values.yaml
@@ -26,14 +26,8 @@ router:
             weight: 1
 
   modelServers:
-    # Select bound launchers ONLY. Both halves of FMA's dual-pods design carry
-    # llm-d.ai/guide, but requester pods never listen on :8000 -- they reserve the
-    # GPU and hold the pod identity while the bound launcher runs vLLM. Selecting
-    # on the guide label alone admits requesters to the pool, and the EPP then
-    # routes a share of traffic to endpoints that refuse the connection. The
-    # component label is set by the FMA chart on launcher pods; unbound launchers
-    # are already excluded because FMA stamps the ISC labels onto a launcher only
-    # once it is bound to a requester.
+    # Selects bound launchers only; requesters carry the guide label but never serve :8000.
+    # Keep llm-d.ai/model in sync with inferenceserverconfig.yaml.
     matchLabels:
       llm-d.ai/guide: "fast-model-actuation"
-      app.kubernetes.io/component: "launcher"
+      llm-d.ai/model: "qwen3-0.6b"


### PR DESCRIPTION
## Problem

The `fast-model-actuation` guide stamps `llm-d.ai/guide: fast-model-actuation` on **both** halves of
FMA's dual-pods design:

- **bound launcher pods** — run vLLM, listening on `:8000`
- **requester pods** — reserve the GPU and hold the pod identity, and **never listen on `:8000`**

The router's `InferencePool` selects on that single label with `targetPorts: 8000`, so the EPP
load-balances across a mix of live vLLM endpoints and endpoints that refuse the connection. Callers
see intermittent:

```
upstream connect error or disconnect/reset before headers.
reset reason: remote connection failure,
transport failure reason: delayed connect error: Connection refused
```

## Fix

Add the launcher component label to the pool selector so only bound launchers are routable:

```yaml
  modelServers:
    matchLabels:
      llm-d.ai/guide: "fast-model-actuation"
+     app.kubernetes.io/component: "launcher"
```

Unbound launchers need no special handling — FMA stamps the `InferenceServerConfig` labels onto a
launcher only once it is bound to a requester, so they were already excluded.

The requester's `llm-d.ai/guide` label is deliberately **left in place**: `llm-d-benchmark`'s
kustomize standup waits for pods matching `llm-d.ai/guide=<guide_name>`, and requesters are the pods
reliably present at that point.

## Changes

- `guides/fast-model-actuation/router/fast-model-actuation.values.yaml` — the selector, plus a
  comment explaining why the guide label alone is insufficient.
- `guides/fast-model-actuation/README.md` — a `> [!NOTE]` documenting the routing topology.

No manifest, image, or version changes.

## Validation

Verified on a live GKE cluster (`Qwen/Qwen3-0.6B`, FMA `v0.6.2`, `GATEWAY_CLASS=epponly`,
2 requesters / 16 launchers):

| Check | Before | After |
|---|---|---|
| `/v1/completions` loop through the EPP | 3 of 8 | **10 of 10** |
| Pods matching the pool selector | 4 (2 launchers + 2 requesters) | **2 bound launchers** |
| EPP `Pod added` entries for `fma-requester-*` | 2 | **0** |

Also confirmed:

- The rendered `InferencePool` carries both labels with `targetPorts[0].number: 8000` unchanged
  (`helm template` against the committed values).
- The selector survives sleep/wake: scaling requesters to `0` unbinds every launcher and the
  selector correctly matches **zero** pods; scaling back to `2` rebinds exactly 2, and traffic is
  10/10 again.
- `scripts/guide.py check` and `render --check` both clean — the README note sits outside the
  `<!-- guide:… -->` markers.

## Follow-ups (not in this PR)

- **`llm-d-benchmark`:** standup `step_10_smoketest.py` and `step_11_inference_test.py` have no
  kustomize branch, so they resolve `{model_id_label}-router-epp` via `find_epponly_endpoint()`
  instead of using the existing `find_kustomize_endpoint(guide_name)` → `{guide_name}-epp`. That
  service does not exist for a guide deployment, so the standup smoketest likely never reaches the
  request path for this guide. Worth its own issue. **Consequence for reviewers: a green nightly does
  not by itself confirm this fix** — the live loop above is the evidence.
- Separately, the `_RETRYABLE_INDICATORS` list in `step_11_inference_test.py` does not include the
  connection-refused text, so `max_retries=3` never engages for this class of failure.
- An unrelated requester replica explosion (245 replicas) observed in an earlier nightly run.