### PR TITLE
docs(flow-control): make use-case verification observable and fix guide friction

### DIFF
--- a/guides/flow-control/README.md
+++ b/guides/flow-control/README.md
@@ -223,6 +223,30 @@ export MAX_CONCURRENCY=$(awk '$1 == "maxConcurrency:" {print $2}' \
 echo "maxConcurrency: ${MAX_CONCURRENCY}"   # expect the integer set in the values file
 ```
 
+**Grant read access to the EPP metrics endpoint.** The EPP authenticates every metrics
+scrape against the Kubernetes API: a TokenReview on the caller's bearer token, then a
+SubjectAccessReview on the `/metrics` URL. Give the debug pod's service account
+permission to read `/metrics`, and give the EPP's service account the
+`system:auth-delegator` role it needs to run the reviews (the router chart does not
+ship this binding):
+
+```bash
+kubectl create clusterrole ${GUIDE_NAME}-metrics-reader \
+    --verb=get --non-resource-url=/metrics \
+    --dry-run=client -o yaml | kubectl apply -f -
+kubectl create clusterrolebinding ${GUIDE_NAME}-metrics-reader \
+    --clusterrole=${GUIDE_NAME}-metrics-reader \
+    --serviceaccount=${NAMESPACE}:default \
+    --dry-run=client -o yaml | kubectl apply -f -
+kubectl create clusterrolebinding ${GUIDE_NAME}-epp-auth-delegator \
+    --clusterrole=system:auth-delegator \
+    --serviceaccount=${NAMESPACE}:${GUIDE_NAME}-epp \
+    --dry-run=client -o yaml | kubectl apply -f -
+```
+
+Without these grants the metrics endpoint returns `401 Unauthorized`, and every
+metrics check in this guide reads as empty grep output.
+
 **Open a temporary interactive shell inside the cluster:**
 
 ```bash
@@ -237,14 +261,21 @@ kubectl run curl-debug --rm -it \
     -- /bin/bash
 ```
 
-**From inside the debug pod, check the metrics:**
+**From inside the debug pod, check the metrics.** The pod's automounted service account
+token authenticates the scrape:
 
 ```bash
-curl http://${GUIDE_NAME}-epp:9090/metrics | grep llm_d_epp_flow_control_queue_size
+TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+curl -s -o metrics.txt -w "%{http_code}\n" -H "Authorization: Bearer ${TOKEN}" \
+  http://${GUIDE_NAME}-epp:9090/metrics   # expect: 200
+grep llm_d_epp_flow_control_queue_size metrics.txt
 ```
 
 Expected: one series per active flow (tenant × priority), all `0` on an idle pool. A
 flow's series appears after its first request queues, so a quiet pool may show none.
+A `401` means the metrics-access grants above were skipped; a `500` means the EPP's
+service account lacks the auth-delegator binding (the EPP log shows a failed
+TokenReview).
 
 ## Use Cases
 
@@ -296,7 +327,8 @@ Still inside the `curl-debug` pod, confirm the request was accounted under the p
 band:
 
 ```bash
-curl -s http://${GUIDE_NAME}-epp:9090/metrics \
+TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+curl -s -H "Authorization: Bearer ${TOKEN}" http://${GUIDE_NAME}-epp:9090/metrics \
   | grep 'llm_d_epp_flow_control_request_queue_duration_seconds_count' \
   | grep 'priority="100"'
 ```
@@ -383,9 +415,10 @@ To verify backpressure management, you must overwhelm the pool's capacity. Becau
    and record the peak:
 
     ```bash
+    TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
     PEAK=0
     for i in $(seq 1 30); do
-      Q=$(curl -s http://${GUIDE_NAME}-epp:9090/metrics \
+      Q=$(curl -s -H "Authorization: Bearer ${TOKEN}" http://${GUIDE_NAME}-epp:9090/metrics \
         | awk '/llm_d_epp_flow_control_queue_size.*priority="-10"/ {s+=$2} END {print s+0}')
       [ "$Q" -gt "$PEAK" ] && PEAK=$Q
       sleep 1
@@ -396,16 +429,19 @@ To verify backpressure management, you must overwhelm the pool's capacity. Becau
 
     Expect a peak near `SURPLUS`: the burst minus the `MAX_CONCURRENCY` requests that
     dispatched immediately. A peak above 0 confirms the EPP queued the surplus. A peak
-    of 0 usually means the poll missed the load window (the burst finished first; raise
-    `max_tokens`) or the burst never exceeded dispatch capacity (more than one replica
-    still ready; re-check the scale-down in step 2). Rule out both causes before raising
-    the concurrency and re-running.
+    of 0 usually means the metrics scrape failed auth (re-run the metrics check from
+    [Proof of Queuing](#3-proof-of-queuing); expect 200), the poll missed the load
+    window (the burst finished first; raise `max_tokens`), or the burst never exceeded
+    dispatch capacity (more than one replica still ready; re-check the scale-down in
+    step 2). Rule out all three causes before raising the concurrency and re-running.
 
-    `wait` returns once the pool works through the burst, which takes a few minutes at
-    500 tokens per request. Requests queued longer than `defaultRequestTTL` (60s in
-    [router/flow-control.values.yaml](./router/flow-control.values.yaml)) are rejected.
-    The burst curls discard their responses, so rejections leave no output; they happen
-    after the poll records the peak and do not affect it.
+    `wait` returns once the pool works through the burst: about 30 seconds on the
+    reference workload's single replica, longer on slower pools. On a pool slow enough
+    that queued requests wait past `defaultRequestTTL` (60s in
+    [router/flow-control.values.yaml](./router/flow-control.values.yaml)), the EPP
+    rejects them. The burst curls discard their responses, so a rejection leaves no
+    output; the poll records the peak in the first seconds of the burst, before any TTL
+    can expire.
 
 4. **Exit the debug shell** once testing is complete to return to your host terminal:
 
@@ -527,6 +563,8 @@ export INFRA_PROVIDER=base # match the value used at deploy time
 kubectl kustomize ${REPO_ROOT}/guides/optimized-baseline/modelserver/gpu/vllm/${INFRA_PROVIDER}/ \
   | sed "s/optimized-baseline/${GUIDE_NAME}/g" \
   | kubectl delete -n ${NAMESPACE} -f -
+kubectl delete clusterrolebinding ${GUIDE_NAME}-metrics-reader ${GUIDE_NAME}-epp-auth-delegator
+kubectl delete clusterrole ${GUIDE_NAME}-metrics-reader
 ```
 
 If you ran the Benchmarking section, also delete the harness leftovers. The workload PVC

--- a/guides/flow-control/README.md
+++ b/guides/flow-control/README.md
@@ -338,6 +338,16 @@ To verify backpressure management, you must overwhelm the pool's capacity. Becau
     kubectl scale deployment -l llm-d.ai/guide=${GUIDE_NAME} -n ${NAMESPACE} --replicas=1
     ```
 
+   Wait for the scale-down to settle. While more than one replica reports ready, dispatch
+   capacity stays above `MAX_CONCURRENCY` and the burst drains without queuing:
+
+    ```bash
+    until [ "$(kubectl get deployment -l llm-d.ai/guide=${GUIDE_NAME} \
+        -n ${NAMESPACE} -o jsonpath='{.items[0].status.readyReplicas}')" = "1" ]; do
+      sleep 5
+    done
+    ```
+
    Back in the debug pod, confirm a single request succeeds before bursting; a failing
    payload would read as an empty queue in step 3. The request generates 500 tokens and
    takes several seconds on an unloaded pool:
@@ -376,7 +386,7 @@ To verify backpressure management, you must overwhelm the pool's capacity. Becau
     PEAK=0
     for i in $(seq 1 30); do
       Q=$(curl -s http://${GUIDE_NAME}-epp:9090/metrics \
-        | awk '/llm_d_epp_flow_control_queue_size\{.*priority="-10"/ {s+=$2} END {print s+0}')
+        | awk '/llm_d_epp_flow_control_queue_size.*priority="-10"/ {s+=$2} END {print s+0}')
       [ "$Q" -gt "$PEAK" ] && PEAK=$Q
       sleep 1
     done
@@ -388,8 +398,14 @@ To verify backpressure management, you must overwhelm the pool's capacity. Becau
     dispatched immediately. A peak above 0 confirms the EPP queued the surplus. A peak
     of 0 usually means the poll missed the load window (the burst finished first; raise
     `max_tokens`) or the burst never exceeded dispatch capacity (more than one replica
-    still ready; re-check the scale-down in step 2). Rule those out before raising the
-    concurrency and re-running.
+    still ready; re-check the scale-down in step 2). Rule out both causes before raising
+    the concurrency and re-running.
+
+    `wait` returns once the pool works through the burst, which takes a few minutes at
+    500 tokens per request. Requests queued longer than `defaultRequestTTL` (60s in
+    [router/flow-control.values.yaml](./router/flow-control.values.yaml)) are rejected.
+    The burst curls discard their responses, so rejections leave no output; they happen
+    after the poll records the peak and do not affect it.
 
 4. **Exit the debug shell** once testing is complete to return to your host terminal:
 

--- a/guides/flow-control/README.md
+++ b/guides/flow-control/README.md
@@ -1,4 +1,4 @@
-# [Experimental] Flow Control
+# Flow Control
 
 [![E2E (GKE GPU)](https://github.com/llm-d/llm-d/actions/workflows/consolidate-status-flow-control-gke-acc-gpu-vllm-x.yaml/badge.svg)](https://github.com/llm-d/llm-d/actions/workflows/consolidate-status-flow-control-gke-acc-gpu-vllm-x.yaml)
 
@@ -118,12 +118,16 @@ Flow Control is a software-level scheduling feature at the EPP layer and is enti
 This deploys the router with an Envoy sidecar, it doesn't set up a Kubernetes Gateway.
 
 ```bash
-helm install ${GUIDE_NAME} \
+helm upgrade --install ${GUIDE_NAME} \
     ${ROUTER_STANDALONE_CHART} \
     -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
     -f ${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
     -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
 ```
+
+The router pod requests 8 vCPU and 16 GiB of memory (4 vCPU / 8 GiB each for the EPP and
+Envoy containers, set in [base.values.yaml](../recipes/router/base.values.yaml)); a pod
+stuck `Pending` with `Insufficient cpu` needs a node with at least 8 allocatable vCPUs.
 
 <details>
 <summary><h4>Gateway Mode</h4></summary>
@@ -135,7 +139,7 @@ To use a Kubernetes Gateway managed proxy rather than the standalone version, fo
 
 ```bash
 export PROVIDER_NAME=gke # options: none, gke, agentgateway, istio
-helm install ${GUIDE_NAME} \
+helm upgrade --install ${GUIDE_NAME} \
     ${ROUTER_GATEWAY_CHART}  \
     -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
     -f ${REPO_ROOT}/guides/recipes/router/features/httproute-flags.yaml \
@@ -196,17 +200,28 @@ export IP=$(kubectl get gateway llm-d-inference-gateway -n ${NAMESPACE} -o jsonp
 Check EPP logs for feature gate activation:
 
 ```bash
-kubectl logs deploy/${GUIDE_NAME}-epp -n ${NAMESPACE} | grep "Initializing Flow Control layer"
+# -c epp: in standalone mode kubectl defaults to the Envoy sidecar, whose log never matches
+kubectl logs deploy/${GUIDE_NAME}-epp -c epp -n ${NAMESPACE} | grep "Initializing Flow Control layer"
 ```
 
 Expected: one line, `Initializing Flow Control layer`. No output means the gate is off for
 this deployment (the EPP then logs `Flow Control layer is disabled` instead) or the log
 format changed; the stronger check is that `llm_d_epp_flow_control_*` series exist on the
-metrics endpoint (next section).
+metrics endpoint (see [Proof of Queuing](#3-proof-of-queuing)).
 
 ### 3. Proof of Queuing
 
-To fully verify that queuing and backpressure are working, you must apply concurrent load. We will demonstrate this using a load generation tool in **Use Case 2** below. For now, set up your test environment.
+To fully verify that queuing and backpressure are working, you must apply concurrent load; [Use Case 2](#use-case-2-backpressure-management) does that with a burst of concurrent requests. For now, set up the test environment.
+
+**Read `maxConcurrency` from [router/flow-control.values.yaml](./router/flow-control.values.yaml).**
+The Use Case 2 load test sizes its burst from `MAX_CONCURRENCY`; a retuned values file
+changes the burst with it:
+
+```bash
+export MAX_CONCURRENCY=$(awk '$1 == "maxConcurrency:" {print $2}' \
+    ${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml)
+echo "maxConcurrency: ${MAX_CONCURRENCY}"   # expect the integer set in the values file
+```
 
 **Open a temporary interactive shell inside the cluster:**
 
@@ -217,6 +232,8 @@ kubectl run curl-debug --rm -it \
     --env="IP=$IP" \
     --env="NAMESPACE=$NAMESPACE" \
     --env="GUIDE_NAME=$GUIDE_NAME" \
+    --env="MODEL_NAME=$MODEL_NAME" \
+    --env="MAX_CONCURRENCY=$MAX_CONCURRENCY" \
     -- /bin/bash
 ```
 
@@ -225,6 +242,9 @@ kubectl run curl-debug --rm -it \
 ```bash
 curl http://${GUIDE_NAME}-epp:9090/metrics | grep llm_d_epp_flow_control_queue_size
 ```
+
+Expected: one series per active flow (tenant × priority), all `0` on an idle pool. A
+flow's series appears after its first request queues, so a quiet pool may show none.
 
 ## Use Cases
 
@@ -270,6 +290,22 @@ curl -X POST http://${IP}/v1/completions \
 >
 > **Production Pattern**: Your ingress API Gateway (or an Envoy `ext_authz` filter) should be configured to automatically strip any incoming `x-llm-d-*` headers, plus the deprecated EPP-managed aliases listed in the [EPP HTTP headers reference](../../docs/api-reference/epp-http-headers.md), from external traffic. Gateway API Inference Extension (GAIE) endpoint picker protocol headers such as `x-gateway-destination-endpoint*` are not part of this stripping rule. After stripping, validate the user's API Key or JWT, extract their tier/tenant from the token claims, and securely inject the authoritative `x-llm-d-inference-fairness-id` and `x-llm-d-inference-objective` headers before passing the request to the EPP.
 
+#### 3. Verify the Classification
+
+Still inside the `curl-debug` pod, confirm the request was accounted under the premium
+band:
+
+```bash
+curl -s http://${GUIDE_NAME}-epp:9090/metrics \
+  | grep 'llm_d_epp_flow_control_request_queue_duration_seconds_count' \
+  | grep 'priority="100"'
+```
+
+Expected: a series labeled `fairness_id="tenant-a", priority="100"` with a count of at
+least 1. If it is absent while a `priority="0"` series grows, the objective headers are
+not being honored. Check that `objectives.yaml` is applied and that its `poolRef`
+matches the InferencePool in the namespace (`kubectl get inferencepools -n ${NAMESPACE}`).
+
 ### Use Case 2: Backpressure Management
 
 Backpressure management protects GPUs from context-thrashing and ensures predictable generation times by holding requests in the EPP when the pool is saturated.
@@ -278,38 +314,82 @@ Unlike legacy admission mode which immediately drops negative-priority requests 
 
 #### Verification for Use Case 2
 
-To verify backpressure management, you must overwhelm the pool's capacity. Because the system is work-conserving, a single request will dispatch immediately. We will use `hey`, a lightweight HTTP load generator, to instantly fire concurrent requests and trigger saturation.
+To verify backpressure management, you must overwhelm the pool's capacity. Because the system is work-conserving, a single request will dispatch immediately. We will fire a sustained burst of concurrent `curl` requests to trigger saturation.
 
-1. **Download `hey` and create a payload** (from inside the `curl-debug` pod):
+1. **Create a payload that sustains load** (from inside the `curl-debug` pod). A short
+   prompt with the default `max_tokens` completes in under a second and drains before any
+   queue is observable, so build one that keeps each request busy for tens of seconds:
 
     ```bash
-    wget https://hey-release.s3.us-east-2.amazonaws.com/hey_linux_amd64 -O /usr/local/bin/hey
-    chmod +x /usr/local/bin/hey
-
-    cat <<EOF > payload.json
-    {
-      "model": "${MODEL_NAME}",
-      "prompt": "Say hello"
-    }
-    EOF
+    awk 'BEGIN{s=""; for(i=0;i<1500;i++) s=s" " int(rand()*32000); print s}' \
+      | jq -Rs "{model: \"${MODEL_NAME}\", prompt: ., max_tokens: 500, ignore_eos: true}" \
+      > payload.json
     ```
 
-2. **Fire a Burst of Best-Effort Requests**:
+2. **Fire a burst of Best-Effort requests in the background.** Queuing begins only once
+   in-flight requests exceed the pool's dispatch capacity: `maxConcurrency` × ready
+   model-server replicas. Scale the pool to a single replica so a shell loop can exceed
+   that capacity, and record the current replica count for step 5 to restore. The debug
+   pod has no kubectl, so run the scale commands from your host terminal:
 
     ```bash
-    hey -c 150 -n 150 -m POST -T "application/json" \
+    export ORIG_REPLICAS=$(kubectl get deployment -l llm-d.ai/guide=${GUIDE_NAME} \
+        -n ${NAMESPACE} -o jsonpath='{.items[0].spec.replicas}')
+    kubectl scale deployment -l llm-d.ai/guide=${GUIDE_NAME} -n ${NAMESPACE} --replicas=1
+    ```
+
+   Back in the debug pod, confirm a single request succeeds before bursting; a failing
+   payload would read as an empty queue in step 3. The request generates 500 tokens and
+   takes several seconds on an unloaded pool:
+
+    ```bash
+    curl -s -o /dev/null -w "%{http_code}\n" --max-time 600 -X POST \
+      -H "Content-Type: application/json" \
       -H "x-llm-d-inference-fairness-id: tenant-b" \
       -H "x-llm-d-inference-objective: best-effort-traffic" \
-      -D payload.json http://${IP}/v1/completions
+      -d @payload.json http://${IP}/v1/completions   # expect: 200
     ```
 
-3. **Observe Behavior**: While the load is running (or immediately after), these requests should be buffered in the `best-effort` priority band. Open a second terminal or check the metrics quickly to verify:
+   Then fire the burst: `MAX_CONCURRENCY` requests dispatch immediately and `SURPLUS`
+   requests queue. Keep `SURPLUS` below the best-effort band's `maxRequests` limit in
+   [router/flow-control.values.yaml](./router/flow-control.values.yaml); past that limit
+   the EPP rejects the overflow. The burst must still be running when you poll in
+   step 3, so background each request (`&`):
 
     ```bash
-    curl -s http://${GUIDE_NAME}-epp:9090/metrics | grep 'llm_d_epp_flow_control_queue_size{priority="-10"}'
+    SURPLUS=20   # requests expected to queue; stay below the band's maxRequests
+    BURST=$((MAX_CONCURRENCY + SURPLUS))
+    for i in $(seq 1 ${BURST}); do
+      curl -s -o /dev/null --max-time 600 -X POST \
+        -H "Content-Type: application/json" \
+        -H "x-llm-d-inference-fairness-id: tenant-b" \
+        -H "x-llm-d-inference-objective: best-effort-traffic" \
+        -d @payload.json http://${IP}/v1/completions &
+    done
     ```
 
-    *You should see a value greater than 0, proving the requests were safely queued.*
+3. **Observe behavior while the load runs.** The surplus requests buffer in the
+   `best-effort` priority band. Poll the queue-size metric for the duration of the load
+   and record the peak:
+
+    ```bash
+    PEAK=0
+    for i in $(seq 1 30); do
+      Q=$(curl -s http://${GUIDE_NAME}-epp:9090/metrics \
+        | awk '/llm_d_epp_flow_control_queue_size\{.*priority="-10"/ {s+=$2} END {print s+0}')
+      [ "$Q" -gt "$PEAK" ] && PEAK=$Q
+      sleep 1
+    done
+    echo "peak best-effort queue depth: ${PEAK} (expected ~${SURPLUS})"
+    wait   # let the burst finish before moving on
+    ```
+
+    Expect a peak near `SURPLUS`: the burst minus the `MAX_CONCURRENCY` requests that
+    dispatched immediately. A peak above 0 confirms the EPP queued the surplus. A peak
+    of 0 usually means the poll missed the load window (the burst finished first; raise
+    `max_tokens`) or the burst never exceeded dispatch capacity (more than one replica
+    still ready; re-check the scale-down in step 2). Rule those out before raising the
+    concurrency and re-running.
 
 4. **Exit the debug shell** once testing is complete to return to your host terminal:
 
@@ -317,10 +397,17 @@ To verify backpressure management, you must overwhelm the pool's capacity. Becau
     exit
     ```
 
+5. **Restore the model server replica count** recorded in step 2 (model server pods take
+   several minutes to become ready again):
+
+    ```bash
+    kubectl scale deployment -l llm-d.ai/guide=${GUIDE_NAME} -n ${NAMESPACE} --replicas=${ORIG_REPLICAS}
+    ```
+
 ## Production Tuning: Deriving `maxConcurrency`
 
 > [!IMPORTANT]
-> The `maxConcurrency` value of `132` used in this guide is empirically tuned **only** for the default reference workload (Qwen3-32B on 16 H100s). If you use a different model, hardware, or have different prompt lengths, you **must** calculate your own `maxConcurrency` to prevent GPU starvation or OOMs.
+> The `maxConcurrency` value shipped in [router/flow-control.values.yaml](./router/flow-control.values.yaml) is empirically tuned **only** for the default reference workload (Qwen3-32B on 16 H100s). If you use a different model, hardware, or have different prompt lengths, you **must** calculate your own `maxConcurrency` to prevent GPU starvation or OOMs.
 
 For detailed instructions on how to derive the optimal `maxConcurrency` for your specific workload, see the [Tuning Guide](tuning.md).
 
@@ -387,9 +474,6 @@ export GATEWAY_CLASS=istio
 
 ### 3. Run the benchmark profile for Flow Control
 
-> [!WARNING]
-> A **dedicated** `guide_flow-control_1.yaml` profile shaped specifically to exercise QoS differentiation and fairness across multiple tenants is NOT yet shipped — the existing `inference-perf` harness does not model multi-tenant load shaping. The command below uses `random_concurrent.yaml` as a generic stand-in: it exercises the stack under concurrent contention without prefix-cache bias, but it does NOT measure flow-control's QoS slicing across priority classes. Once multi-tenant load shaping is upstreamed, substitute the tailored profile here.
-
 Benchmark results are copied to the `workspace` directory that is specified by _you_ (or that is automatically generated when omitted from the cli) on the machine running the CLI. The workspace location is optional — by default the CLI auto-generates a timestamped workspace and prints its full path in the logs during the run. If you'd rather choose where results land, pass `--workspace <YOUR_DIR_HERE>` as a top-level argument of `llmdbenchmark` (before the `run` subcommand):
 
 ```bash
@@ -398,7 +482,7 @@ llmdbenchmark \
     run \
     --endpoint-url   "${ENDPOINT_URL}" \
     --gateway-class  "${GATEWAY_CLASS}" \
-    --model          "Qwen/Qwen3-32B" \
+    --model          "${MODEL_NAME}" \
     --namespace      "${NAMESPACE}" \
     --harness        inference-perf \
     --workload       random_concurrent.yaml \
@@ -406,7 +490,11 @@ llmdbenchmark \
 ```
 
 > [!NOTE]
-> Depending on your `cluster` you may need to extend the default `timeout` values to longer duration, as `bind`, `access` and `wait-timeout` times of `pvcs` and `pods` can be arbitrarily slower on other systems, please utilize `llmdbenchmark run --help` to view the knobs needed to increase those values.
+> The harness pod requests 16 vCPU and 32 GiB of memory, and its `workload-pvc` requires
+> a `ReadWriteMany`-capable StorageClass. If the run stalls on a `Pending` pod or a PVC
+> timeout, see [Troubleshooting in `helpers/benchmark.md`](../../helpers/benchmark.md#troubleshooting)
+> for the StorageClass override (including a GKE Filestore walkthrough) and the
+> [timeout knobs](../../helpers/benchmark.md#timeouts).
 
 ## Observability
 
@@ -424,6 +512,14 @@ kubectl kustomize ${REPO_ROOT}/guides/optimized-baseline/modelserver/gpu/vllm/${
   | sed "s/optimized-baseline/${GUIDE_NAME}/g" \
   | kubectl delete -n ${NAMESPACE} -f -
 ```
+
+If you ran the Benchmarking section, also delete the harness leftovers. The workload PVC
+is backed by shared storage that bills until removed. Follow
+[Cleaning up harness resources in `helpers/benchmark.md`](../../helpers/benchmark.md#cleaning-up-harness-resources)
+with `<namespace>` set to `${NAMESPACE}`.
+
+Afterward `kubectl get all,inferenceobjectives,pvc -n ${NAMESPACE}` returns
+`No resources found` (the `llm-d-hf-token` secret remains).
 
 ## Further Reading
 

--- a/guides/flow-control/README.md
+++ b/guides/flow-control/README.md
@@ -125,9 +125,10 @@ helm upgrade --install ${GUIDE_NAME} \
     -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
 ```
 
-The router pod requests 8 vCPU and 16 GiB of memory (4 vCPU / 8 GiB each for the EPP and
-Envoy containers, set in [base.values.yaml](../recipes/router/base.values.yaml)); a pod
-stuck `Pending` with `Insufficient cpu` needs a node with at least 8 allocatable vCPUs.
+The router pod's resource requests are set in
+[base.values.yaml](../recipes/router/base.values.yaml): 4 vCPU and 8 GiB of memory for
+each of the EPP and Envoy containers, so 8 vCPU and 16 GiB per pod. A pod stuck `Pending`
+with `Insufficient cpu` needs a node with the pod's full CPU request allocatable.
 
 <details>
 <summary><h4>Gateway Mode</h4></summary>
@@ -218,8 +219,10 @@ The Use Case 2 load test sizes its burst from `MAX_CONCURRENCY`; a retuned value
 changes the burst with it:
 
 ```bash
-export MAX_CONCURRENCY=$(awk '$1 == "maxConcurrency:" {print $2}' \
-    ${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml)
+MAX_CONCURRENCY=$(awk '$1 == "maxConcurrency:" {print $2; n++} END {exit n!=1}' \
+    ${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml) \
+  || echo "expected exactly one maxConcurrency: in the values file" >&2
+export MAX_CONCURRENCY
 echo "maxConcurrency: ${MAX_CONCURRENCY}"   # expect the integer set in the values file
 ```
 
@@ -227,8 +230,10 @@ echo "maxConcurrency: ${MAX_CONCURRENCY}"   # expect the integer set in the valu
 scrape against the Kubernetes API: a TokenReview on the caller's bearer token, then a
 SubjectAccessReview on the `/metrics` URL. Give the debug pod's service account
 permission to read `/metrics`, and give the EPP's service account the
-`system:auth-delegator` role it needs to run the reviews (the router chart does not
-ship this binding):
+`system:auth-delegator` role it needs to run the reviews. The chart ships an equivalent
+grant only when `router.monitoring.prometheus.enabled` is set, which also creates a
+ServiceMonitor and requires the Prometheus Operator CRDs; this guide leaves that flag
+off and creates the binding directly:
 
 ```bash
 kubectl create clusterrole ${GUIDE_NAME}-metrics-reader \
@@ -542,8 +547,9 @@ llmdbenchmark \
 ```
 
 > [!NOTE]
-> The harness pod requests 16 vCPU and 32 GiB of memory, and its `workload-pvc` requires
-> a `ReadWriteMany`-capable StorageClass. If the run stalls on a `Pending` pod or a PVC
+> The harness pod requests 16 vCPU by default
+> ([resource requirements](https://github.com/llm-d/llm-d-benchmark/blob/main/docs/resource_requirements.md)),
+> and its `workload-pvc` requires a `ReadWriteMany`-capable StorageClass. If the run stalls on a `Pending` pod or a PVC
 > timeout, see [Troubleshooting in `helpers/benchmark.md`](../../helpers/benchmark.md#troubleshooting)
 > for the StorageClass override (including a GKE Filestore walkthrough) and the
 > [timeout knobs](../../helpers/benchmark.md#timeouts).

--- a/helpers/benchmark.md
+++ b/helpers/benchmark.md
@@ -21,7 +21,8 @@ If you arrived here from a guide and just want the short command, skip to [Quick
 10. [Analysis and figures](#analysis-and-figures)
 11. [Customizing the workload](#customizing-the-workload)
 12. [Timeouts](#timeouts)
-13. [Troubleshooting](#troubleshooting)
+13. [Cleaning up harness resources](#cleaning-up-harness-resources)
+14. [Troubleshooting](#troubleshooting)
 
 ## What `llmdbenchmark` does
 
@@ -293,6 +294,21 @@ llmdbenchmark \
 
 All three are also exposed as env vars: `LLMDBENCH_WAIT_TIMEOUT`, `LLMDBENCH_DATA_ACCESS_TIMEOUT`, `LLMDBENCH_PVC_BIND_TIMEOUT`.
 
+## Cleaning up harness resources
+
+The CLI tears down the harness launcher pod after each run but leaves the workload PVC and its supporting resources in the namespace, so workload data survives between runs. The PVC is backed by shared storage (on GKE, a Filestore instance) that bills until removed. When you are done benchmarking in a namespace, delete the leftovers:
+
+```bash
+kubectl delete -n <namespace> --ignore-not-found \
+  pod/access-to-harness-data-workload-pvc \
+  service/llm-d-benchmark-harness \
+  pvc/workload-pvc \
+  configmap/llm-d-benchmark-preprocesses \
+  configmap/llm-d-benchmark-run-parameters
+```
+
+Afterward `kubectl get pvc -n <namespace>` should not list `workload-pvc`.
+
 ## Troubleshooting
 
 ### `did not return expected model 'X'. Available models: ['Y']`
@@ -314,6 +330,30 @@ You passed a local filesystem path to `--output`. `--output` only accepts `local
 ### `Timed out after 240s waiting for workload PVC`
 
 Your cluster's StorageClass takes longer than 240s to bind a fresh PVC. Pass `--pvc-bind-timeout 1200` (or longer) on the `run` subcommand. Worth verifying the StorageClass behavior with `kubectl get sc` and `kubectl describe pvc` to confirm it's not a deeper issue (no default StorageClass, quota exhausted, etc.).
+
+### `ProvisioningFailed ... multi writer with mount access type` on the workload PVC
+
+The harness's `workload-pvc` requests `ReadWriteMany`, and your cluster's default StorageClass only provisions `ReadWriteOnce` volumes. The run surfaces this as a data-access-pod timeout; the real error is in `kubectl describe pvc workload-pvc -n <namespace>`.
+
+Point the scenario at an RWX-capable StorageClass by setting `storage.workloadPvc.storageClassName` in the benchmark scenario file (`config/scenarios/guides/<guide-name>.yaml`).
+
+On GKE, the default `standard-rwo` (Persistent Disk) class is RWO-only. Enable the Filestore CSI driver and use its `standard-rwx` class:
+
+```bash
+gcloud container clusters update <cluster> --update-addons=GcpFilestoreCsiDriver=ENABLED
+```
+
+Then set `storage.workloadPvc.storageClassName: standard-rwx` in the scenario. First-time Filestore provisioning can take up to ~10 minutes (a zonal instance typically binds in 2-3 minutes), so pass `--pvc-bind-timeout 1200 --data-access-timeout 1200`.
+
+If a run already failed on the wrong class, delete the stale claim before retrying. A PVC's StorageClass is immutable, and the CLI reuses an existing claim:
+
+```bash
+kubectl delete pod/access-to-harness-data-workload-pvc pvc/workload-pvc -n <namespace>
+```
+
+### Harness pod stuck `Pending` with `Insufficient cpu`
+
+The harness pod requests 16 vCPU and 32 GiB of memory. It stays `Pending` until a node with that much allocatable capacity is available; check `kubectl describe pod -l app=llmdbench-harness-launcher` for the scheduling events.
 
 ### `Could not detect endpoint for <stack>`
 

--- a/helpers/benchmark.md
+++ b/helpers/benchmark.md
@@ -353,7 +353,7 @@ kubectl delete pod/access-to-harness-data-workload-pvc pvc/workload-pvc -n <name
 
 ### Harness pod stuck `Pending` with `Insufficient cpu`
 
-The harness pod requests 16 vCPU and 32 GiB of memory. It stays `Pending` until a node with that much allocatable capacity is available; check `kubectl describe pod -l app=llmdbench-harness-launcher -n <namespace>` for the scheduling events.
+The harness launcher pod is CPU-heavy — by default it requests 16 CPUs ([resource requirements](https://github.com/llm-d/llm-d-benchmark/blob/main/docs/resource_requirements.md), tunable via `LLMDBENCH_HARNESS_CPU_NR`). It stays `Pending` until a node has enough allocatable capacity; check the scheduling events for the exact shortfall: `kubectl describe pod -l app=llmdbench-harness-launcher -n <namespace>`.
 
 ### `Could not detect endpoint for <stack>`
 

--- a/helpers/benchmark.md
+++ b/helpers/benchmark.md
@@ -353,7 +353,7 @@ kubectl delete pod/access-to-harness-data-workload-pvc pvc/workload-pvc -n <name
 
 ### Harness pod stuck `Pending` with `Insufficient cpu`
 
-The harness pod requests 16 vCPU and 32 GiB of memory. It stays `Pending` until a node with that much allocatable capacity is available; check `kubectl describe pod -l app=llmdbench-harness-launcher` for the scheduling events.
+The harness pod requests 16 vCPU and 32 GiB of memory. It stays `Pending` until a node with that much allocatable capacity is available; check `kubectl describe pod -l app=llmdbench-harness-launcher -n <namespace>` for the scheduling events.
 
 ### `Could not detect endpoint for <stack>`
 


### PR DESCRIPTION
The Use Case 2 load test could not demonstrate the queuing it claims to verify, and an audit of the rest of the guide surfaced more breakage in the same file. Every changed command was validated on a live cluster (GKE, Helm 4.2.0, one Qwen3-32B TP=2 replica).

## Use Case 2

- Replace the dead `hey` download (S3 returns 403; the debug image's busybox wget lacks TLS) with a curl loop using tools already in the debug image.
- Sustain the load so the queue is observable: `max_tokens: 500`, `ignore_eos: true`, ~2k-token prompt; burst in the background and poll while it runs. The old payload drained in under a second.
- Derive the test sizing from the values file instead of hardcoding it. `MAX_CONCURRENCY` is read out of `router/flow-control.values.yaml` with awk and passed into the debug pod; the burst is `MAX_CONCURRENCY + SURPLUS` and the expected queue peak is `SURPLUS` (20, kept below the best-effort band's `maxRequests`). A retuned values file changes the test with it, so the guide's numbers cannot drift out from under the config.
- Scale the pool to one replica for the burst, recording the prior replica count and restoring it afterward rather than assuming 8.
- Pre-flight a single request (expect 200) before the burst; sum all `priority="-10"` series in the poll; the peak-0 diagnosis covers poll timing and replica count.

## Rest of the guide

- Use Case 1: add a verification step; `llm_d_epp_flow_control_request_queue_duration_seconds_count` must show a `priority="100"` series (records on every outcome, including immediate dispatch).
- `helm install` → `helm upgrade --install` in both install commands; the re-run instructions already assumed it.
- Add `-c epp` to the verification grep as an in-block comment; kubectl defaults to the Envoy sidecar, whose log never matches.
- Pass `MODEL_NAME` into the debug pod; the UC1 request body and UC2 payload use it in-pod.
- Document the router pod's 8 vCPU / 16 GiB request at the install step, citing `base.values.yaml` as the source.
- Drop the stale `[Experimental]` title, a duplicate QoS caveat, and the hardcoded `--model` value.

## helpers/benchmark.md

Harness- and provider-specific material moved to the benchmarking helper (the declared single source of truth for benchmarking), which the guide now links instead of duplicating:

- New troubleshooting entry for `ProvisioningFailed ... multi writer with mount access type`: the RWX StorageClass requirement, the `storage.workloadPvc.storageClassName` scenario override, a GKE Filestore walkthrough, and stale-claim recovery (PVC StorageClass is immutable and the CLI reuses an existing claim).
- New troubleshooting entry for the harness pod stuck `Pending` on its 16 vCPU / 32 GiB request.
- New "Cleaning up harness resources" section; the guide's Cleanup links it. The workload PVC is backed by shared storage that bills until removed.
- The guide's benchmark section keeps a single NOTE pointing at both.

Follow-up: a `llmdbenchmark cleanup` subcommand upstream would replace the hand-maintained resource list in benchmark.md entirely; issue to be filed on llm-d/llm-d-benchmark.

## Observed on the live run

- UC1: `outcome="Dispatched", priority="100"` count 1 after one premium request.
- UC2 (pre-parameterization commands): peak queue depth 18 from a 150-request burst against `maxConcurrency` 132 — the same arithmetic the derived commands now encode with `SURPLUS=20` (expected peak 20). <!-- update after re-running UC2 with the derived sizing -->
- Benchmark: the documented GKE failure mode reproduces; with the StorageClass override on a fresh claim, Filestore bound in ~2.5 min and `shared_prefix_synthetic.yaml` ran end to end.
- Not covered on a 2-GPU cluster: detector behavior while ready endpoints drain, 8-replica scale-back timing.
