### PR TITLE
fix(observability): honor selected kubeconfig

### DIFF
--- a/.github/workflows/ci-kustomize-dry-run.yaml
+++ b/.github/workflows/ci-kustomize-dry-run.yaml
@@ -22,6 +22,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Test observability kubeconfig targeting
+        run: guides/recipes/observability/tests/test-kubeconfig-targeting.sh
+
       - name: Install client dependencies
         run: helpers/client-setup/install-deps.sh
 
@@ -303,4 +306,3 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
           exit $failed
-

--- a/guides/recipes/observability/generate-prometheus-tls-certs.sh
+++ b/guides/recipes/observability/generate-prometheus-tls-certs.sh
@@ -88,10 +88,10 @@ setup_env() {
       log_error "Error, the context file \"$KUBERNETES_CONTEXT\", passed via command-line option, does not exist!"
       exit 1
     fi
-    KCMD="kubectl --kubeconfig $KUBERNETES_CONTEXT"
-  else
-    KCMD="kubectl"
+    export KUBECONFIG="$KUBERNETES_CONTEXT"
   fi
+
+  KCMD="kubectl"
 }
 
 generate_certificates() {

--- a/guides/recipes/observability/install-prometheus-grafana.sh
+++ b/guides/recipes/observability/install-prometheus-grafana.sh
@@ -108,12 +108,11 @@ setup_env() {
       log_error "Error, the context file \"$KUBERNETES_CONTEXT\", passed via command-line option, does not exist!"
       exit 1
     fi
-    KCMD="kubectl --kubeconfig $KUBERNETES_CONTEXT"
-    HCMD="helm --kubeconfig $KUBERNETES_CONTEXT"
-  else
-    KCMD="kubectl"
-    HCMD="helm"
+    export KUBECONFIG="$KUBERNETES_CONTEXT"
   fi
+
+  KCMD="kubectl"
+  HCMD="helm"
 
   if [[ "$CENTRAL_MODE" == "true" ]]; then
     if [[ -z "$MONITORING_NAMESPACE" ]]; then

--- a/guides/recipes/observability/tests/bin/cluster-command
+++ b/guides/recipes/observability/tests/bin/cluster-command
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${STUB_LOG:?STUB_LOG must be set}"
+: "${STUB_MUTATIONS:?STUB_MUTATIONS must be set}"
+
+command_name="${STUB_COMMAND:?STUB_COMMAND must be set}"
+arguments=""
+for argument in "$@"; do
+  arguments+="[$argument]"
+done
+printf 'command=%s kubeconfig=[%s] args=%s\n' \
+  "$command_name" "${KUBECONFIG-<unset>}" "$arguments" >> "$STUB_LOG"
+
+record_mutation() {
+  printf 'command=%s kubeconfig=[%s] args=%s\n' \
+    "$command_name" "${KUBECONFIG-<unset>}" "$arguments" >> "$STUB_MUTATIONS"
+}
+
+case "$command_name:$1" in
+  kubectl:cluster-info)
+    if [[ "${STUB_MODE:-}" == selected-fails && "${KUBECONFIG:-}" == "${SELECTED_KUBECONFIG:-}" ]]; then
+      exit 1
+    fi
+    ;;
+  kubectl:get)
+    case "${2:-}" in
+      clusterversion|crd)
+        exit 1
+        ;;
+      namespace)
+        [[ "${STUB_MODE:-}" == tls ]] && exit 0
+        ;;
+      secret|configmap)
+        exit 1
+        ;;
+    esac
+    ;;
+  kubectl:create|kubectl:apply|kubectl:delete|helm:install|helm:uninstall|oc:create)
+    record_mutation
+    ;;
+esac
+
+if [[ "$command_name" == helm && "${1:-}" == repo && "${2:-}" == list ]]; then
+  printf '%s\n' 'prometheus-community https://prometheus-community.github.io/helm-charts'
+fi
+
+if [[ "$command_name" == helm && "${1:-}" == show && "${2:-}" == crds ]]; then
+  printf '%s\n' 'apiVersion: apiextensions.k8s.io/v1'
+fi

--- a/guides/recipes/observability/tests/bin/helm
+++ b/guides/recipes/observability/tests/bin/helm
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+STUB_COMMAND=helm exec "$(dirname "$0")/cluster-command" "$@"

--- a/guides/recipes/observability/tests/bin/kubectl
+++ b/guides/recipes/observability/tests/bin/kubectl
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+STUB_COMMAND=kubectl exec "$(dirname "$0")/cluster-command" "$@"

--- a/guides/recipes/observability/tests/bin/oc
+++ b/guides/recipes/observability/tests/bin/oc
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+STUB_COMMAND=oc exec "$(dirname "$0")/cluster-command" "$@"

