### PR TITLE
fix: allowlist retuned in typos config

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -7,6 +7,7 @@ IST = "IST"      # Indian Standard Time (used in benchmark timestamps)
 ND = "ND"        # Azure VM SKU prefix (e.g., Standard_ND96asr_v4)
 ahd = "ahd"      # SVG arrowhead marker id in diagram HTML
 mis = "mis"      # intentional hyphenated compounds (mis-gate, mis-price)
+retuned = "retuned"   # re-tuning (adjusting tuning parameters, e.g. maxConcurrency)
 
 [default.extend-identifiers]
 OFO = "OFO"      # TCP OutOfOrder netstat counter (used in a metrics regex)


### PR DESCRIPTION
### Description

`retuned` in guides/flow-control/README.md:221 is a false positive. The sentence refers to re-tuning the values file ("a retuned values file changes the burst with it"), and "retune"/"retuning" is used correctly in several other places (proposals/llm-d-planner.md, autoscaling guide comments). Changing the text to "returned" would be grammatically wrong.

Added `retuned` to `[default.extend-words]` in `_typos.toml`, as the issue instructions suggest for false positives.

Closes #2303
