### PR TITLE
fix(xpu): use llm-d-xpu main image

### DIFF
--- a/.github/workflows/nightly-e2e-optimized-baseline-intel-acc-xpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-intel-acc-xpu-vllm-x.yaml
@@ -70,7 +70,7 @@ concurrency:
 
 jobs:
   nightly:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@f851f1cafbb3407bed238888e8f2f85f568feeaf
     with:
       scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
       standup_method: ${{ inputs.standup_method || 'kustomize' }}

--- a/.github/workflows/nightly-e2e-optimized-baseline-intel-acc-xpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-intel-acc-xpu-vllm-x.yaml
@@ -70,7 +70,7 @@ concurrency:
 
 jobs:
   nightly:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@f851f1cafbb3407bed238888e8f2f85f568feeaf
+    uses: xiaojun-zhang/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@f851f1cafbb3407bed238888e8f2f85f568feeaf
     with:
       scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
       standup_method: ${{ inputs.standup_method || 'kustomize' }}
@@ -95,7 +95,6 @@ jobs:
       workload: ${{ inputs.workload || 'sanity_random.yaml' }}
 #      workload: ${{ inputs.workload || 'guide_optimized-baseline_1.yaml' }}
       cleanup: ${{ inputs.cleanup || 'true' }}
-    secrets: inherit
 
   update-badge:
     needs: [nightly]

--- a/.github/workflows/nightly-e2e-optimized-baseline-intel-acc-xpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-intel-acc-xpu-vllm-x.yaml
@@ -70,7 +70,7 @@ concurrency:
 
 jobs:
   nightly:
-    uses: xiaojun-zhang/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@f851f1cafbb3407bed238888e8f2f85f568feeaf
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
       scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
       standup_method: ${{ inputs.standup_method || 'kustomize' }}
@@ -95,6 +95,7 @@ jobs:
       workload: ${{ inputs.workload || 'sanity_random.yaml' }}
 #      workload: ${{ inputs.workload || 'guide_optimized-baseline_1.yaml' }}
       cleanup: ${{ inputs.cleanup || 'true' }}
+    secrets: inherit
 
   update-badge:
     needs: [nightly]

--- a/guides/optimized-baseline/modelserver/xpu/vllm/kustomization.yaml
+++ b/guides/optimized-baseline/modelserver/xpu/vllm/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 namePrefix: optimized-baseline-xpu-vllm-
 
 components:
-  - ../../../../recipes/modelserver/components/images/xpu-vllm/release
+  - ../../../../recipes/modelserver/components/images/xpu-vllm/llm-d
 
 labels:
   - pairs:

--- a/guides/precise-prefix-cache-routing/modelserver/xpu/vllm/kustomization.yaml
+++ b/guides/precise-prefix-cache-routing/modelserver/xpu/vllm/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 namePrefix: precise-prefix-cache-routing-xpu-vllm-
 
 components:
-  - ../../../../recipes/modelserver/components/images/xpu-vllm/release
+  - ../../../../recipes/modelserver/components/images/xpu-vllm/llm-d
 
 labels:
   - pairs:

--- a/guides/recipes/modelserver/components/images/xpu-vllm/llm-d/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/xpu-vllm/llm-d/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Component
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: ghcr.io/llm-d/llm-d-xpu
-    newTag: v0.9.0-rc.2
+    newTag: main
 
 # Workaround for https://github.com/vllm-project/vllm/issues/44548, required with vLLM v0.20.0+ due to torch 2.11+
 # See: https://github.com/vllm-project/vllm/blob/main/requirements/xpu.txt#L15

--- a/guides/recipes/modelserver/components/images/xpu-vllm/llm-d/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/xpu-vllm/llm-d/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Component
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: ghcr.io/llm-d/llm-d-xpu
-    newTag: v0.8.1
+    newTag: v0.9.0-rc.2
 
 # Workaround for https://github.com/vllm-project/vllm/issues/44548, required with vLLM v0.20.0+ due to torch 2.11+
 # See: https://github.com/vllm-project/vllm/blob/main/requirements/xpu.txt#L15


### PR DESCRIPTION
- xpu guides to use recipes in "recipes/modelserver/components/images/xpu-vllm/ll-d" since the xpu image is custimozed based on upstream vllm image
- the llm-d XPU image from `v0.8.1` to `main`. 

