### PR TITLE
fix(guides): unify PROVIDER_NAME default to none

### DIFF
--- a/guides/modelexpress-p2p/README.md
+++ b/guides/modelexpress-p2p/README.md
@@ -73,6 +73,8 @@ git clone https://github.com/llm-d/llm-d.git && cd llm-d && git checkout ${BRANC
 
 * Set the guide specific environment variables:
 
+`PROVIDER_NAME` selects gateway-provider-specific resources in the router chart. The default `none` renders no provider resources. On GKE, set `PROVIDER_NAME=gke`, or the load balancer health check fails against vLLM and requests return 503. `istio` adds a DestinationRule; `agentgateway` requires no provider-specific resources.
+
 <!-- guide:env.static start -->
 ```bash
 export BRANCH=main
@@ -88,7 +90,7 @@ export HF_TOKEN=HF_TOKEN_PLACEHOLDER
 <!-- llm-d-cicd:skip end -->
 ```bash
 export MODEL=openai/gpt-oss-120b
-export PROVIDER_NAME=gke # options: none, gke, agentgateway, istio
+export PROVIDER_NAME=none # options: none, gke, agentgateway, istio
 export INFRA_PROVIDER=coreweave # options: base, coreweave
 export CURL_TEST_IMAGE=cfmanteiga/alpine-bash-curl-jq:latest
 ```

--- a/guides/modelexpress-p2p/guide.yaml
+++ b/guides/modelexpress-p2p/guide.yaml
@@ -16,7 +16,12 @@ env:
 
     MODEL: {default: "openai/gpt-oss-120b"}
 
-    PROVIDER_NAME: {default: gke, values: [none, gke, agentgateway, istio]}
+    # Gateway provider for the router chart (--set provider.name=). "none" is
+    # provider-neutral and matches the chart default, but on GKE you must set
+    # "gke" or the HealthCheckPolicy is omitted and requests fail with 503s.
+    # "istio" renders a DestinationRule; "agentgateway" needs no
+    # provider-specific resources (the chart renders nothing, same as "none").
+    PROVIDER_NAME: {default: none, values: [none, gke, agentgateway, istio]}
     INFRA_PROVIDER: {default: coreweave, values: [base, coreweave]}
 
     # VERIFICATION

--- a/guides/optimized-baseline/README.md
+++ b/guides/optimized-baseline/README.md
@@ -64,6 +64,8 @@ git clone https://github.com/llm-d/llm-d.git && cd llm-d && git checkout ${BRANC
 
 - Set the guide specific environment variables:
 
+`PROVIDER_NAME` selects gateway-provider-specific resources in the router chart. The default `none` renders no provider resources. On GKE, set `PROVIDER_NAME=gke`, or the load balancer health check fails against vLLM and requests return 503. `istio` adds a DestinationRule; `agentgateway` requires no provider-specific resources.
+
 <!-- guide:env.static start -->
 ```bash
 export BRANCH=main
@@ -78,6 +80,7 @@ export HF_TOKEN=HF_TOKEN_PLACEHOLDER
 <!-- llm-d-cicd:skip end -->
 ```bash
 export MONITORING_VALUES=
+export ROUTER_CHART_VERSION=v0
 export PROVIDER_NAME=none # options: none, gke, agentgateway, istio
 export ACCELERATOR_TYPE=gpu # options: gpu, amd, xpu, hpu, tpu/v6, tpu/v7, cpu
 export MODEL_SERVER=vllm # options: vllm, sglang, trtllm
@@ -88,7 +91,6 @@ export BENCHMARK_REF=main
 export HARNESS=inference-perf
 export WORKLOAD=guide_optimized-baseline_1.yaml
 export GATEWAY_CLASS=epponly # options: epponly, gke, agentgateway, istio
-export ROUTER_CHART_VERSION=v0 # options are any semver llm-d-router release of v0 for latest
 ```
 <!-- guide:env.static end -->
 

--- a/guides/optimized-baseline/guide.yaml
+++ b/guides/optimized-baseline/guide.yaml
@@ -15,7 +15,15 @@ env:
 
     MONITORING_VALUES: {default: ""}
 
