### PR TITLE
fix(precise): tokenize against the model the XPU overlay serves

### DIFF
--- a/guides/precise-prefix-cache-routing/README.md
+++ b/guides/precise-prefix-cache-routing/README.md
@@ -32,7 +32,7 @@ The routing decision combines precise cache knowledge with token-based load bala
 | NVIDIA GPU           | `modelserver/gpu/vllm/`    | Qwen/Qwen3-32B                          | Default configuration                                    |
 | NVIDIA GPU (SGLang)  | `modelserver/gpu/sglang/`  | Qwen/Qwen3-32B                          | SGLang; `--page-size=64` matches the producer's `blockSizeTokens`; requires `render/standalone/` |
 | AMD GPU              | `modelserver/amd/vllm/`    | Qwen/Qwen3-32B                          | AMD GPU                                                  |
-| Intel XPU            | `modelserver/xpu/vllm/`    | Qwen/Qwen3-0.6B                         | CI-sized; update router `modelName` for real use         |
+| Intel XPU            | `modelserver/xpu/vllm/`    | Qwen/Qwen3-0.6B                         | CI-sized; pair with `router/xpu.values.yaml`             |
 | Google TPU v6e       | `modelserver/tpu/v6/vllm/` | Qwen/Qwen3-32B                          | GKE TPU                                                  |
 | Google TPU v7        | `modelserver/tpu/v7/vllm/` | Qwen3-Coder-480B-FP8                    | GKE TPU                                                  |
 | CPU                  | `modelserver/cpu/vllm/`    | Llama-3.2-3B-Instruct                   | CI-sized                                                 |
@@ -108,6 +108,17 @@ helm install ${GUIDE_NAME} \
   ${ROUTER_STANDALONE_CHART} \
   -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
   -f ${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
+  -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
+```
+
+For Intel XPU, add the XPU router override so the `token-producer` tokenizes against the Qwen3-0.6B that `modelserver/xpu/vllm/` serves:
+
+```bash
+helm install ${GUIDE_NAME} \
+  ${ROUTER_STANDALONE_CHART} \
+  -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
+  -f ${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
+  -f ${REPO_ROOT}/guides/${GUIDE_NAME}/router/xpu.values.yaml \
   -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
 ```
 

--- a/guides/precise-prefix-cache-routing/router/xpu.values.yaml
+++ b/guides/precise-prefix-cache-routing/router/xpu.values.yaml
@@ -1,0 +1,63 @@
+## Intel XPU overrides for the precise-prefix-cache-routing router.
+## Layer on top of: precise-prefix-cache-routing.values.yaml
+##
+## `modelserver/xpu/vllm/` serves a CI-sized Qwen3-0.6B, and the `../render/`
+## Service fronts those same pods, so the `token-producer` `modelName` must be
+## the XPU model — with the guide default (Qwen3-32B) vLLM answers the render
+## call with 404 and prefix-cache routing silently degrades to no-op scoring.
+##
+## Helm replaces `pluginsCustomConfig` entries wholesale (the value is a single
+## YAML string), so the whole plugin config is repeated here. Keep it in sync
+## with precise-prefix-cache-routing.values.yaml.
+
+router:
+  epp:
+    pluginsCustomConfig:
+      precise-prefix-cache-routing-plugins.yaml: |
+        apiVersion: llm-d.ai/v1alpha1
+        kind: EndpointPickerConfig
+        plugins:
+          - type: token-producer
+            parameters:
+              modelName: Qwen/Qwen3-0.6B
+              vllm:
+                # Guide render Service (../render/), not a loopback sidecar.
+                # `precise-prefix-cache-routing-` namePrefix + Service name `render`.
+                url: "http://precise-prefix-cache-routing-render:8000"
+          - type: endpoint-notification-source
+          - type: precise-prefix-cache-producer # `precise-prefix-cache-scorer` is deprecated
+            parameters:
+              tokenProcessorConfig:
+                blockSizeTokens: 64
+              speculativeIndexing: true
+              indexerConfig:
+                kvBlockIndexConfig:
+                  enableMetrics: true
+              kvEventsConfig:
+                topicFilter: "kv@"
+                concurrency: 8
+                discoverPods: true
+                podDiscoveryConfig:
+                  socketPort: 5556
+                  replaySocketPort: 5559
+          - type: inflight-load-producer
+            parameters:
+              prefixMatchInfoProducerName: precise-prefix-cache-producer
+          - type: prefix-cache-affinity-filter
+            parameters:
+              prefixMatchInfoProducerName: precise-prefix-cache-producer
+              # Inherited from the H100/Qwen3-32B reference setup; not yet
+              # re-measured on XPU with
+              # guides/recipes/router/calibration/calibrate.sh.
+              peakPrefillThroughput: 15926
+          - type: token-load-scorer
+        dataLayer: # metrics-data-source + core-metrics-extractor injected by default
+          sources:
+            - pluginRef: endpoint-notification-source
+              extractors:
+                - pluginRef: precise-prefix-cache-producer
+        schedulingProfiles:
+          - name: default
+            plugins:
+              - pluginRef: prefix-cache-affinity-filter
+              - pluginRef: token-load-scorer


### PR DESCRIPTION
`modelserver/xpu/vllm/` serves a CI-sized Qwen/Qwen3-0.6B, but the router values hardcode the guide's reference `modelName: Qwen/Qwen3-32B` for the `token-producer` plugin. Since the default `../render/` overlay fronts the model servers themselves, vLLM answers the render call with

  404 The model `Qwen/Qwen3-32B` does not exist.

The EPP stays Ready and requests still succeed, so the failure is silent: `token-producer` produces no token IDs and precise prefix-cache routing degrades to no-op scoring for the whole run.

Add an XPU router override that pins the tokenizer to Qwen/Qwen3-0.6B, and document it next to the existing standalone helm command.