### PR TITLE
fix(workload-autoscaling): capture WVA controller diagnostics before CKS teardown

### DIFF
--- a/guides/workload-autoscaling/scripts/nightly-deploy-cks.sh
+++ b/guides/workload-autoscaling/scripts/nightly-deploy-cks.sh
@@ -118,8 +118,21 @@ echo "==> Applying WVA + autoscaling assets"
 kubectl apply -k "${OUTPUT_DIR}"
 
 echo "==> Waiting for WVA controller to become Available"
-kubectl wait deployment/wva-controller-manager \
-  -n "${NAMESPACE}" --for=condition=Available --timeout=300s
+# The controller pod is force-deleted during teardown, so if it never becomes Available,
+# capture its state here — this is the only chance to see why before the evidence is gone.
+if ! kubectl wait deployment/wva-controller-manager \
+  -n "${NAMESPACE}" --for=condition=Available --timeout=300s; then
+  echo "ERROR: wva-controller-manager did not become Available — capturing diagnostics before teardown" >&2
+  echo "--- kubectl describe deploy/wva-controller-manager ---" >&2
+  kubectl describe deployment/wva-controller-manager -n "${NAMESPACE}" >&2 || true
+  for pod in $(kubectl get pods -n "${NAMESPACE}" -o name | grep '^pod/wva-controller-manager-' || true); do
+    echo "--- kubectl describe ${pod} ---" >&2
+    kubectl describe "${pod}" -n "${NAMESPACE}" >&2 || true
+    echo "--- kubectl logs ${pod} ---" >&2
+    kubectl logs "${pod}" -n "${NAMESPACE}" --all-containers --tail=200 >&2 || true
+  done
+  exit 1
+fi
 
 echo "==> Waiting for the ScaledObject to be Ready"
 # Ready only means KEDA accepted the trigger and created its HPA — not that the metric works.


### PR DESCRIPTION
Motivation:
The nightly CKS workload-autoscaling lane
(workload-autoscaling-cks-acc-gpu-vllm-x) has failed for at least seven
consecutive nights waiting for wva-controller-manager to become
Available. The root cause is unknown because the controller pod is
force-deleted during teardown before its state can be inspected —
kubectl describe output and pod logs never make it into the run output.

Approach:
Wrap the `kubectl wait deployment/wva-controller-manager ... --for=condition=Available`
step in nightly-deploy-cks.sh so that on failure, before the script exits
(and before the calling workflow tears the namespace down), it captures
and prints to stderr:
  - `kubectl describe` of the Deployment
  - `kubectl describe` and `kubectl logs --all-containers` for every pod
    matching the wva-controller-manager- name prefix
This mirrors the existing diagnostics block later in the same script
(the KEDA fallback check) and the equivalent pattern already present in
nightly-deploy-ocp.sh, so it matches this file's own conventions. The
script still exits 1 on failure, preserving the original CI failure
semantics.

This does not fix the underlying reason the controller never becomes
Available — that root cause is still unconfirmed and requires
inspecting a live CKS run. This change implements next step #1 from
the issue report ("Capture kubectl describe deploy/wva-controller-manager
plus the controller pod's events and logs before teardown runs") so the
next nightly failure leaves enough evidence in the run log to diagnose
the real problem.

Validation:
No live CKS/GPU cluster is available in this environment, so the
underlying Available-timeout failure itself could not be reproduced or
confirmed fixed (it isn't meant to be fixed by this change). What was
run:
  - `bash -n guides/workload-autoscaling/scripts/nightly-deploy-cks.sh` — passed.
  - `shellcheck -x --severity=warning guides/workload-autoscaling/scripts/nightly-deploy-cks.sh` — zero warnings.
    (Note: this repo's .pre-commit-config.yaml only runs the shellcheck
    hook against docker/scripts/*.sh, so this script is not gated by
    that hook; ran shellcheck manually as an extra check.)
  - Extracted the new diagnostic block into an isolated harness with a
    stubbed `kubectl` simulating the exact failure mode from the issue
    (kubectl wait returns 1, one matching pod
    wva-controller-manager-6bfcf4cfb5-qxvkw as in the issue's log
    excerpt). Confirmed: describe/logs output print in the correct
    order for the deployment and the matching pod, the pod-name grep
    matches correctly and is empty-safe under pipefail, and the script
    still exits 1, preserving the original failure path for the caller.

Report: https://github.com/llm-d/llm-d/issues/2124
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)

Fixes #2124