### PR TITLE
feat(workload-autoscaling): guide.yaml for slo-aware + multi-inference-pool; scale-event verify for keda-epp-queue

### DIFF
--- a/guides/workload-autoscaling/keda-epp-queue/guide.yaml
+++ b/guides/workload-autoscaling/keda-epp-queue/guide.yaml
@@ -78,8 +78,8 @@ deploy:
 verify:
   # ScaledObject Ready=True confirms the scaler config is valid; KEDA then creates
   # the named HPA. A non-empty currentMetrics list shows the HPA is receiving KEDA's
-  # external metrics (it can take several polling intervals to appear). Driving load
-  # and asserting the scale event is added in a follow-up (scale-event verify).
+  # external metrics (it can take several polling intervals to appear). The
+  # scale_event test then proves load actually drives a scaling DECISION.
   tests:
     scaledobject:
       - run: |
@@ -89,6 +89,45 @@ verify:
       - run: |
           kubectl get hpa ${HPA_NAME} -n ${NAMESPACE}
           kubectl get hpa ${HPA_NAME} -n ${NAMESPACE} -o jsonpath='{.status.currentMetrics}' | jq
+
+    # Fire a concurrent burst and assert the KEDA scale event fired:
+    #   baseline desiredReplicas == min -> burst -> desiredReplicas > min (up)
+    #                                   -> drain -> desiredReplicas == min (down)
+    # We assert the autoscaler DECISION (hpa .status.desiredReplicas), NOT that the
+    # new pod becomes Ready — on a contended GPU cluster the 2nd replica may stay
+    # Pending. desiredReplicas>min transitively proves the whole chain worked: EPP
+    # emits the metric -> Prometheus/Thanos -> KEDA reads it over threshold -> HPA
+    # raises the target. Ported from .github/scripts/e2e/e2e-validate-scale-event.sh.
+    scale_event:
+      - run: |
+          # Burst/timeout knobs (override via env). SCALE_DOWN_TIMEOUT matches the
+          # ScaledObject's 300s scaleDown stabilization window; the nightly lowers
+          # that window and can override this shorter.
+          : "${SCALE_CONCURRENCY:=30}" "${SCALE_TOTAL:=400}" "${SCALE_MAX_TOKENS:=512}" "${SCALE_UP_TIMEOUT:=120}" "${SCALE_DOWN_TIMEOUT:=360}"
+          MIN=$(kubectl get hpa ${HPA_NAME} -n ${NAMESPACE} -o jsonpath='{.spec.minReplicas}' 2>/dev/null); MIN=${MIN:-1}
+          HOST=$(kubectl get service optimized-baseline-epp -n ${NAMESPACE} -o jsonpath='{.spec.clusterIP}'):80
+          POD=curl-scale-$$
+          trap 'kubectl delete pod -n ${NAMESPACE} $POD --ignore-not-found --wait=false >/dev/null 2>&1 || true' EXIT
+          kubectl run $POD -n ${NAMESPACE} --image=curlimages/curl --restart=Never -- sleep 3600 >/dev/null
+          kubectl wait --for=condition=Ready pod/$POD -n ${NAMESPACE} --timeout=120s
+          printf '{"model":"%s","prompt":"Write a very long, detailed story about a robot that learns to paint.","max_tokens":%s}' "${MODEL}" "${SCALE_MAX_TOKENS}" \
+            | kubectl exec -i -n ${NAMESPACE} $POD -- tee /tmp/payload.json >/dev/null
+          BASE=$(kubectl get hpa ${HPA_NAME} -n ${NAMESPACE} -o jsonpath='{.status.desiredReplicas}' 2>/dev/null); BASE=${BASE:-$MIN}
+          [ "$BASE" -le "$MIN" ] || { echo "baseline desiredReplicas=$BASE already above min=$MIN"; exit 1; }
+          echo "-- firing burst (concurrency=${SCALE_CONCURRENCY} total=${SCALE_TOTAL}) to drive running-requests over threshold --"
+          kubectl exec -n ${NAMESPACE} $POD -- sh -c \
+            "seq 1 ${SCALE_TOTAL} | xargs -I{} -P ${SCALE_CONCURRENCY} curl -sS --max-time 300 -o /dev/null -X POST http://${HOST}/v1/completions -H 'content-type: application/json' --data-binary @/tmp/payload.json" >/dev/null 2>&1 &
+          BURST=$!
+          up=false; end=$((SECONDS + SCALE_UP_TIMEOUT))
+          while [ $SECONDS -lt $end ]; do d=$(kubectl get hpa ${HPA_NAME} -n ${NAMESPACE} -o jsonpath='{.status.desiredReplicas}' 2>/dev/null); if [ -n "$d" ] && [ "$d" -gt "$MIN" ]; then echo "  scale-up decision: desiredReplicas=$d"; up=true; break; fi; sleep 5; done
+          kill $BURST 2>/dev/null || true
+          kubectl delete pod -n ${NAMESPACE} $POD --ignore-not-found --wait=false >/dev/null 2>&1 || true
+          $up || { echo "no scale-up within ${SCALE_UP_TIMEOUT}s (raise SCALE_CONCURRENCY / SCALE_MAX_TOKENS, or check the trigger)"; exit 1; }
+          echo "-- load stopped; waiting up to ${SCALE_DOWN_TIMEOUT}s for scale-down (matches the 300s scaleDown window) --"
+          down=false; end=$((SECONDS + SCALE_DOWN_TIMEOUT))
+          while [ $SECONDS -lt $end ]; do d=$(kubectl get hpa ${HPA_NAME} -n ${NAMESPACE} -o jsonpath='{.status.desiredReplicas}' 2>/dev/null); if [ -n "$d" ] && [ "$d" -le "$MIN" ]; then echo "  scale-down decision: desiredReplicas=$d"; down=true; break; fi; sleep 5; done
+          $down || { echo "no scale-down within ${SCALE_DOWN_TIMEOUT}s (check scaleDown stabilization/cooldown)"; exit 1; }
+          echo "Scale-event verified: min ${MIN} -> >${MIN} -> ${MIN} (decision asserted; 2nd-pod readiness intentionally not required)"
 
 cleanup:
   # Deleting the ScaledObject also removes the KEDA-managed HPA. It does not delete

