### PR TITLE
docs(p2p): apply #2067 review follow-ups

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -33,7 +33,7 @@ llm-d provides a comprehensive ecosystem for managing and reusing the KV cache a
 - [Prefix-Cache Aware Routing](advanced/kv-management/prefix-cache-aware-routing.md): Heuristic and precise techniques to maximize cache hits.
 - [KV-Cache Indexing](advanced/kv-management/kv-indexer.md): Event-driven tracking of cache state across all model servers.
 - [KV Offloading](advanced/kv-management/kv-offloader.md): Tiered storage hierarchy (CPU, SSD) for extending cache capacity.
-- [P2P Sharing](../well-lit-paths/foundations/enable-p2p-reuse.md): Pulling cached prefix KV blocks from a peer's CPU tier instead of recomputing them.
+- [P2P Prefix Cache Sharing](../well-lit-paths/foundations/enable-p2p-prefix-cache-sharing.md): Pulling cached prefix KV blocks from a peer's CPU tier instead of recomputing them.
 
 See [KV Cache Management](advanced/kv-management/README.md) for an overview of how these components compose.
 

--- a/docs/architecture/advanced/kv-management/README.md
+++ b/docs/architecture/advanced/kv-management/README.md
@@ -26,4 +26,4 @@ The "capacity" layer that extends the cache beyond the limited high-bandwidth me
 
 The "sharing" layer that composes the three pillars into a fleet-wide cache: the index knows which peer holds a request's prefix, the router stamps the request with that source, and the model server pulls the blocks directly from the peer's CPU offload tier over NIXL instead of recomputing them. The source pod's GPU is never touched, so serving a pull costs it no prefill capacity, and an ordinary lookup miss or partial match degrades to a normal recompute rather than failing the request (a promised-but-undelivered block is a documented limitation - see the guide).
 
-**See [Enable P2P Reuse](../../../well-lit-paths/foundations/enable-p2p-reuse.md)** for the mechanism and the when-to-use rule, and the **[P2P KV Cache Sharing guide](../../../../guides/p2p-kv-cache-sharing)** for deployment and benchmarks.
+**See [Enable P2P Prefix Cache Sharing](../../../well-lit-paths/foundations/enable-p2p-prefix-cache-sharing.md)** for the mechanism and the when-to-use rule, and the **[P2P KV Cache Sharing guide](../../../../guides/p2p-kv-cache-sharing)** for deployment and benchmarks.

--- a/docs/well-lit-paths/foundations/README.md
+++ b/docs/well-lit-paths/foundations/README.md
@@ -14,7 +14,7 @@ These guides teach single architectural capabilities that you can configure inde
 
 - **[Precise Prefix Cache Routing](precise-prefix-cache-routing.md)**: Near-real-time routing based on exact cache state published by model servers.
 - **[Tiered Prefix Cache](tiered-prefix-cache.md)**: Efficiently managing KV caches by offloading to CPU RAM, NVMe, or network storage to improve prefix-cache re-use.
-- **[Enable P2P Reuse](enable-p2p-reuse.md)**: Pulling cached prefix KV blocks directly from a peer's CPU offload tier instead of recomputing them, turning per-pod prefix caches into a fleet-wide resource.
+- **[Enable P2P Prefix Cache Sharing](enable-p2p-prefix-cache-sharing.md)**: Pulling cached prefix KV blocks directly from a peer's CPU offload tier instead of recomputing them, turning per-pod prefix caches into a fleet-wide resource.
 
 ### Serving Large Models
 

--- a/docs/well-lit-paths/foundations/enable-p2p-prefix-cache-sharing.md
+++ b/docs/well-lit-paths/foundations/enable-p2p-prefix-cache-sharing.md
@@ -1,4 +1,4 @@
-# Enable P2P Reuse
+# Enable P2P Prefix Cache Sharing
 
 Prefix caches are per-pod, but their content is often fleet-wide: shared
 system prompts, common documents, session histories. Prefix-aware routing
@@ -7,7 +7,7 @@ always follow the cache: a hot prefix's owner saturates, a working set
 outgrows any single pod, a session is rebalanced. Those requests recompute
 KV tensors that already exist on a peer.
 
-P2P reuse closes that gap: a model server pulls cached prefix KV blocks
+P2P prefix cache sharing closes that gap: a model server pulls cached prefix KV blocks
 from a peer's CPU offload tier instead of recomputing them. The transfer
 is CPU-to-CPU over NIXL. The source pod's GPU is never touched, so serving
 a pull costs the source no prefill capacity.
@@ -31,9 +31,9 @@ sequenceDiagram
     Note over S: computes the prefix KV, caches it,<br/>offloads a copy to its CPU tier
     Note over R: request 2 arrives sharing request 1's prefix,<br/>but placement picks a different pod
     R->>C: request 2 + header naming the source pod
