### PR TITLE
fix(autoscaling): set WVA --watch-namespace in guide.yaml, not just README

### DIFF
--- a/guides/workload-autoscaling/wva/guide.yaml
+++ b/guides/workload-autoscaling/wva/guide.yaml
@@ -43,12 +43,18 @@ deploy:
   crds:
     - run: kubectl apply -k github.com/llm-d/llm-d-workload-variant-autoscaler/config/base/crd?ref=main
 
-  # Install the WVA controller. The overlay carries its own namespace, so point it
-  # at ${WVA_NAMESPACE} first (this edits platform/${PLATFORM}/kustomization.yaml;
-  # revert with `git checkout` afterwards), then apply it (no -n needed).
+  # Install the WVA controller. Point the overlay at ${WVA_NAMESPACE} and set the
+  # controller's --watch-namespace to match (this edits
+  # platform/${PLATFORM}/kustomization.yaml and base/controller-deployment-patch.yaml;
+  # revert both with `git checkout` afterwards), then apply it (no -n needed).
   controller:
     - run: |
         (cd ${CONTROLLER_ROOT}/platform/${PLATFORM} && kustomize edit set namespace ${WVA_NAMESPACE})
+
+        sed -i.bak "s|--watch-namespace=.*|--watch-namespace=${WVA_NAMESPACE}|" \
+          ${CONTROLLER_ROOT}/base/controller-deployment-patch.yaml \
+          && rm ${CONTROLLER_ROOT}/base/controller-deployment-patch.yaml.bak
+
         kubectl apply -k ${CONTROLLER_ROOT}/platform/${PLATFORM}
 
   # Enable autoscaling via KEDA (recommended): the ScaledObject reads


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

#2283 fixed WVA namespace overrides by adding a `sed` that patches the controller's `--watch-namespace` to `${WVA_NAMESPACE}` (the patch file hardcodes `--watch-namespace=llm-d-optimized-baseline`, so an overridden namespace moves the overlay but the controller keeps watching the old one). However, that change edited only `README.md` — specifically the content **inside** the `<!-- guide:deploy.controller start/end -->` markers, which `scripts/guide.py` regenerates from `guide.yaml`. Because `guide.yaml`'s `deploy.controller` step was not updated:

- `guide.py render --check` reports `README.md` as out of date, and the next `guide.py render` silently strips the `sed` back out.
- The fix never reaches `guide.yaml`, which is the execution source of truth the WVA nightlies are migrating to.

This PR reconciles the source of truth:

- Add the `--watch-namespace` `sed` to `deploy.controller.run` in `guides/workload-autoscaling/wva/guide.yaml`, matching what #2283 put in the README.
- Update the stale step comment to mention the `base/controller-deployment-patch.yaml` edit and "revert both".
- Re-rendered the README — it is byte-identical to the merged version, so the diff is a single file (`guide.yaml`).

Verification:

- `python3 scripts/guide.py render guides/workload-autoscaling/wva --check` → up to date (was: stale on merged main).
- `guide.yaml` renders/validates cleanly.
- Functionally tested the `sed` against the real patch file with an overridden `WVA_NAMESPACE`: rewrites the arg correctly, is idempotent, removes its `.bak`, and leaves valid YAML.
- Default `WVA_NAMESPACE` equals the hardcoded value, so the nightly (default namespace) is unaffected — this is override-only.

**Which issue(s) this PR fixes**:

Fixes N/A — follow-up to #2283 (no separate tracking issue)

**Release note**:

​```release-note
NONE
​```
