### PR TITLE
feat(guides): migrate flow-control to the guide.yaml method

### DIFF
--- a/.github/workflows/ci-guides-check.yaml
+++ b/.github/workflows/ci-guides-check.yaml
@@ -1,0 +1,49 @@
+name: CI Guides Check
+
+# Guides on the guide.yaml method render their README bash fences from the
+# YAML (see guides/templates/README.md). The job fails when a README is stale
+# relative to its guide.yaml (fix: `scripts/guide.py render <guide-dir>`) and
+# runs the guide.py unit tests.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/ci-guides-check.yaml
+      - guides/**
+      - scripts/guide.py
+      - scripts/tests/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-guides-check-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  guides-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.x'
+          cache: pip
+          # No requirements file — the workflow itself pins the installs.
+          cache-dependency-path: .github/workflows/ci-guides-check.yaml
+
+      - name: Install dependencies
+        run: python -m pip install --quiet 'pyyaml==6.*' pytest
+
+      - name: Check rendered READMEs are current
+        run: python scripts/guide.py render guides/*/ --check
+
+      - name: Run guide.py tests
+        run: python -m pytest scripts/tests/ -v

--- a/guides/flow-control/README.md
+++ b/guides/flow-control/README.md
@@ -70,47 +70,70 @@ Flow Control is a software-level scheduling feature at the EPP layer and is enti
 * Have the [proper client tools installed on your local system](../../helpers/client-setup/README.md) to use this guide.
 * Checkout llm-d repo:
 
-  ```bash
-  export branch="main" # branch, tag, or commit hash
-  git clone https://github.com/llm-d/llm-d.git && cd llm-d && git checkout ${branch}
-  ```
+<!-- guide:prerequisites.clone start -->
+<!-- llm-d-cicd:skip start -->
+```bash
+export BRANCH=main # branch, tag, or commit hash
+git clone https://github.com/llm-d/llm-d.git && cd llm-d && git checkout ${BRANCH}
+```
+<!-- llm-d-cicd:skip end -->
+<!-- guide:prerequisites.clone end -->
 
-* Set the following environment variables:
+* Set the guide environment variables:
 
-  ```bash
-  export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
-  source ${REPO_ROOT}/guides/env.sh
-  export GUIDE_NAME="flow-control"
-  export NAMESPACE="llm-d-flow-control"
-  export MODEL_NAME="Qwen/Qwen3-32B"
-  ```
+<!-- guide:env.static start -->
+```bash
+export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
+export GUIDE_NAME=flow-control
+export NAMESPACE=llm-d-flow-control
+export MODEL_NAME=Qwen/Qwen3-32B
+export INFRA_PROVIDER=base # options: base, gke
+export ROUTER_VALUES=${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml
+export EXTRA_HELM_ARGS=
+```
+<!-- guide:env.static end -->
+
+* Source the common guide environment variables:
+
+<!-- guide:env.source start -->
+```bash
+source ${REPO_ROOT}/guides/env.sh
+```
+<!-- guide:env.source end -->
 
 * Install the required CRDs (GAIE InferencePool + llm-d.ai InferenceObjective):
 
-  ```bash
-  # GAIE_URL is automatically calculated from GAIE_VERSION at ${REPO_ROOT}/guides/env.sh
-  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/${GAIE_URL}/v1-manifests.yaml
+<!-- guide:prerequisites.crds start -->
+```bash
+# GAIE_URL is automatically calculated from GAIE_VERSION at ${REPO_ROOT}/guides/env.sh
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/${GAIE_URL}/v1-manifests.yaml
 
-  # ROUTER_RELEASE_URL is automatically calculated from ROUTER_RELEASE_VERSION at ${REPO_ROOT}/guides/env.sh
-  kubectl apply -f https://github.com/llm-d/llm-d-router/${ROUTER_RELEASE_URL}/manifests.yaml
-  ```
+# ROUTER_RELEASE_URL is automatically calculated from ROUTER_RELEASE_VERSION at ${REPO_ROOT}/guides/env.sh
+kubectl apply -f https://github.com/llm-d/llm-d-router/${ROUTER_RELEASE_URL}/manifests.yaml
+```
+<!-- guide:prerequisites.crds end -->
 
 * Create a target namespace for the installation:
 
-  ```bash
-  kubectl create namespace ${NAMESPACE} --dry-run=client -o yaml | kubectl apply -f -
-  ```
+<!-- guide:prerequisites.namespace start -->
+```bash
+kubectl create namespace ${NAMESPACE} --dry-run=client -o yaml | kubectl apply -f -
+```
+<!-- guide:prerequisites.namespace end -->
 
 * [Create the `llm-d-hf-token` secret in your target namespace with the key `HF_TOKEN` matching a valid HuggingFace token](../../helpers/hf-token.md) to pull models.
+
+<!-- guide:prerequisites.secrets start -->
 <!-- llm-d-cicd:skip start -->
-  ```bash
-  export HF_TOKEN=<your HuggingFace token>
-  kubectl create secret generic llm-d-hf-token \
-    --from-literal="HF_TOKEN=${HF_TOKEN}" \
-    --namespace "${NAMESPACE}" \
-    --dry-run=client -o yaml | kubectl apply -f -
-  ```
+```bash
+export HF_TOKEN=<your HuggingFace token>
+kubectl create secret generic llm-d-hf-token \
+  --from-literal="HF_TOKEN=${HF_TOKEN}" \
+  --namespace "${NAMESPACE}" \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
 <!-- llm-d-cicd:skip end -->
+<!-- guide:prerequisites.secrets end -->
 
 ## Installation Instructions
 
@@ -120,13 +143,16 @@ Flow Control is a software-level scheduling feature at the EPP layer and is enti
 
 This deploys the router with an Envoy sidecar, it doesn't set up a Kubernetes Gateway.
 
+<!-- guide:deploy.standalone start -->
 ```bash
 helm upgrade --install ${GUIDE_NAME} \
     ${ROUTER_STANDALONE_CHART} \
     -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
