### PR TITLE
docs(optimized-baseline): fix helm values -f pattern in guide.yaml, the render source

### DIFF
--- a/guides/optimized-baseline/README.md
+++ b/guides/optimized-baseline/README.md
@@ -88,7 +88,6 @@ export BENCHMARK_REF=main
 export HARNESS=inference-perf
 export WORKLOAD=guide_optimized-baseline_1.yaml
 export GATEWAY_CLASS=epponly # options: epponly, gke, agentgateway, istio
-export ROUTER_CHART_VERSION=v0 # options are any semver llm-d-router release of v0 for latest
 ```
 <!-- guide:env.static end -->
 
@@ -107,7 +106,9 @@ source ${REPO_ROOT}/guides/env.sh
 > [!NOTE]
 > This file defines shared variables required by subsequent steps, including
 > `GAIE_VERSION`, `ROUTER_CHART_VERSION`, and the router chart reference for
-> the selected deployment mode.
+> the selected deployment mode. `env.sh` always sets `ROUTER_CHART_VERSION=v0`
+> (the floating release channel); to pin a specific llm-d-router chart release,
+> re-export the variable after sourcing.
 
 - Install the Gateway API Inference Extension CRDs:
 
@@ -146,16 +147,17 @@ kubectl create secret generic llm-d-hf-token \
 
 <!-- guide:deploy.router_values start -->
 ```bash
-export ROUTER_BASE_VALUES="-f ${REPO_ROOT}/guides/recipes/router/base.values.yaml"
+# Paths to values files
+export ROUTER_BASE_VALUES="${REPO_ROOT}/guides/recipes/router/base.values.yaml"
 
 # only when MODEL_SERVER=vllm or sglang:
-export ROUTER_VALUES="-f ${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml"
+export ROUTER_VALUES="${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml"
 
 # only when MODEL_SERVER=trtllm:
 #
 # Comment out the above `ROUTER_VALUES` and uncomment the below for TensorRT-LLM (trtllm-serve)
 #
-# export ROUTER_VALUES="-f ${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}-trtllm.values.yaml"
+# export ROUTER_VALUES="${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}-trtllm.values.yaml"
 ```
 <!-- guide:deploy.router_values end -->
 
@@ -169,6 +171,9 @@ export ROUTER_VALUES="-f ${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.
 ```bash
 #
 # Uncomment the below to enable Prometheus monitoring on the llm-d router
+#
+# Unlike the ROUTER_*_VALUES paths above, this variable carries its own
+# -f flag: it is empty by default, so the helm commands expand it as-is.
 #
 # export MONITORING_VALUES="-f ${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml"
 ```
@@ -198,9 +203,9 @@ This deploys the llm-d Router in [Standalone Mode](../../docs/architecture/core/
 # Assuming base-directory is the root of the llm-d repo
 helm install ${GUIDE_NAME} \
   ${ROUTER_STANDALONE_CHART} \
-  ${ROUTER_BASE_VALUES} \
+  -f ${ROUTER_BASE_VALUES} \
   ${MONITORING_VALUES} \
-  ${ROUTER_VALUES} \
+  -f ${ROUTER_VALUES:?run the ROUTER_VALUES export from the router values step first} \
   -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
 ```
 <!-- guide:deploy.standalone end -->
@@ -217,14 +222,16 @@ To use a Kubernetes Gateway managed proxy rather than the standalone version, fo
 
 > [!IMPORTANT]
 > Before running the command below, execute the path setup commands from the previous section: the `export ROUTER_BASE_VALUES=...` and `export ROUTER_VALUES=...` commands above.
