### PR TITLE
docs: drop the InternalRequest envelope from the Pub/Sub quickstart payload

### DIFF
--- a/guides/batch-serving/asynchronous-processing/gcp-pubsub/README.md
+++ b/guides/batch-serving/asynchronous-processing/gcp-pubsub/README.md
@@ -76,13 +76,13 @@ For deployment instructions, please refer to the [main README](../README.md#inst
 
 1. **Publish a message**:
 
-   Requests are consumed as an `InternalRequest` envelope: a `request_kind` tag
-   (`pubsub` for Pub/Sub) wrapping the caller-visible request under `data`. Note
-   that `deadline` and `created` are Unix-seconds **numbers**, not strings — a
-   quoted `deadline` fails to decode.
+   Publish the request on its own — on Pub/Sub, unlike Redis, it is **not** wrapped
+   in an `InternalRequest` envelope. The consumer builds that itself from the Pub/Sub
+   message. Note that `deadline` and `created` are Unix-seconds **numbers**, not
+   strings — a quoted `deadline` fails to decode.
 
    ```bash
-   gcloud pubsub topics publish $REQUEST_TOPIC_NAME --message='{"request_kind":"pubsub","internal":{},"data":{"id":"testmsg","created":1700000000,"deadline":1999999999,"payload":{"model":"your-model","prompt":"Hi, good morning"}}}'
+   gcloud pubsub topics publish $REQUEST_TOPIC_NAME --message='{"id":"testmsg","created":1700000000,"deadline":1999999999,"payload":{"model":"your-model","prompt":"Hi, good morning"}}'
    ```
 
 2. **Pull from results subscription**:


### PR DESCRIPTION
Fixes #2327.

The Pub/Sub quickstart publishes its request wrapped in the `InternalRequest`
envelope. That envelope belongs to the Redis path only.

`llm-d-async`'s Pub/Sub consumer (`pkg/pubsub/pubsubimpl.go`) unmarshals the message
body into a bare `api.RequestMessage` and constructs the `InternalRequest` itself,
from the Pub/Sub message ID and the subscriber ID:

```go
var body api.RequestMessage
err := json.Unmarshal(msg.Data, &body)
...
irout := api.InternalRouting{TransportCorrelationID: msg.ID, RequestQueueName: subscriberID}
...
ir := api.NewInternalRequest(irout, &body)
```

There is no envelope-unwrapping step here — the Redis path gets one via
`InternalRequest.UnmarshalJSON`, which is what rejects a body with no `request_kind`.
So on Pub/Sub `request_kind`, `internal` and `data` are simply unknown fields,
`encoding/json` ignores unknown fields by default, and the decode **succeeds** with
every field zeroed. `deadline=0` makes the request already expired, and
`gcloud pubsub topics publish` reports success, so the guide reads as if it worked.

Decoding both payloads through the real `api` package (`llm-d-async` `804a8a3`):

| payload | result |
|---|---|
| current, enveloped | `id="" created=0 deadline=0 payload=map[]` |
| this PR, bare | `id="testmsg" created=1700000000 deadline=1999999999 payload=map[model:your-model prompt:Hi, good morning]` |

The bare form matches what `guides/batch-serving/asynchronous-processing/multitenant/README.md`
already publishes for Pub/Sub.

The note above the command is reworded for the same reason: it currently states the
Redis envelope contract on a Pub/Sub page. The numbers-not-strings half of it is
correct and is kept.
