### PR TITLE
guides: pin router chart to released v0.9.0

### DIFF
--- a/guides/env.sh
+++ b/guides/env.sh
@@ -5,7 +5,9 @@
 
 export REPO_ROOT=${REPO_ROOT:-$(realpath "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null)}
 export GAIE_VERSION=v1.5.0
-export ROUTER_CHART_VERSION=v0
+# Pinned to a released chart tag rather than the mutable `v0` channel so guide
+# walkthroughs and CI are reproducible. Bump deliberately on each router release.
+export ROUTER_CHART_VERSION=v0.9.0
 export ROUTER_EPP_VERSION=main
 # GitHub release tag for CRD manifests. Distinct from ROUTER_CHART_VERSION:
 # the chart channel (v0) floats on the OCI registry and has no matching


### PR DESCRIPTION
env.sh set ROUTER_CHART_VERSION=v0, a rolling tag, so guides installed
whatever landed upstream last. llm-d-router#1681 went into v0 and broke EPP

service creation with flowControl/monitoring enabled.
pinning to a released tag makes guides and CI reproducible. env.sh is the
only assignment; everything else reads from it.

note v0.10.0-rc.1 was cut yesterday (pre-release), so this will need a bump when it goes stable.

fixes #2207