### PR TITLE
docs(router): drop monitoring values from the agentgateway install command

### DIFF
--- a/guides/recipes/router/README.md
+++ b/guides/recipes/router/README.md
@@ -44,7 +44,6 @@ agentgateway can be used as the sidecar proxy in place of Envoy. In this mode ag
 helm install <release-name> \
   ${ROUTER_STANDALONE_CHART} \
   -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
-  -f ${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml \
   -f ${REPO_ROOT}/guides/recipes/router/features/agentgateway-proxy.values.yaml \
   -f ${REPO_ROOT}/guides/<your-guide>/router/<your-guide>.values.yaml \
   --set router.proxy.proxyType=agentgateway \
@@ -95,6 +94,14 @@ helm upgrade <release-name> \
   -n ${NAMESPACE} \
   --version ${ROUTER_CHART_VERSION}
 ```
+
+> [!NOTE]
+> `helm upgrade` does not inherit the previous release's values. Re-supply every `-f` and
+> `--set` the original install used, or the upgrade reverts them to chart defaults. For an
+> agentgateway release that means adding
+> `-f ${REPO_ROOT}/guides/recipes/router/features/agentgateway-proxy.values.yaml` and the
+> `router.proxy.proxyType`, `router.inferencePool.create` and
+> `router.epp.flags.secure-serving` flags to the command above.
 
 If your cluster already has the Prometheus Operator CRDs installed, you can also add
 `-f ${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml` to the initial


### PR DESCRIPTION
Follow-up to #2134 / #2138. Fixes #2322.

`guides/recipes/router/README.md` has three `helm install` commands. #2138 removed
`features/monitoring.values.yaml` from **Standalone with Envoy** and **With Kubernetes
Gateway API**, and missed the third — **Standalone with agentgateway** — which still
carried it. That block already had the flag at `709a67e2^` (added in #1719), so this is
a miss rather than a later regression.

## Why it still failed

Nothing in the agentgateway path suppresses the `ServiceMonitor`:
`features/agentgateway-proxy.values.yaml` only overrides `router.proxy.args`, and
`features/monitoring.values.yaml` still sets `router.monitoring.prometheus.enabled: true`.

Rendering the documented command against the published chart, before this change:

```
$ helm template test oci://ghcr.io/llm-d/charts/llm-d-router-standalone --version v0 \
    -f base.values.yaml -f monitoring.values.yaml -f agentgateway-proxy.values.yaml \
    --set router.proxy.proxyType=agentgateway \
    --set router.inferencePool.create=false \
    --set router.epp.flags.secure-serving=false \
    --set router.modelServers.matchLabels.app=demo -n testns | grep -E '^kind:|^apiVersion: monitoring'

apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
```

So on a cluster without the Prometheus Operator CRDs the whole install aborts with the
`no matches for kind "ServiceMonitor"` error from #2134. After this change the same
render emits no `ServiceMonitor`.

## Second change

The **Enable Prometheus Monitoring (Optional)** section tells the reader to layer
monitoring onto an existing release with `helm upgrade`, but its command carries neither
`agentgateway-proxy.values.yaml` nor the three `--set` flags. Since `helm upgrade` does
not inherit the previous release's values, an agentgateway user following it would revert
their proxy configuration to chart defaults. Removing the flag from the install command
without saying this would just move the trap, so I added a `NOTE` to that section.

## Not addressed here

The agentgateway command also cannot be templated as written:

```
Error: execution error at (llm-d-router-standalone/templates/epp.yaml:2:3):
.Values.router.modelServers.matchLabels is required when
.Values.router.inferencePool.create=false
```

`router.inferencePool.create=false` is required for agentgateway (the README's own `NOTE`
says so), and the chart then requires `router.modelServers.matchLabels`, which neither the
command nor the surrounding text mentions. Presumably it is meant to come from
`<your-guide>.values.yaml`, but that is not stated. Left out to keep this reviewable —
happy to fold it in or file it separately.
