### PR TITLE
fix(ci): use env.sh release URL vars in flow-control nightly deploy

### DIFF
--- a/guides/flow-control/scripts/nightly-deploy-gke.sh
+++ b/guides/flow-control/scripts/nightly-deploy-gke.sh
@@ -25,11 +25,12 @@ export GUIDE_NAME="flow-control"
 INFRA_PROVIDER="gke"
 
 echo "=== Installing CRDs (GAIE InferencePool + llm-d.ai InferenceObjective) ==="
-# ROUTER_RELEASE_VERSION, not ROUTER_CHART_VERSION: the chart channel (v0)
-# floats on the OCI registry and has no matching GitHub release, so the CRD
-# bundle needs the release tag. Same pair the README's prerequisites use.
-kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml"
-kubectl apply -f "https://github.com/llm-d/llm-d-router/releases/download/${ROUTER_RELEASE_VERSION}/manifests.yaml"
+# GAIE_URL / ROUTER_RELEASE_URL are computed from *_VERSION (default latest)
+# by the env.sh sourced above. ROUTER_RELEASE_URL, not the chart channel (v0):
+# that floats on the OCI registry with no matching GitHub release, so the CRD
+# bundle needs the release path. Same pair the README's prerequisites use.
+kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/${GAIE_URL}/v1-manifests.yaml"
+kubectl apply -f "https://github.com/llm-d/llm-d-router/${ROUTER_RELEASE_URL}/manifests.yaml"
 
 # CI-only (1 of 3): force a low concurrency-detector maxConcurrency so the
 # saturation gate closes under the validate script's modest burst. Without it


### PR DESCRIPTION
## What

Fixes the CRD install step that killed Nightly - Flow Control E2E (GKE GPU) #\76:

```
error: unable to read URL "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/latest/v1-manifests.yaml", server reported 404 Not Found
```

## Why

GitHub serves release assets at `releases/latest/download/<asset>` for the floating latest release and at `releases/download/<tag>/<asset>` for a pinned tag. #2299 added `GAIE_URL` and `ROUTER_RELEASE_URL` to `guides/env.sh` to compute the correct path from `GAIE_VERSION` and `ROUTER_RELEASE_VERSION`, and the flow-control README prerequisites use those variables.

`guides/flow-control/scripts/nightly-deploy-gke.sh` was restored in #1918 before #2299 merged and still built `releases/download/${GAIE_VERSION}` by hand. The nightly passed while the versions were pinned on the CI PR and started failing after the release cut, when both versions defaulted to `latest`.

## Change

The two `kubectl apply` URLs in `nightly-deploy-gke.sh` now use `${GAIE_URL}` and `${ROUTER_RELEASE_URL}`. The script already sources `guides/env.sh`. No other behavior changes.

Verified locally:

- Default versions (`latest`): both URLs return HTTP 200.
- Pinned versions (`GAIE_VERSION=v1.6.0`, `ROUTER_RELEASE_VERSION=v0.10.0`): both URLs return HTTP 200.
- `bash -n` passes.

## Follow-ups (out of scope)

- Other files still build release URLs from `*_VERSION` directly and 404 with the `latest` default. Tracked in #2340.
- The nightly floats both CRD bundles at the latest upstream release. Pinning the versions in the workflow env, or logging the resolved release before applying, would make upstream-caused failures bisectable. Tracked in #2341.