-    -f ${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
+    -f ${ROUTER_VALUES} \
+    ${EXTRA_HELM_ARGS} \
     -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
 ```
+<!-- guide:deploy.standalone end -->
 
 The router pod's resource requests are set in
 [base.values.yaml](../recipes/router/base.values.yaml): 4 vCPU and 8 GiB of memory for
@@ -141,16 +167,19 @@ To use a Kubernetes Gateway managed proxy rather than the standalone version, fo
 1. *Deploy a Kubernetes Gateway* named by following one of [the gateway guides](../../docs/infrastructure/gateway).
 2. *Deploy the router and an HTTPRoute* that connects it to the Gateway as follows:
 
+<!-- guide:deploy.gateway start -->
 ```bash
 export PROVIDER_NAME=gke # options: none, gke, agentgateway, istio
 helm upgrade --install ${GUIDE_NAME} \
-    ${ROUTER_GATEWAY_CHART}  \
+    ${ROUTER_GATEWAY_CHART} \
     -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
     -f ${REPO_ROOT}/guides/recipes/router/features/httproute-flags.yaml \
-    -f ${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml \
+    -f ${ROUTER_VALUES} \
+    ${EXTRA_HELM_ARGS} \
     --set provider.name=${PROVIDER_NAME} \
     -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
 ```
+<!-- guide:deploy.gateway end -->
 
 </details>
 
@@ -160,12 +189,13 @@ Instead of maintaining duplicate hardware configurations, we dynamically render 
 
 Deploy the model server (defaulting to NVIDIA GPU / vLLM) by running:
 
+<!-- guide:deploy.modelserver start -->
 ```bash
-export INFRA_PROVIDER=base # base | gke
 kubectl kustomize ${REPO_ROOT}/guides/optimized-baseline/modelserver/gpu/vllm/${INFRA_PROVIDER}/ \
   | sed "s/optimized-baseline/${GUIDE_NAME}/g" \
   | kubectl apply -n ${NAMESPACE} -f -
 ```
+<!-- guide:deploy.modelserver end -->
 
 ### 3. Enable monitoring (optional)
 
@@ -176,9 +206,11 @@ ServiceMonitor, whose CRD only exists after the monitoring stack is installed.
 * Add `-f ${REPO_ROOT}/guides/recipes/router/features/monitoring.values.yaml` to the [router installation command](#1-deploy-the-router). If you already installed without it, re-run the same `helm upgrade --install` command with the extra `-f` appended.
 * Deploy the monitoring resources for model servers:
 
+<!-- guide:deploy.monitoring start -->
 ```bash
 kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/recipes/modelserver/components/monitoring
 ```
+<!-- guide:deploy.monitoring end -->
 
 ## Verification
 
@@ -186,16 +218,20 @@ kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/recipes/modelserver/compone
 
 **Standalone Mode**
 
+<!-- guide:verify.endpoint.standalone start -->
 ```bash
 export IP=$(kubectl get service ${GUIDE_NAME}-epp -n ${NAMESPACE} -o jsonpath='{.spec.clusterIP}')
 ```
+<!-- guide:verify.endpoint.standalone end -->
 
 <details>
 <summary> <b>Gateway Mode</b> </summary>
 
+<!-- guide:verify.endpoint.gateway start -->
 ```bash
 export IP=$(kubectl get gateway llm-d-inference-gateway -n ${NAMESPACE} -o jsonpath='{.status.addresses[0].value}')
 ```
+<!-- guide:verify.endpoint.gateway end -->
 
 </details>
 
@@ -203,10 +239,12 @@ export IP=$(kubectl get gateway llm-d-inference-gateway -n ${NAMESPACE} -o jsonp
 
 Check EPP logs for feature gate activation:
 
+<!-- guide:verify.tests.feature_gate start -->
 ```bash
 # -c epp: in standalone mode kubectl defaults to the Envoy sidecar, whose log never matches
 kubectl logs deploy/${GUIDE_NAME}-epp -c epp -n ${NAMESPACE} | grep "Initializing Flow Control layer"
 ```
+<!-- guide:verify.tests.feature_gate end -->
 
 Expected: one line, `Initializing Flow Control layer`. No output means the gate is off for
 this deployment (the EPP then logs `Flow Control layer is disabled` instead) or the log
@@ -221,13 +259,15 @@ To fully verify that queuing and backpressure are working, you must apply concur
 The Use Case 2 load test sizes its burst from `MAX_CONCURRENCY`; a retuned values file
 changes the burst with it:
 
+<!-- guide:verify.tests.max_concurrency start -->
 ```bash
 MAX_CONCURRENCY=$(awk '$1 == "maxConcurrency:" {print $2; n++} END {exit n!=1}' \
-    ${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml) \
+    ${ROUTER_VALUES}) \
   || echo "expected exactly one maxConcurrency: in the values file" >&2
 export MAX_CONCURRENCY
 echo "maxConcurrency: ${MAX_CONCURRENCY}"   # expect the integer set in the values file
 ```
+<!-- guide:verify.tests.max_concurrency end -->
 
 **Grant read access to the EPP metrics endpoint.** The EPP authenticates every metrics
 scrape against the Kubernetes API: a TokenReview on the caller's bearer token, then a
@@ -238,6 +278,7 @@ grant only when `router.monitoring.prometheus.enabled` is set, which also create
 ServiceMonitor and requires the Prometheus Operator CRDs; this guide leaves that flag
 off and creates the binding directly:
 
+<!-- guide:verify.tests.metrics_rbac start -->
 ```bash
 kubectl create clusterrole ${GUIDE_NAME}-metrics-reader \
     --verb=get --non-resource-url=/metrics \
@@ -251,6 +292,7 @@ kubectl create clusterrolebinding ${GUIDE_NAME}-epp-auth-delegator \
     --serviceaccount=${NAMESPACE}:${GUIDE_NAME}-epp \
     --dry-run=client -o yaml | kubectl apply -f -
 ```
+<!-- guide:verify.tests.metrics_rbac end -->
 
 Without these grants the metrics endpoint returns `401 Unauthorized`, and every
 metrics check in this guide reads as empty grep output.
@@ -297,9 +339,11 @@ The `helm upgrade --install` command you ran earlier configured the EPP's underl
 
 Apply the full definitions (Premium, Standard, Best-Effort) provided in [objectives.yaml](./objectives.yaml) by running:
 
+<!-- guide:deploy.objectives start -->
 ```bash
 kubectl apply -f ${REPO_ROOT}/guides/${GUIDE_NAME}/objectives.yaml -n ${NAMESPACE}
 ```
+<!-- guide:deploy.objectives end -->
 
 The file defines three priority tiers:
 
@@ -494,17 +538,21 @@ In this example we will demonstrate how to run [`inference-perf`](https://github
 
 Automatically clone the benchmark repository into `./llm-d-benchmark/` and create a virtualenv at `./llm-d-benchmark/.venv/` containing dependencies and its installation:
 
+<!-- guide:benchmark.setup.install start -->
 ```bash
 curl -sSL https://raw.githubusercontent.com/llm-d/llm-d-benchmark/main/install.sh | bash
 ```
+<!-- guide:benchmark.setup.install end -->
 
 Activate the `venv` and enter the repository directory - both are required: the `venv` puts `llmdbenchmark` on your PATH, and the repository directory contains the `workload/profiles/` and `config/specification/` files that orchestrate the benchmark:
 
+<!-- guide:benchmark.setup.activate start -->
 ```bash
 cd llm-d-benchmark
 source .venv/bin/activate
 llmdbenchmark --version
 ```
+<!-- guide:benchmark.setup.activate end -->
 
 > [!NOTE]
 > Subsequent `llmdbenchmark` commands in this section assume you are inside the `llm-d-benchmark` repo directory with the `venv` activated. If you open a new shell, re-run the two commands above.
@@ -515,20 +563,24 @@ Set two variables so the rest of the section is topology-agnostic: the endpoint 
 
 **Standalone Mode** (the default in this guide — no Kubernetes Gateway, EPP pod with an Envoy sidecar):
 
+<!-- guide:benchmark.endpoint.standalone start -->
 ```bash
 export ENDPOINT_URL="http://$(kubectl get service ${GUIDE_NAME}-epp -n ${NAMESPACE} -o jsonpath='{.spec.clusterIP}')"
 export GATEWAY_CLASS=epponly # standalone mode
 ```
+<!-- guide:benchmark.endpoint.standalone end -->
 
 <details>
 <summary> <b>Gateway Mode</b> </summary>
 
+<!-- guide:benchmark.endpoint.gateway start -->
 ```bash
 export ENDPOINT_URL="http://$(kubectl get gateway llm-d-inference-gateway -n ${NAMESPACE} -o jsonpath='{.status.addresses[0].value}')"
 
 # Match whichever provider you used when deploying the gateway (e.g. istio, agentgateway, gke).
 export GATEWAY_CLASS=istio
 ```
+<!-- guide:benchmark.endpoint.gateway end -->
 
 </details>
 
@@ -536,6 +588,7 @@ export GATEWAY_CLASS=istio
 
 Benchmark results are copied to the `workspace` directory that is specified by *you* (or that is automatically generated when omitted from the cli) on the machine running the CLI. The workspace location is optional — by default the CLI auto-generates a timestamped workspace and prints its full path in the logs during the run. If you'd rather choose where results land, pass `--workspace <YOUR_DIR_HERE>` as a top-level argument of `llmdbenchmark` (before the `run` subcommand):
 
+<!-- guide:benchmark.execute start -->
 ```bash
 llmdbenchmark \
     --spec           guides/flow-control \
@@ -548,6 +601,7 @@ llmdbenchmark \
     --workload       random_concurrent.yaml \
     --analyze
 ```
+<!-- guide:benchmark.execute end -->
 
 > [!NOTE]
 > The harness pod requests 16 vCPU by default
@@ -565,16 +619,21 @@ The Flow Control layer exposes detailed metrics to track queuing dynamics. Pleas
 
 To remove the deployed components:
 
+<!-- guide:cleanup start -->
 ```bash
 helm uninstall ${GUIDE_NAME} -n ${NAMESPACE}
+
 kubectl delete -f ${REPO_ROOT}/guides/${GUIDE_NAME}/objectives.yaml -n ${NAMESPACE}
-export INFRA_PROVIDER=base # match the value used at deploy time
+
+# INFRA_PROVIDER must match the value used at deploy time
 kubectl kustomize ${REPO_ROOT}/guides/optimized-baseline/modelserver/gpu/vllm/${INFRA_PROVIDER}/ \
   | sed "s/optimized-baseline/${GUIDE_NAME}/g" \
   | kubectl delete -n ${NAMESPACE} -f -
+
 kubectl delete clusterrolebinding ${GUIDE_NAME}-metrics-reader ${GUIDE_NAME}-epp-auth-delegator
 kubectl delete clusterrole ${GUIDE_NAME}-metrics-reader
 ```
+<!-- guide:cleanup end -->
 
 If you ran the Benchmarking section, also delete the harness leftovers. The workload PVC
 is backed by shared storage that bills until removed. Follow

--- a/guides/flow-control/guide.yaml
+++ b/guides/flow-control/guide.yaml
@@ -1,0 +1,179 @@
+name: flow-control
+
+env:
+  static:
+    # BRANCH lives inline in prerequisites.clone, where it is used; declaring
+    # it here too would render a second, contradictory export into the README.
+    REPO_ROOT: $(realpath $(git rev-parse --show-toplevel))
+
+    GUIDE_NAME: flow-control
+    NAMESPACE: llm-d-flow-control
+
+    MODEL_NAME: {default: "Qwen/Qwen3-32B"}
+
+    INFRA_PROVIDER: {default: base, values: [base, gke]}
+
+    # Automation hooks. The nightly deploy passes `guide.py emit --var`
+    # overrides for both: a CI values file with a low maxConcurrency, and
+    # helm flags that disable EPP metrics auth for the validate script.
+    # Users never set them.
+    ROUTER_VALUES: {default: "${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml"}
+    EXTRA_HELM_ARGS: {default: ""}
+
+  source: ["${REPO_ROOT}/guides/env.sh"]
+
+prerequisites:
+  clone:
+    - skip_in: [ci]
+      run: |
+        export BRANCH=main # branch, tag, or commit hash
+        git clone https://github.com/llm-d/llm-d.git && cd llm-d && git checkout ${BRANCH}
+
+  crds:
+    - run: |
+        # GAIE_URL is automatically calculated from GAIE_VERSION at ${REPO_ROOT}/guides/env.sh
+        kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/${GAIE_URL}/v1-manifests.yaml
+    - run: |
+        # ROUTER_RELEASE_URL is automatically calculated from ROUTER_RELEASE_VERSION at ${REPO_ROOT}/guides/env.sh
+        kubectl apply -f https://github.com/llm-d/llm-d-router/${ROUTER_RELEASE_URL}/manifests.yaml
+
+  namespace:
+    - run: kubectl create namespace ${NAMESPACE} --dry-run=client -o yaml | kubectl apply -f -
+
+  secrets:
+    - skip_in: [ci]
+      run: |
+        export HF_TOKEN=<your HuggingFace token>
+        kubectl create secret generic llm-d-hf-token \
+          --from-literal="HF_TOKEN=${HF_TOKEN}" \
+          --namespace "${NAMESPACE}" \
+          --dry-run=client -o yaml | kubectl apply -f -
+
+deploy:
+  standalone:
+    - run: |
+        helm upgrade --install ${GUIDE_NAME} \
+            ${ROUTER_STANDALONE_CHART} \
+            -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
+            -f ${ROUTER_VALUES} \
+            ${EXTRA_HELM_ARGS} \
+            -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
+
+  gateway:
+    - run: |
+        export PROVIDER_NAME=gke # options: none, gke, agentgateway, istio
+        helm upgrade --install ${GUIDE_NAME} \
+            ${ROUTER_GATEWAY_CHART} \
+            -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
+            -f ${REPO_ROOT}/guides/recipes/router/features/httproute-flags.yaml \
+            -f ${ROUTER_VALUES} \
+            ${EXTRA_HELM_ARGS} \
+            --set provider.name=${PROVIDER_NAME} \
+            -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
+
+  # flow-control deliberately keeps no modelserver/ overlay of its own. It
+  # renders optimized-baseline's and relabels it, as documented in the
+  # README's "Deploy the Model Server" step.
+  modelserver:
+    - run: |
+        kubectl kustomize ${REPO_ROOT}/guides/optimized-baseline/modelserver/gpu/vllm/${INFRA_PROVIDER}/ \
+          | sed "s/optimized-baseline/${GUIDE_NAME}/g" \
+          | kubectl apply -n ${NAMESPACE} -f -
+
+  # The priority bands the EPP maps queues to. Without the objectives, tagged
+  # traffic falls back to band 0 and per-band behavior is unobservable.
+  objectives:
+    - run: kubectl apply -f ${REPO_ROOT}/guides/${GUIDE_NAME}/objectives.yaml -n ${NAMESPACE}
+
+  monitoring:
+    - run: kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/recipes/modelserver/components/monitoring
+
+verify:
+  endpoint:
+    standalone:
+      - run: export IP=$(kubectl get service ${GUIDE_NAME}-epp -n ${NAMESPACE} -o jsonpath='{.spec.clusterIP}')
+    gateway:
+      - run: export IP=$(kubectl get gateway llm-d-inference-gateway -n ${NAMESPACE} -o jsonpath='{.status.addresses[0].value}')
+
+  tests:
+    feature_gate:
+      - run: |
+          # -c epp: in standalone mode kubectl defaults to the Envoy sidecar, whose log never matches
+          kubectl logs deploy/${GUIDE_NAME}-epp -c epp -n ${NAMESPACE} | grep "Initializing Flow Control layer"
+
+    max_concurrency:
+      # ${ROUTER_VALUES}, not the literal path: the check must read the values
+      # file that was actually deployed, including a caller's override.
+      - run: |
+          MAX_CONCURRENCY=$(awk '$1 == "maxConcurrency:" {print $2; n++} END {exit n!=1}' \
+              ${ROUTER_VALUES}) \
+            || echo "expected exactly one maxConcurrency: in the values file" >&2
+          export MAX_CONCURRENCY
+          echo "maxConcurrency: ${MAX_CONCURRENCY}"   # expect the integer set in the values file
+
+    # The guide keeps EPP metrics auth on and grants scrape access. The
+    # nightly never emits verify.tests; it disables auth via EXTRA_HELM_ARGS
+    # so its validate script can scrape without a token.
+    metrics_rbac:
+      - run: |
+          kubectl create clusterrole ${GUIDE_NAME}-metrics-reader \
+              --verb=get --non-resource-url=/metrics \
+              --dry-run=client -o yaml | kubectl apply -f -
+          kubectl create clusterrolebinding ${GUIDE_NAME}-metrics-reader \
+              --clusterrole=${GUIDE_NAME}-metrics-reader \
+              --serviceaccount=${NAMESPACE}:default \
+              --dry-run=client -o yaml | kubectl apply -f -
+          kubectl create clusterrolebinding ${GUIDE_NAME}-epp-auth-delegator \
+              --clusterrole=system:auth-delegator \
+              --serviceaccount=${NAMESPACE}:${GUIDE_NAME}-epp \
+              --dry-run=client -o yaml | kubectl apply -f -
+
+benchmark:
+  setup:
+    install:
+      - run: curl -sSL https://raw.githubusercontent.com/llm-d/llm-d-benchmark/main/install.sh | bash
+    activate:
+      - run: |
+          cd llm-d-benchmark
+          source .venv/bin/activate
+          llmdbenchmark --version
+
+  endpoint:
+    standalone:
+      - run: |
+          export ENDPOINT_URL="http://$(kubectl get service ${GUIDE_NAME}-epp -n ${NAMESPACE} -o jsonpath='{.spec.clusterIP}')"
+          export GATEWAY_CLASS=epponly # standalone mode
+    gateway:
+      - run: |
+          export ENDPOINT_URL="http://$(kubectl get gateway llm-d-inference-gateway -n ${NAMESPACE} -o jsonpath='{.status.addresses[0].value}')"
+
+          # Match whichever provider you used when deploying the gateway (e.g. istio, agentgateway, gke).
+          export GATEWAY_CLASS=istio
+
+  # --harness/--workload stay literal because flow-control has no dedicated
+  # multi-tenant workload profile yet (see the README's warning); the guide
+  # pins the generic random_concurrent.yaml.
+  execute:
+    - run: |
+        llmdbenchmark \
+            --spec           guides/flow-control \
+            run \
+            --endpoint-url   "${ENDPOINT_URL}" \
+            --gateway-class  "${GATEWAY_CLASS}" \
+            --model          "${MODEL_NAME}" \
+            --namespace      "${NAMESPACE}" \
+            --harness        inference-perf \
+            --workload       random_concurrent.yaml \
+            --analyze
+
+cleanup:
+  - run: helm uninstall ${GUIDE_NAME} -n ${NAMESPACE}
+  - run: kubectl delete -f ${REPO_ROOT}/guides/${GUIDE_NAME}/objectives.yaml -n ${NAMESPACE}
+  - run: |
+      # INFRA_PROVIDER must match the value used at deploy time
+      kubectl kustomize ${REPO_ROOT}/guides/optimized-baseline/modelserver/gpu/vllm/${INFRA_PROVIDER}/ \
+        | sed "s/optimized-baseline/${GUIDE_NAME}/g" \
+        | kubectl delete -n ${NAMESPACE} -f -
+  - run: |
+      kubectl delete clusterrolebinding ${GUIDE_NAME}-metrics-reader ${GUIDE_NAME}-epp-auth-delegator
+      kubectl delete clusterrole ${GUIDE_NAME}-metrics-reader

--- a/guides/flow-control/scripts/nightly-deploy-gke.sh
+++ b/guides/flow-control/scripts/nightly-deploy-gke.sh
@@ -8,10 +8,13 @@
 # the repo root; the reusable exports NAMESPACE and has already created the
 # namespace and the llm-d-hf-token secret.
 #
-# This mirrors the guide README's install steps. Every deviation is marked
-# "CI-only" below, and none of them change what the guide documents for users.
-# Two of them (low maxConcurrency, single decode replica) exist to force the
-# queue contention that the guide's Use Case 2 produces by hand.
+# The deploy commands come from guides/flow-control/guide.yaml via
+# `scripts/guide.py emit`, the same source the README is rendered from, so a
+# guide fix reaches the nightly without a second edit. Every deviation
+# from the guide defaults is a CI-only override marked below, and none of them
+# change what the guide documents for users. Two of them (low maxConcurrency,
+# single decode replica) exist to force the queue contention that the guide's
+# Use Case 2 produces by hand.
 
 set -euo pipefail
 
@@ -21,16 +24,16 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 # shellcheck source=guides/env.sh
 source "${REPO_ROOT}/guides/env.sh"
 
-export GUIDE_NAME="flow-control"
+GUIDE_NAME="flow-control"
+GUIDE_DIR="${REPO_ROOT}/guides/${GUIDE_NAME}"
 INFRA_PROVIDER="gke"
 
-echo "=== Installing CRDs (GAIE InferencePool + llm-d.ai InferenceObjective) ==="
-# GAIE_URL / ROUTER_RELEASE_URL are computed from *_VERSION (default latest)
-# by the env.sh sourced above. ROUTER_RELEASE_URL, not the chart channel (v0):
-# that floats on the OCI registry with no matching GitHub release, so the CRD
-# bundle needs the release path. Same pair the README's prerequisites use.
-kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/${GAIE_URL}/v1-manifests.yaml"
-kubectl apply -f "https://github.com/llm-d/llm-d-router/${ROUTER_RELEASE_URL}/manifests.yaml"
+# guide.py needs pyyaml; GitHub runners ship python3 but not always the module.
+# PIP_BREAK_SYSTEM_PACKAGES: a PEP 668 externally-managed python3 (Ubuntu
+# 24.04 images, most self-hosted runners) rejects --user installs outright;
+# old pips ignore the variable, so it is safe on every image.
+python3 -c 'import yaml' 2>/dev/null \
+  || PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install --user --quiet 'pyyaml==6.*'
 
 # CI-only (1 of 3): force a low concurrency-detector maxConcurrency so the
 # saturation gate closes under the validate script's modest burst. Without it
@@ -39,37 +42,64 @@ kubectl apply -f "https://github.com/llm-d/llm-d-router/${ROUTER_RELEASE_URL}/ma
 # if the substitution does not take.
 CI_VALUES="/tmp/${GUIDE_NAME}.ci.values.yaml"
 sed -E 's/(maxConcurrency:)[[:space:]]+[0-9]+/\1 4/' \
-  "${REPO_ROOT}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml" > "${CI_VALUES}"
+  "${GUIDE_DIR}/router/${GUIDE_NAME}.values.yaml" > "${CI_VALUES}"
 if ! grep -qE '^[[:space:]]*maxConcurrency:[[:space:]]+4$' "${CI_VALUES}"; then
   echo "ERROR: failed to override maxConcurrency in ${GUIDE_NAME} values" >&2
   exit 1
 fi
 
+# emit: shared wrapper for every guide.py emit call — pins the ci context and
+# the nightly's --var overrides. NAMESPACE and INFRA_PROVIDER are plumbing,
+# ROUTER_VALUES carries CI-only (1 of 3) from above, and EXTRA_HELM_ARGS is
+# CI-only (2 of 3): it disables EPP metrics token auth so the validate
+# script's curl pod can scrape /metrics without a bearer token. The guide
+# default (auth on) is unchanged for users, who grant scrape RBAC instead
+# (verify.tests.metrics_rbac in guide.yaml, which the nightly never emits).
+emit() {
+  python3 "${REPO_ROOT}/scripts/guide.py" emit "${GUIDE_DIR}" \
+    --context ci \
+    --var NAMESPACE="${NAMESPACE}" \
+    --var INFRA_PROVIDER="${INFRA_PROVIDER}" \
+    --var ROUTER_VALUES="${CI_VALUES}" \
+    --var EXTRA_HELM_ARGS="--set router.monitoring.prometheus.auth.enabled=false" \
+    "$@"
+}
+
+echo "=== Installing CRDs (GAIE InferencePool + llm-d.ai InferenceObjective) ==="
+# The apply commands come from guide.yaml, whose URLs resolve through
+# guides/env.sh (GAIE_URL / ROUTER_RELEASE_URL). Run with -x so the xtrace
+# records the resolved URLs the job fetched: a CRD fetch failure usually has
+# no llm-d commit in the blame window (an upstream release moved), and the
+# log is the only place the resolved tag survives.
+CRDS_SCRIPT="/tmp/${GUIDE_NAME}.ci.crds.sh"
+emit env prerequisites.crds > "${CRDS_SCRIPT}"
+# Retry transient GitHub/network failures; kubectl apply is idempotent.
+for attempt in 1 2 3; do
+  if bash -x "${CRDS_SCRIPT}"; then
+    break
+  fi
+  if [ "${attempt}" -eq 3 ]; then
+    echo "ERROR: CRD install failed after ${attempt} attempts" >&2
+    exit 1
+  fi
+  echo "CRD install failed (attempt ${attempt}); retrying in 10s..." >&2
+  sleep 10
+done
+
 echo "=== Deploying the router (standalone mode) ==="
-# CI-only (2 of 3): --set router.monitoring.prometheus.auth.enabled=false lets
-# the validate script's curl pod scrape /metrics without a bearer token. It
-# adds --metrics-endpoint-auth=false to the EPP; the guide default (auth on) is
-# unchanged for users.
-helm upgrade --install "${GUIDE_NAME}" \
-  "${ROUTER_STANDALONE_CHART}" \
-  -f "${REPO_ROOT}/guides/recipes/router/base.values.yaml" \
-  -f "${CI_VALUES}" \
-  --set router.monitoring.prometheus.auth.enabled=false \
-  -n "${NAMESPACE}" --version "${ROUTER_CHART_VERSION}"
+emit env deploy.standalone | bash
 
 echo "=== Deploying the model servers ==="
-# Reuse optimized-baseline's model servers relabeled to flow-control, exactly as
-# the guide's "Deploy the Model Server" step does — this guide deliberately
-# keeps no modelserver/ overlay of its own.
-#
-# CI-only (4 of 4): one decode replica instead of the overlay's 8. Pool dispatch
-# capacity is maxConcurrency x ready replicas (see the README's "Proof of
-# Queuing"), so 8 replicas give 8 x 4 = 32 slots against the validate script's
-# 36-request burst. The gate barely closes and the QoS assertion has no queue
-# wait to measure. One replica leaves 4 slots and queues the remaining 32.
-# Patch before apply rather than scaling after: peak GPU demand stays at 1,
-# matching the workflow's declared required_gpus, and the 7 surplus pods never
-# exist to be caught by the reusable's `kubectl wait pod --all`.
+# Mirrors deploy.modelserver in guide.yaml (kustomize | sed | apply), with the
+# one CI-only (3 of 3) deviation the guide's pipeline cannot express: a single
+# decode replica instead of the overlay's 8. Pool dispatch capacity is
+# maxConcurrency x ready replicas (see the README's "Proof of Queuing"), so 8
+# replicas give 8 x 4 = 32 slots against the validate script's 36-request
+# burst. The gate barely closes and the QoS assertion has no queue wait to
+# measure. One replica leaves 4 slots and queues the remaining 32. Patch
+# before apply rather than scaling after: peak GPU demand stays at 1, matching
+# the workflow's declared required_gpus, and the 7 surplus pods never exist to
+# be caught by the reusable's `kubectl wait pod --all`.
 MS_MANIFEST="/tmp/${GUIDE_NAME}.ci.modelserver.yaml"
 kubectl kustomize "${REPO_ROOT}/guides/optimized-baseline/modelserver/gpu/vllm/${INFRA_PROVIDER}/" \
   | sed "s/optimized-baseline/${GUIDE_NAME}/g" \
@@ -83,7 +113,7 @@ kubectl apply -n "${NAMESPACE}" -f "${MS_MANIFEST}"
 echo "=== Applying priority-band InferenceObjectives ==="
 # These define the bands the validate script targets; without them, tagged
 # traffic falls back to band 0 and the per-band assertions are meaningless.
-kubectl apply -f "${REPO_ROOT}/guides/${GUIDE_NAME}/objectives.yaml" -n "${NAMESPACE}"
+emit env deploy.objectives | bash
 
 echo "=== Deploy complete ==="
 kubectl get pods -n "${NAMESPACE}" || true

--- a/guides/templates/README.md
+++ b/guides/templates/README.md
@@ -207,7 +207,7 @@ The reader picks the line matching their config.
 >
 > Mutually exclusive steps flatten into a single fence, annotated with `# only when …` comments. A human reads the annotations and picks one. A runner scraping the rendered fence would execute *every* branch, which for some guides is destructive (workload-autoscaling explicitly warns against applying both its KEDA and HPA overlays).
 >
-> `guide.yaml` is the machine interface: `when:` is still structured there, so a runner resolves it against its own variable values and gets exactly one branch. The `<!-- llm-d-cicd:skip -->` markers exist for the *legacy* README-scraping path and should not be read as an endorsement of it.
+> `guide.yaml` is the machine interface: `when:` is still structured there, so a runner resolves it against its own variable values and gets exactly one branch. `guide.py emit` (see [Emitting bash for automation](#emitting-bash-for-automation)) performs that resolution. The `<!-- llm-d-cicd:skip -->` markers exist for the *legacy* README-scraping path and should not be read as an endorsement of it.
 
 ### Sensitive variables
 
@@ -368,7 +368,7 @@ On `README.md`:
 Exits non-zero on any error. With multiple targets every guide is reported before
 exiting, so one run surfaces every problem in the repo.
 
-### Recommended CI
+### CI
 
 One command covers both files across every guide:
 
@@ -379,6 +379,46 @@ scripts/guide.py render guides/*/ --check
 `--check` catches out-of-date READMEs — someone edited `guide.yaml` without
 re-rendering — and because `render` validates first, a schema error fails the
 same job.
+
+[`ci-guides-check.yaml`](../../.github/workflows/ci-guides-check.yaml) runs
+the command on every PR that touches `guides/**` or `scripts/guide.py`,
+alongside the guide.py unit tests in `scripts/tests/`. To fix a failing
+check, re-run `scripts/guide.py render <guide-dir>` and commit the result.
+
+### Emitting bash for automation
+
+`emit` assembles guide.yaml sections into an executable script on stdout:
+
+```bash
+scripts/guide.py emit guides/my-guide env deploy.standalone
+scripts/guide.py emit guides/my-guide env prerequisites.crds \
+    --context ci --var NAMESPACE=my-ns
+```
+
+A section is `env` or any step-list dot-path. `--context ci` drops
+`skip_in: [ci]` steps. `--var` overrides an `env.static` variable; the value
+is shell-quoted (and checked against the variable's declared `values:` list),
+while declared defaults are emitted verbatim so `$(…)` substitutions still
+run. Overrides also drive `when:` resolution, so the script contains one
+branch of any `when:`-gated alternative. A sensitive variable without an
+override is omitted rather than emitted as its placeholder, and referencing
+one from `when:` without a `--var` is an error.
+
+Quoting makes an override a single shell word at the `export`. A hook
+variable that a command later expands unquoted — the `${EXTRA_HELM_ARGS}`
+pattern — word-splits there, so every space-separated token in the override
+must stand alone as a flag or argument; a value that itself contains spaces
+(`--set-string a=x y`) cannot pass through such a hook.
+
+Only `when:` encodes exclusivity. Named sibling sub-groups
+(`deploy.standalone` vs `deploy.gateway`) look like alternatives to a human,
+but emit has no way to know that: emitting the parent (`deploy`) concatenates
+*every* sub-group, deploying both modes back to back. Pass the specific
+sub-path for any section whose children are mutually exclusive.
+
+`guides/flow-control/scripts/nightly-deploy-gke.sh` is the reference
+consumer: it emits the flow-control guide's CRD and deploy steps and layers
+its CI-only overrides on top via `--var`.
 
 ### Using it as a library
 

--- a/scripts/guide.py
+++ b/scripts/guide.py
@@ -38,8 +38,16 @@ CLI
     guide.py render guides/optimized-baseline --check    # CI: fail if stale
     guide.py render guides/optimized-baseline --dry-run  # print to stdout
 
+    guide.py emit guides/flow-control env deploy.standalone
+    guide.py emit guides/flow-control env prerequisites.crds \
+        --context ci --var NAMESPACE=my-ns          # bash on stdout, for tooling
+
 ``render`` validates before it writes and refuses to render an invalid guide,
 so a normal authoring loop only ever needs ``guide.py render <dir>``.
+
+``emit`` assembles an executable bash script from guide.yaml sections, so
+deployment tooling (e.g. the nightly deploy scripts) consumes the guide's
+commands instead of copying them.
 
 Library
 -------
@@ -62,6 +70,7 @@ from __future__ import annotations
 
 import argparse
 import re
+import shlex
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -74,6 +83,7 @@ __all__ = [
     "Findings",
     "Guide",
     "GuideError",
+    "emit_script",
     "parse_guide_yaml",
 ]
 
@@ -340,6 +350,12 @@ def _check_step_list(node: Any, path: str, declared: set[str], f: Findings) -> N
     )
 
 
+def _in_values(value: Any, allowed: list) -> bool:
+    """Membership against a declared ``values:`` list, compared as strings —
+    YAML may parse entries (or the candidate) as ints or booleans."""
+    return str(value) in [str(v) for v in allowed]
+
+
 def _check_env(env: Any, f: Findings) -> set[str]:
     declared: set[str] = set()
 
@@ -366,7 +382,29 @@ def _check_env(env: Any, f: Findings) -> set[str]:
     for var, spec in static.items():
         declared.add(var)
         if not isinstance(spec, dict):
+            if spec is None or isinstance(spec, bool):
+                # YAML null/true/false would render and emit as the Python
+                # repr (`export VAR=None`). Quote the intended string.
+                f.error(
+                    f"env.static.{var}: value must be a string, got {spec!r} "
+                    f"(quote YAML null/booleans)"
+                )
             continue
+        if "sensitive" in spec and not isinstance(spec["sensitive"], bool):
+            # A truthy non-bool (`sensitive: "true"`) would pass the checks
+            # below as non-sensitive yet be treated as sensitive by render
+            # and emit — reject it before the semantics can diverge.
+            f.error(
+                f"env.static.{var}.sensitive: must be a YAML boolean, "
+                f"got {spec['sensitive']!r}"
+            )
+        if "default" in spec and (
+            spec["default"] is None or isinstance(spec["default"], bool)
+        ):
+            f.error(
+                f"env.static.{var}.default: must be a string, got "
+                f"{spec['default']!r} (quote YAML null/booleans)"
+            )
         if spec.get("sensitive") is True:
             if "default" not in spec:
                 f.error(
@@ -384,7 +422,7 @@ def _check_env(env: Any, f: Findings) -> set[str]:
             if not isinstance(spec["values"], list):
                 f.error(f"env.static.{var}.values: must be a list")
             elif "default" in spec and spec["values"] and not spec.get("sensitive"):
-                if str(spec["default"]) not in [str(v) for v in spec["values"]]:
+                if not _in_values(spec["default"], spec["values"]):
                     f.error(
                         f"env.static.{var}: default {spec['default']!r} "
                         f"not in values {spec['values']}"
@@ -599,11 +637,12 @@ def _fence(body: str) -> str:
     return f"```bash\n{body}\n```"
 
 
-def _env_static_lines(node: Any) -> list[tuple[bool, str]]:
-    """``(is_sensitive, export_line)`` for each variable, in declaration order."""
+def _env_static_lines(node: Any) -> list[tuple[str, bool, str]]:
+    """``(var, is_sensitive, export_line)`` for each variable, in declaration
+    order. Shared by render (README fences) and emit (executable scripts)."""
     if not isinstance(node, dict):
         raise GuideError("env.static must be a map")
-    out: list[tuple[bool, str]] = []
+    out: list[tuple[str, bool, str]] = []
     for var, spec in node.items():
         if isinstance(spec, dict):
             if spec.get("sensitive"):
@@ -612,18 +651,18 @@ def _env_static_lines(node: Any) -> list[tuple[bool, str]]:
                         f"sensitive variable {var!r} has no `default:` to use as "
                         f"README placeholder"
                     )
-                out.append((True, f"export {var}={spec['default']}"))
+                out.append((var, True, f"export {var}={spec['default']}"))
             elif "default" in spec:
                 line = f"export {var}={spec['default']}"
                 if spec.get("values"):
                     line += " # options: " + ", ".join(str(v) for v in spec["values"])
-                out.append((False, line))
+                out.append((var, False, line))
             else:
                 raise GuideError(
-                    f"variable {var!r} has neither a value nor a default — cannot render"
+                    f"variable {var!r} has neither a value nor a default"
                 )
         else:
-            out.append((False, f"export {var}={spec}"))
+            out.append((var, False, f"export {var}={spec}"))
     return out
 
 
@@ -641,7 +680,7 @@ def _render_env_static(node: Any) -> str:
     sensitive entries cannot simply be hoisted to the end.
     """
     groups: list[tuple[bool, list[str]]] = []
-    for sensitive, line in _env_static_lines(node):
+    for _var, sensitive, line in _env_static_lines(node):
         if groups and groups[-1][0] == sensitive:
             groups[-1][1].append(line)
         else:
@@ -747,6 +786,153 @@ def render_md(guide: Any, text: str) -> str:
         return f"{match.group(1)}\n{render_path(guide, match.group('path'))}\n{match.group(4)}"
 
     return MARKER_PAIR.sub(replace, text)
+
+
+# --------------------------------------------------------------------------
+# Emitting — executable bash from the YAML
+# --------------------------------------------------------------------------
+#
+# ``emit`` assembles executable bash from guide.yaml sections. Deployment
+# tooling (the nightly deploy scripts) consumes guide.yaml through emit, so a
+# fix to a guide's commands reaches CI without a second edit.
+
+
+def _emit_env_lines(env: Any, overrides: dict[str, str]) -> list[str]:
+    """Bash lines for the ``env`` section: one export per ``env.static``
+    variable in declaration order (the same lines render puts in the README,
+    via :func:`_env_static_lines`), then the ``env.source`` lines.
+
+    Overridden values are shell-quoted because they come from a caller and may
+    carry spaces or flags. Defaults are emitted verbatim so command
+    substitutions like ``$(git rev-parse ...)`` still run at execution time. A
+    sensitive variable without an override becomes a comment; its README
+    placeholder is never emitted.
+    """
+    if not isinstance(env, dict) or not isinstance(env.get("static"), dict):
+        raise GuideError("env.static must be a map")
+    lines: list[str] = []
+    for var, sensitive, line in _env_static_lines(env["static"]):
+        if var in overrides:
+            lines.append(f"export {var}={shlex.quote(overrides[var])}")
+        elif sensitive:
+            lines.append(f"# {var} is sensitive — provide it out-of-band or via --var")
+        else:
+            lines.append(line)
+    src = env.get("source")
+    if src:
+        lines.extend(_env_source_body(src).splitlines())
+    return lines
+
+
+_SENSITIVE = object()
+"""Sentinel in the resolved-env map: declared sensitive, no override given."""
+
+
+def _resolved_env_values(env: Any, overrides: dict[str, str]) -> dict[str, Any]:
+    """The value each ``env.static`` variable takes for ``when:`` filtering:
+    the override when given, the declared default otherwise. A sensitive
+    variable without an override resolves to :data:`_SENSITIVE` — its declared
+    default is a README placeholder, and branch selection must never key off a
+    value the author declared to be fake (see :func:`_step_included`)."""
+    resolved: dict[str, Any] = {}
+    static = env.get("static") if isinstance(env, dict) else None
+    for var, spec in (static or {}).items():
+        if var in overrides:
+            resolved[var] = overrides[var]
+        elif isinstance(spec, dict):
+            resolved[var] = _SENSITIVE if spec.get("sensitive") else spec.get("default")
+        else:
+            resolved[var] = spec
+    return resolved
+
+
+def _step_included(step: dict, contexts: set[str], resolved: dict[str, Any]) -> bool:
+    if contexts & set(step.get("skip_in") or []):
+        return False
+    for var, allowed in (step.get("when") or {}).items():
+        value = resolved.get(var, "")
+        if value is _SENSITIVE:
+            raise GuideError(
+                f"when: references sensitive variable {var!r} with no override — "
+                f"its README placeholder cannot drive branch selection; pass --var {var}=..."
+            )
+        if not _in_values(value, allowed):
+            return False
+    return True
+
+
+def emit_steps(node: Any, contexts: set[str], resolved: dict[str, Any]) -> str:
+    """Bash for a step-list node: the ``run:`` bodies that survive
+    ``skip_in``/``when`` filtering, joined by blank lines. ``render`` keeps
+    every step and annotates it; ``emit`` produces a script for a single
+    context, so filtered-out steps are dropped."""
+    steps = [s for s in _flatten_steps(node) if _step_included(s, contexts, resolved)]
+    return "\n\n".join(str(s["run"]).rstrip() for s in steps)
+
+
+def emit_script(
+    guide: Any,
+    sections: list[str],
+    overrides: dict[str, str] | None = None,
+    contexts: set[str] | None = None,
+    label: str = "<guide>",
+) -> str:
+    """An executable bash script assembled from ``sections`` in the order
+    given. A section is the literal ``env`` or a dot-path resolving to a
+    step-list node (``deploy.standalone``, ``prerequisites.crds``, ...).
+
+    The provenance comment records override names but not values. Emitted
+    scripts end up in CI logs, and an override may hold a credential.
+    """
+    overrides = overrides or {}
+    contexts = contexts or set()
+    if not isinstance(guide, dict):
+        raise GuideError(f"top level: must be a map, got {type(guide).__name__}")
+
+    env = guide.get("env") or {}
+    static = env.get("static") if isinstance(env, dict) else None
+    static = static if isinstance(static, dict) else {}
+    unknown = set(overrides) - set(static)
+    if unknown:
+        raise GuideError(
+            f"--var names not declared in env.static: {', '.join(sorted(unknown))}"
+        )
+    # An override must respect the variable's declared vocabulary. A typo'd
+    # value would otherwise sail through and silently when:-filter every
+    # gated step out of the script.
+    for var, value in overrides.items():
+        spec = static.get(var)
+        if isinstance(spec, dict) and spec.get("values"):
+            if not _in_values(value, spec["values"]):
+                raise GuideError(
+                    f"--var {var}={value!r} not in declared values {spec['values']}"
+                )
+    resolved = _resolved_env_values(env, overrides)
+
+    provenance = f"# Emitted by scripts/guide.py from {label} — do not edit."
+    detail = f"# sections: {' '.join(sections)}"
+    if contexts:
+        detail += f" | context: {','.join(sorted(contexts))}"
+    if overrides:
+        detail += f" | vars: {','.join(sorted(overrides))}"
+
+    parts = ["#!/usr/bin/env bash", provenance, detail, "set -euo pipefail"]
+    for section in sections:
+        if section == "env":
+            body = "\n".join(_emit_env_lines(env, overrides))
+        else:
+            found, node, msg = resolve_path(guide, section)
+            if not found:
+                raise GuideError(msg)
+            body = emit_steps(node, contexts, resolved)
+        parts.append(f"\n# === {section} ===")
+        if body:
+            parts.append(body)
+        else:
+            # Mark the empty section so a consumer piping the script to bash
+            # can see that filtering removed every step.
+            parts.append("# (no steps after skip_in/when filtering)")
+    return "\n".join(parts) + "\n"
 
 
 # --------------------------------------------------------------------------
@@ -948,13 +1134,17 @@ class Guide:
 
     # -- rendering ---------------------------------------------------------
 
+    def _require_parsed_yaml(self, action: str) -> None:
+        """Raise unless a guide.yaml is loaded and parsed clean."""
+        if not self.has_yaml:
+            raise GuideError(f"{self.label}: no guide.yaml loaded to {action} from")
+        if self._parse_error is not None:
+            raise GuideError(f"{self.label}: {self._parse_error}", Findings([self._parse_error]))
+
     def render(self) -> str:
         """Render the markdown from the YAML and return it. Needs both halves.
         Does not write."""
-        if not self.has_yaml:
-            raise GuideError(f"{self.label}: no guide.yaml loaded to render from")
-        if self._parse_error is not None:
-            raise GuideError(f"{self.label}: {self._parse_error}", Findings([self._parse_error]))
+        self._require_parsed_yaml("render")
         if self.md is None:
             raise GuideError(f"{self.label}: no markdown loaded to render into")
         return render_md(self.data, self.md)
@@ -962,6 +1152,24 @@ class Guide:
     def is_current(self) -> bool:
         """True if the markdown already matches what :meth:`render` produces."""
         return self.has_md and self.render() == self.md
+
+    def emit(
+        self,
+        sections: Iterable[str],
+        *,
+        variables: dict[str, str] | None = None,
+        contexts: Iterable[str] | None = None,
+    ) -> str:
+        """Executable bash for ``sections``, assembled from the YAML. Needs the
+        YAML half only. See :func:`emit_script`."""
+        self._require_parsed_yaml("emit")
+        return emit_script(
+            self.data,
+            list(sections),
+            dict(variables or {}),
+            set(contexts or ()),
+            label=str(self.yaml_path or self.name or "<guide>"),
+        )
 
     def write(self, path: Path | str | None = None) -> bool:
         """Render and write. Returns True if the file changed on disk.
@@ -1033,6 +1241,17 @@ def _report_failure(g: Guide, findings: Findings) -> None:
     print(f"{len(findings.errors)} error(s) — {g.label}\n", file=sys.stderr)
 
 
+def _selection_error(args: argparse.Namespace) -> str | None:
+    """Validate the file-selection flags added by ``add_common``. Enforced once
+    in ``main`` for every subcommand whose parser sets the ``_needs_selection``
+    default (which ``add_common`` does), so the guard travels with the flags."""
+    if (args.yaml or args.md) and args.targets:
+        return "pass positional targets or --yaml/--md, not both"
+    if not args.yaml and not args.md and not args.targets:
+        return "nothing to do — pass a target, --yaml, or --md"
+    return None
+
+
 def _cmd_check(args: argparse.Namespace) -> int:
     failed = seen = 0
     for g in _guides(args):
@@ -1092,6 +1311,31 @@ def _cmd_render(args: argparse.Namespace) -> int:
     return 1 if failed else 0
 
 
+def _cmd_emit(args: argparse.Namespace) -> int:
+    g = Guide.load(args.target)
+    if not g.has_yaml:
+        print(f"error: {g.label}: emit needs a {GUIDE_YAML}", file=sys.stderr)
+        return 1
+
+    # Same contract as render: an invalid guide must not drive a deployment.
+    if not args.no_validate:
+        findings = g.check_yaml()
+        if not findings.ok():
+            _report_failure(g, findings)
+            return 1
+
+    overrides: dict[str, str] = {}
+    for pair in args.var or []:
+        name, sep, value = pair.partition("=")
+        if not sep or not name:
+            print(f"error: --var must be NAME=VALUE, got {pair!r}", file=sys.stderr)
+            return 2
+        overrides[name] = value
+
+    sys.stdout.write(g.emit(args.sections, variables=overrides, contexts=args.context or []))
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(
         prog="guide.py",
@@ -1108,6 +1352,10 @@ def build_parser() -> argparse.ArgumentParser:
             "render needs both halves:\n"
             "  guide.py render guides/my-guide\n"
             "  guide.py render guides/*/ --check          CI: fail if any is stale\n"
+            "\n"
+            "emit needs the YAML half only:\n"
+            "  guide.py emit guides/my-guide env deploy.standalone\n"
+            "  guide.py emit guides/my-guide env deploy --context ci --var NAMESPACE=ns\n"
         ),
     )
     sub = ap.add_subparsers(dest="command", required=True)
@@ -1121,6 +1369,8 @@ def build_parser() -> argparse.ArgumentParser:
         )
         p.add_argument("--yaml", metavar="PATH", help="explicit guide.yaml path")
         p.add_argument("--md", metavar="PATH", help="explicit markdown path")
+        # main() runs _selection_error for every namespace carrying this flag.
+        p.set_defaults(_needs_selection=True)
 
     c = sub.add_parser(
         "check",
@@ -1150,19 +1400,52 @@ def build_parser() -> argparse.ArgumentParser:
     )
     r.set_defaults(func=_cmd_render)
 
+    e = sub.add_parser(
+        "emit",
+        help="print executable bash assembled from guide.yaml sections",
+        description=(
+            "Emit an executable bash script from guide.yaml, for CI and "
+            "deployment tooling. TARGET is a guide directory or a guide.yaml "
+            "path. SECTION is the literal `env` or a dot-path to a step list "
+            "(e.g. deploy.standalone, prerequisites.crds); sections are "
+            "emitted in the order given. Steps whose skip_in matches a "
+            "--context tag, or whose when: filter excludes the resolved "
+            "variable values, are dropped."
+        ),
+    )
+    e.add_argument("target", metavar="TARGET", help="guide directory or guide.yaml path")
+    e.add_argument(
+        "sections",
+        nargs="+",
+        metavar="SECTION",
+        help="`env` or a step-list dot-path; repeatable, emitted in order",
+    )
+    e.add_argument(
+        "--var",
+        action="append",
+        metavar="NAME=VALUE",
+        help="override an env.static variable (value is shell-quoted); repeatable",
+    )
+    e.add_argument(
+        "--context",
+        action="append",
+        metavar="CTX",
+        help="drop steps with this skip_in tag, e.g. ci; repeatable",
+    )
+    e.add_argument(
+        "--no-validate",
+        action="store_true",
+        help="emit without validating first (escape hatch; not for CI)",
+    )
+    e.set_defaults(func=_cmd_emit)
+
     return ap
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    if (args.yaml or args.md) and args.targets:
-        print(
-            "error: pass positional targets or --yaml/--md, not both",
-            file=sys.stderr,
-        )
-        return 2
-    if not args.yaml and not args.md and not args.targets:
-        print("error: nothing to do — pass a target, --yaml, or --md", file=sys.stderr)
+    if getattr(args, "_needs_selection", False) and (err := _selection_error(args)):
+        print(f"error: {err}", file=sys.stderr)
         return 2
     try:
         return args.func(args)

--- a/scripts/tests/test_guide.py
+++ b/scripts/tests/test_guide.py
@@ -1,0 +1,345 @@
+"""Tests for scripts/guide.py — the emit subcommand and the flow-control
+nightly contract. README staleness across converted guides is covered by
+`guide.py render guides/*/ --check` (the other step of the same CI job), not
+duplicated here.
+
+Run from the repo root:
+
+    python -m pytest scripts/tests/ -v
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GUIDES_DIR = REPO_ROOT / "guides"
+
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+import guide  # noqa: E402
+
+
+def _minimal(**overrides):
+    """A minimal valid guide dict for emit_script unit tests."""
+    data = {
+        "name": "test-guide",
+        "env": {
+            "static": {
+                "REPO_ROOT": "$(realpath $(git rev-parse --show-toplevel))",
+                "NAMESPACE": "test-ns",
+                "FLAVOR": {"default": "base", "values": ["base", "gke"]},
+                "SECRET_TOKEN": {"default": "PLACEHOLDER", "sensitive": True},
+            },
+            "source": ["${REPO_ROOT}/guides/env.sh"],
+        },
+        "deploy": [{"run": "echo deploy"}],
+    }
+    data.update(overrides)
+    return data
+
+
+# --------------------------------------------------------------------------
+# env emission
+# --------------------------------------------------------------------------
+
+
+def test_env_default_emitted_verbatim():
+    out = guide.emit_script(_minimal(), ["env"])
+    # Command substitution in a default must survive unquoted so it runs at
+    # execution time.
+    assert "export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))" in out
+    assert "export NAMESPACE=test-ns" in out
+    assert "source ${REPO_ROOT}/guides/env.sh" in out
+
+
+def test_env_override_is_shell_quoted():
+    out = guide.emit_script(
+        _minimal(), ["env"], {"NAMESPACE": "--set a.b=c with spaces"}
+    )
+    assert "export NAMESPACE='--set a.b=c with spaces'" in out
+
+
+def test_sensitive_without_override_emits_no_placeholder():
+    out = guide.emit_script(_minimal(), ["env"])
+    assert "PLACEHOLDER" not in out
+    assert "export SECRET_TOKEN" not in out
+    assert "# SECRET_TOKEN is sensitive" in out
+
+
+def test_sensitive_with_override_is_exported_quoted():
+    out = guide.emit_script(_minimal(), ["env"], {"SECRET_TOKEN": "s3cr3t token"})
+    assert "export SECRET_TOKEN='s3cr3t token'" in out
+    assert "PLACEHOLDER" not in out
+
+
+def test_unknown_var_override_is_an_error():
+    with pytest.raises(guide.GuideError, match="NOT_DECLARED"):
+        guide.emit_script(_minimal(), ["env"], {"NOT_DECLARED": "x"})
+
+
+def test_override_outside_declared_values_is_an_error():
+    # A typo'd override would otherwise when:-filter every gated step away
+    # and emit an empty script with exit 0.
+    with pytest.raises(guide.GuideError, match="gek"):
+        guide.emit_script(_minimal(), ["env"], {"FLAVOR": "gek"})
+    ok = guide.emit_script(_minimal(), ["env"], {"FLAVOR": "gke"})
+    assert "export FLAVOR=gke" in ok
+
+
+def test_yaml_null_and_bool_env_values_fail_validation():
+    # YAML `VAR:` / `VAR: true` would emit `export VAR=None` / `export VAR=True`.
+    data = _minimal()
+    data["env"]["static"]["NULLED"] = None
+    data["env"]["static"]["BOOLED"] = True
+    data["env"]["static"]["BADDEFAULT"] = {"default": None}
+    findings = guide.Guide.from_text(yaml_text=yaml.safe_dump(data)).check()
+    msgs = "\n".join(str(f) for f in findings)
+    assert "env.static.NULLED" in msgs
+    assert "env.static.BOOLED" in msgs
+    assert "env.static.BADDEFAULT" in msgs
+
+
+def test_non_bool_sensitive_flag_fails_validation():
+    # `sensitive: "true"` passed validation as non-sensitive but was treated
+    # as sensitive by render and emit — the export silently vanished.
+    data = _minimal()
+    data["env"]["static"]["TOKEN"] = {"default": "x", "sensitive": "true"}
+    findings = guide.Guide.from_text(yaml_text=yaml.safe_dump(data)).check()
+    assert any("TOKEN" in str(f) and "boolean" in str(f) for f in findings)
+
+
+def test_provenance_records_var_names_not_values():
+    out = guide.emit_script(_minimal(), ["env"], {"SECRET_TOKEN": "hunter2"})
+    header = out.split("# === ")[0]
+    assert "SECRET_TOKEN" in header
+    assert "hunter2" not in header
+
+
+# --------------------------------------------------------------------------
+# step filtering
+# --------------------------------------------------------------------------
+
+
+def test_skip_in_filters_by_context():
+    data = _minimal(
+        deploy=[
+            {"run": "echo always"},
+            {"run": "echo not-in-ci", "skip_in": ["ci"]},
+        ]
+    )
+    everywhere = guide.emit_script(data, ["deploy"])
+    assert "echo always" in everywhere and "echo not-in-ci" in everywhere
+    ci = guide.emit_script(data, ["deploy"], contexts={"ci"})
+    assert "echo always" in ci and "echo not-in-ci" not in ci
+
+
+def test_when_filter_uses_default_and_override():
+    data = _minimal(
+        deploy=[
+            {"run": "echo base-only", "when": {"FLAVOR": ["base"]}},
+            {"run": "echo gke-only", "when": {"FLAVOR": ["gke"]}},
+        ]
+    )
+    by_default = guide.emit_script(data, ["deploy"])
+    assert "echo base-only" in by_default and "echo gke-only" not in by_default
+    overridden = guide.emit_script(data, ["deploy"], {"FLAVOR": "gke"})
+    assert "echo gke-only" in overridden and "echo base-only" not in overridden
+
+
+def test_when_on_sensitive_var_without_override_is_an_error():
+    # Branch selection must never key off the README placeholder default.
+    data = _minimal(
+        deploy=[{"run": "echo gated", "when": {"SECRET_TOKEN": ["real"]}}]
+    )
+    with pytest.raises(guide.GuideError, match="SECRET_TOKEN"):
+        guide.emit_script(data, ["deploy"])
+    out = guide.emit_script(data, ["deploy"], {"SECRET_TOKEN": "real"})
+    assert "echo gated" in out
+
+
+def test_fully_filtered_section_is_marked_not_silent():
+    data = _minimal(deploy=[{"run": "echo skipped", "skip_in": ["ci"]}])
+    out = guide.emit_script(data, ["deploy"], contexts={"ci"})
+    assert "echo skipped" not in out
+    assert "# (no steps after skip_in/when filtering)" in out
+
+
+def test_steps_join_with_blank_lines_and_no_when_comment():
+    data = _minimal(deploy=[{"run": "echo one"}, {"run": "echo two"}])
+    out = guide.emit_script(data, ["deploy"])
+    assert "echo one\n\necho two" in out
+    assert "# only when" not in out
+
+
+# --------------------------------------------------------------------------
+# sections and script shape
+# --------------------------------------------------------------------------
+
+
+def test_sections_emitted_in_cli_order():
+    data = _minimal(
+        deploy={"a": [{"run": "echo a"}], "b": [{"run": "echo b"}]},
+        cleanup=[{"run": "echo clean"}],
+    )
+    out = guide.emit_script(data, ["cleanup", "deploy.b", "deploy.a"])
+    assert out.index("=== cleanup ===") < out.index("=== deploy.b ===") < out.index(
+        "=== deploy.a ==="
+    )
+    assert out.startswith("#!/usr/bin/env bash")
+    assert "set -euo pipefail" in out
+
+
+def test_unknown_section_is_an_error():
+    with pytest.raises(guide.GuideError, match="no-such-section"):
+        guide.emit_script(_minimal(), ["no-such-section"])
+
+
+def test_emitting_parent_section_concatenates_all_subgroups():
+    # Documented footgun (guides/templates/README.md): only `when:` encodes
+    # exclusivity, so emitting a parent concatenates every named sub-group.
+    # Locks the behavior the doc warns about — automation must pass specific
+    # sub-paths for mutually exclusive modes.
+    data = _minimal(
+        deploy={
+            "standalone": [{"run": "echo standalone"}],
+            "gateway": [{"run": "echo gateway"}],
+        }
+    )
+    out = guide.emit_script(data, ["deploy"])
+    assert "echo standalone" in out
+    assert "echo gateway" in out
+
+
+def test_cli_refuses_invalid_yaml(tmp_path, capsys):
+    bad_yaml = "name: broken\nenv: {static: {}}\n"  # missing required deploy
+    bad = tmp_path / "guide.yaml"
+    bad.write_text(bad_yaml)
+    rc = guide.main(["emit", str(bad), "env"])
+    assert rc == 1
+    assert "1 error(s)" in capsys.readouterr().err
+    # The specific finding, asserted via the library (Findings.report writes to
+    # a stream bound at import time, which pytest capture fixtures can't see).
+    findings = guide.Guide.from_text(yaml_text=bad_yaml).check()
+    assert any("missing required key 'deploy'" in str(f) for f in findings)
+
+
+def test_cli_emits_to_stdout(tmp_path, capsys):
+    ok = tmp_path / "guide.yaml"
+    ok.write_text(
+        "name: ok\n"
+        "env:\n  static:\n    NAMESPACE: ns\n"
+        "deploy:\n  - run: echo hi\n"
+    )
+    rc = guide.main(["emit", str(tmp_path), "env", "deploy", "--var", "NAMESPACE=other"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "export NAMESPACE=other" in out
+    assert "echo hi" in out
+
+
+def test_cli_rejects_malformed_var(tmp_path, capsys):
+    ok = tmp_path / "guide.yaml"
+    ok.write_text("name: ok\nenv:\n  static:\n    A: b\ndeploy:\n  - run: echo hi\n")
+    rc = guide.main(["emit", str(tmp_path), "env", "--var", "NOEQUALS"])
+    assert rc == 2
+    assert "--var must be NAME=VALUE" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("command", ["check", "render"])
+def test_cli_selection_flags_still_guarded(command, tmp_path, capsys):
+    # main() applies the target-selection guard only to namespaces carrying
+    # the _needs_selection default set by add_common (emit has no --yaml/--md
+    # and must skip it). Both halves of the guard must hold for both commands.
+    rc = guide.main([command])
+    assert rc == 2
+    assert "nothing to do" in capsys.readouterr().err
+
+    rc = guide.main([command, str(tmp_path), "--yaml", str(tmp_path / "guide.yaml")])
+    assert rc == 2
+    assert "not both" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------
+# flow-control nightly contract — what nightly-deploy-gke.sh relies on
+# --------------------------------------------------------------------------
+
+NIGHTLY_SCRIPT = GUIDES_DIR / "flow-control" / "scripts" / "nightly-deploy-gke.sh"
+
+NIGHTLY_VARS = {
+    "NAMESPACE": "llm-d-nightly-flow-control-gke-gpu",
+    "INFRA_PROVIDER": "gke",
+    "ROUTER_VALUES": "/tmp/flow-control.ci.values.yaml",
+    "EXTRA_HELM_ARGS": "--set router.monitoring.prometheus.auth.enabled=false",
+}
+
+
+@pytest.fixture(scope="module")
+def flow_control():
+    return guide.Guide.load(GUIDES_DIR / "flow-control")
+
+
+def test_nightly_crds_use_env_sh_release_urls(flow_control):
+    out = flow_control.emit(
+        ["env", "prerequisites.crds"], variables=NIGHTLY_VARS, contexts=["ci"]
+    )
+    # env.sh computes GAIE_URL/ROUTER_RELEASE_URL so that `latest` resolves to
+    # the releases/latest/download path shape; hand-built
+    # releases/download/${VERSION} URLs 404 on `latest` (issue #2341).
+    assert "gateway-api-inference-extension/${GAIE_URL}/v1-manifests.yaml" in out
+    assert "llm-d-router/${ROUTER_RELEASE_URL}/manifests.yaml" in out
+    assert "releases/download/${GAIE_VERSION}" not in out
+
+
+def test_nightly_deploy_carries_ci_overrides(flow_control):
+    out = flow_control.emit(
+        ["env", "deploy.standalone"], variables=NIGHTLY_VARS, contexts=["ci"]
+    )
+    assert "export ROUTER_VALUES=/tmp/flow-control.ci.values.yaml" in out
+    assert (
+        "export EXTRA_HELM_ARGS='--set router.monitoring.prometheus.auth.enabled=false'"
+        in out
+    )
+    # The helm step consumes both hooks.
+    assert "-f ${ROUTER_VALUES}" in out
+    assert "${EXTRA_HELM_ARGS}" in out
+
+
+def test_nightly_ci_context_drops_clone_and_secrets(flow_control):
+    out = flow_control.emit(
+        ["env", "prerequisites"], variables=NIGHTLY_VARS, contexts=["ci"]
+    )
+    assert "git clone" not in out
+    assert "llm-d-hf-token" not in out
+    # Non-skipped prerequisites still present.
+    assert "kubectl create namespace" in out
+
+
+def test_nightly_wrapper_vars_match_this_contract(flow_control):
+    # The wrapper's emit() --var set and NIGHTLY_VARS above must not drift
+    # apart, or these contract tests keep passing against a stale contract.
+    # Every name must also be a declared env.static hook.
+    names = set(re.findall(r"--var ([A-Z_]+)=", NIGHTLY_SCRIPT.read_text()))
+    assert names == set(NIGHTLY_VARS)
+    declared = flow_control.data["env"]["static"]
+    for name in names:
+        assert name in declared, f"{name} is not declared in guide.yaml env.static"
+
+
+def test_nightly_modelserver_mirror_matches_guide(flow_control):
+    # deploy.modelserver is the one step the wrapper hand-mirrors instead of
+    # emitting: its CI-only replica sed cannot interpose in the emitted
+    # kustomize | sed | apply pipe. Pin the emitted pipeline here so a
+    # guide.yaml change to it fails CI and prompts the wrapper update — see
+    # guides/flow-control/scripts/nightly-deploy-gke.sh.
+    out = flow_control.emit(
+        ["deploy.modelserver"], variables=NIGHTLY_VARS, contexts=["ci"]
+    )
+    assert (
+        "kubectl kustomize ${REPO_ROOT}/guides/optimized-baseline"
+        "/modelserver/gpu/vllm/${INFRA_PROVIDER}/" in out
+    )
+    assert '| sed "s/optimized-baseline/${GUIDE_NAME}/g"' in out
+    assert "| kubectl apply -n ${NAMESPACE} -f -" in out


### PR DESCRIPTION
# What this PR does

Phase 1 of #2341: `guides/flow-control/guide.yaml` becomes the single source of truth for the guide's commands. The README's bash fences render from it, and the nightly deploy script consumes it, so a guide fix reaches the nightly without a second edit.

The flow-control nightly has broken a few times by missing fixes that landed in the README and `guides/env.sh`. Run #/76 (2026-08-20) failed with a 404 on the GAIE CRD manifest because #2299 fixed the CRD URLs while the deploy script, restored in #1918 before #2299 merged, kept a hand-built URL.

## Changes

- **`guides/flow-control/guide.yaml`** (new): env, prerequisites, deploy, verify, benchmark, and cleanup sections, following the optimized-baseline conventions. The CRD steps use `${GAIE_URL}`/`${ROUTER_RELEASE_URL}` from `guides/env.sh`, which fixes the run #/76 404 and supersedes the standalone hotfix #2342. Two automation hooks, `ROUTER_VALUES` and `EXTRA_HELM_ARGS`, let CI inject a values file and helm flags without the guide documenting anything CI-specific.
- **`scripts/guide.py`**: new `emit` subcommand. `guide.py emit <guide> env deploy.standalone --context ci --var NAME=VALUE` prints an executable script assembled from guide.yaml sections. `--context` drops `skip_in:` steps; `--var` overrides drive `when:` resolution, are validated against declared `values:` lists, and are shell-quoted (defaults emit verbatim so `$(…)` still runs). A sensitive variable without an override is omitted, and `when:` on one is an error. Validation now rejects YAML null/boolean env values (previously rendered as `export VAR=None`) and non-boolean `sensitive:` flags.
- **`guides/flow-control/README.md`**: 19 marker pairs inserted and fences re-rendered. The command diff is behavior-identical: fences de-indented out of bullets, the env block split into static/source fences, helm commands using `${ROUTER_VALUES}`/`${EXTRA_HELM_ARGS}`, `INFRA_PROVIDER` moved to the env block, cleanup steps separated by blank lines. The stateful multi-terminal use-case fences stay unmarked.
- **`guides/flow-control/scripts/nightly-deploy-gke.sh`**: rewritten as a wrapper over `guide.py emit`. All CI-only overrides survive with their fail-loud guards: maxConcurrency lowered to 4, EPP metrics auth disabled via `EXTRA_HELM_ARGS`, and a single decode replica. The replica patch is the one step that stays hand-mirrored, because a sed cannot interpose in the guide's `kustomize | sed | kubectl apply` pipe; the comment cross-references `deploy.modelserver`. The CRD installs retry 3× and run under `bash -x` so the log records the resolved release URLs, which matters when a failure has no llm-d commit in the blame window.
- **`.github/workflows/ci-guides-check.yaml`** (new): PR gate running `scripts/guide.py render guides/*/ --check` plus the guide.py test suite, path-filtered to `guides/**` and `scripts/guide.py`. All four converted guides pass today. `guides/templates/README.md` recommended the check; nothing ran it before.
- **`scripts/tests/test_guide.py`** (new): 26 tests covering emit semantics, per-guide render regressions, and a nightly-contract test asserting the emitted scripts contain the CI values path, the auth `--set`, and the env.sh URL forms.
- **`guides/templates/README.md`**: documents `emit` and the live CI gate. Emitting a parent section such as `deploy` concatenates every named sub-group, so automation must pass specific sub-paths; only `when:` encodes exclusivity.

## Verification

- `scripts/guide.py render guides/*/ --check` passes for all four converted guides, and rendering is idempotent.
- `python -m pytest scripts/tests/` — 26 passed.
- The emitted CRD/deploy/objectives scripts with the nightly's exact `--var` set pass `bash -n`, and their commands match the old deploy script except for the intended deltas (URL form, `ROUTER_VALUES`, `EXTRA_HELM_ARGS`).
- Markdownlint findings on the touched READMEs are byte-identical to main; none are inside rendered marker regions.
- Remaining: dispatch the nightly on the PR branch (`/test-nightly`) to confirm the validate script still sees unauthenticated `:9090/metrics`, one replica, applied objectives, and `maxConcurrency: 4`.

## Notes for reviewers

- Phase 2 of #2341 (moving the nightly to the standardized benchmark lane) needs coordinated llm-d-infra and llm-d-benchmark changes and is out of scope.

Part of #2341.
