### PR TITLE
[ci/test]: Update gke workflows to use the cluster in us east5 

### DIFF
--- a/.github/workflows/nightly-e2e-optimized-baseline-gke-acc-gpu-sglang-x.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-gke-acc-gpu-sglang-x.yaml
@@ -77,6 +77,8 @@ jobs:
       infra_provider: ${{ inputs.infra_provider || 'gke' }}
       connector: ${{ inputs.connector || '' }}
       cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-optimized-baseline-gke-gpu-sglang' }}
+      cluster_name: ${{ inputs.cluster_name || 'llm-d-e2e-us-east5' }}
+      cluster_zone: ${{ inputs.cluster_zone || 'us-east5' }}
       helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-gke-sglang' }}
       workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-gke-sglang' }}
       bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}

--- a/.github/workflows/nightly-e2e-optimized-baseline-gke-acc-gpu-trtllm-x.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-gke-acc-gpu-trtllm-x.yaml
@@ -77,6 +77,8 @@ jobs:
       infra_provider: ${{ inputs.infra_provider || 'gke' }}
       connector: ${{ inputs.connector || '' }}
       cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-optimized-baseline-gke-gpu-trtllm' }}
+      cluster_name: ${{ inputs.cluster_name || 'llm-d-e2e-us-east5' }}
+      cluster_zone: ${{ inputs.cluster_zone || 'us-east5' }}
       helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-gke-trtllm' }}
       workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-gke-trtllm' }}
       bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}

--- a/.github/workflows/nightly-e2e-optimized-baseline-gke-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-gke-acc-gpu-vllm-x.yaml
@@ -82,6 +82,8 @@ jobs:
       infra_provider: ${{ inputs.infra_provider || 'gke' }}
       connector: ${{ inputs.connector || '' }}
       cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-optimized-baseline-gke-gpu' }}
+      cluster_name: ${{ inputs.cluster_name || 'llm-d-e2e-us-east5' }}
+      cluster_zone: ${{ inputs.cluster_zone || 'us-east5' }}
       helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-gke' }}
       workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-gke' }}
       bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}

--- a/.github/workflows/nightly-e2e-precise-prefix-cache-routing-gke-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-precise-prefix-cache-routing-gke-acc-gpu-vllm-x.yaml
@@ -82,6 +82,8 @@ jobs:
       infra_provider: ${{ inputs.infra_provider || 'gke' }}
       connector: ${{ inputs.connector || '' }}
       cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-precise-prefix-cache-routing-gke-gpu' }}
+      cluster_name: ${{ inputs.cluster_name || 'llm-d-e2e-us-east5' }}
+      cluster_zone: ${{ inputs.cluster_zone || 'us-east5' }}
       helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-gke' }}
       workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-gke' }}
       bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-lmcache.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-lmcache.yaml
@@ -83,6 +83,8 @@ jobs:
       offloading_target: ${{ inputs.offloading_target || 'cpu' }}
       connector: ${{ inputs.connector || 'lmcache-connector' }}
       cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-tiered-prefix-cache-gke-gpu' }}
+      cluster_name: ${{ inputs.cluster_name || 'llm-d-e2e-us-east5' }}
+      cluster_zone: ${{ inputs.cluster_zone || 'us-east5' }}
       helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-gke' }}
       workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-gke' }}
       bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}

--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-native.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-native.yaml
@@ -83,6 +83,8 @@ jobs:
       offloading_target: ${{ inputs.offloading_target || 'cpu' }}
       connector: ${{ inputs.connector || 'native' }}
       cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-tiered-prefix-cache-gke-gpu' }}
+      cluster_name: ${{ inputs.cluster_name || 'llm-d-e2e-us-east5' }}
+      cluster_zone: ${{ inputs.cluster_zone || 'us-east5' }}
       helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-gke' }}
       workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-gke' }}
       bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}


### PR DESCRIPTION
**Problem**
Presently, the nightly pipeline executes against the cluster in us south1. Due to stockouts in that cluster, the pipeline has been failing recently.

**Proposed Fix**
Start using cluster in us east5, since the cluster does have reservation. This should help avoid stockout issues in future.

This change should fix the workflows that run on H100s. P/D and wide ep can be fixed separately since they need H200s.