-    PROVIDER_NAME: {default: gke, values: [none, gke, agentgateway, istio]}
+    # Any semver release of the llm-d-router chart; "v0" tracks the latest v0.x.
+    ROUTER_CHART_VERSION: v0
+
+    # Gateway provider for the router chart (--set provider.name=). "none" is
+    # provider-neutral and matches the chart default, but on GKE you must set
+    # "gke" or the HealthCheckPolicy is omitted and requests fail with 503s.
+    # "istio" renders a DestinationRule; "agentgateway" needs no
+    # provider-specific resources (the chart renders nothing, same as "none").
+    PROVIDER_NAME: {default: none, values: [none, gke, agentgateway, istio]}
     ACCELERATOR_TYPE: {default: gpu, values: [gpu, amd, xpu, hpu, "tpu/v6", "tpu/v7", cpu]}
     MODEL_SERVER: {default: vllm, values: [vllm, sglang, trtllm]}
     INFRA_PROVIDER: {default: base, values: [base, gke]}

--- a/guides/recipes/router/README.md
+++ b/guides/recipes/router/README.md
@@ -68,10 +68,15 @@ helm install <release-name> \
   ${ROUTER_GATEWAY_CHART} \
   -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
   -f ${REPO_ROOT}/guides/<your-guide>/router/<your-guide>.values.yaml \
-  --set provider.name=<gke|istio|none> \
+  --set provider.name=<none|gke|agentgateway|istio> \
   -n ${NAMESPACE} \
   --version ${ROUTER_CHART_VERSION}
 ```
+
+`provider.name` selects gateway-provider-specific resources in the chart: `gke` renders a
+`HealthCheckPolicy` (required on GKE; without it the load balancer health check fails against
+vLLM and requests return 503), `istio` renders a `DestinationRule`, and `agentgateway` and
+`none` render no provider-specific resources.
 
 ## Enable Prometheus Monitoring (Optional)
 
@@ -90,7 +95,7 @@ helm upgrade <release-name> \
   -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
   -f ${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml \
   -f ${REPO_ROOT}/guides/<your-guide>/router/<your-guide>.values.yaml \
-  --set provider.name=<gke|istio|none> \
+  --set provider.name=<none|gke|agentgateway|istio> \
   -n ${NAMESPACE} \
   --version ${ROUTER_CHART_VERSION}
 ```


### PR DESCRIPTION
`guides/optimized-baseline` and `guides/modelexpress-p2p` documented different defaults for `PROVIDER_NAME`, the value passed to `--set provider.name=` in the router gateway install. PR #2260 changed the optimized-baseline README default to `none` inside the rendered `guide:env.static` block. Both `guide.yaml` files, the render source of truth, still said `gke`, so `scripts/guide.py render` would have reverted the README.

Both guides default `PROVIDER_NAME` to `none`, matching the router chart's default for `provider.name`. GKE users must set `PROVIDER_NAME=gke`: with `none`, the chart omits the `HealthCheckPolicy`, the load balancer health check fails against vLLM, and requests return 503. Each `guide.yaml` carries a comment above the variable stating the requirement, and each README states it in prose above the env block.

Related fixes in the same files:

- optimized-baseline `guide.yaml` declares `ROUTER_CHART_VERSION`. The variable existed only in the README's rendered block, so `guide.py render` deleted it and `render --check` failed on `main`.
- `guides/recipes/router/README.md` documented `provider.name=<gke|istio|none>`. The placeholder lists all four accepted values, and a paragraph describes what each value renders.

Seven other guide READMEs export `PROVIDER_NAME=gke` without a warning; a follow-up issue should track that sweep.

**Verification:**

- `scripts/guide.py check` and `scripts/guide.py render --check` pass for both guides.
- The scheduled GKE nightlies for both guides use `gateway_class: epponly` (standalone mode), which does not read `PROVIDER_NAME`, so the default change does not affect CI.

Fixes #2330
