### PR TITLE
fix: Disable USE_SCCACHE when the sccache fallback kicks in

### DIFF
--- a/docker/scripts/common/setup-sccache.sh
+++ b/docker/scripts/common/setup-sccache.sh
@@ -38,6 +38,8 @@ if [ "${USE_SCCACHE}" = "true" ]; then
         # Remove sccache binary so meson/cmake can't accidentally try to use it
         rm -f /usr/local/bin/sccache || true
         unset CMAKE_C_COMPILER_LAUNCHER CMAKE_CXX_COMPILER_LAUNCHER CMAKE_CUDA_COMPILER_LAUNCHER
+        # Sourcing scripts branch on this to decide whether to put sccache in CC/CXX
+        export USE_SCCACHE="false"
         return 0
     fi
 
@@ -47,6 +49,7 @@ if [ "${USE_SCCACHE}" = "true" ]; then
         # Remove sccache binary so meson/cmake can't accidentally try to use it
         rm -f /usr/local/bin/sccache || true
         unset CMAKE_C_COMPILER_LAUNCHER CMAKE_CXX_COMPILER_LAUNCHER CMAKE_CUDA_COMPILER_LAUNCHER
+        export USE_SCCACHE="false"
         return 0
     fi
 

--- a/docker/scripts/common/setup-sccache.sh
+++ b/docker/scripts/common/setup-sccache.sh
@@ -35,8 +35,6 @@ if [ "${USE_SCCACHE}" = "true" ]; then
 
     if ! /usr/local/bin/sccache --start-server; then
         echo "Warning: sccache failed to start, continuing without cache" >&2
-        # Remove sccache binary so meson/cmake can't accidentally try to use it
-        rm -f /usr/local/bin/sccache || true
         unset CMAKE_C_COMPILER_LAUNCHER CMAKE_CXX_COMPILER_LAUNCHER CMAKE_CUDA_COMPILER_LAUNCHER
         # Sourcing scripts branch on this to decide whether to put sccache in CC/CXX
         export USE_SCCACHE="false"
@@ -46,8 +44,6 @@ if [ "${USE_SCCACHE}" = "true" ]; then
     if ! /usr/local/bin/sccache --show-stats >/dev/null 2>&1; then
         echo "Warning: sccache not responding properly, disabling cache" >&2
         /usr/local/bin/sccache --stop-server 2>/dev/null || true
-        # Remove sccache binary so meson/cmake can't accidentally try to use it
-        rm -f /usr/local/bin/sccache || true
         unset CMAKE_C_COMPILER_LAUNCHER CMAKE_CXX_COMPILER_LAUNCHER CMAKE_CUDA_COMPILER_LAUNCHER
         export USE_SCCACHE="false"
         return 0

--- a/docker/scripts/cuda/builder/install-sccache.sh
+++ b/docker/scripts/cuda/builder/install-sccache.sh
@@ -36,8 +36,8 @@ if [ "${USE_SCCACHE}" = "true" ]; then
     # shellcheck source=/dev/null
     source /usr/local/bin/setup-sccache
 
-    # verify sccache works with a simple test (only if binary still exists after setup)
-    if [ -x /usr/local/bin/sccache ]; then
+    # setup-sccache clears USE_SCCACHE when it could not reach the cache
+    if [ "${USE_SCCACHE}" = "true" ]; then
         echo "int main() { return 0; }" | sccache gcc -x c - -o /dev/null
         echo "sccache installation and S3 connectivity verified"
     fi


### PR DESCRIPTION
Fixes #2223

### Problem

`docker/scripts/common/setup-sccache.sh` degrades gracefully when sccache cannot start, but the degrade path leaves the build broken in two separate ways.

**1. `USE_SCCACHE` is never cleared.**

The script removes the binary, unsets the CMake launcher variables and returns success — but the input variable still says `true`. Every consumer sources the script and then branches on it, so they still believe sccache is available:

```bash
. /usr/local/bin/setup-sccache
...
if [ "${USE_SCCACHE}" = "true" ]; then
    export CC="sccache gcc" CXX="sccache g++"   # binary was just deleted
fi
```

gdrcopy builds with a plain Makefile rather than CMake, so unsetting the `CMAKE_*_COMPILER_LAUNCHER` variables has no effect on it. The hardcoded `sccache` in `CC` is what actually breaks the build:

```
make[1]: sccache: No such file or directory
make[1]: *** [<builtin>: gdrapi.o] Error 127
make: *** [Makefile:63: lib] Error 2
```

`build-ucx.sh:29` and `build-nixl.sh:32` set `CC` the same way and fail identically. `build-gdrcopy.sh:62`, `build-ucx.sh:62`, `build-nvshmem.sh:147`, `build-lmcache.sh:88` and `build-compiled-wheels.sh:106` call bare `sccache --show-stats` after the binary is gone, which aborts under `set -e`.

**2. Deleting the binary breaks the final image layer.**

`docker/Dockerfile.cuda:493-494` copies sccache out of the builder stage, and its comment states the invariant the degrade path violates:

```dockerfile
# sccache binary is always installed in builder; only configured/started when USE_SCCACHE=true
COPY --from=builder /usr/local/bin/sccache /usr/local/bin/sccache
```

Once the builder stage stops failing, the build gets one step further and dies here instead:

```
ERROR: failed to build: failed to solve: failed to compute cache key:
failed to calculate checksum of ref ...: "/usr/local/bin/sccache": not found
```

Together these fail every CUDA-family image build — both architectures, both base OSes, plus the debug, gb200 and aws variants.

**3. The install-time smoke test uses the binary as a success proxy.**

`install-sccache.sh:40` decides whether to run its verification compile by testing whether the binary still exists:

```bash
source /usr/local/bin/setup-sccache

# verify sccache works with a simple test (only if binary still exists after setup)
if [ -x /usr/local/bin/sccache ]; then
    echo "int main() { return 0; }" | sccache gcc -x c - -o /dev/null
```

That check is only meaningful because of the `rm -f` in (2), and it contradicts the file's own header comment: "Always install sccache binary (small download) so `COPY --from=builder` works in downstream stages regardless of `USE_SCCACHE` setting." With the binary preserved, the smoke test runs even though the cache is unreachable and aborts the builder stage under `set -Eeux`:

```
+ sccache gcc -x c - -o /dev/null
sccache: error: Server startup failed: ... InvalidAccessKeyId
#24 ERROR: process "/bin/sh -c /tmp/install-sccache.sh ..." did not complete successfully: exit code: 2
```

### Fix

Export `USE_SCCACHE=false` in both fallback branches, stop deleting the binary, and gate the smoke test on the flag rather than on the binary's existence.

The script is sourced, so the export covers every consumer in one place, and it matches the pattern `build-nvshmem.sh:32` already uses when it opts out of sccache. Every reference to the `sccache` binary in every consumer script is inside an `if [ "${USE_SCCACHE}" = "true" ]` guard, so the `rm -f` no longer protects against anything — its stated purpose ("so meson/cmake can't accidentally try to use it") is already covered by the unset launchers plus the disabled flag.

Only the degrade paths and the one guard are touched; the successful-sccache path is unchanged.

### Verification

Ran the real `build-gdrcopy.sh` in a container with no working sccache, which is exactly the CI condition:

| | exit code | output |
|---|---|---|
| before | `2` | `make[1]: sccache: No such file or directory` / `Error 127` |
| after | `0` | `cc -shared -Wl,-soname,libgdrapi.so.2 -o libgdrapi.so.2.5 ...` → installed |

And confirmed the resulting state after sourcing the script with a stub sccache that fails to start the way CI's does:

```
+ '[' true = true ']'
+ source /usr/local/bin/setup-sccache
++ /usr/local/bin/sccache --start-server
sccache: error: Server startup failed: InvalidAccessKeyId
Warning: sccache failed to start, continuing without cache
++ export USE_SCCACHE=false
+ '[' false = true ']'
---- results ----
exit code: 0
binary PRESENT
```

### Why this surfaced now

`detect-changes` lists `docker/common-versions` as a trigger for every platform. PRs touching only one platform's Dockerfile skip the CUDA jobs entirely, so the bug stays hidden; any PR that edits the shared `common-versions` file turns all platform builds on and hits it immediately. #1230 is the PR that ran into it.

The three failure modes masked each other: the builder stage died at gdrcopy before reaching `COPY --from=builder`, and the smoke test was skipped only because the binary had been deleted. The CI credentials for the `vllm-nightly-sccache` bucket currently return `InvalidAccessKeyId`, so the degrade path is taken on every run rather than occasionally.
