### PR TITLE
parrent workflow calls must have permission to write ID tokens

### DIFF
--- a/.github/workflows/ci-pr-test.yaml
+++ b/.github/workflows/ci-pr-test.yaml
@@ -22,6 +22,7 @@ permissions:
   contents: read
   packages: write
   security-events: write
+  id-token: write
 
 concurrency:
   group: ci-pr-test-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/nightly-build-image.yaml
+++ b/.github/workflows/nightly-build-image.yaml
@@ -27,6 +27,7 @@ permissions:
   contents: read
   packages: write
   security-events: write
+  id-token: write
 
 concurrency:
   group: nightly-build-image-${{ github.ref }}


### PR DESCRIPTION
cc @llm-d/release-crew 

Failed run ref: https://github.com/llm-d/llm-d/actions/runs/32269019887

issue - workflow calls inherit permissions from their parents. So the workflow that gets called cannot have a more permissions than the base