--- a/guides/recipes/observability/tests/bin/openssl
+++ b/guides/recipes/observability/tests/bin/openssl
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${STUB_OPENSSL_LOG:?STUB_OPENSSL_LOG must be set}"
+arguments=""
+for argument in "$@"; do
+  arguments+="[$argument]"
+done
+printf 'command=openssl args=%s\n' "$arguments" >> "$STUB_OPENSSL_LOG"
+
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == -out ]]; then
+    shift
+    : > "${1:?missing -out value}"
+    break
+  fi
+  shift
+done
+
+if [[ "${1:-}" == x509 ]]; then
+  printf '%s\n' 'X509v3 Subject Alternative Name'
+fi

--- a/guides/recipes/observability/tests/test-kubeconfig-targeting.sh
+++ b/guides/recipes/observability/tests/test-kubeconfig-targeting.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPOSITORY="$(cd "${TEST_DIR}/../../../.." && pwd)"
+INSTALLER="${REPOSITORY}/guides/recipes/observability/install-prometheus-grafana.sh"
+TLS_HELPER="${REPOSITORY}/guides/recipes/observability/generate-prometheus-tls-certs.sh"
+STUB_DIR="${TEST_DIR}/bin"
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/llm-d-kubeconfig-test.XXXXXX")"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+SELECTED_KUBECONFIG="${WORK_DIR}/selected kubeconfig"
+AMBIENT_KUBECONFIG="${WORK_DIR}/ambient kubeconfig"
+touch "$SELECTED_KUBECONFIG" "$AMBIENT_KUBECONFIG"
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  grep -F -- "$expected" "$file" >/dev/null || {
+    printf 'FAIL: expected [%s] in %s\n' "$expected" "$file" >&2
+    exit 1
+  }
+}
+
+assert_all_selected() {
+  local file="$1"
+  local line
+  local count=0
+  while IFS= read -r line; do
+    [[ "$line" == command=* ]] || continue
+    count=$((count + 1))
+    [[ "$line" == *"kubeconfig=[${SELECTED_KUBECONFIG}]"* ]] || {
+      printf 'FAIL: wrong selected kubeconfig: %s\n' "$line" >&2
+      exit 1
+    }
+  done < "$file"
+  [[ "$count" -gt 0 ]] || { printf 'FAIL: no client command recorded\n' >&2; exit 1; }
+}
+
+run_installer() {
+  local mode="$1"
+  local log_file="$2"
+  local mutation_file="$3"
+  shift 3
+  env \
+    PATH="${STUB_DIR}:/usr/bin:/bin" \
+    STUB_COMMAND=unused \
+    STUB_MODE="$mode" \
+    STUB_LOG="$log_file" \
+    STUB_MUTATIONS="$mutation_file" \
+    SELECTED_KUBECONFIG="$SELECTED_KUBECONFIG" \
+    KUBECONFIG="$AMBIENT_KUBECONFIG" \
+    bash "$INSTALLER" "$@"
+}
+
+# A selected target that fails reachability must stop before any mutation.
+selected_failure_log="${WORK_DIR}/selected-failure.log"
+selected_failure_mutations="${WORK_DIR}/selected-failure.mutations"
+: > "$selected_failure_log"
+: > "$selected_failure_mutations"
+set +e
+run_installer selected-fails "$selected_failure_log" "$selected_failure_mutations" \
+  -g "$SELECTED_KUBECONFIG" -c >/dev/null 2>&1
+status=$?
+set -e
+[[ "$status" -ne 0 ]] || { printf 'FAIL: selected reachability unexpectedly succeeded\n' >&2; exit 1; }
+assert_contains "$selected_failure_log" "command=kubectl kubeconfig=[${SELECTED_KUBECONFIG}] args=[cluster-info]"
+[[ ! -s "$selected_failure_mutations" ]] || { printf 'FAIL: mutation after reachability failure\n' >&2; exit 1; }
+printf '%s\n' 'PASS selected target controls validation and prevents mutation.'
+
+# CRD-only uses the selected file for both clients, including a path with spaces.
+selected_log="${WORK_DIR}/selected.log"
+selected_mutations="${WORK_DIR}/selected.mutations"
+: > "$selected_log"
+: > "$selected_mutations"
+run_installer success "$selected_log" "$selected_mutations" -g "$SELECTED_KUBECONFIG" -c >/dev/null 2>&1
+assert_all_selected "$selected_log"
+assert_contains "$selected_log" "command=helm kubeconfig=[${SELECTED_KUBECONFIG}] args=[show][crds][prometheus-community/kube-prometheus-stack]"
+assert_contains "$selected_log" "command=kubectl kubeconfig=[${SELECTED_KUBECONFIG}] args=[apply][--server-side][--validate=false][-f][-]"
+printf '%s\n' 'PASS selected kubeconfig is inherited by helm and kubectl.'
+
+# Without -g, an ambient KUBECONFIG remains effective.
+ambient_log="${WORK_DIR}/ambient.log"
+ambient_mutations="${WORK_DIR}/ambient.mutations"
+: > "$ambient_log"
+: > "$ambient_mutations"
+run_installer success "$ambient_log" "$ambient_mutations" -c >/dev/null 2>&1
+assert_contains "$ambient_log" "command=kubectl kubeconfig=[${AMBIENT_KUBECONFIG}] args=[cluster-info]"
+assert_contains "$ambient_log" "command=helm kubeconfig=[${AMBIENT_KUBECONFIG}] args=[repo][list]"
+printf '%s\n' 'PASS ambient kubeconfig is preserved without -g.'
+
+# The TLS helper changes directory before Kubernetes calls; its selected target
+# must still be inherited, and certificate paths may contain spaces.
+tls_log="${WORK_DIR}/tls.log"
+tls_mutations="${WORK_DIR}/tls.mutations"
+openssl_log="${WORK_DIR}/openssl.log"
+cert_dir="${WORK_DIR}/tls certs"
+: > "$tls_log"
+: > "$tls_mutations"
+: > "$openssl_log"
+env \
+  PATH="${STUB_DIR}:/usr/bin:/bin" \
+  STUB_MODE=tls \
+  STUB_LOG="$tls_log" \
+  STUB_MUTATIONS="$tls_mutations" \
+  STUB_OPENSSL_LOG="$openssl_log" \
+  KUBECONFIG="$AMBIENT_KUBECONFIG" \
+  bash "$TLS_HELPER" -g "$SELECTED_KUBECONFIG" -d "$cert_dir" >/dev/null 2>&1
+assert_all_selected "$tls_log"
+assert_contains "$tls_log" "command=kubectl kubeconfig=[${SELECTED_KUBECONFIG}] args=[create][secret][generic][prometheus-web-tls]"
+assert_contains "$tls_log" "command=kubectl kubeconfig=[${SELECTED_KUBECONFIG}] args=[create][configmap][prometheus-web-tls-ca]"
+printf '%s\n' 'PASS TLS helper retains the selected target after changing directory.'
+
+printf '%s\n' 'All kubeconfig-targeting tests passed.'


