### PR TITLE
ROCm ATOM support

### DIFF
--- a/.github/workflows/consolidate-status-optimized-baseline-amd-acc-rocm-atom-x.yaml
+++ b/.github/workflows/consolidate-status-optimized-baseline-amd-acc-rocm-atom-x.yaml
@@ -1,0 +1,36 @@
+name: Past Status - Optimized Baseline E2E (AMD ROCM ATOM)
+
+on:
+  workflow_dispatch:
+    inputs:
+      workflow_name_query:
+        description: 'Name of the workflow to be queried'
+        required: false
+        type: 'string'
+        default: 'nightly-e2e-optimized-baseline-amd-acc-rocm-atom-x.yaml'
+      time_window_query:
+        description: 'How many days in the past to query'
+        required: true
+        type: 'string'
+        default: '5'
+      branch_query:
+        description: 'Branch to be queried'
+        required: false
+        type: string
+        default: 'main'
+
+#  push:
+#    branches:
+#      - main
+
+  schedule:
+    - cron: '17 12 * * *'  # 12:17 UTC daily
+
+jobs:
+  check_for_success:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-query-success-past-runs.yaml@main
+    with:
+      workflow_name_query: ${{ inputs.workflow_name_query || 'nightly-e2e-optimized-baseline-amd-acc-rocm-atom-x.yaml' }}
+      time_window_query: ${{ inputs.time_window_query || '5' }}
+      branch_query: ${{ inputs.branch_query || 'main' }}
+    secrets: inherit

--- a/.github/workflows/nightly-e2e-optimized-baseline-amd-acc-rocm-atom-x.yaml
+++ b/.github/workflows/nightly-e2e-optimized-baseline-amd-acc-rocm-atom-x.yaml
@@ -1,0 +1,109 @@
+name: Nightly - Optimized Baseline E2E (AMD ROCM ATOM)
+
+on:
+  workflow_dispatch:
+    inputs:
+      decode_pods:
+        description: 'Number of decode (atom "standalone") pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      prefill_pods:
+        description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      gateway_class:
+        description: 'Class of gateway used ("istio", "agentgateway", "epponly" (i.e., "standalone"), "none")'
+        required: false
+        default: 'epponly'
+      monitoring_enabled:
+        description: 'Enabled monitoring ("true", "false")'
+        required: false
+        type: 'string'
+        default: 'false'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode ("true", "false")'
+        required: false
+        default: 'false'
+      verbose:
+        description: 'Execute workflow in "verbose" mode ("true", "false")'
+        required: false
+        default: 'false'
+        type: 'string'
+      harness:
+        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
+        required: false
+        default: 'inference-perf'
+        type: 'string'
+      workload:
+        description: 'Workload profile to be used during "run" operation (check list under "workload/profiles")'
+        required: false
+        default: 'sanity_random.yaml'
+#        default: 'guide_optimized-baseline_1.yaml'
+        type: 'string'
+      cleanup:
+        description: 'Cleanup the llm-d stack stood up by this workflow'
+        required: false
+        default: 'true'
+        type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
+
+#  push:
+#    branches:
+#      - main
+
+  schedule:
+    - cron: '17 12 * * *'  # 12:17 UTC daily
+
+permissions:
+  contents: write
+  actions: read
+
+concurrency:
+  group: nightly-e2e-optimized-baseline-amd-rocm-atom
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
+    with:
+      scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
+      standup_method: ${{ inputs.standup_method || 'kustomize' }}
+      standup_scenario: ${{ inputs.standup_scenario || 'optimized-baseline' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'amd' }}
+      backend_type: ${{ inputs.backend_type || 'atom' }}
+      infra_provider: ${{ inputs.infra_provider || 'amd-ci' }}
+      connector: ${{ inputs.connector || '' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-inference-rocm-gpu-atom' }}
+      persistent_model: ${{ inputs.persistent_model || 'true' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-rocm-atom' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-rocm-atom' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions/optimized-baseline' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'sanity_random.yaml' }}
+      cleanup: ${{ inputs.cleanup || 'true' }}
+    secrets: inherit
+
+  update-badge:
+    needs: [nightly]
+    if: always() && inputs.update_badge != 'false'
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
+    with:
+      badge_name: optimized-baseline-rocm-atom
+      badge_label: "ATOM ROCm"
+      result: ${{ needs.nightly.result }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/guides/optimized-baseline/modelserver/amd/atom/amd-ci/kustomization.yaml
+++ b/guides/optimized-baseline/modelserver/amd/atom/amd-ci/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+
+components:
+  - ../../../../../recipes/modelserver/components/model-cache

--- a/guides/optimized-baseline/modelserver/amd/atom/base/kustomization.yaml
+++ b/guides/optimized-baseline/modelserver/amd/atom/base/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../../recipes/modelserver/base/single-host/default
+
+namePrefix: optimized-baseline-rocm-atom-
+
+components:
+  - ../../../../../recipes/modelserver/components/images/amd-atom
+
+labels:
+  - pairs:
+      llm-d.ai/guide: optimized-baseline
+      llm-d.ai/model: Qwen3-32B
+      llm-d.ai/accelerator-variant: gpu
+      llm-d.ai/accelerator-vendor: amd
+      llm-d.ai/engine-type: atom
+    includeSelectors: true
+    includeTemplates: true
+patches:
+  - path: patch-atom.yaml

--- a/guides/optimized-baseline/modelserver/amd/atom/base/patch-atom.yaml
+++ b/guides/optimized-baseline/modelserver/amd/atom/base/patch-atom.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: modelserver
+          command: ["python", "-m", "atom.entrypoints.openai_server"]
+          args:
+            - "--model=Qwen/Qwen3-32B"
+            - "--host=0.0.0.0"
+            - "--server-port=8000"
+            - "--tensor-parallel-size=8"
+            - "--kv_cache_dtype=fp8"
+            - "--gpu-memory-utilization=0.9"
+            - "--enable_prefix_caching"
+          env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
+            - name: AITER_LOG_LEVEL
+              value: "WARNING"
+          resources:
+            limits:
+              cpu: "64"
+              memory: 160Gi
+              amd.com/gpu: 8
+            requests:
+              cpu: "32"
+              memory: 128Gi
+              amd.com/gpu: 8
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: dshm
+          startupProbe:
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 120
+          livenessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 30
+            failureThreshold: 5
+          readinessProbe:
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 40Gi

--- a/guides/optimized-baseline/render/kustomization.yaml
+++ b/guides/optimized-baseline/render/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# The optimized-baseline uses approx-prefix-cache-producer which does not
+# require an external tokenizer (render) service. This directory exists so
+# that `just deploy-render` (which calls `kustomize build ./render`) succeeds
+# without deploying any resources.
+resources: []

--- a/guides/recipes/modelserver/components/images/amd-atom/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/amd-atom/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+images:
+  - name: REPLACE_MODEL_SERVER_IMAGE
+    newName: rocm/atom-dev
+    newTag: "nightly_202608241610_4e0848dcdf94f3d4be0c1e3ce51db99bc93f8b8c"


### PR DESCRIPTION
Add support for the ROCm ATOM inference engine to the **optimized-baseline** guide.

**Changes:**
- Adds the pinned ATOM image and Kubernetes overlays (base + amd-ci) under `guides/optimized-baseline/modelserver/amd/atom/`.
- Wires `atom` into the optimized-baseline guide (`MODEL_SERVER` option) and regenerates the guide README.
- Adds the nightly E2E and status-consolidation workflows for AMD ROCm ATOM.

Note: pd-disaggregation ATOM support is **not** included in this PR and remains AMD-vLLM-only; it will be addressed separately.