### PR TITLE
fix(guides): repair CRD install URLs that break on the latest default

### DIFF
--- a/guides/coord-disaggregation/README.md
+++ b/guides/coord-disaggregation/README.md
@@ -120,7 +120,8 @@ topology choice:
 * Install the Gateway API Inference Extension CRDs:
 
   ```bash
-  kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+  # GAIE_URL is automatically calculated from GAIE_VERSION at ${REPO_ROOT}/guides/env.sh
+  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/${GAIE_URL}/v1-manifests.yaml
   ```
 
 * Create a target namespace for the installation:

--- a/guides/env.sh
+++ b/guides/env.sh
@@ -6,6 +6,8 @@
 export REPO_ROOT=${REPO_ROOT:-$(realpath "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null)}
 
 ### Release Versions for grabbing CRDs
+# The *_URL variables are recomputed on every source; a *_URL value exported
+# beforehand is discarded. To pin a release, export the matching *_VERSION.
 export GATEWAY_API_VERSION=${GATEWAY_API_VERSION:-latest}
 if [[ $GATEWAY_API_VERSION == "latest" ]]; then
   export GATEWAY_API_URL=releases/latest/download

--- a/guides/multimodal-serving/e-disaggregation/README.md
+++ b/guides/multimodal-serving/e-disaggregation/README.md
@@ -115,7 +115,8 @@ For SGLang E/PD, use the variables and cluster requirements in the [SGLang XPU E
 * Install the Gateway API Inference Extension CRDs:
 
 ```bash
-kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+# GAIE_URL is automatically calculated from GAIE_VERSION at ${REPO_ROOT}/guides/env.sh
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/${GAIE_URL}/v1-manifests.yaml
 ```
 
 * Create a target namespace for the installation:

--- a/guides/recipes/gateway/install-gateway-crds.sh
+++ b/guides/recipes/gateway/install-gateway-crds.sh
@@ -36,13 +36,33 @@ else
   exit 1
 fi
 
+# GitHub serves release assets at releases/latest/download/<asset> for the
+# floating latest release and releases/download/<tag>/<asset> for pinned tags.
+# "latest" arrives here whenever the caller has sourced guides/env.sh, which
+# exports GATEWAY_API_VERSION=latest by default.
+release_url() {
+  local version=$1
+  if [[ "$version" == "latest" ]]; then
+    echo "releases/latest/download"
+  else
+    echo "releases/download/${version}"
+  fi
+}
+
+KUBECTL_FLAGS=()
+if [[ "$MODE" == "delete" ]]; then
+  KUBECTL_FLAGS=(--ignore-not-found)
+fi
+
 GATEWAY_API_VERSION=${GATEWAY_API_VERSION:-"v1.5.1"}
 ### Base CRDs (standard GA APIs only)
 log_success "📜 Base CRDs: ${LOG_ACTION_NAME}..."
-kubectl $MODE -f https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml || true
+kubectl "$MODE" "${KUBECTL_FLAGS[@]}" -f "https://github.com/kubernetes-sigs/gateway-api/$(release_url "$GATEWAY_API_VERSION")/standard-install.yaml"
 
 
-GATEWAY_API_INFERENCE_EXTENSION_VERSION=${GATEWAY_API_INFERENCE_EXTENSION_VERSION:-"v1.5.0"}
+# guides/env.sh exports the short-form GAIE_VERSION; honor it when the long
+# form is unset so a sourced shell pins both installs consistently.
+GATEWAY_API_INFERENCE_EXTENSION_VERSION=${GATEWAY_API_INFERENCE_EXTENSION_VERSION:-${GAIE_VERSION:-"v1.5.0"}}
 ### GAIE CRDs
 log_success "🚪 GAIE CRDs: ${LOG_ACTION_NAME}..."
-kubectl $MODE -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GATEWAY_API_INFERENCE_EXTENSION_VERSION}/v1-manifests.yaml || true
+kubectl "$MODE" "${KUBECTL_FLAGS[@]}" -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/$(release_url "$GATEWAY_API_INFERENCE_EXTENSION_VERSION")/v1-manifests.yaml"

--- a/guides/wide-ep-lws/README.precise-prefix-cache-routing.md
+++ b/guides/wide-ep-lws/README.precise-prefix-cache-routing.md
@@ -51,7 +51,8 @@ networking on CoreWeave.
 * Install the Gateway API Inference Extension CRDs:
 
   ```bash
-  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${GAIE_VERSION}/v1-manifests.yaml
+  # GAIE_URL is automatically calculated from GAIE_VERSION at ${REPO_ROOT}/guides/env.sh
+  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/${GAIE_URL}/v1-manifests.yaml
   ```
 
 * Create the target namespace:


### PR DESCRIPTION
## What

Fixes #2340. Repairs the four remaining CRD install sites that break when the release version variables carry their default of `latest`. The flow-control nightly instance of the same defect is fixed in #2342.

## Changes

1. `guides/wide-ep-lws/README.precise-prefix-cache-routing.md`: the CRD install applied `releases/download/${GAIE_VERSION}/v1-manifests.yaml`, which 404s when `GAIE_VERSION=latest`. Switched to the env.sh-computed `${GAIE_URL}`, matching the other guides.

2. `guides/coord-disaggregation/README.md` and `guides/multimodal-serving/e-disaggregation/README.md`: both applied the GAIE CRDs via `kubectl apply -k .../config/crd?ref=${GAIE_VERSION}`, and the GAIE repo has no `latest` git ref, so the default fails at the first install step. The one CRD present in `config/crd` but absent from the release bundle is `InferencePoolImport`, and neither guide references it, so both sites now apply the released `v1-manifests.yaml` via `${GAIE_URL}`.

3. `guides/recipes/gateway/install-gateway-crds.sh`: the script pins its own defaults, but a shell that has sourced `guides/env.sh` carries `GATEWAY_API_VERSION=latest`, which produced the broken URL shape while `|| true` suppressed the 404 behind a green success message. The script now handles the `latest` URL shape, fails loudly in apply mode, and uses `--ignore-not-found` in delete mode, which is what the `|| true` was papering over.

4. `guides/env.sh`: documents that the `*_URL` variables are recomputed on every source and that exporting `*_VERSION` is the supported way to pin a release. A `*_URL` value exported beforehand is silently discarded, which cost debugging time during the #2340 investigation.

## Verification

- `bash -n` passes on the edited script.
- All four constructed URL shapes return HTTP 200: gateway-api `latest` and `v1.5.1`, GAIE `latest` and `v1.5.0`.
- `grep -rn 'releases/download/\${' guides/ docs/` and `grep -rn 'config/crd?ref' guides/ docs/` show no further affected sites. The remaining hits are env.sh's own pinned-tag branch, the flow-control nightly script that #2342 fixes, the `release_url` helper added here, and `docs/infrastructure/gateway/install-crds.md`, whose install and uninstall blocks both pin their versions inline immediately before use.