--- a/guides/workload-autoscaling/multi-inference-pool/README.md
+++ b/guides/workload-autoscaling/multi-inference-pool/README.md
@@ -13,17 +13,37 @@ Complete the [optimized-baseline](../../optimized-baseline/README.md) guide. At 
 
 Install an additional Helm release in the same namespace as the optimized-baseline. Each release must use a **unique `matchLabels`** selector so its InferencePool discovers only the correct model's pods. The example below adds a pool called `model-b`; repeat with a different release name and values file for every additional pool.
 
-```bash
-export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
-source ${REPO_ROOT}/guides/env.sh
-export NAMESPACE=llm-d-optimized-baseline
+Set the guide environment variables:
 
-helm install model-b \
-    ${ROUTER_STANDALONE_CHART} \
-    -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
-    -f ${REPO_ROOT}/guides/workload-autoscaling/multi-inference-pool/model-b.values.yaml \
-    -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
+<!-- guide:env.static start -->
+```bash
+export BRANCH=main
+export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
+export NAMESPACE=llm-d-optimized-baseline
+export RELEASE=model-b
+export VALUES=model-b.values.yaml
 ```
+<!-- guide:env.static end -->
+
+Source the common guide environment variables:
+
+<!-- guide:env.source start -->
+```bash
+source ${REPO_ROOT}/guides/env.sh
+```
+<!-- guide:env.source end -->
+
+Install the additional release:
+
+<!-- guide:deploy.helm start -->
+```bash
+helm install ${RELEASE} \
+  ${ROUTER_STANDALONE_CHART} \
+  -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
+  -f ${REPO_ROOT}/guides/workload-autoscaling/multi-inference-pool/${VALUES} \
+  -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
+```
+<!-- guide:deploy.helm end -->
 
 > [!WARNING]
 > The standalone chart creates a `ConfigMap` named `envoy` with a hardcoded name (not prefixed with the release name). Installing another release in the same namespace will fail with an ownership conflict on this ConfigMap. To work around this, reassign the ConfigMap's Helm ownership annotations to the new release before installing it:
@@ -45,13 +65,12 @@ Deploy the model server for the new pool the same way as the [optimized-baseline
 
 ## Verification
 
+<!-- guide:verify.tests.pools start -->
 ```bash
