### PR TITLE
Stale workflow filename left behind in TPU consolidate-status after nightly rename

### DIFF
--- a/.github/workflows/consolidate-status-precise-prefix-cache-routing-gke-acc-tpu-vllm-x.yaml
+++ b/.github/workflows/consolidate-status-precise-prefix-cache-routing-gke-acc-tpu-vllm-x.yaml
@@ -7,7 +7,7 @@ on:
         description: 'Name of the workflow to be queried'
         required: false
         type: 'string'
-        default: 'nightly-e2e-precise-prefix-cache-gke-acc-tpu-vllm-x.yaml'
+        default: 'nightly-e2e-precise-prefix-cache-routing-gke-acc-tpu-vllm-x.yaml'
       time_window_query:
         description: 'How many days in the past to query'
         required: true
@@ -30,7 +30,7 @@ jobs:
   check_for_success:
     uses: llm-d/llm-d-infra/.github/workflows/reusable-query-success-past-runs.yaml@main
     with:
-      workflow_name_query: ${{ inputs.workflow_name_query || 'nightly-e2e-precise-prefix-cache-gke-acc-tpu-vllm-x.yaml' }}
+      workflow_name_query: ${{ inputs.workflow_name_query || 'nightly-e2e-precise-prefix-cache-routing-gke-acc-tpu-vllm-x.yaml' }}
       time_window_query: ${{ inputs.time_window_query || '5' }}
       branch_query: ${{ inputs.branch_query || 'main' }}
     secrets: inherit


### PR DESCRIPTION
PR #2258 renamed  `nightly-e2e-precise-prefix-cache-gke-acc-tpu-vllm-x.yaml` to `nightly-e2e-precise-prefix-cache-routing-gke-acc-tpu-vllm-x.yaml`
but left two stale references to the old filename in its companion consolidate-status workflow. 

As a result, the daily scheduled status check queries a non-existent workflow and permanently fails to find any success records for that lane.