### PR TITLE
guides(pd-disaggregation): add P/D Multi Tier KV cache path

### DIFF
--- a/.github/workflows/ci-kustomize-dry-run.yaml
+++ b/.github/workflows/ci-kustomize-dry-run.yaml
@@ -120,6 +120,19 @@ jobs:
           done
           exit $failed
 
+      - name: Dry-run router (pd-disaggregation multi-tier)
+        run: |
+          CHART_VERSION=v0
+          echo "--- helm template ---"
+          helm template pd-multi-tier-router \
+            "oci://ghcr.io/llm-d/charts/llm-d-router-standalone" \
+            -f guides/recipes/router/base.values.yaml \
+            -f guides/pd-disaggregation/router/pd-disaggregation.values.yaml \
+            -f guides/pd-disaggregation/router/pd-multi-tier.values.yaml \
+            --version "${CHART_VERSION}" > /tmp/rendered.yaml
+          echo "--- kubectl apply --dry-run=server ---"
+          kubectl apply --dry-run=server -f /tmp/rendered.yaml
+
       - name: Dry-run router (precise-prefix-cache-routing)
         run: |
           CHART_VERSION=v0
@@ -303,4 +316,3 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
           exit $failed
-

--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -13,10 +13,11 @@ This guide deploys `openai/gpt-oss-120b` with prefill-decode disaggregation, imp
 * 8 TP=1 Prefill Instances
 * 2 TP=4 Decode Instances
 
-This guide also has two alternate variants:
+This guide also has alternate variants:
 
 * **[Google TPU](./README.tpu.md)** — the same P/D pattern on GKE TPU (v6e & v7x).
 * **[DisaggregatedSet](./README.ds.md)** — the same deployment managed as a single LWS `DisaggregatedSet` resource, with coordinated P/D rollouts, `slices` for replicating the whole topology into independent copies, and per-domain placement policy.
+* **[P/D Multi Tier KV Cache](./README.multi-tier.md)** — NIXL P/D with CPU KV-cache retention beyond HBM capacity.
 
 ### P/D Best Practices
 

--- a/guides/pd-disaggregation/README.multi-tier.md
+++ b/guides/pd-disaggregation/README.multi-tier.md
@@ -13,7 +13,7 @@ prefill-to-decode transfer. On each prefiller, `MultiConnector` composes:
 
 | Configuration | P/D transport | Prefix-cache tiers |
 | --- | --- | --- |
-| Plain P/D | NIXL | HBM |
+| PD NIXL | NIXL | HBM |
 | PD Multi Tier | NIXL | HBM, CPU |
 
 ## When to use Multi Tier
@@ -296,24 +296,31 @@ is only the harness result directory and is unrelated to model-server KV
 storage. Per-request lifecycle output is disabled to avoid a multi-gigabyte
 trace; the overall and per-stage summaries remain enabled.
 
-Use three arms to separate the engine and placement effects: PD NIXL, PD NIXL
-+ CPU offload, and PD Multi Tier. PD NIXL + CPU offload uses CPU backend weight
-`0.0`; PD Multi Tier uses the same byte-identical offload engine with CPU
-backend weight `0.4`. Restart every engine and the router between arms to clear
-HBM, CPU-tier, and precise-index state. Snapshot the CPU-to-GPU counter before
-and after each CPU arm. Compare per-stage request rate, TTFT, latency, success
-count, and full completion time. A fixed arrival window alone hides the
-queued-work tail after saturation.
+Use three arms to separate the engine and placement effects:
+
+| Arm | Prefill connector configuration | Router CPU-tier behavior |
+| --- | --- | --- |
+| PD NIXL | `NixlConnector` only; HBM KV cache | No CPU tier |
+| PD NIXL + CPU offload | `MultiConnector`: `NixlConnector` for P/D transfer plus `OffloadingConnector` with 100 GiB CPU | Precise CPU backend weight `0.0`; CPU-tier hits do not affect placement |
+| PD Multi Tier | `MultiConnector`: `NixlConnector` for P/D transfer plus `OffloadingConnector` with 100 GiB CPU | Precise CPU backend weight `0.4`; CPU-tier hits affect placement |
+
+The two CPU-tier arms use the same connector configuration so the comparison
+isolates whether CPU-tier locality participates in routing. Restart every
+engine and the router between arms to clear HBM, CPU-tier, and precise-index
+state. Snapshot the CPU-to-GPU counter before and after each CPU arm. Compare
+per-stage request rate, TTFT, latency, success count, and full completion time.
+A fixed arrival window alone hides the queued-work tail after saturation.
 
 On the measured Fozzie 16x H200 topology, all three arms completed all 10,800
 requests. At the 40-QPS stage, PD NIXL, PD NIXL + CPU offload, and PD Multi
 Tier sustained 22.10, 32.62, and 36.04 request/s respectively. Across the full
 run, enabling CPU offload reduced P90 request latency from 24.010 to 8.078
-seconds. Enabling CPU-aware placement on the same engine reduced it further to
-2.859 seconds. The PD Multi Tier arm logged 3.58 TiB restored from CPU with
-zero allocation failures, confirming that the read path was active. These are
-single runs with generated seeds, so use the result to demonstrate the
-mechanism and repeat it before treating the percentages as a capacity estimate.
+seconds. Enabling CPU-aware placement on the `MultiConnector` CPU-tier
+configuration reduced it further to 2.859 seconds. The PD Multi Tier arm logged
+3.58 TiB restored from CPU with zero allocation failures, confirming that the
+read path was active. These are single runs with generated seeds, so use the
+result to demonstrate the mechanism and repeat it before treating the
+percentages as a capacity estimate.
 
 On the measured 8x TP=1 prefill and 2x TP=4 decode topology, plain NIXL had the
 best document-Q&A success count and mean latency. CPU Multi Tier was effectively

--- a/guides/pd-disaggregation/README.multi-tier.md
+++ b/guides/pd-disaggregation/README.multi-tier.md
@@ -296,22 +296,22 @@ is only the harness result directory and is unrelated to model-server KV
 storage. Per-request lifecycle output is disabled to avoid a multi-gigabyte
 trace; the overall and per-stage summaries remain enabled.
 
-Use three arms to separate the engine and placement effects: plain NIXL with
-CPU backend weight `0.0`, the CPU-offload engine with CPU backend weight `0.0`,
-and the same byte-identical CPU-offload engine with CPU backend weight `0.4`.
-Restart every engine and the router between arms to clear HBM, CPU-tier, and
-precise-index state. Snapshot the CPU-to-GPU counter before and after each CPU
-arm. Compare per-stage request rate, TTFT, latency, success count, and full
-completion time. A fixed arrival window alone hides the queued-work tail after
-saturation.
+Use three arms to separate the engine and placement effects: PD NIXL, PD NIXL
++ CPU offload, and PD Multi Tier. PD NIXL + CPU offload uses CPU backend weight
+`0.0`; PD Multi Tier uses the same byte-identical offload engine with CPU
+backend weight `0.4`. Restart every engine and the router between arms to clear
+HBM, CPU-tier, and precise-index state. Snapshot the CPU-to-GPU counter before
+and after each CPU arm. Compare per-stage request rate, TTFT, latency, success
+count, and full completion time. A fixed arrival window alone hides the
+queued-work tail after saturation.
 
 On the measured Fozzie 16x H200 topology, all three arms completed all 10,800
-requests. At the 40-QPS stage, plain NIXL, CPU-blind offload, and CPU-aware
-Multi Tier sustained 22.10, 32.62, and 36.04 request/s respectively. Across the
-full run, enabling CPU offload reduced P90 request latency from 24.010 to 8.078
+requests. At the 40-QPS stage, PD NIXL, PD NIXL + CPU offload, and PD Multi
+Tier sustained 22.10, 32.62, and 36.04 request/s respectively. Across the full
+run, enabling CPU offload reduced P90 request latency from 24.010 to 8.078
 seconds. Enabling CPU-aware placement on the same engine reduced it further to
-2.859 seconds. The CPU-aware arm logged 3.58 TiB restored from CPU with zero
-allocation failures, confirming that the read path was active. These are
+2.859 seconds. The PD Multi Tier arm logged 3.58 TiB restored from CPU with
+zero allocation failures, confirming that the read path was active. These are
 single runs with generated seeds, so use the result to demonstrate the
 mechanism and repeat it before treating the percentages as a capacity estimate.
 

--- a/guides/pd-disaggregation/README.multi-tier.md
+++ b/guides/pd-disaggregation/README.multi-tier.md
@@ -256,15 +256,17 @@ llmdbenchmark \
   --model "openai/gpt-oss-120b" \
   --namespace "${NAMESPACE}" \
   --harness inference-perf \