### PR DESCRIPTION
## What changed

The observability installer now uses the kubeconfig selected with `-g/--context` for every Kubernetes client it starts.

The change:

- exports the selected path through `KUBECONFIG`
- keeps the `kubectl` and `helm` command variables as executable names
- lets child scripts, including TLS generation and dashboard loading, inherit the same target
- adds a hermetic regression test to the existing path-filtered guide dry-run workflow

## Why

Before this change, some commands used the selected kubeconfig while bare `kubectl` and `oc` commands used the ambient configuration. A validation check could therefore pass against one cluster while a later operation changed another cluster.

For example, suppose the ambient kubeconfig points to production and the user runs the installer with `-g staging.kubeconfig`. Before this fix, Helm could install resources in staging while the reachability check, OpenShift commands, or dashboard helper still used production. One installer run could therefore read from or modify two different clusters. After this fix, every command uses staging.

The old command-string approach also broke when the selected path contained spaces.

## How to reproduce

Use different ambient and selected kubeconfigs, then run the CRD-only installer path:

```bash
export KUBECONFIG=/path/to/production.kubeconfig
guides/recipes/observability/install-prometheus-grafana.sh \
  -g "/path/to/staging kubeconfig" \
  -c
```

The regression test reproduces the dangerous case without real clusters:

1. The ambient target is configured to succeed.
2. The selected target is configured to fail `kubectl cluster-info`.
3. The installer is invoked with `-g` pointing to the selected target.

Before this fix, the initial bare `kubectl` could validate the ambient target and execution could continue. The path containing spaces could also be split as part of a command string. After this fix, validation uses the selected target and exits before any mutation; the path remains one value.

## Tests

- Bash syntax checks for the changed scripts and test clients
- Committed hermetic test covering selected-target validation, mutation prevention, paths with spaces, ambient configuration without `-g`, and TLS helper inheritance after changing directory
- External hermetic checks for the OpenShift path and dashboard helper
- YAML parse and whitespace checks

The committed test uses fake client binaries and does not require a live cluster, credentials, network access, or a new test dependency. It runs as a step in the existing guide dry-run workflow, which is path-filtered to guide or workflow changes, keeping the ongoing CI cost bounded.

## Related issue

No separate GitHub issue was opened for this bug. This PR contains the problem statement, concrete reproduction, fix, and regression coverage. `#2215` is the pull request number, not an issue number.

## Follow-up

The TLS helper still has the existing limitation that a relative kubeconfig path can stop resolving after it changes directory. Resolving that path before the directory change should be handled separately.