### PR TITLE
Fix nightly typos

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -6,3 +6,7 @@ aks = "aks"      # Azure Kubernetes Service (lowercase)
 IST = "IST"      # Indian Standard Time (used in benchmark timestamps)
 ND = "ND"        # Azure VM SKU prefix (e.g., Standard_ND96asr_v4)
 ahd = "ahd"      # SVG arrowhead marker id in diagram HTML
+mis = "mis"      # intentional hyphenated compounds (mis-gate, mis-price)
+
+[default.extend-identifiers]
+OFO = "OFO"      # TCP OutOfOrder netstat counter (used in a metrics regex)

--- a/guides/recipes/modelserver/components/images/README.md
+++ b/guides/recipes/modelserver/components/images/README.md
@@ -31,12 +31,11 @@ This directory contains Kustomize Components that define the **default container
 
 ### Why are there both `llm-d` and `vllm` images?
 
-llm-d is moving towards using upstream images for both `sglang` and `vLLM`. As llm-d was orrigionally only supported vllm, `llm-d` image variants were produced to account for any feature gaps in development of vLLM. Some of these feature gaps still exist today, for example the `ec-connector` work is still open in vLLM at the time of documeting this. As a stop-gap measure, the `llm-d` community will continue to host its own images as applicable, until they can be deprecated and safely migrate to upstream images.
-
+llm-d is moving towards using upstream images for both `sglang` and `vLLM`. As llm-d originally supported only vLLM, `llm-d` image variants were produced to account for any feature gaps in development of vLLM. Some of these feature gaps still exist today, for example the `ec-connector` work is still open in vLLM at the time of documenting this. As a stop-gap measure, the `llm-d` community will continue to host its own images as applicable, until they can be deprecated and safely migrate to upstream images.
 
 #### Known gap - NVSHMEM on RoCE networking
 
-Upstream vLLM currently [pins NVSHMEM to `v3.4.5`](https://github.com/vllm-project/vllm/blob/ac70ce96e0b9f69dd834bd1b0cd2d2b4c4a9db46/requirements/test/cuda.txt#L648). This version of NVSHMEM requires [a patch](../../../../../patches/nvshmem_zero_ibv_ah_attr_v3.4.5-0.patch) guarding aginst where "static_rate must be a known value and is passed directly to the device". Any image runnign on ROCE should use `llm-d` image variants.
+Upstream vLLM currently [pins NVSHMEM to `v3.4.5`](https://github.com/vllm-project/vllm/blob/ac70ce96e0b9f69dd834bd1b0cd2d2b4c4a9db46/requirements/test/cuda.txt#L648). This version of NVSHMEM requires [a patch](../../../../../patches/nvshmem_zero_ibv_ah_attr_v3.4.5-0.patch) guarding against where "static_rate must be a known value and is passed directly to the device". Any image running on ROCE should use `llm-d` image variants.
 
 ## Usage
 

--- a/guides/recipes/modelserver/components/images/gpu-vllm/ec-connector/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/gpu-vllm/ec-connector/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 images:
-  # NOTE: llm-d does not release vLLM images, this is an exception tracking the open EC conenctor work, see: https://github.com/vllm-project/vllm/pull/42998
+  # NOTE: llm-d does not release vLLM images, this is an exception tracking the open EC connector work, see: https://github.com/vllm-project/vllm/pull/42998
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: ghcr.io/llm-d/vllm-openai
     newTag: ec-cpu-connector-support


### PR DESCRIPTION
Resolves the remaining findings from the nightly typo scan in #2233 (the `compatability`
finding was already fixed by #2257).

Real typos fixed:
- `guides/recipes/modelserver/components/images/README.md`: `aginst` → `against`,
  `runnign` → `running`, plus two typos in the same paragraph the scanner does not
  detect (`orrigionally`, `documeting`) and the surrounding grammar.
- `guides/recipes/modelserver/components/images/gpu-vllm/ec-connector/kustomization.yaml`:
  `conenctor` → `connector` (comment).

False positives excluded in `_typos.toml`, following the pattern from #2117:
- `OFO` under `[default.extend-identifiers]` — the TCP OutOfOrder netstat counter inside
  the metrics regex in the wide-ep-lws GLM-5.2 prefill/decode manifests. Identifier-level
  exclusion is the narrowest mechanism that covers it.
- `mis` under `[default.extend-words]` — intentional hyphenated compounds (mis-gate,
  mis-price, mis-addressed) in four docs. `typos` splits identifiers on hyphens, so an
  identifier-level exclusion for `mis-gate` does not work; a word-level exclusion is the
  narrowest available option.

One additional blank-line hunk in the images README comes from the repo's own
`markdownlint --fix` pre-commit hook (MD012) running on the touched file.

Verified: `typos .` now exits clean (was 9 findings), and `pre-commit run` passes on all
changed files.

Fixes #2233