+>
+> Also set `PROVIDER_NAME` to the gateway provider you deployed in step 1 (e.g. `gke`, `istio`). The default, `none`, renders no provider-specific resources — on GKE that means no `HealthCheckPolicy`, so the Gateway marks the backends unhealthy and requests fail with 503s.
 
 <!-- guide:deploy.gateway start -->
 ```bash
 helm install ${GUIDE_NAME} \
   ${ROUTER_GATEWAY_CHART} \
-  ${ROUTER_BASE_VALUES} \
+  -f ${ROUTER_BASE_VALUES} \
   ${MONITORING_VALUES} \
-  ${ROUTER_VALUES} \
+  -f ${ROUTER_VALUES:?run the ROUTER_VALUES export from the router values step first} \
   --set provider.name=${PROVIDER_NAME} \
   --set httpRoute.create=true \
   --set httpRoute.inferenceGatewayName=llm-d-inference-gateway \

--- a/guides/optimized-baseline/guide.yaml
+++ b/guides/optimized-baseline/guide.yaml
@@ -15,7 +15,7 @@ env:
 
     MONITORING_VALUES: {default: ""}
 
-    PROVIDER_NAME: {default: gke, values: [none, gke, agentgateway, istio]}
+    PROVIDER_NAME: {default: none, values: [none, gke, agentgateway, istio]}
     ACCELERATOR_TYPE: {default: gpu, values: [gpu, amd, xpu, hpu, "tpu/v6", "tpu/v7", cpu]}
     MODEL_SERVER: {default: vllm, values: [vllm, sglang, trtllm]}
     INFRA_PROVIDER: {default: base, values: [base, gke]}
@@ -54,22 +54,27 @@ prerequisites:
 deploy:
 
   router_values:
-    - run: export ROUTER_BASE_VALUES="-f ${REPO_ROOT}/guides/recipes/router/base.values.yaml"
+    - run: |
+        # Paths to values files
+        export ROUTER_BASE_VALUES="${REPO_ROOT}/guides/recipes/router/base.values.yaml"
 
     - when: {MODEL_SERVER: [vllm, sglang]}
-      run: export ROUTER_VALUES="-f ${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml"
+      run: export ROUTER_VALUES="${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml"
 
     - when: {MODEL_SERVER: [trtllm]}
       run: |
         #
         # Comment out the above `ROUTER_VALUES` and uncomment the below for TensorRT-LLM (trtllm-serve)
         #
-        # export ROUTER_VALUES="-f ${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}-trtllm.values.yaml"
+        # export ROUTER_VALUES="${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}-trtllm.values.yaml"
 
   monitoring_values:
     - run: |
         #
         # Uncomment the below to enable Prometheus monitoring on the llm-d router
+        #
+        # Unlike the ROUTER_*_VALUES paths above, this variable carries its own
+        # -f flag: it is empty by default, so the helm commands expand it as-is.
         #
         # export MONITORING_VALUES="-f ${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml"
 
@@ -78,18 +83,18 @@ deploy:
         # Assuming base-directory is the root of the llm-d repo
         helm install ${GUIDE_NAME} \
           ${ROUTER_STANDALONE_CHART} \
-          ${ROUTER_BASE_VALUES} \
+          -f ${ROUTER_BASE_VALUES} \
           ${MONITORING_VALUES} \
-          ${ROUTER_VALUES} \
+          -f ${ROUTER_VALUES:?run the ROUTER_VALUES export from the router values step first} \
           -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
 
   gateway:
     - run: |
         helm install ${GUIDE_NAME} \
           ${ROUTER_GATEWAY_CHART} \
-          ${ROUTER_BASE_VALUES} \
+          -f ${ROUTER_BASE_VALUES} \
           ${MONITORING_VALUES} \
-          ${ROUTER_VALUES} \
+          -f ${ROUTER_VALUES:?run the ROUTER_VALUES export from the router values step first} \
           --set provider.name=${PROVIDER_NAME} \
           --set httpRoute.create=true \
           --set httpRoute.inferenceGatewayName=llm-d-inference-gateway \

--- a/guides/templates/README.md
+++ b/guides/templates/README.md
@@ -75,7 +75,7 @@ Valid marker targets in the current schema (with live examples from optimized-ba
 | `env.static` | `env: static:` — rendered as `export VAR=…` lines |
 | `env.source` | `env: source:` — rendered as `source <path>` lines |
 | `prerequisites.<sub-group>` | `prerequisites:` — optimized-baseline uses `clone`, `gaie`, `namespace`, `secrets` |
-| `deploy.<sub-group>` | `deploy:` — optimized-baseline uses `values`, `standalone`, `gateway`, `modelserver`, `monitoring` |
+| `deploy.<sub-group>` | `deploy:` — optimized-baseline uses `router_values`, `monitoring_values`, `standalone`, `gateway`, `modelserver`, `monitoring` |
 | `verify.endpoint.<mode>` | one entry per mode (`standalone`, `gateway`) |
 | `verify.tests` | `verify: tests:` |
 | `benchmark.setup` / `benchmark.endpoint.<mode>` / `benchmark.execute` | (optional section) |
@@ -99,9 +99,9 @@ Concrete example — how the `helm install` block in optimized-baseline got conv
 ```bash
 helm install ${GUIDE_NAME} \
   ${ROUTER_STANDALONE_CHART} \
