### PR TITLE
Cover prometheus-operated in the Prometheus serving certificate

### DIFF
--- a/guides/recipes/observability/generate-prometheus-tls-certs.sh
+++ b/guides/recipes/observability/generate-prometheus-tls-certs.sh
@@ -101,9 +101,12 @@ generate_certificates() {
   mkdir -p "${CERT_DIR}"
   cd "${CERT_DIR}"
 
-  # Define the Prometheus service DNS names
+  # Define the Prometheus service DNS names. Both the chart's Service and the
+  # operator-managed headless Service are covered: guides address Prometheus by
+  # either name, and WVA's controller verifies the hostname against this cert.
   PROMETHEUS_SVC="${RELEASE_NAME}-kube-prometheus-stack-prometheus"
-  DNS_NAMES="DNS.1:${PROMETHEUS_SVC}.${MONITORING_NAMESPACE}.svc,DNS.2:${PROMETHEUS_SVC}.${MONITORING_NAMESPACE}.svc.cluster.local,DNS.3:localhost"
+  PROMETHEUS_OPERATED_SVC="prometheus-operated"
+  DNS_NAMES="DNS.1:${PROMETHEUS_SVC}.${MONITORING_NAMESPACE}.svc,DNS.2:${PROMETHEUS_SVC}.${MONITORING_NAMESPACE}.svc.cluster.local,DNS.3:${PROMETHEUS_OPERATED_SVC}.${MONITORING_NAMESPACE}.svc,DNS.4:${PROMETHEUS_OPERATED_SVC}.${MONITORING_NAMESPACE}.svc.cluster.local,DNS.5:localhost"
 
   log_info "📝 Certificate will be valid for: ${DNS_NAMES}"
 
@@ -130,7 +133,9 @@ subjectAltName = @alt_names
 [alt_names]
 DNS.1 = ${PROMETHEUS_SVC}.${MONITORING_NAMESPACE}.svc
 DNS.2 = ${PROMETHEUS_SVC}.${MONITORING_NAMESPACE}.svc.cluster.local
-DNS.3 = localhost
+DNS.3 = ${PROMETHEUS_OPERATED_SVC}.${MONITORING_NAMESPACE}.svc
+DNS.4 = ${PROMETHEUS_OPERATED_SVC}.${MONITORING_NAMESPACE}.svc.cluster.local
+DNS.5 = localhost
 IP.1 = 127.0.0.1
 
 [v3_ext]


### PR DESCRIPTION
## Summary

`generate-prometheus-tls-certs.sh` issues a certificate naming only `<release>-kube-prometheus-stack-prometheus.<ns>.svc[.cluster.local]` and `localhost`. The workload-autoscaling guide, however, addresses Prometheus as `prometheus-operated.<ns>.svc` - in the WVA controller's k8s platform patch and in the shipped KEDA trigger's `serverAddress`. That name is absent from the SANs, so hostname verification against it cannot succeed.

This adds `prometheus-operated.<ns>.svc` and `.svc.cluster.local` to the SAN list. No other behaviour changes.

## Why it matters

The CA is mounted into the WVA controller precisely so the Prometheus connection *can* be verified, and as issued that verification is impossible. It is masked today rather than fatal - the controller ships `PROMETHEUS_TLS_INSECURE_SKIP_VERIFY: "true"` and the KEDA trigger sets `unsafeSsl: "true"` - so anyone tightening either setting hits a hard failure that looks like a cluster problem rather than a certificate one.

This affects every platform that uses the generator, not one accelerator.

## Test plan

Verified on a TLS-enabled `kube-prometheus-stack` install (chart 88.3.0, operator v0.93.0) on Kubernetes.

Before, against `prometheus-operated.llm-d-monitoring.svc`:

```
verify error:num=62:hostname mismatch
curl: (60) SSL: no alternative certificate subject name matches target host name
```

The stack Service name verified cleanly in the same run, confirming the CA and the serving certificate were otherwise healthy.

After regenerating with this change and restarting the Prometheus pod, all three names verify against the CA and return HTTP 200:

- `prometheus-operated.llm-d-monitoring.svc`
- `prometheus-operated.llm-d-monitoring.svc.cluster.local`
- `llmd-kube-prometheus-stack-prometheus.llm-d-monitoring.svc`

Prometheus continued scraping across the rotation (34 targets up).
