### PR TITLE
fix: wrong KEDA_VERSION format in download URL

### DIFF
--- a/guides/workload-autoscaling/slo-aware/README.md
+++ b/guides/workload-autoscaling/slo-aware/README.md
@@ -103,7 +103,7 @@ Set the guide environment variables:
 export BRANCH=main
 export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
 export NAMESPACE=llm-d-optimized-baseline
-export KEDA_VERSION=v2.20.1
+export KEDA_VERSION=2.20.1
 export SLO_DIR=${REPO_ROOT}/guides/workload-autoscaling/slo-aware
 ```
 <!-- guide:env.static end -->
@@ -120,7 +120,7 @@ Install KEDA (see the APIService caveat above):
 
 <!-- guide:prerequisites.keda start -->
 ```bash
-kubectl apply --server-side -f https://github.com/kedacore/keda/releases/download/${KEDA_VERSION}/keda-${KEDA_VERSION}.yaml
+kubectl apply --server-side -f https://github.com/kedacore/keda/releases/download/v${KEDA_VERSION}/keda-${KEDA_VERSION}.yaml
 ```
 <!-- guide:prerequisites.keda end -->
 

--- a/guides/workload-autoscaling/slo-aware/guide.yaml
+++ b/guides/workload-autoscaling/slo-aware/guide.yaml
@@ -8,7 +8,7 @@ env:
     NAMESPACE: llm-d-optimized-baseline
 
     # KEDA is installed from its upstream release (>= 2.15; benchmarked on 2.20.1).
-    KEDA_VERSION: { default: "v2.20.1" }
+    KEDA_VERSION: { default: "2.20.1" }
 
     # Flat manifests for this experimental guide (kube-state-metrics, recording
     # rules, and the ScaledObject). Adjust the example names inside each file to
@@ -21,7 +21,7 @@ prerequisites:
   # KEDA provides the external-metrics API the ScaledObject drives. Note the
   # APIService caveat in the README if another external-metrics adapter is present.
   keda:
-    - run: kubectl apply --server-side -f https://github.com/kedacore/keda/releases/download/${KEDA_VERSION}/keda-${KEDA_VERSION}.yaml
+    - run: kubectl apply --server-side -f https://github.com/kedacore/keda/releases/download/v${KEDA_VERSION}/keda-${KEDA_VERSION}.yaml
 
 deploy:
   # kube-state-metrics (skip if you already run KSM), the PrometheusRule recording


### PR DESCRIPTION
If `KEDA_VERSION=v2.20.1`, the download URL becomes `.../download/v2.20.1/keda-v2.20.1.yaml`,
while the actual URL is `.../download/v2.20.1/keda-2.20.1.yaml`.

```
https://github.com/kedacore/keda/releases/download/v2.20.1/keda-2.20.1.yaml
```

fix: set `KEDA_VERSION=2.20.1` and add the `v` prefix only in the tag path



