### PR TITLE
guides(p2p): clarify block-size requirements

### DIFF
--- a/guides/p2p-kv-cache-sharing/README.md
+++ b/guides/p2p-kv-cache-sharing/README.md
@@ -145,10 +145,14 @@ a crossover measured on your own transport.
 
 ## Best Practices
 
-* `--block-size` identical on every pod and in the router's
-  `precise-prefix-cache-producer` (`tokenProcessorConfig.blockSize`). A
-  mismatch leaves the prefix index empty and the whole path silently
-  inert: requests still serve, nothing pulls.
+* Keep the offloading block size identical across all P2P peers. This
+  guide omits `kv_connector_extra_config.block_size`, so it defaults to
+  the engine's `--block-size`; therefore `--block-size` must be
+  identical across all model-server pods in this deployment. If an
+  explicit offloading `block_size` is configured instead, use the same
+  value on every peer and ensure that it is a multiple of each peer's
+  engine block size. The router's `tokenProcessorConfig.blockSize` is
+  an independent indexing granularity and may differ.
 * `PYTHONHASHSEED` pinned to the same value fleet-wide. vLLM seeds block
   hashes per process; unpinned seeds mean no block hash ever matches
   across pods and every lookup misses.

--- a/guides/p2p-kv-cache-sharing/modelserver/gpu/vllm/base/patch-vllm.yaml
+++ b/guides/p2p-kv-cache-sharing/modelserver/gpu/vllm/base/patch-vllm.yaml
@@ -19,8 +19,10 @@ spec:
             - --port=8200
             - --disable-access-log-for-endpoints=/health,/metrics,/v1/models
             - --tensor-parallel-size=1
-            # block-size MUST match the router's precise-prefix-cache-producer
-            # tokenProcessorConfig.blockSize, or the prefix index stays empty.
+            # The offloading config below omits `block_size`, so it defaults to
+            # this engine block size. Keep it identical across all P2P peers.
+            # It does not need to match the router's
+            # tokenProcessorConfig.blockSize.
             - --block-size=64
             - --max-model-len=65536
             # Tuning knob: raise for more GPU cache, lower to leave headroom.

--- a/guides/p2p-kv-cache-sharing/router/p2p-kv-cache-sharing.values.yaml
+++ b/guides/p2p-kv-cache-sharing/router/p2p-kv-cache-sharing.values.yaml
@@ -91,6 +91,8 @@ router:
                 - name: cpu
                   weight: 0.4
               tokenProcessorConfig:
+                # Router indexing granularity. This is independent of the model
+                # server and offloading block sizes; see Best Practices.
                 blockSize: 64
               # Seeds predicted cache entries for the selected endpoint right
               # after the routing decision, so the next same-prefix request


### PR DESCRIPTION
## Summary

- distinguish the router's canonical indexing block size from vLLM's offloading block size
- explain why this deployment keeps the engine block size identical across P2P peers
- document the requirements when an explicit offloading block size is configured

## Why

The guide currently says the router and engine block sizes must match. The router supports a separate canonical indexing granularity. In this deployment, the offloading block size defaults to the engine block size, so the peer requirement still applies across model-server pods, independently of the router setting.

## Validation

- `git diff --check`
