### PR TITLE
guides(tiered-prefix-cache): use ${CONNECTOR}/${VARIANT} in model ser…

### DIFF
--- a/guides/tiered-prefix-cache/README.md
+++ b/guides/tiered-prefix-cache/README.md
@@ -166,10 +166,10 @@ Deploy **one** of the paths below. Each `kubectl apply -k` targets an overlay di
 
 ```bash
 export MODEL_SERVER=vllm # vllm
-export CONNECTOR=native  # native
+export CONNECTOR=native  # native | lmcache-connector
 export VARIANT=cpu       # cpu | fs
 export INFRA_PROVIDER=base  # base | gke
-kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/gpu/vllm/native/cpu/${INFRA_PROVIDER}/
+kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/tiered-prefix-cache/modelserver/gpu/vllm/${CONNECTOR}/${VARIANT}/${INFRA_PROVIDER}/
 ```
 
 #### vLLM native — CPU RAM + Filesystem


### PR DESCRIPTION

The benchmark harness picks the first README command matching 'modelserver/<accelerator>/<backend>' and never inspects CONNECTOR, so the hardcoded native path was always deployed and the lmcache-connector overlay was unreachable. This made the LMCache nightlies deploy the native overlay instead.