### PR TITLE
docs: migrate deprecated plugin and config

### DIFF
--- a/guides/agentic-serving/router/agentic-serving-gpu.values.yaml
+++ b/guides/agentic-serving/router/agentic-serving-gpu.values.yaml
@@ -21,11 +21,11 @@ router:
         apiVersion: llm-d.ai/v1alpha1
         kind: EndpointPickerConfig
         plugins:
-        - type: disagg-headers-handler
         - type: always-disagg-pd-decider
         - type: disagg-profile-handler
           parameters:
-            deciderPluginName: always-disagg-pd-decider
+            deciders:
+              prefill: always-disagg-pd-decider
         - type: prefill-filter
         - type: decode-filter
         - type: approx-prefix-cache-producer

--- a/guides/agentic-serving/router/agentic-serving-tpu-disagg.values.yaml
+++ b/guides/agentic-serving/router/agentic-serving-tpu-disagg.values.yaml
@@ -21,11 +21,11 @@ router:
         apiVersion: llm-d.ai/v1alpha1
         kind: EndpointPickerConfig
         plugins:
-        - type: disagg-headers-handler
         - type: always-disagg-pd-decider
         - type: disagg-profile-handler
           parameters:
-            deciderPluginName: always-disagg-pd-decider
+            deciders:
+              prefill: always-disagg-pd-decider
         - type: prefill-filter
         - type: decode-filter
         - type: approx-prefix-cache-producer

--- a/guides/multimodal-serving/e-disaggregation/router/vllm/e-p-d-disaggregation.values.yaml
+++ b/guides/multimodal-serving/e-disaggregation/router/vllm/e-p-d-disaggregation.values.yaml
@@ -20,7 +20,6 @@ router:
         # concurrent in-flight requests, not prefill throughput. Encode is
         # unchanged.
         plugins:
-        - type: disagg-headers-handler
         - type: always-disagg-multimodal-decider
         - type: always-disagg-pd-decider
         - type: disagg-profile-handler

--- a/guides/multimodal-serving/e-disaggregation/router/vllm/e-pd-disaggregation.values.yaml
+++ b/guides/multimodal-serving/e-disaggregation/router/vllm/e-pd-disaggregation.values.yaml
@@ -18,7 +18,6 @@ router:
         # token-producer stays in the pipeline — the scorer needs per-request token
         # counts, and image inputs have no text length to read. Encode is unchanged.
         plugins:
-        - type: disagg-headers-handler
         - type: always-disagg-multimodal-decider
         - type: disagg-profile-handler
           parameters:

--- a/guides/p2p-kv-cache-sharing/benchmarking/epp-glm-c64-approx-p2p.yaml
+++ b/guides/p2p-kv-cache-sharing/benchmarking/epp-glm-c64-approx-p2p.yaml
@@ -2,11 +2,11 @@
 apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
-  - type: disagg-headers-handler
   - type: always-disagg-pd-decider
   - type: disagg-profile-handler
     parameters:
-      deciderPluginName: always-disagg-pd-decider
+      deciders:
+        prefill: always-disagg-pd-decider
   - type: prefill-filter
   - type: decode-filter
   - name: gpu-prefix-cache-producer

--- a/guides/p2p-kv-cache-sharing/benchmarking/epp-glm-c64-approx.yaml
+++ b/guides/p2p-kv-cache-sharing/benchmarking/epp-glm-c64-approx.yaml
@@ -2,11 +2,11 @@
 apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
-  - type: disagg-headers-handler
   - type: always-disagg-pd-decider
   - type: disagg-profile-handler
     parameters:
-      deciderPluginName: always-disagg-pd-decider
+      deciders:
+        prefill: always-disagg-pd-decider
   - type: prefill-filter
   - type: decode-filter
   - type: approx-prefix-cache-producer

--- a/guides/p2p-kv-cache-sharing/benchmarking/epp-glm-c64-precise-p2p.yaml
+++ b/guides/p2p-kv-cache-sharing/benchmarking/epp-glm-c64-precise-p2p.yaml
@@ -5,11 +5,11 @@
 apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
-  - type: disagg-headers-handler
   - type: always-disagg-pd-decider
   - type: disagg-profile-handler
     parameters:
-      deciderPluginName: always-disagg-pd-decider
+      deciders:
+        prefill: always-disagg-pd-decider
   - type: prefill-filter
   - type: decode-filter
   - type: token-producer

--- a/guides/p2p-kv-cache-sharing/benchmarking/epp-glm-c64-precise.yaml
+++ b/guides/p2p-kv-cache-sharing/benchmarking/epp-glm-c64-precise.yaml
@@ -5,11 +5,11 @@
 apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
-  - type: disagg-headers-handler
   - type: always-disagg-pd-decider
   - type: disagg-profile-handler
     parameters:
-      deciderPluginName: always-disagg-pd-decider
+      deciders:
+        prefill: always-disagg-pd-decider
   - type: prefill-filter
   - type: decode-filter
   - type: token-producer

--- a/guides/p2p-kv-cache-sharing/benchmarking/epp-glm-loadfirst-p2p.yaml
+++ b/guides/p2p-kv-cache-sharing/benchmarking/epp-glm-loadfirst-p2p.yaml
@@ -1,11 +1,11 @@
 apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
-- type: disagg-headers-handler
 - type: always-disagg-pd-decider
 - type: disagg-profile-handler
   parameters:
-    deciderPluginName: always-disagg-pd-decider
+    deciders:
+      prefill: always-disagg-pd-decider
 - type: prefill-filter
 - type: decode-filter
 - type: token-producer

--- a/guides/p2p-kv-cache-sharing/benchmarking/epp-glm-loadfirst.yaml
+++ b/guides/p2p-kv-cache-sharing/benchmarking/epp-glm-loadfirst.yaml
@@ -1,11 +1,11 @@
 apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
-- type: disagg-headers-handler
 - type: always-disagg-pd-decider
 - type: disagg-profile-handler
   parameters:
-    deciderPluginName: always-disagg-pd-decider
+    deciders:
+      prefill: always-disagg-pd-decider
 - type: prefill-filter
 - type: decode-filter
 - type: token-producer

--- a/guides/p2p-kv-cache-sharing/benchmarking/epp-glm-precise-p2p.yaml
+++ b/guides/p2p-kv-cache-sharing/benchmarking/epp-glm-precise-p2p.yaml
@@ -6,11 +6,11 @@
 apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
-- type: disagg-headers-handler
 - type: always-disagg-pd-decider
 - type: disagg-profile-handler
   parameters:
-    deciderPluginName: always-disagg-pd-decider
+    deciders:
+      prefill: always-disagg-pd-decider
 - type: prefill-filter
 - type: decode-filter
 - type: token-producer

--- a/guides/p2p-kv-cache-sharing/benchmarking/epp-glm-precise.yaml
+++ b/guides/p2p-kv-cache-sharing/benchmarking/epp-glm-precise.yaml
@@ -5,11 +5,11 @@
 apiVersion: llm-d.ai/v1alpha1
 kind: EndpointPickerConfig
 plugins:
-- type: disagg-headers-handler
 - type: always-disagg-pd-decider
 - type: disagg-profile-handler
   parameters:
-    deciderPluginName: always-disagg-pd-decider
+    deciders:
+      prefill: always-disagg-pd-decider
 - type: prefill-filter
 - type: decode-filter
 - type: token-producer

--- a/guides/pd-disaggregation/router/pd-disaggregation.values.yaml
+++ b/guides/pd-disaggregation/router/pd-disaggregation.values.yaml
@@ -17,11 +17,11 @@ router:
         apiVersion: llm-d.ai/v1alpha1
         kind: EndpointPickerConfig
         plugins:
-        - type: disagg-headers-handler
         - type: always-disagg-pd-decider
         - type: disagg-profile-handler
           parameters:
-            deciderPluginName: always-disagg-pd-decider
+            deciders:
+              prefill: always-disagg-pd-decider
         - type: prefill-filter
         - type: decode-filter
         - type: approx-prefix-cache-producer

--- a/guides/predicted-latency-routing/router/predicted-latency-pd.values.yaml
+++ b/guides/predicted-latency-routing/router/predicted-latency-pd.values.yaml
@@ -22,11 +22,11 @@ router:
         apiVersion: llm-d.ai/v1alpha1
         kind: EndpointPickerConfig
         plugins:
-        - type: disagg-headers-handler
         - type: always-disagg-pd-decider
         - type: disagg-profile-handler
           parameters:
-            deciderPluginName: always-disagg-pd-decider
+            deciders:
+              prefill: always-disagg-pd-decider
         - type: prefill-filter
         - type: decode-filter
         - type: approx-prefix-cache-producer

--- a/guides/wide-ep-lws/router/glm-5.2-overrides.values.yaml
+++ b/guides/wide-ep-lws/router/glm-5.2-overrides.values.yaml
@@ -9,11 +9,11 @@ router:
         apiVersion: llm-d.ai/v1alpha1
         kind: EndpointPickerConfig
         plugins:
-        - type: disagg-headers-handler
         - type: always-disagg-pd-decider
         - type: disagg-profile-handler
           parameters:
-            deciderPluginName: always-disagg-pd-decider
+            deciders:
+              prefill: always-disagg-pd-decider
         - type: prefill-filter
         - type: decode-filter
         - type: approx-prefix-cache-producer

--- a/guides/wide-ep-lws/router/precise-routing.values.yaml
+++ b/guides/wide-ep-lws/router/precise-routing.values.yaml
@@ -21,11 +21,11 @@ router:
         apiVersion: llm-d.ai/v1alpha1
         kind: EndpointPickerConfig
         plugins:
-        - type: disagg-headers-handler
         - type: always-disagg-pd-decider
         - type: disagg-profile-handler
           parameters:
-            deciderPluginName: always-disagg-pd-decider
+            deciders:
+              prefill: always-disagg-pd-decider
         - type: prefill-filter
         - type: decode-filter
         - type: token-producer

--- a/guides/wide-ep-lws/router/wide-ep-lws.values.yaml
+++ b/guides/wide-ep-lws/router/wide-ep-lws.values.yaml
@@ -12,11 +12,11 @@ router:
         apiVersion: llm-d.ai/v1alpha1
         kind: EndpointPickerConfig
         plugins:
-        - type: disagg-headers-handler
         - type: always-disagg-pd-decider
         - type: disagg-profile-handler
           parameters:
-            deciderPluginName: always-disagg-pd-decider
+            deciders:
+              prefill: always-disagg-pd-decider
         - type: prefill-filter
         - type: decode-filter
         - type: prefix-cache-scorer


### PR DESCRIPTION
# Notes
- from `deciderPluginName` to `deciders.prefill`
- remove `disagg-header-handler `as it is already native support in `disagg-profile-handler`

cc @roytman 