-  --workload guide_p2p-kv-cache-sharing_1.yaml \
+  --workload-file-path \
+    "${REPO_ROOT}/guides/pd-disaggregation/benchmark-templates/document-qa.yaml.in" \
   --monitoring \
   --analyze
 ```
 
-This profile schedules 1,152 turns across 192 six-turn conversations. Each
-conversation has a private 49,152-token document prefix, so reuse occurs
-within a conversation rather than through one global shared prefix. Compare
-success count and the full TTFT distribution in addition to request rate; the
+The checked-in [`document-qa.yaml.in`](./benchmark-templates/document-qa.yaml.in)
+profile schedules 1,152 turns across 192 six-turn conversations. Each
+conversation has a private 49,152-token document prefix, so reuse occurs within
+a conversation rather than through one global shared prefix. Compare success
+count and the full TTFT distribution in addition to request rate; the
 180-second request timeout makes failures part of the result.
 
 ### Eviction-pressure comparison

--- a/guides/pd-disaggregation/README.multi-tier.md
+++ b/guides/pd-disaggregation/README.multi-tier.md
@@ -1,0 +1,332 @@
+# P/D Disaggregation with Multi Tier KV Cache
+
+> **Experimental:** P/D Multi Tier KV cache support is experimental. Validate
+> correctness, resource sizing, and performance on the target topology before
+> using it for production traffic.
+
+This variant extends the [P/D disaggregation guide](./README.md) with vLLM
+Multi Tier KV-cache offloading. NIXL remains responsible for the
+prefill-to-decode transfer. On each prefiller, `MultiConnector` composes:
+
+- `NixlConnector` for the normal P/D handoff.
+- `OffloadingConnector` for HBM to CPU cache retention.
+
+| Configuration | P/D transport | Prefix-cache tiers |
+| --- | --- | --- |
+| Plain P/D | NIXL | HBM |
+| PD Multi Tier | NIXL | HBM, CPU |
+
+## When to use Multi Tier
+
+Multi Tier is most useful when prompts reuse prefixes and the active prefix
+working set is larger than GPU KV-cache capacity but fits in the configured CPU
+tier.
+
+Multi Tier is unlikely to improve workloads with little prefix reuse. It also
+adds host-memory copies, so measure the complete throughput and latency
+distribution before enabling it for such workloads.
+
+## Architecture
+
+The default Multi Tier overlay configures only the prefill workers with CPU
+offloading. Decode workers continue to use `NixlConnector` for the P/D transfer:
+
+```text
+request -> router -> prefill HBM
+                         |
+                         v
+                   CPU primary tier
+                         |
+                         +---- NIXL P/D handoff ----> decoder
+```
+
+## Prerequisites
+
+- Complete the [main guide prerequisites](./README.md#prerequisites), including
+  RDMA networking and the `llm-d-hf-token` Secret.
+- At least 16 GPUs for the guide topology: 8 TP=1 prefill instances and 2 TP=4
+  decode instances.
+- vLLM v0.27.1 or later. The overlays pin v0.27.1.
+- Enough host memory for the configured tier. The example reserves 100 GiB per
+  prefiller.
+- The same vLLM `--block-size` and router
+  `tokenProcessorConfig.blockSizeTokens`. This guide uses 128 tokens.
+- The same `PYTHONHASHSEED` on every engine pod. The overlay sets `0`.
+
+## Installation
+
+Set the environment variables and create the namespace and Hugging Face Secret
+as described by the [main guide](./README.md#checkout-repo--setups).
+
+```bash
+export GUIDE_NAME="pd-disaggregation"
+export NAMESPACE="llm-d-pd-disaggregation"
+export INFRA_PROVIDER="base" # base | coreweave
+```
+
+### 1. Deploy the router
+
+Multi Tier uses precise prefix-cache events so CPU-resident prefixes continue
+to influence placement after their HBM copies are evicted.
+
+```bash
+helm install ${GUIDE_NAME} \
+  ${ROUTER_STANDALONE_CHART} \
+  -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
+  -f ${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
+  -f ${REPO_ROOT}/guides/${GUIDE_NAME}/router/pd-multi-tier.values.yaml \
+  -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
+```
+
+Deploy the Service that exposes vLLM's renderer endpoint to the router:
+
+```bash
+kubectl apply -n ${NAMESPACE} \
+  -k ${REPO_ROOT}/guides/${GUIDE_NAME}/render/multi-tier
+```
+
+### 2. Deploy PD Multi Tier
+
+```bash
+kubectl apply -n ${NAMESPACE} \
+  -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/gpu/vllm/multi-tier-${INFRA_PROVIDER}
+```
+
+The CoreWeave overlay adds the `rdma/ib` resource and container capabilities
+required by the NIXL transport.
+
+### Data-parallel KV-event sockets
+
+Precise routing requires one ZMQ publisher for every data-parallel engine.
+Each engine in the same pod must bind a different port. The router's
+`podDiscoveryConfig.socketPort` is the first local port in that range.
+
+For a multi-pod DP deployment, vLLM adds the global DP rank to the port in
+`kv-events-config.endpoint`. Subtract the pod's first global rank so every pod
+publishes on the same local port range. For example, DP=8 per pod and router
+`socketPort: 5557` use:
+
+```bash
+START_RANK=$((LWS_WORKER_INDEX * DP_SIZE_LOCAL))
+EVENT_PORT_BASE=5557
+ROUTER_API_PORT_BASE=8000
+KV_EVENTS_BASE=$((EVENT_PORT_BASE - START_RANK))
+
+KV_EVENTS_ARGS="--kv-events-config {\"enable_kv_cache_events\":true,\"publisher\":\"zmq\",\"endpoint\":\"tcp://*:${KV_EVENTS_BASE}\",\"topic\":\"kv@${POD_IP}:${ROUTER_API_PORT_BASE}@${MODEL}\"}"
+```
+
+Ranks 0-7 therefore bind `5557-5564` on every pod. The topic's endpoint port
+is the router-visible API base. With
+`--data-parallel-multi-port-external-lb`, the topics identify endpoints
+`8000-8007` in this example. A routing proxy can expose that range even when
+the corresponding vLLM ports use a different base, such as `8200-8207`.
+Binding every rank directly to `tcp://*:5557` causes a port collision.
+Omitting the `START_RANK` adjustment on the second pod instead publishes on
+`5565-5572`, which does not match router discovery.
+
+Before benchmarking, verify all eight listeners on every model-server pod and
+all eight established router subscriptions. A correct listener check prints
+the same range for each pod:
+
+```bash
+kubectl exec -n ${NAMESPACE} ${POD} -c modelserver -- python3 -c '
+ports = []
+for line in open("/proc/net/tcp"):
+    fields = line.split()
+    if len(fields) > 3 and fields[3] == "0A":
+        port = int(fields[1].split(":")[1], 16)
+        if 5557 <= port <= 5564:
+            ports.append(port)
+print(sorted(ports))
+'
+```
+
+Also reject startup logs containing `Address already in use` or a ZMQ bind
+error. Listener checks alone are insufficient: the router must have one
+established connection to every rank before traffic starts.
+
+Check the router metrics endpoint before sending traffic:
+
+```bash
+kubectl port-forward -n ${NAMESPACE} deploy/${GUIDE_NAME}-epp 9090:9090
+
+curl -s localhost:9090/metrics \
+  | grep -E 'llm_d_router_epp_kv_cache_events_active_subscribers|llm_d_epp_ready_endpoints'
+```
+
+Both values must equal the number of routable DP endpoints. The measured
+DP=8 prefill plus DP=8 decode topology reported 16 active subscribers and 16
+ready endpoints, with listeners `5557-5564` reachable on both pods.
+
+## Verification
+
+Wait for all model-server pods:
+
+```bash
+kubectl get pods -n ${NAMESPACE} -l llm-d.ai/guide=pd-disaggregation -w
+```
+
+Confirm that each prefiller created its CPU tier:
+
+```bash
+kubectl logs -n ${NAMESPACE} \
+  -l llm-d.ai/role=prefill -c modelserver --prefix \
+  | grep -E 'CPUOffloadingManager|SharedOffloadRegion|CPU KV'
+```
+
+Inspect the offload metrics after sending traffic:
+
+```bash
+kubectl exec -n ${NAMESPACE} \
+  $(kubectl get pod -n ${NAMESPACE} -l llm-d.ai/role=prefill -o name | head -1) \
+  -c modelserver -- curl -s localhost:8000/metrics \
+  | grep -E 'kv_offload_(total_bytes|cpu_allocation|tiering)'
+```
+
+`vllm:kv_offload_total_bytes_total{transfer_type="GPU_to_CPU"}` counts data
+retained in local CPU memory, and `transfer_type="CPU_to_GPU"` counts data
+restored from it. A non-zero restore delta during the benchmark window is the
+mechanism check for CPU Multi Tier.
+
+## CPU sizing
+
+`cpu_bytes_to_use` is the capacity of one `OffloadingConnector` instance. The
+guide's TP=1 pods have one instance, so 100 GiB means 100 GiB per prefiller.
+With data parallelism, each local DP engine creates its own connector: DP=8 and
+`cpu_bytes_to_use: 107374182400` therefore reserve up to 800 GiB per pod. Size
+the pod and node for the multiplied capacity, not just the YAML value. If the
+CPU tier is smaller than the reusable working set, older blocks are evicted and
+must be recomputed.
+
+Size the pod memory limit for the CPU tier plus vLLM's normal host-memory use,
+and leave node-level headroom for concurrent prefiller pods. Monitor
+`vllm:kv_offload_allocation_failure_total` and CPU-cache usage under the target
+concurrency; a nominal cache capacity is not sufficient if active transfers pin
+most of the available blocks.
+
+Size from measured token capacity and the target reusable working set. On the
+measured H200 topology, each TP=1 prefiller exposed 1,630,790 HBM KV tokens, or
+13,046,320 tokens across eight prefills. The eviction benchmark below uses an
+approximate 17,280,000-token unique prefill working set. Its 4,233,680-token
+excess over aggregate HBM, plus transfer and concurrency headroom, fits in the
+configured 800 GiB aggregate CPU tier. Re-run the capacity check after changing
+the model, tensor parallelism, block size, or GPU memory utilization.
+
+## Benchmarking
+
+Use the main guide's dedicated `guide_pd-disaggregation_1.yaml` profile for a
+like-for-like comparison:
+
+```bash
+llmdbenchmark \
+  --spec guides/pd-disaggregation \
+  run \
+  --endpoint-url "${ENDPOINT_URL}" \
+  --gateway-class epponly \
+  --model "openai/gpt-oss-120b" \
+  --namespace "${NAMESPACE}" \
+  --harness inference-perf \
+  --workload guide_pd-disaggregation_1.yaml \
+  --monitoring \
+  --analyze
+```
+
+The profile sends random 5,000-token prompts with 250 output tokens at 45 QPS
+for 120 seconds. It is the guide's saturation test, but it intentionally has
+little prefix reuse. It measures the steady-state cost of CPU offloading; it is
+not a best-case cache-reuse workload. See the
+[Multi Tier benchmark report](./benchmark-results/vllm-gpt-oss-120b-h200-multi-tier.md)
+for the controlled NIXL and CPU Multi Tier comparison.
+
+The
+[GLM-5.2-FP8 DP benchmark](./benchmark-results/vllm-glm-5.2-fp8-h200-dp-multi-tier.md)
+compares precise NIXL P/D with precise CPU Multi Tier on a DP=8 prefill plus
+DP=8 decode topology. In its single 300-second Weka C32 cut, CPU Multi Tier
+improved successful request rate by 6.4%, reduced mean TTFT by 13.6%, and
+restored 25.23 GiB from CPU. It does not use a filesystem tier.
+
+For a prefix-reuse comparison, run the document-Q&A profile:
+
+```bash
+llmdbenchmark \
+  --spec guides/pd-disaggregation \
+  run \
+  --endpoint-url "${ENDPOINT_URL}" \
+  --gateway-class epponly \
+  --model "openai/gpt-oss-120b" \
+  --namespace "${NAMESPACE}" \
+  --harness inference-perf \
+  --workload guide_p2p-kv-cache-sharing_1.yaml \
+  --monitoring \
+  --analyze
+```
+
+This profile schedules 1,152 turns across 192 six-turn conversations. Each
+conversation has a private 49,152-token document prefix, so reuse occurs
+within a conversation rather than through one global shared prefix. Compare
+success count and the full TTFT distribution in addition to request rate; the
+180-second request timeout makes failures part of the result.
+
+### Eviction-pressure comparison
+
+Use the checked-in eviction profile when the goal is to verify that CPU
+retention extends useful prefix capacity beyond HBM:
+
+```bash
+llmdbenchmark \
+  --spec guides/pd-disaggregation \
+  run \
+  --endpoint-url "${ENDPOINT_URL}" \
+  --gateway-class epponly \
+  --model "openai/gpt-oss-120b" \
+  --namespace "${NAMESPACE}" \
+  --harness inference-perf \
+  --workload-file-path \
+    "${REPO_ROOT}/guides/pd-disaggregation/benchmark-templates/tiered-eviction.yaml.in" \
+  --wait-timeout 7200 \
+  --monitoring \
+  --analyze
+```
+
+The profile schedules 10,800 requests in eight 60-second Poisson stages from
+5 to 40 QPS. It uses 1,000 groups with five prompts per group, a 16,000-token
+shared prefix, 256 new input tokens, and 256 requested output tokens. It does
+not use a filesystem KV tier. The `storage.local_storage` field in the profile
+is only the harness result directory and is unrelated to model-server KV
+storage. Per-request lifecycle output is disabled to avoid a multi-gigabyte
+trace; the overall and per-stage summaries remain enabled.
+
+Run it once against the main guide's plain NIXL deployment and once against
+the CPU Multi Tier overlay. Keep the precise router configuration identical,
+restart the router between arms to clear its prefix index, and snapshot the
+CPU-to-GPU counter before and after the Multi Tier arm. Compare per-stage
+request rate, TTFT, latency, success count, and full completion time. A fixed
+arrival window alone hides the queued-work tail after saturation.
+
+On the measured Fozzie 16x H200 topology, CPU Multi Tier sustained 35.43
+request/s at the 40-QPS stage versus 22.44 for HBM-only NIXL. Across the full
+run it improved successful request rate by 8.9%, reduced measured completion
+time by 8.2%, and reduced mean TTFT from 6.405 seconds to 0.512 seconds. It
+restored 3.52 TiB from CPU, confirming that the read path was active. The CPU
+arm completed 10,799 of 10,800 requests; the HBM-only arm completed all 10,800.
+These are single runs, so use the result to demonstrate the mechanism and
+repeat it before treating the percentage as a capacity estimate.
+
+On the measured 8x TP=1 prefill and 2x TP=4 decode topology, plain NIXL had the
+best document-Q&A success count and mean latency. CPU Multi Tier was effectively
+tied with NIXL on the random guide workload and did not improve document Q&A,
+but it prevented the saturation collapse in the deliberate eviction-pressure
+profile. See the benchmark report for the full tables, exact CPU sizing, and
+limitations.
+
+## Cleanup
+
+Delete the overlay that was deployed, the render Service, and the router:
+
+```bash
+kubectl delete -n ${NAMESPACE} \
+  -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/gpu/vllm/multi-tier-${INFRA_PROVIDER}
+kubectl delete -n ${NAMESPACE} \
+  -k ${REPO_ROOT}/guides/${GUIDE_NAME}/render/multi-tier
+helm uninstall ${GUIDE_NAME} -n ${NAMESPACE}
+```

--- a/guides/pd-disaggregation/README.multi-tier.md
+++ b/guides/pd-disaggregation/README.multi-tier.md
@@ -296,21 +296,24 @@ is only the harness result directory and is unrelated to model-server KV
 storage. Per-request lifecycle output is disabled to avoid a multi-gigabyte
 trace; the overall and per-stage summaries remain enabled.
 
-Run it once against the main guide's plain NIXL deployment and once against
-the CPU Multi Tier overlay. Keep the precise router configuration identical,
-restart the router between arms to clear its prefix index, and snapshot the
-CPU-to-GPU counter before and after the Multi Tier arm. Compare per-stage
-request rate, TTFT, latency, success count, and full completion time. A fixed
-arrival window alone hides the queued-work tail after saturation.
+Use three arms to separate the engine and placement effects: plain NIXL with
+CPU backend weight `0.0`, the CPU-offload engine with CPU backend weight `0.0`,
+and the same byte-identical CPU-offload engine with CPU backend weight `0.4`.
+Restart every engine and the router between arms to clear HBM, CPU-tier, and
+precise-index state. Snapshot the CPU-to-GPU counter before and after each CPU
+arm. Compare per-stage request rate, TTFT, latency, success count, and full
+completion time. A fixed arrival window alone hides the queued-work tail after
+saturation.
 
-On the measured Fozzie 16x H200 topology, CPU Multi Tier sustained 35.43
-request/s at the 40-QPS stage versus 22.44 for HBM-only NIXL. Across the full
-run it improved successful request rate by 8.9%, reduced measured completion
-time by 8.2%, and reduced mean TTFT from 6.405 seconds to 0.512 seconds. It
-restored 3.52 TiB from CPU, confirming that the read path was active. The CPU
-arm completed 10,799 of 10,800 requests; the HBM-only arm completed all 10,800.
-These are single runs, so use the result to demonstrate the mechanism and
-repeat it before treating the percentage as a capacity estimate.
+On the measured Fozzie 16x H200 topology, all three arms completed all 10,800
+requests. At the 40-QPS stage, plain NIXL, CPU-blind offload, and CPU-aware
+Multi Tier sustained 22.10, 32.62, and 36.04 request/s respectively. Across the
+full run, enabling CPU offload reduced P90 request latency from 24.010 to 8.078
+seconds. Enabling CPU-aware placement on the same engine reduced it further to
+2.859 seconds. The CPU-aware arm logged 3.58 TiB restored from CPU with zero
+allocation failures, confirming that the read path was active. These are
+single runs with generated seeds, so use the result to demonstrate the
+mechanism and repeat it before treating the percentages as a capacity estimate.
 
 On the measured 8x TP=1 prefill and 2x TP=4 decode topology, plain NIXL had the
 best document-Q&A success count and mean latency. CPU Multi Tier was effectively

--- a/guides/pd-disaggregation/benchmark-results/vllm-glm-5.2-fp8-h200-dp-multi-tier.md
+++ b/guides/pd-disaggregation/benchmark-results/vllm-glm-5.2-fp8-h200-dp-multi-tier.md
@@ -1,0 +1,97 @@
+# GLM-5.2-FP8 DP P/D Multi Tier on H200
+
+This report compares precise NIXL P/D with precise CPU Multi Tier under data
+parallelism. Neither arm uses a filesystem KV tier.
+
+## Testbed
+
+- Cluster: CoreWeave Piggy.
+- Model: `zai-org/GLM-5.2-FP8`.
+- Engine image: `quay.io/niliguy/vllm-openai:nightly-6f91edf9-pr50302`.
+- Topology: one TP=1, DP=8 prefill pod on an 8x H200 node and one TP=1, DP=8
+  decode pod on a second 8x H200 node.
+- P/D transport: `NixlConnector` over the CoreWeave RDMA resource.
+- Engine and precise-router block size: 64 tokens.
+- Router: the same DP-aware precise configuration in both arms, including
+  `precise-prefix-cache-producer`, CPU backend weight 0.4,
+  `prefix-cache-affinity-filter`, and `token-load-scorer`.
+- Model loading: `runai_streamer`, distributed loading with concurrency 16,
+  and persistent `VLLM_CACHE_ROOT` storage.
+- One measured run per arm, in NIXL-then-Multi-Tier order.
+
+Both pods exposed one ZMQ publisher per DP rank. Ports `5557-5564` were
+reachable on each pod before traffic started, and the router reported 16
+active KV-event subscribers and 16 ready endpoints. Per-rank request counters
+and KV metrics were collected every two seconds.
+
+The controlled connector difference was:
+
+| Arm | Prefill KV configuration | Decode KV configuration |
+| --- | --- | --- |
+| Precise PD NIXL | `NixlConnector`; HBM only | `NixlConnector`; HBM only |
+| Precise PD Multi Tier | `MultiConnector`: NIXL plus CPU `OffloadingConnector` | `NixlConnector`; HBM only |
+
+The CPU connector used `offload_prompt_only: true`, LRU eviction, and
+`kv_load_failure_policy: recompute`. Its `cpu_bytes_to_use` was 100 GiB per
+local DP engine, or up to 800 GiB on the DP=8 prefill pod.
+
+## Workload and measurement window
+
+The AIPerf workload used `semianalysis_cc_traces_weka_062126`, concurrency 32,
+48 dataset entries, maximum synthesized ISL 115,000, maximum synthesized OSL
+2,048, and random seed 67. Requests were admitted for 300 seconds with a
+120-second grace period.
+
+The summary uses the terminal-by-cutoff method: a request counts only when its
+terminal timestamp is no later than 300 seconds after the first credit was
+issued. Requests admitted by the cutoff but completed later are retained in
+the raw artifacts and excluded from the table. This makes the comparison
+independent of post-window drain time. Because this is a closed-loop workload,
+the faster arm can admit more requests within the same window.
+
+## Results
+
+| Arm | Terminal | OK/error | Success req/s | Input ktok/s | Output tok/s | Admitted but not terminal |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Precise PD NIXL | 408 | 404/4 | 1.347 | 64.453 | 576.553 | 22 |
+| Precise PD Multi Tier | 437 | 430/7 | 1.433 | 68.467 | 638.157 | 19 |
+| Multi Tier delta | +7.1% | +26 OK | +6.4% | +6.2% | +10.7% | -3 |
+
+| Arm | Mean TTFT | P50 TTFT | P90 TTFT | P99 TTFT | Mean latency | P50 latency | P90 latency | P99 latency |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Precise PD NIXL | 10.618 s | 7.754 s | 25.040 s | 45.411 s | 17.411 s | 14.031 s | 35.321 s | 61.576 s |
+| Precise PD Multi Tier | 9.174 s | 5.468 s | 22.339 s | 42.726 s | 16.038 s | 12.244 s | 33.928 s | 58.236 s |
+| Multi Tier delta | -13.6% | -29.5% | -10.8% | -5.9% | -7.9% | -12.7% | -3.9% | -5.4% |
+
+All cutoff errors were HTTP 400 context-length rejections after the same Weka
+conversation reached 120,000 input tokens. Multi Tier has three more such
+errors because it progressed to three later turns before the cutoff. Both arms
+recorded zero failed NIXL transfers, failed NIXL notifications, and expired
+NIXL requests.
+
+## Mechanism evidence
+
+The NIXL arm exposed no CPU-offload counters. AIPerf's run-level counter
+deltas, including the post-cutoff drain, recorded:
+
+- 344.82 GiB transferred from GPU to CPU.
+- 25.23 GiB restored from CPU to GPU.
+- Non-zero CPU-to-GPU bytes on seven of eight DP ranks.
+- An aggregate prefill prefix-hit ratio of 66.73%, versus 63.24% for NIXL.
+
+The non-zero restore bytes distinguish this result from a run that merely
+allocates a CPU tier or writes unused copies. These restores are local CPU
+reads.
+
+## Conclusion
+
+In this single Weka C32 cut, CPU Multi Tier improved successful request rate
+by 6.4%, reduced mean TTFT by 13.6%, and reduced mean request latency by 7.9%.
+The mechanism counters and higher prefix-hit ratio are consistent with CPU
+retention avoiding some repeated prefill work.
+
+This is a directional result, not a stable capacity estimate. Repeat both
+arms and reverse their order before publishing the percentages as expected
+performance. The topology also differs from a 2-prefill, 2-decode C64 test:
+it uses half the pods and half the concurrency while preserving four
+concurrent requests per prefill DP rank.

--- a/guides/pd-disaggregation/benchmark-results/vllm-gpt-oss-120b-h200-multi-tier.md
+++ b/guides/pd-disaggregation/benchmark-results/vllm-gpt-oss-120b-h200-multi-tier.md
@@ -81,11 +81,11 @@ block size, and precise router scorer weights. The router and all engines were
 restarted between arms to clear the precise index, HBM cache, and CPU tier.
 The controlled arms separate the engine and placement effects:
 
-| Arm | Prefill engine | Precise CPU backend weight | Isolated effect |
-| --- | --- | ---: | --- |
-| PD NIXL | `NixlConnector` | 0.0 | HBM-only baseline |
-| PD NIXL + CPU offload | `MultiConnector` with NIXL and 100 GiB CPU | 0.0 | CPU retention without CPU-aware placement |
-| PD Multi Tier | Same byte-identical engine as PD NIXL + CPU offload | 0.4 | CPU-aware placement |
+| Arm | Prefill connector configuration | Router CPU-tier behavior | Isolated effect |
+| --- | --- | --- | --- |
+| PD NIXL | `NixlConnector` only; HBM KV cache | No CPU tier | HBM-only P/D baseline |
+| PD NIXL + CPU offload | `MultiConnector`: `NixlConnector` for P/D transfer plus `OffloadingConnector` with 100 GiB CPU | Precise CPU backend weight `0.0`; CPU-tier hits do not affect placement | CPU retention without CPU-aware placement |
+| PD Multi Tier | `MultiConnector`: `NixlConnector` for P/D transfer plus `OffloadingConnector` with 100 GiB CPU | Precise CPU backend weight `0.4`; CPU-tier hits affect placement | CPU-aware placement on the Multi Tier engine |
 
 | Arm | OK/fail | Request/s | Measured time | Mean latency | P90 latency | Mean TTFT | P90 TTFT | Mean TPOT |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |

--- a/guides/pd-disaggregation/benchmark-results/vllm-gpt-oss-120b-h200-multi-tier.md
+++ b/guides/pd-disaggregation/benchmark-results/vllm-gpt-oss-120b-h200-multi-tier.md
@@ -42,11 +42,11 @@ higher and mean TTFT is 0.48% higher.
 
 ## Workload 2: document Q&A
 
-`guide_p2p-kv-cache-sharing_1.yaml` schedules 1,152 turns across 192 private
-documents. Each conversation has a 49,152-token document prefix, six turns,
-256 new input tokens per turn, requested 256-token output, concurrency 128,
-and a 180-second request timeout. Reuse is private to each conversation rather
-than one global shared prefix.
+[`document-qa.yaml.in`](../benchmark-templates/document-qa.yaml.in) schedules
+1,152 turns across 192 private documents. Each conversation has a 49,152-token
+document prefix, six turns, 256 new input tokens per turn, requested 256-token
+output, concurrency 128, and a 180-second request timeout. Reuse is private to
+each conversation rather than one global shared prefix.
 
 | Arm | OK/fail | Request/s | Mean latency | Median latency | P95 latency | P99 latency | Mean TTFT | Median TTFT | P95 TTFT |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |

--- a/guides/pd-disaggregation/benchmark-results/vllm-gpt-oss-120b-h200-multi-tier.md
+++ b/guides/pd-disaggregation/benchmark-results/vllm-gpt-oss-120b-h200-multi-tier.md
@@ -75,47 +75,63 @@ tokens across eight prefills. The approximate unique prefill working set is
 17,280,000 tokens, 1.32 times aggregate HBM capacity. The CPU arm adds 100 GiB
 per prefiller, 800 GiB total. Neither arm uses a filesystem KV tier.
 
-Both Fozzie arms used the same model, vLLM image, 8x TP=1 prefill plus 2x TP=4
-decode topology, NIXL/RDMA P/D transport, 128-token engine and router block
-size, and corrected DP-aware precise router configuration. The only engine
-change was HBM-only NIXL versus NIXL plus the prefill CPU tier. The router was
-restarted between arms to clear the precise cache index.
+All three Fozzie arms used the same model, vLLM image, 8x TP=1 prefill plus 2x
+TP=4 decode topology, NIXL/RDMA P/D transport, 128-token engine and router
+block size, and precise router scorer weights. The router and all engines were
+restarted between arms to clear the precise index, HBM cache, and CPU tier.
+The controlled arms separate the engine and placement effects:
+
+| Arm | Prefill engine | Precise CPU backend weight | Isolated effect |
+| --- | --- | ---: | --- |
+| PD NIXL | `NixlConnector` | 0.0 | HBM-only baseline |
+| CPU offload, CPU-blind | `MultiConnector` with NIXL and 100 GiB CPU | 0.0 | CPU retention and engine-local restore |
+| PD Multi Tier, CPU-aware | Same byte-identical engine as CPU-blind | 0.4 | CPU-aware placement |
 
 | Arm | OK/fail | Request/s | Measured time | Mean latency | P90 latency | Mean TTFT | P90 TTFT | Mean TPOT |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| PD NIXL | 10,800/0 | 10.699 | 1,009.45 s | 8.120 s | 20.705 s | 6.405 s | 19.112 s | 6.677 ms |
-| PD Multi Tier | 10,799/1 | 11.650 | 926.98 s | 2.365 s | 2.869 s | 0.512 s | 0.840 s | 7.223 ms |
+| PD NIXL | 10,800/0 | 10.598 | 1,019.07 s | 9.100 s | 24.010 s | 7.404 s | 22.324 s | 6.573 ms |
+| CPU offload, CPU-blind | 10,800/0 | 11.325 | 953.68 s | 4.144 s | 8.078 s | 2.288 s | 5.950 s | 7.211 ms |
+| PD Multi Tier, CPU-aware | 10,800/0 | 11.466 | 941.90 s | 2.390 s | 2.859 s | 0.491 s | 0.846 s | 7.375 ms |
 
-| Target QPS | NIXL request/s | Multi Tier request/s | NIXL P90 latency | Multi Tier P90 latency | NIXL P90 TTFT | Multi Tier P90 TTFT |
+| Target QPS | NIXL request/s | CPU-blind request/s | CPU-aware request/s | NIXL P90 latency | CPU-blind P90 latency | CPU-aware P90 latency |
 | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| 5 | 4.60 | 5.17 | 2.163 s | 2.091 s | 1.007 s | 0.968 s |
-| 10 | 9.61 | 9.73 | 2.093 s | 2.034 s | 0.813 s | 0.818 s |
-| 15 | 15.14 | 14.72 | 2.332 s | 2.248 s | 0.908 s | 0.747 s |
-| 20 | 18.75 | 19.69 | 3.144 s | 2.143 s | 1.552 s | 0.669 s |
-| 25 | 24.33 | 24.29 | 4.631 s | 2.447 s | 2.790 s | 0.706 s |
-| 30 | 25.40 | 29.72 | 7.374 s | 2.700 s | 5.514 s | 0.776 s |
-| 35 | 24.20 | 33.43 | 17.721 s | 3.019 s | 15.988 s | 0.959 s |
-| 40 | 22.44 | 35.43 | 37.859 s | 3.448 s | 36.271 s | 1.632 s |
+| 5 | 4.81 | 5.11 | 4.59 | 2.050 s | 2.034 s | 2.061 s |
+| 10 | 9.10 | 9.84 | 9.13 | 2.149 s | 2.174 s | 2.133 s |
+| 15 | 14.01 | 14.23 | 14.41 | 2.381 s | 2.113 s | 2.121 s |
+| 20 | 18.52 | 19.22 | 19.63 | 3.217 s | 2.569 s | 2.259 s |
+| 25 | 23.18 | 22.99 | 24.01 | 4.576 s | 3.779 s | 2.580 s |
+| 30 | 26.52 | 27.88 | 29.15 | 8.491 s | 5.952 s | 2.652 s |
+| 35 | 23.91 | 29.53 | 32.94 | 23.027 s | 7.377 s | 3.173 s |
+| 40 | 22.10 | 32.62 | 36.04 | 40.267 s | 12.477 s | 3.511 s |
 
-Plain NIXL peaks at 25.40 request/s in the 30-QPS stage, then declines as
-HBM-only prefix eviction drives repeated prefill work. Multi Tier sustains
-33.43 request/s at 35 QPS and 35.43 request/s at 40 QPS. Across the full run,
-Multi Tier improves successful request rate by 8.9%, shortens measured
-completion time by 8.2%, and reduces mean TTFT by 92.0%. Its mean TPOT is 8.2%
-higher, so CPU restore overhead remains visible after the first token.
+The CPU-blind arm shows that the engine tier itself provides most of the
+capacity gain over plain NIXL. It improves full-run successful request rate by
+6.9%, reduces mean request latency by 54.5%, and reduces P90 request latency by
+66.4%. The CPU-aware arm then isolates the placement algorithm: compared with
+the byte-identical CPU-blind engine, it reduces mean request latency by 42.3%
+and P90 request latency by 64.6%. At the 40-QPS stage it increases achieved
+request rate from 32.62 to 36.04 request/s and reduces P90 latency from 12.477
+to 3.511 seconds.
 
-The CPU counters started at zero. During the measured arm, prefills restored
-3.52 TiB from CPU to GPU in 7,055 operations and wrote 1.51 TiB from GPU to CPU
-in 4,738 operations. This verifies that the result exercises CPU retention and
-restore rather than only allocating an unused tier. The one failure occurred
-in the 40-QPS stage, a 0.009% overall failure rate. One run per arm is not
-enough to claim a stable percentage; repeat the comparison before using the
-delta as a capacity target.
+The overall request/s difference understates the latency improvement because
+the profile contains a fixed 60-second gap between stages. Per-stage request
+rate and the queued-work tail expose the saturation behavior. Plain NIXL
+declines after 30 QPS, the CPU-blind engine extends the saturation knee, and
+CPU-aware placement sustains the highest rate through 40 QPS.
 
-Inference-perf flagged output-token count mismatches on 8,811 NIXL requests
-and 8,758 Multi Tier requests. Its aggregate output-token totals still matched
-256 tokens per successful request, but the mismatch makes TPOT less reliable
-than request rate, completion time, and TTFT for this comparison.
+During the CPU-aware arm, periodic vLLM counters across the eight prefills
+logged 3.58 TiB of CPU-to-GPU loads and 1.54 TiB of GPU-to-CPU stores, with
+zero CPU allocation failures. These are aggregate transfer activities, not a
+unique KV footprint. They verify that CPU-aware placement exercised retention
+and restore rather than only allocating an unused tier.
+
+Inference-perf flagged output-token count mismatches on 8,746 NIXL requests,
+8,741 CPU-blind requests, and 8,715 CPU-aware requests. Aggregate output-token
+totals still matched 256 tokens per successful request, but the mismatch makes
+TPOT less reliable than request rate, completion time, and TTFT for this
+comparison. Each arm is a single run and inference-perf generated a different
+seed for each run, so repeat the comparison before treating the percentages as
+a stable capacity estimate.
 
 ## Mechanism evidence
 
@@ -123,7 +139,7 @@ than request rate, completion time, and TTFT for this comparison.
 | --- | ---: | --- |
 | Random guide workload | 0 GiB | no reuse path engaged |
 | Document Q&A | about 201 GiB | local CPU restores occurred |
-| Eviction pressure | 3.52 TiB | sustained local CPU restores beyond HBM capacity |
+| Eviction pressure | 3.58 TiB | sustained local CPU restores beyond HBM capacity |
 
 ## Conclusion
 
@@ -134,5 +150,7 @@ the reusable working set must exceed HBM capacity, fit in CPU memory, and be
 revisited enough for CPU restore to beat recomputation. Plain NIXL has the best
 document-Q&A success count and mean latency in these single runs.
 
-Use the CPU-only overlay as the primary Multi Tier guide comparison. Repeat the
-two arms before treating any percentage as a stable performance estimate.
+Use the NIXL plus CPU overlay as the primary Multi Tier guide comparison. The
+controlled eviction test shows separate gains from the CPU tier and from
+CPU-aware placement. Repeat all three arms before treating any percentage as a
+stable performance estimate.

--- a/guides/pd-disaggregation/benchmark-results/vllm-gpt-oss-120b-h200-multi-tier.md
+++ b/guides/pd-disaggregation/benchmark-results/vllm-gpt-oss-120b-h200-multi-tier.md
@@ -84,16 +84,16 @@ The controlled arms separate the engine and placement effects:
 | Arm | Prefill engine | Precise CPU backend weight | Isolated effect |
 | --- | --- | ---: | --- |
 | PD NIXL | `NixlConnector` | 0.0 | HBM-only baseline |
-| CPU offload, CPU-blind | `MultiConnector` with NIXL and 100 GiB CPU | 0.0 | CPU retention and engine-local restore |
-| PD Multi Tier, CPU-aware | Same byte-identical engine as CPU-blind | 0.4 | CPU-aware placement |
+| PD NIXL + CPU offload | `MultiConnector` with NIXL and 100 GiB CPU | 0.0 | CPU retention without CPU-aware placement |
+| PD Multi Tier | Same byte-identical engine as PD NIXL + CPU offload | 0.4 | CPU-aware placement |
 
 | Arm | OK/fail | Request/s | Measured time | Mean latency | P90 latency | Mean TTFT | P90 TTFT | Mean TPOT |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 | PD NIXL | 10,800/0 | 10.598 | 1,019.07 s | 9.100 s | 24.010 s | 7.404 s | 22.324 s | 6.573 ms |
-| CPU offload, CPU-blind | 10,800/0 | 11.325 | 953.68 s | 4.144 s | 8.078 s | 2.288 s | 5.950 s | 7.211 ms |
-| PD Multi Tier, CPU-aware | 10,800/0 | 11.466 | 941.90 s | 2.390 s | 2.859 s | 0.491 s | 0.846 s | 7.375 ms |
+| PD NIXL + CPU offload | 10,800/0 | 11.325 | 953.68 s | 4.144 s | 8.078 s | 2.288 s | 5.950 s | 7.211 ms |
+| PD Multi Tier | 10,800/0 | 11.466 | 941.90 s | 2.390 s | 2.859 s | 0.491 s | 0.846 s | 7.375 ms |
 
-| Target QPS | NIXL request/s | CPU-blind request/s | CPU-aware request/s | NIXL P90 latency | CPU-blind P90 latency | CPU-aware P90 latency |
+| Target QPS | PD NIXL request/s | PD NIXL + CPU offload request/s | PD Multi Tier request/s | PD NIXL P90 latency | PD NIXL + CPU offload P90 latency | PD Multi Tier P90 latency |
 | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 | 5 | 4.81 | 5.11 | 4.59 | 2.050 s | 2.034 s | 2.061 s |
 | 10 | 9.10 | 9.84 | 9.13 | 2.149 s | 2.174 s | 2.133 s |
@@ -104,34 +104,34 @@ The controlled arms separate the engine and placement effects:
 | 35 | 23.91 | 29.53 | 32.94 | 23.027 s | 7.377 s | 3.173 s |
 | 40 | 22.10 | 32.62 | 36.04 | 40.267 s | 12.477 s | 3.511 s |
 
-The CPU-blind arm shows that the engine tier itself provides most of the
-capacity gain over plain NIXL. It improves full-run successful request rate by
-6.9%, reduces mean request latency by 54.5%, and reduces P90 request latency by
-66.4%. The CPU-aware arm then isolates the placement algorithm: compared with
-the byte-identical CPU-blind engine, it reduces mean request latency by 42.3%
-and P90 request latency by 64.6%. At the 40-QPS stage it increases achieved
-request rate from 32.62 to 36.04 request/s and reduces P90 latency from 12.477
-to 3.511 seconds.
+The PD NIXL + CPU offload arm shows that the engine tier itself provides most
+of the capacity gain over PD NIXL. It improves full-run successful request
+rate by 6.9%, reduces mean request latency by 54.5%, and reduces P90 request
+latency by 66.4%. The PD Multi Tier arm then isolates the placement algorithm:
+compared with the byte-identical offload engine, it reduces mean request
+latency by 42.3% and P90 request latency by 64.6%. At the 40-QPS stage it
+increases achieved request rate from 32.62 to 36.04 request/s and reduces P90
+latency from 12.477 to 3.511 seconds.
 
 The overall request/s difference understates the latency improvement because
 the profile contains a fixed 60-second gap between stages. Per-stage request
-rate and the queued-work tail expose the saturation behavior. Plain NIXL
-declines after 30 QPS, the CPU-blind engine extends the saturation knee, and
-CPU-aware placement sustains the highest rate through 40 QPS.
+rate and the queued-work tail expose the saturation behavior. PD NIXL declines
+after 30 QPS, PD NIXL + CPU offload extends the saturation knee, and PD Multi
+Tier sustains the highest rate through 40 QPS.
 
-During the CPU-aware arm, periodic vLLM counters across the eight prefills
+During the PD Multi Tier arm, periodic vLLM counters across the eight prefills
 logged 3.58 TiB of CPU-to-GPU loads and 1.54 TiB of GPU-to-CPU stores, with
 zero CPU allocation failures. These are aggregate transfer activities, not a
 unique KV footprint. They verify that CPU-aware placement exercised retention
 and restore rather than only allocating an unused tier.
 
-Inference-perf flagged output-token count mismatches on 8,746 NIXL requests,
-8,741 CPU-blind requests, and 8,715 CPU-aware requests. Aggregate output-token
-totals still matched 256 tokens per successful request, but the mismatch makes
-TPOT less reliable than request rate, completion time, and TTFT for this
-comparison. Each arm is a single run and inference-perf generated a different
-seed for each run, so repeat the comparison before treating the percentages as
-a stable capacity estimate.
+Inference-perf flagged output-token count mismatches on 8,746 PD NIXL
+requests, 8,741 PD NIXL + CPU offload requests, and 8,715 PD Multi Tier
+requests. Aggregate output-token totals still matched 256 tokens per successful
+request, but the mismatch makes TPOT less reliable than request rate,
+completion time, and TTFT for this comparison. Each arm is a single run and
+inference-perf generated a different seed for each run, so repeat the
+comparison before treating the percentages as a stable capacity estimate.
 
 ## Mechanism evidence
 

--- a/guides/pd-disaggregation/benchmark-results/vllm-gpt-oss-120b-h200-multi-tier.md
+++ b/guides/pd-disaggregation/benchmark-results/vllm-gpt-oss-120b-h200-multi-tier.md
@@ -1,0 +1,138 @@
+# GPT-OSS-120B P/D Multi Tier KV Cache on H200
+
+This report compares plain NIXL P/D with CPU KV offloading. Neither arm uses a
+filesystem KV tier.
+
+## Testbed
+
+- Cluster: CoreWeave Kermit for the random and document-Q&A workloads;
+  CoreWeave Fozzie for the eviction-pressure workload.
+- Model: `openai/gpt-oss-120b`.
+- Engine: vLLM v0.27.1.
+- Topology: 8 TP=1 prefills on one 8x H200 node and 2 TP=4 decoders on a
+  second 8x H200 node.
+- P/D transport: `NixlConnector` over the CoreWeave RDMA resource.
+- Engine block size and precise router block size: 128 tokens.
+- Model loading: `runai_streamer`, distributed loading with concurrency 16,
+  and a persistent `VLLM_CACHE_ROOT` host volume.
+- One measured run per arm. Treat small differences as directional, not as a
+  stable performance estimate.
+
+Both arms use the same precise prefill placement: prefix score weight 3, queue
+weight 2, KV-utilization weight 2, and decode active-request weight 2.
+
+| Arm | Engine tiers and policy | Router difference |
+| --- | --- | --- |
+| PD NIXL | HBM; NIXL P/D handoff | controlled precise |
+| PD Multi Tier | HBM + 100 GiB CPU on each prefiller; decode is NIXL only | none |
+
+## Workload 1: checked-in P/D guide profile
+
+`guide_pd-disaggregation_1.yaml` sends 5,400 random requests at 45 QPS over a
+120-second window. Every request has 5,000 input tokens and requests 250 output
+tokens. Random prompts intentionally provide little reusable prefix state.
+
+| Arm | OK/fail | Request/s | Mean latency | P95 latency | P99 latency | Mean TTFT | P95 TTFT |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| PD NIXL | 5,400/0 | 44.27 | 2.355 s | 2.900 s | 3.719 s | 0.518 s | 1.052 s |
+| PD Multi Tier | 5,400/0 | 44.35 | 2.361 s | 2.899 s | 3.608 s | 0.521 s | 1.038 s |
+
+CPU-only Multi Tier is effectively tied with plain NIXL: mean latency is 0.25%
+higher and mean TTFT is 0.48% higher.
+
+## Workload 2: document Q&A
+
+`guide_p2p-kv-cache-sharing_1.yaml` schedules 1,152 turns across 192 private
+documents. Each conversation has a 49,152-token document prefix, six turns,
+256 new input tokens per turn, requested 256-token output, concurrency 128,
+and a 180-second request timeout. Reuse is private to each conversation rather
+than one global shared prefix.
+
+| Arm | OK/fail | Request/s | Mean latency | Median latency | P95 latency | P99 latency | Mean TTFT | Median TTFT | P95 TTFT |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| PD NIXL | 1,133/19 | 4.303 | 13.947 s | 5.590 s | 72.955 s | 159.100 s | 11.282 s | 2.827 s | 70.646 s |
+| PD Multi Tier | 1,117/35 | 4.305 | 16.657 s | 6.481 s | 104.042 s | 176.812 s | 13.882 s | 3.447 s | 101.837 s |
+
+Compared with plain NIXL, CPU-only Multi Tier has 19.4% higher mean latency,
+23.1% higher mean TTFT, and 16 fewer successes.
+
+Successful output length varied across runs despite the same seeded workload:
+mean output tokens were 619 for plain NIXL and 625 for CPU Multi Tier. Median
+output stayed 251-252 tokens. This is another reason not to over-interpret
+one-run mean differences.
+
+## Workload 3: eviction pressure beyond HBM capacity
+
+[`tiered-eviction.yaml.in`](../benchmark-templates/tiered-eviction.yaml.in)
+schedules 10,800 requests over eight 60-second Poisson stages from 5 to 40
+QPS. It uses 1,000 prefix groups, five prompts per group, a 16,000-token shared
+prefix, 256 new input tokens, and 256 requested output tokens. Multi-turn chat
+is disabled.
+
+This workload was calibrated from live vLLM capacity rather than nominal GPU
+memory. Each TP=1 prefiller reported 1,630,790 HBM KV tokens, or 13,046,320
+tokens across eight prefills. The approximate unique prefill working set is
+17,280,000 tokens, 1.32 times aggregate HBM capacity. The CPU arm adds 100 GiB
+per prefiller, 800 GiB total. Neither arm uses a filesystem KV tier.
+
+Both Fozzie arms used the same model, vLLM image, 8x TP=1 prefill plus 2x TP=4
+decode topology, NIXL/RDMA P/D transport, 128-token engine and router block
+size, and corrected DP-aware precise router configuration. The only engine
+change was HBM-only NIXL versus NIXL plus the prefill CPU tier. The router was
+restarted between arms to clear the precise cache index.
+
+| Arm | OK/fail | Request/s | Measured time | Mean latency | P90 latency | Mean TTFT | P90 TTFT | Mean TPOT |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| PD NIXL | 10,800/0 | 10.699 | 1,009.45 s | 8.120 s | 20.705 s | 6.405 s | 19.112 s | 6.677 ms |
+| PD Multi Tier | 10,799/1 | 11.650 | 926.98 s | 2.365 s | 2.869 s | 0.512 s | 0.840 s | 7.223 ms |
+
+| Target QPS | NIXL request/s | Multi Tier request/s | NIXL P90 latency | Multi Tier P90 latency | NIXL P90 TTFT | Multi Tier P90 TTFT |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 5 | 4.60 | 5.17 | 2.163 s | 2.091 s | 1.007 s | 0.968 s |
+| 10 | 9.61 | 9.73 | 2.093 s | 2.034 s | 0.813 s | 0.818 s |
+| 15 | 15.14 | 14.72 | 2.332 s | 2.248 s | 0.908 s | 0.747 s |
+| 20 | 18.75 | 19.69 | 3.144 s | 2.143 s | 1.552 s | 0.669 s |
+| 25 | 24.33 | 24.29 | 4.631 s | 2.447 s | 2.790 s | 0.706 s |
+| 30 | 25.40 | 29.72 | 7.374 s | 2.700 s | 5.514 s | 0.776 s |
+| 35 | 24.20 | 33.43 | 17.721 s | 3.019 s | 15.988 s | 0.959 s |
+| 40 | 22.44 | 35.43 | 37.859 s | 3.448 s | 36.271 s | 1.632 s |
+
+Plain NIXL peaks at 25.40 request/s in the 30-QPS stage, then declines as
+HBM-only prefix eviction drives repeated prefill work. Multi Tier sustains
+33.43 request/s at 35 QPS and 35.43 request/s at 40 QPS. Across the full run,
+Multi Tier improves successful request rate by 8.9%, shortens measured
+completion time by 8.2%, and reduces mean TTFT by 92.0%. Its mean TPOT is 8.2%
+higher, so CPU restore overhead remains visible after the first token.
+
+The CPU counters started at zero. During the measured arm, prefills restored
+3.52 TiB from CPU to GPU in 7,055 operations and wrote 1.51 TiB from GPU to CPU
+in 4,738 operations. This verifies that the result exercises CPU retention and
+restore rather than only allocating an unused tier. The one failure occurred
+in the 40-QPS stage, a 0.009% overall failure rate. One run per arm is not
+enough to claim a stable percentage; repeat the comparison before using the
+delta as a capacity target.
+
+Inference-perf flagged output-token count mismatches on 8,811 NIXL requests
+and 8,758 Multi Tier requests. Its aggregate output-token totals still matched
+256 tokens per successful request, but the mismatch makes TPOT less reliable
+than request rate, completion time, and TTFT for this comparison.
+
+## Mechanism evidence
+
+| Workload | CPU to GPU | Interpretation |
+| --- | ---: | --- |
+| Random guide workload | 0 GiB | no reuse path engaged |
+| Document Q&A | about 201 GiB | local CPU restores occurred |
+| Eviction pressure | 3.52 TiB | sustained local CPU restores beyond HBM capacity |
+
+## Conclusion
+
+For this checked-in P/D topology, CPU Multi Tier is nearly free on the random
+saturation profile, does not improve document Q&A, and strongly improves the
+deliberate 1.32x-HBM eviction-pressure profile. The value is workload-specific:
+the reusable working set must exceed HBM capacity, fit in CPU memory, and be
+revisited enough for CPU restore to beat recomputation. Plain NIXL has the best
+document-Q&A success count and mean latency in these single runs.
+
+Use the CPU-only overlay as the primary Multi Tier guide comparison. Repeat the
+two arms before treating any percentage as a stable performance estimate.

--- a/guides/pd-disaggregation/benchmark-templates/document-qa.yaml.in
+++ b/guides/pd-disaggregation/benchmark-templates/document-qa.yaml.in
@@ -1,0 +1,65 @@
+load:
+  type: concurrent
+  num_workers: 8
+  worker_max_concurrency: 1000
+  request_timeout: 180
+  stages:
+    # 192 session blueprints x 6 turns; 128 requests in flight.
+    - num_requests: 1152
+      concurrency_level: 128
+api:
+  type: completion
+  streaming: true
+server:
+  type: vllm
+  model_name: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+  base_url: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
+  ignore_eos: true
+tokenizer:
+  pretrained_model_name_or_path: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+data:
+  type: conversation_replay
+  conversation_replay:
+    seed: 37
+    max_model_len: 65536
+    num_conversations: 192
+    shared_system_prompt_len: 256
+    # Each conversation carries a private 49,152-token document prefix.
+    dynamic_system_prompt_len:
+      type: lognormal
+      min: 49152
+      max: 49152
+      mean: 49152
+      std_dev: 1
+    turns_per_conversation:
+      type: lognormal
+      min: 6
+      max: 6
+      mean: 6
+      std_dev: 1
+    input_tokens_per_turn:
+      type: lognormal
+      min: 256
+      max: 256
+      mean: 256
+      std_dev: 1
+    output_tokens_per_turn:
+      type: lognormal
+      min: 256
+      max: 256
+      mean: 256
+      std_dev: 1
+    tool_call_latency_sec:
+      type: lognormal
+      min: 1
+      max: 2
+      mean: 1
+      std_dev: 1
+report:
+  request_lifecycle:
+    summary: true
+    per_stage: true
+    per_request: true
+storage:
+  local_storage:
+    path: /workspace

--- a/guides/pd-disaggregation/benchmark-templates/tiered-eviction.yaml.in
+++ b/guides/pd-disaggregation/benchmark-templates/tiered-eviction.yaml.in
@@ -1,0 +1,47 @@
+load:
+  type: poisson
+  interval: 60.0
+  stages:
+    - rate: 5
+      duration: 60
+    - rate: 10
+      duration: 60
+    - rate: 15
+      duration: 60
+    - rate: 20
+      duration: 60
+    - rate: 25
+      duration: 60
+    - rate: 30
+      duration: 60
+    - rate: 35
+      duration: 60
+    - rate: 40
+      duration: 60
+api:
+  type: completion
+  streaming: true
+server:
+  type: vllm
+  model_name: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+  base_url: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
+  ignore_eos: true
+tokenizer:
+  pretrained_model_name_or_path: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+data:
+  type: shared_prefix
+  shared_prefix:
+    num_groups: 1000
+    num_prompts_per_group: 5
+    system_prompt_len: 16000
+    question_len: 256
+    output_len: 256
+    enable_multi_turn_chat: false
+report:
+  request_lifecycle:
+    summary: true
+    per_stage: true
+    per_request: false
+storage:
+  local_storage:
+    path: /workspace

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/multi-tier-base/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/multi-tier-base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../multi-tier

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/multi-tier-coreweave/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/multi-tier-coreweave/kustomization.yaml
@@ -1,0 +1,52 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../multi-tier
+
+patches:
+  - target:
+      kind: Deployment
+      name: prefill
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: prefill
+      spec:
+        template:
+          spec:
+            containers:
+              - name: modelserver
+                securityContext:
+                  capabilities:
+                    add: [IPC_LOCK, SYS_RAWIO]
+                  runAsUser: 0
+                  runAsGroup: 0
+                resources:
+                  limits:
+                    rdma/ib: "1"
+                  requests:
+                    rdma/ib: "1"
+  - target:
+      kind: Deployment
+      name: decode
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: decode
+      spec:
+        template:
+          spec:
+            containers:
+              - name: modelserver
+                securityContext:
+                  capabilities:
+                    add: [IPC_LOCK, SYS_RAWIO]
+                  runAsUser: 0
+                  runAsGroup: 0
+                resources:
+                  limits:
+                    rdma/ib: "1"
+                  requests:
+                    rdma/ib: "1"

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/multi-tier/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/multi-tier/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+
+components:
+  - ../../../../../recipes/modelserver/components/images/gpu-vllm/release
+
+# MultiConnector is provided by this vLLM release.
+images:
+  - name: docker.io/vllm/vllm-openai
+    newTag: v0.27.1
+
+patches:
+  - path: patch-prefill.yaml
+  - path: patch-decode.yaml

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/multi-tier/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/multi-tier/kustomization.yaml
@@ -10,6 +10,8 @@ components:
 images:
   - name: docker.io/vllm/vllm-openai
     newTag: v0.27.1
+  - name: ghcr.io/llm-d/llm-d-router-disagg-sidecar
+    newTag: v0.9.0
 
 patches:
   - path: patch-prefill.yaml

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/multi-tier/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/multi-tier/patch-decode.yaml
@@ -5,6 +5,14 @@ metadata:
 spec:
   template:
     spec:
+      initContainers:
+        - name: routing-proxy
+          args:
+            - "--port=8000"
+            - "--vllm-port=8200"
+            - "--kv-connector=nixlv2"
+            - "--zap-log-level=1"
+            - "--secure-proxy=false"
       containers:
         - name: modelserver
           args:

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/multi-tier/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/multi-tier/patch-decode.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  template:
+    spec:
+      containers:
+        - name: modelserver
+          args:
+            - "openai/gpt-oss-120b"
+            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+            - "--tensor-parallel-size=4"
+            - "--block-size=128"
+            - "--kv-transfer-config"
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_load_failure_policy":"recompute"}'
+            - "--kv-events-config"
+            - '{"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"$(KV_EVENTS_ENDPOINT)","topic":"kv@$(POD_IP):8000@openai/gpt-oss-120b"}'
+            - "--no-disable-hybrid-kv-cache-manager"
+            - "--port=8200"
+          env:
+            - name: PYTHONHASHSEED
+              value: "0"
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: KV_EVENTS_ENDPOINT
+              value: "tcp://*:5556"

--- a/guides/pd-disaggregation/modelserver/gpu/vllm/multi-tier/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/vllm/multi-tier/patch-prefill.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prefill
+spec:
+  template:
+    spec:
+      containers:
+        - name: modelserver
+          args:
+            - "openai/gpt-oss-120b"
+            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+            - "--tensor-parallel-size=1"
+            - "--block-size=128"
+            - "--kv-transfer-config"
+            # NIXL remains the prefill-to-decode transport. OffloadingConnector
+            # extends the prefill cache from HBM to CPU memory.
+            - >-
+              {"kv_connector":"MultiConnector","kv_role":"kv_both",
+              "kv_load_failure_policy":"recompute",
+              "kv_connector_extra_config":{"connectors":[
+              {"kv_connector":"NixlConnector","kv_role":"kv_both"},
+              {"kv_connector":"OffloadingConnector","kv_role":"kv_both",
+              "kv_connector_extra_config":{"cpu_bytes_to_use":107374182400,
+              "eviction_policy":"lru"}}]}}
+            - "--kv-events-config"
+            - '{"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"$(KV_EVENTS_ENDPOINT)","topic":"kv@$(POD_IP):8000@openai/gpt-oss-120b"}'
+            - "--no-disable-hybrid-kv-cache-manager"
+          env:
+            - name: PYTHONHASHSEED
+              value: "0"
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: KV_EVENTS_ENDPOINT
+              value: "tcp://*:5556"
+          resources:
+            limits:
+              cpu: "16"
+              memory: 220Gi
+              nvidia.com/gpu: "1"
+            requests:
+              cpu: "8"
+              memory: 160Gi
+              nvidia.com/gpu: "1"
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 120Gi

--- a/guides/pd-disaggregation/render/multi-tier/kustomization.yaml
+++ b/guides/pd-disaggregation/render/multi-tier/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - service.yaml

--- a/guides/pd-disaggregation/render/multi-tier/service.yaml
+++ b/guides/pd-disaggregation/render/multi-tier/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pd-multi-tier-render
+spec:
+  # vLLM serves /v1/completions/render on each prefill engine.
+  selector:
+    llm-d.ai/guide: pd-disaggregation
+    llm-d.ai/model: gpt-oss-120b
+    llm-d.ai/role: prefill
+  ports:
+    - name: render-http
+      port: 8000
+      targetPort: 8000

--- a/guides/pd-disaggregation/router/pd-multi-tier.values.yaml
+++ b/guides/pd-disaggregation/router/pd-multi-tier.values.yaml
@@ -1,0 +1,82 @@
+router:
+  epp:
+    image:
+      tag: v0.10.0-rc.1
+      pullPolicy: Always
+    pluginsConfigFile: "pd-multi-tier.yaml"
+    pluginsCustomConfig:
+      pd-multi-tier.yaml: |
+        apiVersion: llm-d.ai/v1alpha1
+        kind: EndpointPickerConfig
+        plugins:
+        - type: disagg-headers-handler
+        - type: always-disagg-pd-decider
+        - type: disagg-profile-handler
+          parameters:
+            deciderPluginName: always-disagg-pd-decider
+        - type: prefill-filter
+        - type: decode-filter
+        - type: token-producer
+          parameters:
+            modelName: openai/gpt-oss-120b
+            vllm:
+              url: http://pd-multi-tier-render:8000
+        - type: endpoint-notification-source
+        - type: metrics-data-source
+          parameters:
+            scheme: http
+            path: /metrics
+            insecureSkipVerify: true
+        - type: core-metrics-extractor
+        - type: precise-prefix-cache-producer
+          parameters:
+            indexerConfig:
+              kvBlockIndexConfig:
+                inMemoryConfig:
+                  # 8 prefills x (GPU + CPU) plus 2 GPU-only decoders need 18
+                  # holders per block; leave two entries of headroom.
+                  podCacheSize: 20
+              kvCacheBackendConfigs:
+              - name: gpu
+                weight: 1.0
+              - name: cpu
+                weight: 0.4
+            tokenProcessorConfig:
+              # Must equal the engines' --block-size.
+              blockSizeTokens: 128
+            speculativeIndexing: true
+            kvEventsConfig:
+              topicFilter: "kv@"
+              discoverPods: true
+              podDiscoveryConfig:
+                socketPort: 5556
+        - type: prefix-cache-scorer
+          name: precise-prefix-cache-scorer
+          parameters:
+            prefixMatchInfoProducerName: precise-prefix-cache-producer
+        - type: queue-scorer
+        - type: kv-cache-utilization-scorer
+        - type: active-request-scorer
+        dataLayer:
+          sources:
+          - pluginRef: metrics-data-source
+            extractors:
+            - pluginRef: core-metrics-extractor
+          - pluginRef: endpoint-notification-source
+            extractors:
+            - pluginRef: precise-prefix-cache-producer
+        schedulingProfiles:
+        - name: prefill
+          plugins:
+          - pluginRef: prefill-filter
+          - pluginRef: precise-prefix-cache-scorer
+            weight: 3
+          - pluginRef: queue-scorer
+            weight: 2
+          - pluginRef: kv-cache-utilization-scorer
+            weight: 2
+        - name: decode
+          plugins:
+          - pluginRef: decode-filter
+          - pluginRef: active-request-scorer
+            weight: 2


### PR DESCRIPTION
Add an experimental, CPU-only P/D Multi Tier path that keeps NIXL as the P/D transport while extending prefill KV retention into host memory.

## What

- add base and CoreWeave deployment overlays for `MultiConnector` with NIXL plus CPU offloading on prefills
- add precise CPU-tier indexing through the vLLM render endpoint, with matched 128-token block sizing and deterministic engine hashes
- document per-rank ZMQ binding and subscriber validation for data-parallel deployments
- document per-connector CPU sizing, useful-restore counters, and cleanup
- include controlled GPT-OSS-120B and GLM-5.2-FP8 NIXL-versus-Multi-Tier benchmark reports with single-run limitations
- cover the router values in guide dry-run CI

No model-server filesystem KV tier is configured.

## Validation

- `kustomize build` for the base, CoreWeave, and render overlays
- `helm template` with the current standalone router chart and layered P/D Multi Tier values
- rendered manifest assertions for connector composition, vLLM v0.27.1, block size, hash seed, CPU capacity, and NIXL-only decode
- precise-router assertions for `blockSizeTokens`, CPU backend weight, and ZMQ discovery
- local Markdown link checks and `git diff --check`
- stored benchmark summaries checked against the documented request counts, latency, TTFT, and CPU restore totals

Closes #2297