### PR TITLE
fix(xpu): restore Wide EP routing sidecar image

### DIFF
--- a/guides/wide-ep-lws/modelserver/xpu/vllm/decode.yaml
+++ b/guides/wide-ep-lws/modelserver/xpu/vllm/decode.yaml
@@ -35,6 +35,7 @@ spec:
               - --zap-log-level=1
               - --secure-proxy=false
               - --enable-prefiller-sampling
+            image: REPLACE_ROUTING_SIDECAR_IMAGE
             imagePullPolicy: Always
             ports:
               - containerPort: 8000


### PR DESCRIPTION
Restore the missing routing proxy image placeholder in the Wide EP XPU decode manifest.

https://github.com/llm-d/llm-d/pull/2260/changes#diff-86f8d6fdaba732aa683910242c82096f9bcc5ae04d613d8ce44bbbd6c44a2727L38

Without an image, the LeaderWorkerSet could not create the decode pod, causing the nightly CI smoke test to fail with `No decode pods found`.

Failed run: https://github.com/llm-d/llm-d/actions/runs/32205009652