### PR TITLE
fix(templates): replace stale version dropdown, add   flow control and scheduling areas

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -24,24 +24,35 @@ body:
       value: "A bug happened!"
     validations:
       required: true
-  - type: dropdown
+  - type: input
     id: version
     attributes:
       label: Version
-      description: What version of our software are you running?
-      options:
-        - v0.6.0
-        - v0.5.1
-        - v0.5.0
-        - v0.4.0
-        - v0.3.1
-        - v0.3.0
-        - v0.2.2
-        - v0.2.1
-        - v0.2.0
-      default: 0
+      description: What version of llm-d are you running? Use the release tag or container image tag.
+      placeholder: ex. v0.9.0
     validations:
       required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which area of llm-d does this bug relate to?
+      options:
+        - Optimized baseline
+        - Flow Control
+        - Inference Scheduling
+        - Prefill/Decode Disaggregation
+        - KV Cache / Prefix Caching
+        - Wide Expert-Parallelism
+        - Autoscaling
+        - Observability / Monitoring
+        - Container Image / Build
+        - Deployment / Helm Charts
+        - Documentation / Guides
+        - CI/CD
+        - Other
+    validations:
+      required: false
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -21,6 +21,8 @@ body:
       description: Which area of llm-d does this feature relate to?
       options:
         - Optimized baseline
+        - Flow Control
+        - Inference Scheduling
         - Prefill/Decode Disaggregation
         - KV Cache / Prefix Caching
         - Wide Expert-Parallelism


### PR DESCRIPTION
## Summary

The version dropdown in the bug report template stopped at v0.6.0, three releases behind, and preselected its first entry, so reports filed without touching the field were tagged v0.6.0. Nothing in the release process updates the list. The dropdown is now a required free-text input (`ex. v0.9.0`), which removes the per-release maintenance.

The feature request area dropdown had no entry for flow control or the scheduler. Added "Flow Control" and "Inference Scheduling" as separate options, since admission/queuing issues and filter/score/pick issues route to different owners at triage.

The bug report template now carries the same area dropdown. It is optional, so reporters who don't know the area can skip it.

## Changes

- `.github/ISSUE_TEMPLATE/bug.yml`: version dropdown replaced with free-text input; area dropdown added
- `.github/ISSUE_TEMPLATE/feature-request.yml`: "Flow Control" and "Inference Scheduling" added to the area options