-  ${ROUTER_BASE_VALUES} \
+  -f ${ROUTER_BASE_VALUES} \
   ${MONITORING_VALUES} \
-  ${ROUTER_VALUES} \
+  -f ${ROUTER_VALUES} \
   -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
 ```
 ````
@@ -114,9 +114,9 @@ deploy:
     - run: |
         helm install ${GUIDE_NAME} \
           ${ROUTER_STANDALONE_CHART} \
-          ${ROUTER_BASE_VALUES} \
+          -f ${ROUTER_BASE_VALUES} \
           ${MONITORING_VALUES} \
-          ${ROUTER_VALUES} \
+          -f ${ROUTER_VALUES} \
           -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
 ```
 


### PR DESCRIPTION
Fixes #2176

PR #2177 fixed the broken `-f`-in-variable helm pattern in the optimized-baseline README, but `guide.yaml`, the source the README marker blocks are rendered from, kept the old pattern. The #2243 re-render reverted the merged fix. On `main` today, `guide.py render --check` fails for optimized-baseline, and the README contradicts itself: the prose from #2177 says the variables hold paths while the rendered code block embeds the `-f` flag.

Changes:

- `ROUTER_BASE_VALUES` and `ROUTER_VALUES` hold paths only, and `-f` is inlined in the helm commands, matching #2177.
- The `ROUTER_VALUES` expansion uses `${ROUTER_VALUES:?...}`. When the export is skipped (the trtllm variant ships commented out), helm previously received a bare `-f` that consumed the next flag and failed with `open -n: no such file or directory`. The guard fails at expansion with a message naming the missing step.
- `MONITORING_VALUES` keeps its embedded `-f` because the variable is optional and empty by default; a comment in `guide.yaml` records the reason.
- `PROVIDER_NAME` defaults to `none` in `guide.yaml`, adopting the README edit from #2260 that the renderer would otherwise discard. The Gateway Mode section now instructs users to set the variable to their deployed provider, because `none` renders no provider-specific resources; on GKE that omits the `HealthCheckPolicy`, the default HTTP health check fails against vLLM, and requests return 503.
- The hand-added `export ROUTER_CHART_VERSION=v0` line from #2260 is dropped. It preceded `source guides/env.sh`, which re-exports `ROUTER_CHART_VERSION` unconditionally, so the override never took effect. The env.sh note now documents pinning that works: re-export after sourcing.
- `guides/templates/README.md` is updated: the worked example showed the old flag-in-var helm block, and the marker-target table listed a `deploy.values` sub-group that does not exist (`router_values` and `monitoring_values` are the actual names).

Verification: `guide.py render --check` and `guide.py check` pass, and rendering is idempotent.

Follow-ups filed separately rather than included:

- CI does not run `guide.py render --check`, which is how #2243 reverted #2177 and how the #2260 drift landed unnoticed. #2044 (extracting guide rendering into `scripts/render.sh`) is a reasonable place to add the gate.
- `guides/modelexpress-p2p/guide.yaml` still defaults `PROVIDER_NAME=gke` with an identical gateway install, so the two guides document different defaults for the same variable.
- `PROVIDER_NAME=agentgateway` is accepted but the gateway chart renders nothing for it, with no validation error.