-# Confirm all InferencePools and EPP services
 kubectl get inferencepools,svc -n ${NAMESPACE}
-
-# Confirm model server pods are discovered by their pools
 kubectl get pods -n ${NAMESPACE} --show-labels
 ```
+<!-- guide:verify.tests.pools end -->
 
 ## Configuring Autoscaling
 
@@ -77,6 +96,8 @@ Deployment. Either scaling path can be used:
 
 Uninstall each additional release you added:
 
+<!-- guide:cleanup start -->
 ```bash
-helm uninstall model-b -n ${NAMESPACE}
+helm uninstall ${RELEASE} -n ${NAMESPACE}
 ```
+<!-- guide:cleanup end -->

--- a/guides/workload-autoscaling/multi-inference-pool/guide.yaml
+++ b/guides/workload-autoscaling/multi-inference-pool/guide.yaml
@@ -1,0 +1,37 @@
+name: multi-inference-pool
+
+env:
+  static:
+    BRANCH: main
+    REPO_ROOT: $(realpath $(git rev-parse --show-toplevel))
+
+    NAMESPACE: llm-d-optimized-baseline
+
+    # Additional Helm release + values for the extra pool (repeat per pool).
+    RELEASE: { default: "model-b" }
+    VALUES:  { default: "model-b.values.yaml" }
+
+  source: ["${REPO_ROOT}/guides/env.sh"]
+
+deploy:
+  # Install an additional router release in the same namespace as optimized-baseline.
+  # Each release must use a unique matchLabels selector so its InferencePool
+  # discovers only its own model's pods. (If the standalone chart's `envoy`
+  # ConfigMap ownership conflicts, reassign it first — see the README note.)
+  helm:
+    - run: |
+        helm install ${RELEASE} \
+          ${ROUTER_STANDALONE_CHART} \
+          -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
+          -f ${REPO_ROOT}/guides/workload-autoscaling/multi-inference-pool/${VALUES} \
+          -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
+
+verify:
+  tests:
+    pools:
+      - run: |
+          kubectl get inferencepools,svc -n ${NAMESPACE}
+          kubectl get pods -n ${NAMESPACE} --show-labels
+
+cleanup:
+  - run: helm uninstall ${RELEASE} -n ${NAMESPACE}

--- a/guides/workload-autoscaling/slo-aware/README.md
+++ b/guides/workload-autoscaling/slo-aware/README.md
@@ -96,6 +96,34 @@ asymmetry exists — is derived in
 
 ## Deploy
 
+Set the guide environment variables:
+
+<!-- guide:env.static start -->
+```bash
+export BRANCH=main
+export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
+export NAMESPACE=llm-d-optimized-baseline
+export KEDA_VERSION=v2.20.1
+export SLO_DIR=${REPO_ROOT}/guides/workload-autoscaling/slo-aware
+```
+<!-- guide:env.static end -->
+
+Source the common guide environment variables:
+
+<!-- guide:env.source start -->
+```bash
+source ${REPO_ROOT}/guides/env.sh
+```
+<!-- guide:env.source end -->
+
+Install KEDA (see the APIService caveat above):
+
+<!-- guide:prerequisites.keda start -->
+```bash
+kubectl apply --server-side -f https://github.com/kedacore/keda/releases/download/${KEDA_VERSION}/keda-${KEDA_VERSION}.yaml
+```
+<!-- guide:prerequisites.keda end -->
+
 The manifests ship with our example names — **adjust them to your cluster
 before applying:**
 
@@ -109,12 +137,22 @@ before applying:**
   `llm-d-optimized-baseline`, not `monitoring` — the rules belong to the tenant
   they scale), and the `labels` so your Prometheus's `ruleSelector` picks it up.
 
-```sh
-kubectl apply --server-side -f https://github.com/kedacore/keda/releases/download/v2.20.1/keda-2.20.1.yaml   # see APIService caveat above
-kubectl apply -f slo-aware/kube-state-metrics.yaml            # skip if you already run KSM
-kubectl apply -f slo-aware/prometheus-rule.yaml               # recording rules (match its labels to your ruleSelector)
-kubectl apply -f slo-aware/scaledobject.yaml
+<!-- guide:deploy.autoscaler start -->
+```bash
+kubectl apply -f ${SLO_DIR}/kube-state-metrics.yaml
+kubectl apply -f ${SLO_DIR}/prometheus-rule.yaml
+kubectl apply -f ${SLO_DIR}/scaledobject.yaml
 ```
