### PR TITLE
ci: Remove Redundant  modelserver_kustomize_path  Input

### DIFF
--- a/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-lmcache.yaml
+++ b/.github/workflows/nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-lmcache.yaml
@@ -82,7 +82,6 @@ jobs:
       infra_provider: ${{ inputs.infra_provider || 'gke' }}
       offloading_target: ${{ inputs.offloading_target || 'cpu' }}
       connector: ${{ inputs.connector || 'lmcache-connector' }}
-      modelserver_kustomize_path: 'gpu/vllm/lmcache-connector/cpu'
       cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-tiered-prefix-cache-gke-gpu' }}
       helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-gke' }}
       workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-gke' }}


### PR DESCRIPTION
there is no input `modelserver_kustomize_path` in the called [workflow](https://github.com/llm-d/llm-d-infra/blob/main/.github/workflows/reusable-ci-nightly-benchmark.yaml)

