### PR TITLE
docs(rdma): fix NVSHMEM_DISABLE_GDRCOPY spelling

### DIFF
--- a/docs/infrastructure/rdma/README.md
+++ b/docs/infrastructure/rdma/README.md
@@ -175,7 +175,7 @@ For Wide Expert Parallelism, map GPUs to specific HCAs for optimal topology:
   ```
 
 - Source `set_nccl_env.sh` from `/usr/local/gib/scripts/` at container startup
-- Set `NVSHMEM_DISABLED_GDRCOPY=true` (GKE recommendation)
+- Set `NVSHMEM_DISABLE_GDRCOPY=1` (GKE recommendation)
 - Use pod affinity on `cloud.google.com/gce-topology-block` for topology-aware placement
 - GPU-initiated RDMA requires `privileged: true` in the security context
 


### PR DESCRIPTION
## What

Align the GKE note in `docs/infrastructure/rdma/README.md` with the
variable NVSHMEM actually reads.

The RDMA page had `NVSHMEM_DISABLED_GDRCOPY=true`. The GKE provider page
already documents `NVSHMEM_DISABLE_GDRCOPY=1`. An unknown `NVSHMEM_*`
name is ignored, so following the RDMA page does not disable GDRCopy.

Fixes #2354

## How checked

`rg GDRCOPY docs/` now has one spelling on both pages.