### PR TITLE
Fix broken links

### DIFF
--- a/docs/well-lit-paths/foundations/pd-disaggregation.md
+++ b/docs/well-lit-paths/foundations/pd-disaggregation.md
@@ -43,7 +43,7 @@ During the standard request flow:
 
 ## Observability
 
-P/D disaggregation runs prefill and decode as independently scaled pools joined by a NIXL KV transfer, so the signals that matter are pool **balance** and transfer health rather than a single aggregate latency. The [P/D guide's Observability & Troubleshooting section](../../../guides/pd-disaggregation/README.md#4-observability--troubleshooting) covers the key metrics for this path and the common failure modes, backed by the shared [PromQL](../operations/observability/promql.md#prefilldecode-disaggregation) and [metric](../operations/observability/metrics.md) references.
+P/D disaggregation runs prefill and decode as independently scaled pools joined by a NIXL KV transfer, so the signals that matter are pool **balance** and transfer health rather than a single aggregate latency. The [P/D guide's Observability & Troubleshooting section](../../../guides/pd-disaggregation/README.md#4-observability--troubleshooting) covers the key metrics for this path and the common failure modes, backed by the shared [PromQL](../../operations/observability/promql.md#prefilldecode-disaggregation) and [metric](../../operations/observability/metrics.md) references.
 
 ## Further Reading
 


### PR DESCRIPTION
These 2 broken links were causing ci failures in `llm-d/llm-d.github.io` and need to be fixed.

Signed-off-by: David G. Simmons <santafen@mac.com>
