### PR TITLE
Match llm-d.ai/model-id to the served model name

### DIFF
--- a/guides/workload-autoscaling/wva/optimized-baseline/hpa/hpa.yaml
+++ b/guides/workload-autoscaling/wva/optimized-baseline/hpa/hpa.yaml
@@ -8,7 +8,9 @@ metadata:
     llm-d.ai/guide: "optimized-baseline"
   annotations:
     llm-d.ai/managed: "true"
-    llm-d.ai/model-id: "Qwen3-32B"
+    # The served model name vLLM labels its metrics with — see the note in
+    # ../keda/base/wva-scaledobject.yaml.
+    llm-d.ai/model-id: "Qwen/Qwen3-32B"
     llm-d.ai/variant-cost: "30.0"
 spec:
   scaleTargetRef:

--- a/guides/workload-autoscaling/wva/optimized-baseline/keda/base/wva-scaledobject.yaml
+++ b/guides/workload-autoscaling/wva/optimized-baseline/keda/base/wva-scaledobject.yaml
@@ -18,7 +18,12 @@ metadata:
   name: optimized-baseline-nvidia-gpu-vllm-decode-scaler
   annotations:
     llm-d.ai/managed: "true"
-    llm-d.ai/model-id: "Qwen3-32B"
+    # Must match the name vLLM labels its metrics with, which is the served model
+    # name — the guide launches `vllm serve Qwen/Qwen3-32B` with no
+    # --served-model-name, so it is the full repo id. WVA's saturation queries
+    # match `model_name` exactly: shorten this and every query returns no series,
+    # and WVA reports "No saturation metrics available" while still looking healthy.
+    llm-d.ai/model-id: "Qwen/Qwen3-32B"
     llm-d.ai/variant-cost: "30.0"
   labels:
     # WVA copies these labels onto the variant it derives from this object; the


### PR DESCRIPTION
## Summary

The WVA guide annotates its ScaledObject and HPA with `llm-d.ai/model-id: "Qwen3-32B"`, but the model server it ships runs `vllm serve Qwen/Qwen3-32B` with no `--served-model-name`, so vLLM labels its metrics `model_name="Qwen/Qwen3-32B"`. WVA matches that label exactly, so every saturation query returns zero series.

This corrects the annotation in both autoscaling paths to the served model name.

## Why it matters

The failure mode is silent and looks entirely healthy. WVA logs:

```
No saturation metrics available for model, skipping analysis {"modelID": "Qwen3-32B", ...}
Optimization completed successfully {"mode": "saturation", "modelsProcessed": 1, "decisionsApplied": 0}
```

It then publishes `wva_desired_replicas` equal to the *current* replica count, so KEDA consumes a real series and never falls back. The ScaledObject reports `Ready=True`, `Active=True`, `Fallback=False`, the HPA tracks its target, and the stack passes every health check — while the autoscaler is inert and the replica count only ever echoes itself.

Because `Fallback=False` holds either way, the usual smoke test cannot distinguish a working autoscaler from this one.

## Test plan

Verified end to end on a MI355X cluster running the guide's own stack (2 replicas, TP2, KEDA 2.20.1, kube-prometheus-stack over TLS).

With the shipped annotation, across every 15 s optimization cycle:

```
Processing model (V2)  {"modelID": "Qwen3-32B", ...}
No saturation metrics available for model, skipping analysis
EmitReplicaMetrics completed  {"currentReplicas": 2, "desiredReplicas": 2, ...}
```

Correcting only this annotation, with nothing else changed:

```
Processing model (V2)  {"modelID": "Qwen/Qwen3-32B", ...}
EmitReplicaMetrics completed  {"currentReplicas": 2, "desiredReplicas": 1, "accelerator": "MI355X"}
Optimization completed successfully  {"mode": "saturation", "modelsProcessed": 1, "decisionsApplied": 1}
```

`desiredReplicas: 1` against 2 running is the correct call for an idle deployment, and the HPA target moved to `500m/1 (avg)` accordingly.

Queried directly against Prometheus, `Qwen3-32B` returns 0 series and `Qwen/Qwen3-32B` returns the live `vllm:` series the saturation thresholds read.

## Note

Reaching real decisions also requires the `vllm:` series to exist at all, and neither optimized-baseline model server base includes `recipes/modelserver/components/monitoring`. That is a separate gap and I will open an issue for it; this change is necessary regardless, since correcting the scrape alone still leaves every query unmatched.