+<!-- guide:deploy.autoscaler end -->
+
+Verify the ScaledObject is created and KEDA's HPA exists:
+
+<!-- guide:verify.tests.scaledobject start -->
+```bash
+kubectl get scaledobject -n ${NAMESPACE}
+kubectl get hpa -n ${NAMESPACE}
+```
+<!-- guide:verify.tests.scaledobject end -->
 
 The recording rules ship as a Prometheus Operator `PrometheusRule` in the
 workload namespace. For the operator to load it, its namespace must match your
@@ -184,10 +222,19 @@ plotted caught one such crossing. Full methodology and breakdown:
 
 ## Revert
 
+Deleting the ScaledObject hands replica control back to you immediately:
+
+<!-- guide:cleanup start -->
+```bash
+kubectl delete -f ${SLO_DIR}/scaledobject.yaml --ignore-not-found=true
+```
+<!-- guide:cleanup end -->
+
+If another external-metrics adapter (e.g. prometheus-adapter) was displaced by
+the KEDA install, re-apply its APIService, or just remove KEDA and
+kube-state-metrics:
+
 ```sh
-kubectl delete -f slo-aware/scaledobject.yaml    # hands replica control back to you immediately
-# if another external-metrics adapter (e.g. prometheus-adapter) was displaced
-# by the KEDA install, re-apply its APIService, or just remove KEDA:
 kubectl delete -f https://github.com/kedacore/keda/releases/download/v2.20.1/keda-2.20.1.yaml -f slo-aware/kube-state-metrics.yaml
 ```
 

