### PR TITLE
Fix guides typo

### DIFF
--- a/guides/agentic-serving/modelserver/gpu/vllm/nemotron-3-ultra/gke/README.md
+++ b/guides/agentic-serving/modelserver/gpu/vllm/nemotron-3-ultra/gke/README.md
@@ -89,6 +89,6 @@ gcloud storage cp -r ./NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8-block gs://llm-mode
 Once the model is stored in your GCS, please refer back to https://github.com/llm-d/llm-d/blob/main/guides/agentic-serving/nemotron-3-ultra-550b-h200.md#2-deploy-the-model-server-gpus to continue the deployment.
 
 > [!NOTE]
-> Please set `INFRA_PROVIDER` = `gke` to leverage this deploment.
+> Please set `INFRA_PROVIDER` = `gke` to leverage this deployment.
 
 

--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -63,7 +63,7 @@ This guide includes configuration for the following accelerators:
 P/D disaggregation requires a KV transfer backend to move KV cache blocks from prefill workers to decode workers. The transfer backend is configured via vLLM's `--kv-transfer-config` flag.
 
 > [!NOTE]
-> The following table represents vLLM's KVTransfer compatability. SGLang also supports these KVTransfer backends but its implementation will look different and is coming soon.
+> The following table represents vLLM's KVTransfer compatibility. SGLang also supports these KVTransfer backends but its implementation will look different and is coming soon.
 
 | Connector | Overlay | Transport | Notes |
 | --------- | ------- | --------- | ----- |


### PR DESCRIPTION
Addresses #2233

Fix several typos found in the guides.

Changes:
- `compatability` -> `compatibility`
- `deploment` -> `deployment`

Other reported terms such as `mis-price`, `mis-gate`, `mis-addressed`, and `OFO` were left unchanged because they appear to be valid usages / false positives from the typo checker.