-    alt without P2P reuse
+    alt without P2P prefix cache sharing
         Note over C: recomputes the full shared prefix
-    else with P2P reuse
+    else with P2P prefix cache sharing
         C->>S: request the prefix blocks
         S-->>C: prefix KV blocks, CPU tier to CPU tier over NIXL
         Note over C: computes only the remainder<br/>(request 2's unshared tokens)
@@ -41,7 +41,7 @@ sequenceDiagram
 ```
 
 > [!IMPORTANT]
-> P2P reuse builds on the [Tiered Prefix Cache](tiered-prefix-cache.md)
+> P2P prefix cache sharing builds on the [Tiered Prefix Cache](tiered-prefix-cache.md)
 > path: peers serve pulls from their CPU offload tier. The tier must be
 > enabled and sized larger than the per-pod GPU KV cache, block hashes
 > must agree across pods (identical `--block-size` and `PYTHONHASHSEED`

--- a/docs/well-lit-paths/foundations/tiered-prefix-cache.md
+++ b/docs/well-lit-paths/foundations/tiered-prefix-cache.md
@@ -58,7 +58,7 @@ Offloaded KV caches can live on several tiers, ordered by read/write latency: fr
 - **CPU RAM** — Low operational overhead and typically far larger than accelerator HBM, making it the default offload target. Loading from CPU RAM is faster than recomputing prefill in most cases, and asynchronous offload adds little overhead.
 - **Local disk** — Increases capacity further, but is slower than CPU RAM. Suitable when the workload tolerates the added latency and local capacity is sufficient.
 - **Shared (remote) storage** — Provides capacity independent of deployment size, KV-cache sharing across replicas, fast scale-up (new replicas reuse existing cache), and persistence across restarts and failures. Latency and throughput depend on the underlying system, so evaluate that the transfer cost does not outweigh the savings. Mature enterprise systems (for example CephFS, GCP Lustre, IBM Storage Scale, AWS EFS) integrate through standard POSIX file access.
-- **P2P sharing** — Inference replicas can share caches in CPU memory over a peer-to-peer network, extending sharing without additional storage resources. See [Enable P2P Reuse](enable-p2p-reuse.md).
+- **P2P sharing** — Inference replicas can share caches in CPU memory over a peer-to-peer network, extending sharing without additional storage resources. See [Enable P2P Prefix Cache Sharing](enable-p2p-prefix-cache-sharing.md).
 
 ## Deploy
 

--- a/guides/p2p-kv-cache-sharing/benchmark-results/glm-5.2-h200.md
+++ b/guides/p2p-kv-cache-sharing/benchmark-results/glm-5.2-h200.md
@@ -4,7 +4,7 @@ The benchmark runs `zai-org/GLM-5.2-FP8` (753B MoE) prefill/decode
 disaggregated, one prefill and one decode instance, each 16-way
 data/expert-parallel across 2 pods (32x H200 total), ~520K tokens of GPU KV
 and a 100 GiB CPU offload tier per rank, vLLM block size 64, KV transfers
-over NIXL. Routing uses the llm-d inference gateway with the precise
+over NIXL. Routing uses the llm-d router with the precise
 (KV-event-fed) prefix index, `minCachedTokenDelta: 16384` (set from the
 overlay-era crossover; the current upstream-tier crossover recommends
 `12288` - see below). The page carries the pull-versus-recompute crossover,

--- a/guides/p2p-kv-cache-sharing/benchmark-results/gpt-oss-120b-h200.md
+++ b/guides/p2p-kv-cache-sharing/benchmark-results/gpt-oss-120b-h200.md
@@ -5,7 +5,7 @@ pod (TP=1), ~1.22M tokens of GPU KV per pod (measured from the engine
 startup log at `--gpu-memory-utilization=0.85`, `--max-model-len=65536`),
 an 88 GiB CPU offload tier per pod (~1.8x the GPU KV cache), vLLM block
 size 64, KV transfers over NIXL. Routing uses the llm-d
-inference gateway with the precise (KV-event-fed) prefix index; the P2P arm
+router with the precise (KV-event-fed) prefix index; the P2P arm
 adds the `p2p-source-producer` with `minCachedTokenDelta: 2048`. The
 document Q&A and the pool scenarios both ran on 16 pods. Workload
 profiles, EPP arm configurations, and the run protocol are in


### PR DESCRIPTION
Follow-ups from the #2067 review comments:

- Rename the foundations page to "Enable P2P Prefix Cache Sharing" and align every reference - "P2P reuse" was not specific enough as a feature name.
- Call the routing layer the llm-d router in both benchmark-results pages (applies the review suggestion; the gpt-oss page had the same phrase).

Not included: the GLM load-spill payoff refresh - it needs the re-measured numbers and lands separately.

```release-note
NONE
```