### PR TITLE
build(xpu): use official vLLM v0.26.0 image

### DIFF
--- a/docker/Dockerfile.xpu
+++ b/docker/Dockerfile.xpu
@@ -1,17 +1,21 @@
-# Default to the prebuilt vLLM XPU image from upstream CI.
+# Default to the official prebuilt vLLM XPU image.
 # Override at build time via --build-arg BASE_IMAGE=...
 # The default value here is informational only; the workflow always passes
 # BASE_IMAGE explicitly from docker/common-versions (VLLM_XPU_BASE_IMAGE).
-ARG BASE_IMAGE=public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:b1388b1fbf5aaef47937fabe98931211684666a6-xpu
+ARG BASE_IMAGE=vllm/vllm-openai-xpu:v0.26.0
 
 FROM ${BASE_IMAGE}
+
+# PyTorch XPU needs UMF at runtime; upstream's setvars.sh adds this path.
+ENV LD_LIBRARY_PATH=/opt/intel/oneapi/umf/latest/lib:${LD_LIBRARY_PATH}
 
 ARG CACHE_BUSTER
 RUN if [ -n "${CACHE_BUSTER}" ]; then \
         echo "$CACHE_BUSTER" > /tmp/builder-buster; \
     fi;
 
-RUN git clone https://github.com/LMCache/LMCache.git -b v0.5.0 && \
+RUN source /opt/intel/oneapi/setvars.sh --force && \
+    git clone https://github.com/LMCache/LMCache.git -b v0.5.0 && \
     cd LMCache && pip install -r requirements/build.txt && \
     BUILD_WITH_SYCL=1 uv pip install --no-build-isolation -e .
 

--- a/docker/common-versions
+++ b/docker/common-versions
@@ -20,10 +20,10 @@ VLLM_PRECOMPILED_WHEEL_COMMIT=0fc695fc6d1d82e9a5ac6835ac8e4e1c83703665 # maps to
 
 
 
-# Used by XPU: prebuilt vLLM image from upstream CI (vllm-ci-test-repo).
+# Used by XPU: official prebuilt vLLM XPU image from Docker Hub.
 # The XPU image is a thin pass-through over this base; switch tags here to upgrade.
-# Tag corresponds to vLLM v0.23.0 release (commit 0fc695fc6d1d82e9a5ac6835ac8e4e1c83703665).
-VLLM_XPU_BASE_IMAGE=public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:0fc695fc6d1d82e9a5ac6835ac8e4e1c83703665-xpu
+# Official vLLM v0.26.0 release image.
+VLLM_XPU_BASE_IMAGE=vllm/vllm-openai-xpu:v0.26.0
 
 # ============================================================================
 # CUDA Version Configuration


### PR DESCRIPTION
## Summary

- replace the temporary AWS ECR XPU base with the official `vllm/vllm-openai-xpu:v0.26.0` image
- initialize oneAPI before building LMCache with SYCL
- expose the UMF runtime library so direct Python and `vllm serve` entrypoints detect DRA-provisioned XPU devices

## Validation

- workflow-equivalent `linux/amd64` Buildx build with provenance enabled
- verified `vllm==0.26.0+xpu`, `lmcache==0.5.0`, `lmcache.xpu_ops`, and NIXL imports
- deployed `guides/optimized-baseline` XPU overlay on Kind
- brought up two `Qwen/Qwen3-0.6B` replicas on separate Intel Data Center GPU Max 1550 devices through DRA
- completed an OpenAI-compatible chat request through the standalone router/EPP