--- a/guides/workload-autoscaling/slo-aware/guide.yaml
+++ b/guides/workload-autoscaling/slo-aware/guide.yaml
@@ -1,0 +1,48 @@
+name: slo-aware
+
+env:
+  static:
+    BRANCH: main
+    REPO_ROOT: $(realpath $(git rev-parse --show-toplevel))
+
+    NAMESPACE: llm-d-optimized-baseline
+
+    # KEDA is installed from its upstream release (>= 2.15; benchmarked on 2.20.1).
+    KEDA_VERSION: { default: "v2.20.1" }
+
+    # Flat manifests for this experimental guide (kube-state-metrics, recording
+    # rules, and the ScaledObject). Adjust the example names inside each file to
+    # your cluster before applying — see the README.
+    SLO_DIR: ${REPO_ROOT}/guides/workload-autoscaling/slo-aware
+
+  source: ["${REPO_ROOT}/guides/env.sh"]
+
+prerequisites:
+  # KEDA provides the external-metrics API the ScaledObject drives. Note the
+  # APIService caveat in the README if another external-metrics adapter is present.
+  keda:
+    - run: kubectl apply --server-side -f https://github.com/kedacore/keda/releases/download/${KEDA_VERSION}/keda-${KEDA_VERSION}.yaml
+
+deploy:
+  # kube-state-metrics (skip if you already run KSM), the PrometheusRule recording
+  # rules (the saturation signal — match its labels to your ruleSelector), then the
+  # ScaledObject (control law + HPA behavior). Once the ScaledObject exists, KEDA's
+  # HPA owns the target Deployment's replica count.
+  autoscaler:
+    - run: |
+        kubectl apply -f ${SLO_DIR}/kube-state-metrics.yaml
+        kubectl apply -f ${SLO_DIR}/prometheus-rule.yaml
+        kubectl apply -f ${SLO_DIR}/scaledobject.yaml
+
+verify:
+  tests:
+    scaledobject:
+      - run: |
+          kubectl get scaledobject -n ${NAMESPACE}
+          kubectl get hpa -n ${NAMESPACE}
+
+cleanup:
+  # Deleting the ScaledObject hands replica control back immediately. Removing KEDA
+  # / kube-state-metrics is left to the README (it can displace another cluster's
+  # external-metrics APIService — do it deliberately).
+  - run: kubectl delete -f ${SLO_DIR}/scaledobject.yaml --ignore-not-found=true


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Completes the workload-autoscaling guide.yaml migration for the three remaining non-nightly guides, and moves the scale-event assertion into the queue guide's `verify` phase. Follows the keda-epp twins (#2273) and the wva guide (#2274); these guides are lower-risk (no dedicated nightly), so they are grouped together.

Concrete changes:
- Add `multi-inference-pool/guide.yaml` (env, deploy.helm, verify, cleanup) and `slo-aware/guide.yaml` (env, prerequisites.keda, deploy.autoscaler, verify, cleanup), and convert both READMEs to `<!-- guide:… -->` markers rendered by `scripts/guide.py`.
- `slo-aware` manifests stay flat (no `<topology>` subdir): the guide is experimental, applies its manifests with `kubectl apply -f`, and has no planned multi-topology variant. Its how-it-works, tunables, and benchmark sections stay as README prose.
- `replica-rebalancing` intentionally keeps no `guide.yaml`: it is a conceptual guide that deploys the WVA controller repo's own `config/samples/hpa/...` kustomize overlays, not self-contained manifests in this repo, so a guide.yaml would add nothing.
- Add `verify.tests.scale_event` to `keda-epp-queue/guide.yaml`: fire a bounded concurrent burst and assert the KEDA scale decision (`hpa .status.desiredReplicas`) goes `min -> >min -> min`. It asserts the autoscaler decision, not that the new replica becomes Ready — on a contended GPU cluster the second replica may stay Pending, and `desiredReplicas > min` already proves the whole chain (EPP metric -> Prometheus/Thanos -> KEDA over threshold -> HPA). Ported from `.github/scripts/e2e/e2e-validate-scale-event.sh` (kept until the nightly moves to the guide.yaml harness). The down-timeout matches the guide's 300s `scaleDown` stabilization window; burst/timeout knobs default inline and are overridable via env. This is a guide.yaml-only step — it runs in the contract/nightly and is deliberately not rendered into the README, which keeps its manual load-gen + scale-up walkthrough.

Verification:
- `guide.py check` passes for all three guides; `guide.py render` is idempotent (READMEs in sync).
- All README links resolve.
- The e2e scale-event script is untouched (its removal is deferred to the nightly-cutover PR).

**Which issue(s) this PR fixes**:

N/A — part of the workload-autoscaling guide.yaml migration; no GitHub issue filed yet.

**Release note**:

```release-note
The slo-aware and multi-inference-pool autoscaling guides now ship a guide.yaml. The queue-based KEDA+EPP guide (keda-epp-queue) gains an automated scale-event check in its guide.yaml verify phase.
```
