### PR TITLE
docs(well-lit-paths): fix broken observability links in optimized baseline guide

### DIFF
--- a/docs/well-lit-paths/foundations/optimized-baseline.md
+++ b/docs/well-lit-paths/foundations/optimized-baseline.md
@@ -43,7 +43,7 @@ EPP continuously probes each endpoints' metrics by scraping `/metrics` at a regu
 
 ## Observability
 
-The optimized baseline balances two routing objectives, prefix-cache affinity and load-aware spread, so the signals that matter are cache hit rate and per-pod load balance watched together. The [guide's Observability & Troubleshooting section](../../../guides/optimized-baseline/README.md#4-observability--troubleshooting) covers the key metrics for this path and the common failure modes (including the `peakPrefillThroughput` calibration trap on non-default hardware), backed by the shared [PromQL](../operations/observability/promql.md) and [metric](../operations/observability/metrics.md) references.
+The optimized baseline balances two routing objectives, prefix-cache affinity and load-aware spread, so the signals that matter are cache hit rate and per-pod load balance watched together. The [guide's Observability & Troubleshooting section](../../../guides/optimized-baseline/README.md#4-observability--troubleshooting) covers the key metrics for this path and the common failure modes (including the `peakPrefillThroughput` calibration trap on non-default hardware), backed by the shared [PromQL](../../operations/observability/promql.md) and [metric](../../operations/observability/metrics.md) references.
 
 ## Further Reading
 


### PR DESCRIPTION
fixes: #2358

Fix two broken relative links in  [optimized-baseline.md](https://github.com/llm-d/llm-d/blob/main/docs/well-lit-paths/foundations/optimized-baseline.md) by updating the paths to the shared observability documentation.
