### PR TITLE
docs: add llm-d router monitoring to remaining well-lit path guides

### DIFF
--- a/guides/fast-model-actuation/README.md
+++ b/guides/fast-model-actuation/README.md
@@ -201,6 +201,11 @@ You should see:
 - FMA controller pods
 - Router/EPP pods
 
+### 6. (Optional) Enable monitoring
+
+- Install the [Monitoring stack](../../docs/operations/observability/setup.md).
+- To enable Prometheus monitoring on the llm-d router, add `-f ${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml` during the [router installation step](#4-deploy-the-llm-d-router).
+
 ## Verification
 
 ### 1. Get the IP of the Router

--- a/guides/modelexpress-p2p/README.md
+++ b/guides/modelexpress-p2p/README.md
@@ -290,6 +290,9 @@ kubectl get modelmetadata -n ${NAMESPACE} \
 
 ### 4. (Optional) Enable monitoring
 
+* Install the [Monitoring stack](../../docs/operations/observability/setup.md).
+* To enable Prometheus monitoring on the llm-d router, add `-f ${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml` during the [router installation step](#2-deploy-the-llm-d-router).
+
 The monitoring kustomize is a `kind: Component`, so you cannot apply it standalone with `kubectl apply -k`. Layer it into your overlay's `kustomization.yaml` instead (same pattern as the [shared-compile-cache component](./compile-cache.md#option-b-shared-rwx-pvc)):
 
 ```yaml

--- a/guides/predicted-latency-routing/README.md
+++ b/guides/predicted-latency-routing/README.md
@@ -191,7 +191,9 @@ kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/optimized-baseline/modelser
 
 ### 3. Enable monitoring (optional)
 
-Follow [optimized-baseline → Enable monitoring](../optimized-baseline/README.md#3-optional-enable-monitoring) — the same steps apply since this guide reuses the same model server manifests.
+- Install the [Monitoring stack](../../docs/operations/observability/setup.md).
+- To enable Prometheus monitoring on the llm-d router, add `-f ${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml` during the [router installation step](#1-deploy-the-llm-d-router).
+- For model server monitoring, follow [optimized-baseline → Enable monitoring](../optimized-baseline/README.md#3-optional-enable-monitoring) — the same steps apply since this guide reuses the same model server manifests.
 
 ## Send Requests
 


### PR DESCRIPTION
### What this PR does / why we need it
Completes #1777 by adding the llm-d router Prometheus monitoring reference to the last three well-lit path guides that were missing it, following the pattern established in #1916 (and the optional-monitoring convention from #2138).

### Changes
- `guides/predicted-latency-routing/README.md` — added the router monitoring bullet to the "Enable monitoring (optional)" section
- `guides/modelexpress-p2p/README.md` — added the router monitoring bullet to the "Enable monitoring (optional)" section
- `guides/fast-model-actuation/README.md` — added a new "Enable monitoring (optional)" section (router + monitoring stack)

All changes reference the existing `guides/recipes/router/features/monitoring.values.yaml` file — no new charts, manifests, or configs are introduced.

### Testing
- `markdownlint` passes on all changed lines
- Anchor links verified against existing guide headings

### Related Issue
Fixes #1777