### PR TITLE
docs: document WVA throughput analyzer prerequisites

### DIFF
--- a/docs/architecture/advanced/autoscaling/hpa-wva.md
+++ b/docs/architecture/advanced/autoscaling/hpa-wva.md
@@ -12,16 +12,21 @@ WVA is **variant-aware**. A **variant** is one of multiple model servers in an I
 > [!NOTE]
 > WVA assumes a 1:1:1 relationship between InferencePool, Endpoint Picker (EPP), and base model. All variants within an InferencePool share the same EPP and therefore the same EPP metrics (e.g., request queue size).
 
-WVA provides two main scaling analyzers:
+WVA provides the following scaling analyzers:
 
 - **Saturation Analyzer** -- Scales based on resource saturation signals (KV cache utilization, request queue depth, and token-level capacity). When the system detects that model servers are saturated (running out of KV cache space or building up queues), it triggers scale-up on the cheapest available variant. When spare capacity is detected, it scales down the most expensive variant. This is the default analyzer. It has two sub-variants: `saturation-percentage-based` (default) and `saturation-token-based` (experimental).
 
   > [!NOTE]
   > These two sub-variants are also referred to as the **V1** (`saturation-percentage-based`) and **V2** (`saturation-token-based`) saturation engines. The [HPA + WVA guide](../../../../guides/workload-autoscaling/README.wva.md), the WVA configuration keys, and the controller logs (e.g. `V2 saturation analysis completed`) use the V1/V2 names; this document uses the descriptive `saturation-percentage-based` / `saturation-token-based` names for the same engines.
 
+- **Throughput Analyzer** *(Opt-in)* -- Estimates decode-token demand from model-level request arrivals and average output length, then compares that demand with observed and modeled decode-token supply. It is disabled by default and must be explicitly enabled in the `analyzers` list.
+
+  > [!IMPORTANT]
+  > Enable the Throughput Analyzer only when EPP scheduler arrival metrics are present for the model. Without those arrival metrics, a busy model can read as idle and drive spurious scale-down decisions. Adding or removing `throughput` in `wva-saturation-scaling-config` requires a `wva-controller-manager` restart because analyzer registration is read at startup.
+
 - **SLO Analyzer (Queueing Model)** *(Experimental)* -- Scales based on latency SLO targets using queueing theory. It uses a Kalman filter to learn hardware-specific performance parameters online, then applies a state-dependent Markovian queueing model to determine the maximum sustainable request rate per replica that meets target TTFT (Time To First Token) and ITL (Inter-Token Latency). The desired replica count is computed as the ratio of observed arrival rate to this capacity.
 
-Both analyzers integrate with a pipeline that includes cost-aware optimization, scale-to-zero enforcement, and optional GPU resource limiting.
+These analyzers integrate with a pipeline that includes cost-aware optimization, scale-to-zero enforcement, and optional GPU resource limiting.
 
 ## Design
 
@@ -341,6 +346,8 @@ data:
 > ```yaml
 > analyzers:
 >   - name: saturation
+>   # Optional. Requires EPP scheduler arrival metrics and a controller restart.
+>   # - name: throughput
 > ```
 >
 > Populating the `analyzers` list also enables per-analyzer score and threshold

--- a/guides/workload-autoscaling/README.wva.md
+++ b/guides/workload-autoscaling/README.wva.md
@@ -129,12 +129,22 @@ Edit the WVA configmap to enable the v2 saturation engine:
       # percentage-based analyzer.
       analyzers:
         - name: saturation
+        # Optional: enable only after confirming EPP arrival metrics are present.
+        # - name: throughput
       kvCacheThreshold: 0.80
       ...
   ```
 
-The WVA controller will automatically pick up the config change and start using the new saturation engine for scaling decisions. You can verify this by checking the controller logs for messages indicating the active saturation engine. Look for a log line like `V2 saturation analysis completed ` to confirm that the v2 engine is active.
+The WVA controller reloads saturation-only config changes dynamically and starts using the new saturation engine for scaling decisions. You can verify this by checking the controller logs for messages indicating the active saturation engine. Look for a log line like `V2 saturation analysis completed ` to confirm that the v2 engine is active.
 
+> [!IMPORTANT]
+> The `throughput` analyzer is opt-in and disabled by default. Enable it only when the EPP scheduler arrival metric is present for the model, for example `inference_extension_scheduler_attempts_total{status="success",target_model_name="<model>"}`. Without the EPP arrival metric, a busy model can appear idle to the ThroughputAnalyzer and drive spurious scale-down decisions.
+>
+> Adding or removing `throughput` in `wva-saturation-scaling-config` requires a controller restart because analyzer registration is read at startup. After editing the ConfigMap, run:
+>
+> ```bash
+> kubectl rollout restart deployment/wva-controller-manager -n ${WVA_NAMESPACE}
+> ```
 
 ## Enabling Autoscaling for an Inference Deployment
 


### PR DESCRIPTION
## Summary
- Document that the WVA `throughput` analyzer is opt-in and disabled by default.
- Warn operators to enable it only when EPP scheduler arrival metrics are present.
- Clarify that adding or removing `throughput` in `wva-saturation-scaling-config` requires restarting `wva-controller-manager`.

Fixes llm-d/llm-d-workload-variant-autoscaler#1498

## Testing
- `git diff --check`

Not run locally: full markdownlint/pre-commit, because this machine's default Node is v18.20.8 and `markdownlint-cli@0.47.0` requires Node >=20.

Note: supersedes #2217, which was closed while replacing an unsigned local commit with this GitHub-verified commit.