### PR TITLE
Slack notification workflow

### DIFF
--- a/.github/scripts/notify-slack-nightly.py
+++ b/.github/scripts/notify-slack-nightly.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Build the Slack message for a finished nightly run.
+
+Usage:
+  # Render without posting -- works locally against any real run.
+  GH_TOKEN=$(gh auth token) python .github/scripts/notify-slack-nightly.py \
+      --repo llm-d/llm-d --run-id 32211600170 --dry-run
+
+  # In CI: write `channel` and `payload` to $GITHUB_OUTPUT for the posting step.
+  python .github/scripts/notify-slack-nightly.py \
+      --repo "$GITHUB_REPOSITORY" --run-id "$RUN_ID" --github-output
+
+The run is fetched from the API by id rather than read out of the workflow_run
+event payload. That keeps one code path for the real trigger and for a manual
+replay, and -- more importantly -- the event payload cannot answer the question
+this script has to answer: see nightly_outcome() below.
+
+Routing is keyed off the workflow's file name, taken from the run's `path`,
+because file names are stable while display names are not. See
+.github/slack-channels.yaml.
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MAPPING_PATH = REPO_ROOT / ".github" / "slack-channels.yaml"
+
+API_ROOT = "https://api.github.com"
+
+# Jobs that publish the gh-pages badge rather than exercise the guide. They run
+# with `if: always()`, so they are present even when the test failed.
+BADGE_JOB_PREFIX = "update-badge"
+
+FAILED_CONCLUSIONS = ("failure", "timed_out")
+
+# Outcomes worth a message. The notify workflow also filters on the run-level
+# conclusion so it can skip spinning up a runner, but this is the authoritative
+# check: a manual replay bypasses that filter, and "nothing to say about this
+# run" is a property of the run, not of how the script was invoked.
+#
+# "cancelled" is the common exclusion: every nightly sets cancel-in-progress, so
+# dispatching one while a run is in flight cancels that run, which is not news.
+# "skipped" means no job actually exercised the guide.
+NOTIFIABLE_OUTCOMES = ("success", "failure", "timed_out")
+
+
+# ---------------------------------------------------------------------------
+# GitHub API
+# ---------------------------------------------------------------------------
+
+
+def api_get(path: str, token: str) -> dict:
+    request = urllib.request.Request(
+        f"{API_ROOT}{path}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "llm-d-notify-slack-nightly",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as exc:
+        raise SystemExit(f"ERROR: GET {path} returned {exc.code} {exc.reason}") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"ERROR: GET {path} failed: {exc.reason}") from exc
+
+
+def fetch_run(repo: str, run_id: str, token: str) -> dict:
+    return api_get(f"/repos/{repo}/actions/runs/{run_id}", token)
+
+
+def fetch_jobs(repo: str, run_id: str, token: str) -> list[dict]:
+    # A nightly has a handful of jobs; one page is plenty.
+    data = api_get(f"/repos/{repo}/actions/runs/{run_id}/jobs?per_page=100", token)
+    return data.get("jobs", [])
+
+
+# ---------------------------------------------------------------------------
+# Outcome
+# ---------------------------------------------------------------------------
+
+
+def is_badge_job(name: str) -> bool:
+    # Jobs from a called reusable workflow are reported as "<caller> / <inner>".
+    return name == BADGE_JOB_PREFIX or name.startswith(f"{BADGE_JOB_PREFIX} / ")
+
+
+def nightly_outcome(jobs: list[dict]) -> tuple[str, str | None, bool]:
+    """Separate the guide's result from the badge job's result.
+
+    The run-level conclusion cannot be used directly: update-badge runs with
+    `if: always()`, so a green test whose badge push to gh-pages failed comes out
+    as a failed *run*. Reporting that verbatim tells a channel its guide is
+    broken when it is not, and credible false positives are exactly what makes
+    people stop trusting an alert channel.
+
+    Returns (outcome, failing_job_name, badge_failed) where outcome is one of
+    "success", "failure", "timed_out" or "cancelled".
+    """
+    test_jobs = [job for job in jobs if not is_badge_job(job.get("name", ""))]
+    badge_failed = any(
+        job.get("conclusion") in FAILED_CONCLUSIONS for job in jobs if is_badge_job(job.get("name", ""))
+    )
+
+    # Report the first failure in job order, which is the one that actually
+    # broke the run rather than a downstream casualty.
+    for job in test_jobs:
+        if job.get("conclusion") in FAILED_CONCLUSIONS:
+            return job["conclusion"], job.get("name"), badge_failed
+
+    if any(job.get("conclusion") == "cancelled" for job in test_jobs):
+        return "cancelled", None, badge_failed
+
+    # Every job skipped is not a pass -- nothing ran, so there is no result to
+    # report. Reporting green here would be the same false-confidence bug as
+    # reporting a badge failure as a guide failure, just in the other direction.
+    if test_jobs and all(job.get("conclusion") == "skipped" for job in test_jobs):
+        return "skipped", None, badge_failed
+
+    return "success", None, badge_failed
+
+
+def format_duration(started: str | None, ended: str | None) -> str:
+    """Render a run's wall-clock duration as "1h 12m" / "47m" / "38s"."""
+    if not started or not ended:
+        return "unknown"
+    try:
+        start = datetime.fromisoformat(started.replace("Z", "+00:00"))
+        end = datetime.fromisoformat(ended.replace("Z", "+00:00"))
+    except ValueError:
+        return "unknown"
+
+    seconds = int((end - start).total_seconds())
+    if seconds < 0:
+        return "unknown"
+    if seconds < 60:
+        return f"{seconds}s"
+
+    hours, minutes = divmod(seconds // 60, 60)
+    return f"{hours}h {minutes}m" if hours else f"{minutes}m"
+
+
+# ---------------------------------------------------------------------------
+# Routing
+# ---------------------------------------------------------------------------
+
+
+def load_mapping() -> dict:
+    with MAPPING_PATH.open(encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def resolve_channel(mapping: dict, workflow_file: str) -> tuple[str | None, bool]:
+    """Return (channel, is_fallback) for a workflow file name.
+
+    A file listed under `skip` returns (None, False): not notifying it is a
+    recorded decision, not a gap.
+
+    Anything else unknown falls back rather than failing. A red notification job
+    would be a second alert channel nobody watches, and it muddies "did the
+    nightly fail, or did the notifier fail?". The place an unrouted workflow is
+    meant to be caught is scripts/sync-slack-channels.py --check, in the PR that
+    adds it.
+    """
+    if workflow_file in (mapping.get("skip") or {}):
+        return None, False
+
+    for channel, files in (mapping.get("channels") or {}).items():
+        if workflow_file in (files or []):
+            return channel, False
+
+    return mapping.get("fallback_channel"), True
+
+
+# ---------------------------------------------------------------------------
+# Message
+# ---------------------------------------------------------------------------
+
+
+def escape_mrkdwn(text: str) -> str:
+    """Escape the three characters Slack reserves in message text."""
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def build_message(repo: str, run: dict, outcome: str, failing_job: str | None, badge_failed: bool) -> str:
+    name = escape_mrkdwn(run.get("name") or "Unknown workflow")
+    url = run.get("html_url", "")
+    number = run.get("run_number", "?")
+    attempt = run.get("run_attempt", 1) or 1
+    sha = (run.get("head_sha") or "")[:7]
+    duration = format_duration(run.get("run_started_at") or run.get("created_at"), run.get("updated_at"))
+    matrix_url = f"https://github.com/{repo}/blob/main/release/README.md"
+
+    # Coloured circles rather than check/cross marks: a column of them is faster
+    # to scan, and they do not read as emoji reactions on the message.
+    if outcome == "timed_out":
+        headline = f":hourglass_flowing_sand:  *{name}*  ·  timed out after {duration}  ·  `{sha}`"
+    elif outcome == "failure":
+        headline = f":red_circle:  *{name}*  ·  failed after {duration}  ·  `{sha}`"
+    elif outcome != "success":
+        # Defensive: main() filters these out, so reaching here means a new
+        # conclusion appeared and must not be painted green.
+        headline = f":grey_question:  *{name}*  ·  {outcome}  ·  {duration}  ·  `{sha}`"
+    elif badge_failed:
+        headline = f":warning:  *{name}*  ·  test passed, `update-badge` failed  ·  {duration}  ·  `{sha}`"
+    else:
+        headline = f":large_green_circle:  *{name}*  ·  {duration}  ·  `{sha}`"
+
+    # A re-run landing hours off the usual schedule is confusing without this.
+    if attempt > 1:
+        headline += f"  (attempt {attempt})"
+
+    if outcome in FAILED_CONCLUSIONS:
+        detail = []
+        if failing_job:
+            detail.append(f"failed in `{escape_mrkdwn(failing_job)}`")
+        detail.append(f"<{url}|run #{number}>")
+        detail.append(f"<{matrix_url}|matrix>")
+        return headline + "\n" + "  ·  ".join(detail)
+
+    return f"{headline}  ·  <{url}|run #{number}>"
+
+
+def build_payload(channel: str, text: str) -> dict:
+    return {
+        "channel": channel,
+        "text": text,
+        "mrkdwn": True,
+        # Without this Slack expands a preview card for every GitHub link, and a
+        # handful of messages turns the channel into a wall.
+        "unfurl_links": False,
+        "unfurl_media": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+def write_github_output(channel: str, payload: str) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        print("::warning::GITHUB_OUTPUT is not set; skipping step outputs", file=sys.stderr)
+        return
+    with open(output_path, "a", encoding="utf-8") as fh:
+        fh.write(f"channel={channel}\n")
+        fh.write(f"payload={payload}\n")
+
+
+def write_step_summary(lines: list[str]) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    with open(summary_path, "a", encoding="utf-8") as fh:
+        fh.write("\n".join(lines) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="owner/name of the repository")
+    parser.add_argument("--run-id", required=True, help="id of the nightly run to report on")
+    parser.add_argument("--channel", default="", help="post to this channel instead of the mapped one")
+    parser.add_argument("--dry-run", action="store_true", help="print the payload and exit without emitting outputs")
+    parser.add_argument("--json", action="store_true", help="print only the payload JSON")
+    parser.add_argument("--github-output", action="store_true", help="write channel/payload to $GITHUB_OUTPUT")
+    args = parser.parse_args()
+
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        raise SystemExit("ERROR: set GH_TOKEN (locally: GH_TOKEN=$(gh auth token)).")
+
+    run = fetch_run(args.repo, args.run_id, token)
+    jobs = fetch_jobs(args.repo, args.run_id, token)
+
+    workflow_file = Path(run.get("path", "")).name
+    outcome, failing_job, badge_failed = nightly_outcome(jobs)
+
+    if outcome not in NOTIFIABLE_OUTCOMES:
+        print(f"{workflow_file} run {args.run_id} concluded {outcome!r}; nothing worth notifying.")
+        if args.github_output:
+            write_github_output("", "")
+        return 0
+
+    mapping = load_mapping()
+    channel, is_fallback = (args.channel, False) if args.channel else resolve_channel(mapping, workflow_file)
+
+    if channel is None:
+        print(f"{workflow_file} is listed as not notified in {MAPPING_PATH.name}; nothing to send.")
+        if args.github_output:
+            write_github_output("", "")
+        return 0
+
+    if is_fallback:
+        print(
+            f"::warning::{workflow_file} has no Slack channel assigned; "
+            f"falling back to {channel}. Add it to .github/slack-channels.yaml."
+        )
+
+    text = build_message(args.repo, run, outcome, failing_job, badge_failed)
+    if is_fallback:
+        text = f":grey_question:  _unrouted workflow_ `{workflow_file}`\n{text}"
+
+    payload = json.dumps(build_payload(channel, text), ensure_ascii=False)
+
+    if args.json:
+        print(payload)
+        return 0
+
+    print(f"workflow file : {workflow_file}")
+    print(f"upstream event: {run.get('event')}")
+    print(f"run conclusion: {run.get('conclusion')}")
+    print(f"test outcome  : {outcome}" + (f" (in {failing_job})" if failing_job else ""))
+    print(f"badge failed  : {badge_failed}")
+    print(f"channel       : {channel}" + ("  [fallback]" if is_fallback else ""))
+    print("-" * 72)
+    print(text)
+    print("-" * 72)
+
+    write_step_summary(
+        [
+            "### Slack notification",
+            "",
+            f"- **Channel**: `{channel}`" + ("  _(fallback)_" if is_fallback else ""),
+            f"- **Workflow file**: `{workflow_file}`",
+            f"- **Test outcome**: `{outcome}`" + (f" in `{failing_job}`" if failing_job else ""),
+            f"- **Badge job failed**: `{badge_failed}`",
+            "",
+            "```",
+            text,
+            "```",
+        ]
+    )
+
+    if args.dry_run:
+        print("(--dry-run: no outputs emitted, nothing posted)")
+        return 0
+
+    if args.github_output:
+        write_github_output(channel, payload)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/slack-channels.yaml
+++ b/.github/slack-channels.yaml
@@ -1,0 +1,110 @@
+---
+# Slack channel routing for nightly workflow result notifications.
+#
+# This file is the single source of truth. Two consumers read it:
+#
+#   1. scripts/sync-slack-channels.py generates the `workflows:` list in
+#      .github/workflows/notify-slack-nightly.yaml from these entries.
+#      That list is a GENERATED artifact -- never edit it by hand.
+#   2. .github/scripts/notify-slack-nightly.py resolves the destination channel
+#      at runtime from the workflow's FILE NAME.
+#
+# Entries are keyed by file name rather than by the workflow's display `name:`
+# because the file name is the stable identifier -- it is already baked into
+# badge_name, release/README.md, /test-nightly and the consolidate-status-*
+# workflows. A renamed display name can only stop the trigger from firing
+# (which CI catches); it can never misroute a message to the wrong channel.
+#
+# After editing this file, regenerate the trigger list:
+#
+#     python scripts/sync-slack-channels.py --fix
+#
+# The `sync-slack-channels` pre-commit hook verifies both directions on every
+# PR: that the generated list is in sync, and that every nightly workflow is
+# accounted for below (either routed or explicitly skipped).
+
+# Runtime safety net only, not a routing decision. Used when a run arrives for a
+# workflow absent from `channels` -- for example mid-rename, or when a workflow
+# is deleted while the generated trigger list still references it. The intended
+# place to catch an unrouted workflow is the pre-commit hook, because an unmapped
+# workflow is also absent from the trigger and therefore never fires at all:
+# the symptom is missing messages, which is invisible by construction.
+fallback_channel: "#llm-d-ci-alerts"
+
+channels:
+  "#sig-pd-disaggregation":
+    - nightly-e2e-pd-disaggregation-amd-ci-acc-rocm-vllm-x.yaml
+    - nightly-e2e-pd-disaggregation-cks-acc-gpu-vllm-x.yaml
+    - nightly-e2e-pd-disaggregation-gke-acc-gpu-vllm-x.yaml
+    - nightly-e2e-pd-disaggregation-gke-acc-tpu-vllm-x.yaml
+    - nightly-e2e-pd-disaggregation-ibm-acc-gpu-vllm-x.yaml
+
+  "#sig-autoscaling":
+    - nightly-e2e-workload-autoscaling-cks-acc-gpu-vllm-x.yaml
+    - nightly-e2e-workload-autoscaling-ibm-acc-gpu-vllm-x.yaml
+    - nightly-e2e-workload-autoscaling-keda-epp-ibm-acc-gpu-vllm-x.yaml
+
+  # Routing/scheduling guides: precise prefix cache, predicted latency,
+  # optimized baseline and flow control.
+  "#sig-router":
+    - nightly-e2e-flow-control-gke-acc-gpu-vllm-x.yaml
+    - nightly-e2e-optimized-baseline-amd-acc-rocm-vllm-x.yaml
+    - nightly-e2e-optimized-baseline-cks-acc-gpu-vllm-x.yaml
+    - nightly-e2e-optimized-baseline-gke-acc-gpu-trtllm-x.yaml
+    - nightly-e2e-optimized-baseline-gke-acc-gpu-vllm-x.yaml
+    - nightly-e2e-optimized-baseline-gke-acc-tpu-vllm-x.yaml
+    - nightly-e2e-optimized-baseline-ibm-acc-gpu-vllm-x.yaml
+    - nightly-e2e-precise-prefix-cache-routing-amd-ci-acc-rocm-vllm-x.yaml
+    - nightly-e2e-precise-prefix-cache-routing-cks-acc-gpu-vllm-x.yaml
+    - nightly-e2e-precise-prefix-cache-routing-gke-acc-gpu-vllm-x.yaml
+    - nightly-e2e-precise-prefix-cache-routing-gke-acc-tpu-vllm-x.yaml
+    - nightly-e2e-precise-prefix-cache-routing-ibm-acc-gpu-vllm-x.yaml
+    - nightly-e2e-predicted-latency-routing-amd-ci-acc-rocm-vllm-x.yaml
+    - nightly-e2e-predicted-latency-routing-cks-acc-gpu-vllm-x.yaml
+    - nightly-e2e-predicted-latency-routing-gke-acc-gpu-vllm-x.yaml
+    - nightly-e2e-predicted-latency-routing-ibm-acc-gpu-vllm-x.yaml
+
+  # KV cache offloading: tiered prefix cache and wide expert parallelism.
+  "#sig-kv-disaggregation":
+    - nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-lmcache.yaml
+    - nightly-e2e-tiered-prefix-cache-gke-cpu-gpu-vllm-native.yaml
+    - nightly-e2e-tiered-prefix-cache-gke-cpu-tpu-vllm-native.yaml
+    - nightly-e2e-tiered-prefix-cache-ibm-cpu-gpu-vllm-native.yaml
+    - nightly-e2e-wide-ep-lws-cks-acc-gpu-vllm-x.yaml
+    - nightly-e2e-wide-ep-lws-gke-acc-gpu-vllm-x.yaml
+    - nightly-e2e-wide-ep-lws-ibm-acc-gpu-vllm-x.yaml
+
+  # Engine-based split: the SGLang backend goes to the SGLang collaboration
+  # channel regardless of which guide it exercises.
+  "#sglang-collab":
+    - nightly-e2e-optimized-baseline-gke-acc-gpu-sglang-x.yaml
+    - nightly-e2e-pd-disaggregation-gke-acc-gpu-sglang-x.yaml
+
+  # Accelerator-based split: everything running on Intel XPU goes to the Intel
+  # channel regardless of which guide it exercises.
+  "#llm-d-intel":
+    - nightly-e2e-optimized-baseline-intel-acc-xpu-vllm-x.yaml
+    - nightly-e2e-pd-disaggregation-intel-acc-xpu-vllm-x.yaml
+    - nightly-e2e-precise-prefix-cache-routing-intel-acc-xpu-vllm-x.yaml
+    - nightly-e2e-tiered-prefix-cache-intel-acc-xpu-vllm-lmcache.yaml
+    - nightly-e2e-tiered-prefix-cache-intel-acc-xpu-vllm-native.yaml
+    - nightly-e2e-wide-ep-lws-intel-acc-xpu-vllm-x.yaml
+
+  "#fast-model-actuation":
+    - nightly-e2e-fast-model-actuation-ibm-acc-gpu-vllm-x.yaml
+
+# Nightly workflows deliberately NOT notified. Every entry needs a reason:
+# that requirement is what keeps "nobody got around to mapping it" from passing
+# as "we decided not to notify it".
+skip:
+  nightly-build-image.yaml: >-
+    Shared infrastructure, owned by no single SIG. A failure here surfaces as a
+    cascading failure of the guide nightlies that follow it, and those are
+    notified.
+  nightly-e2e-multimodal-serving-aggregation-gke-acc-gpu-vllm-x.yaml: >-
+    No SIG owner assigned yet, and its schedule is commented out, so it only
+    ever runs via workflow_dispatch and would never notify anyway.
+  nightly-e2e-multimodal-serving-aggregation-gke-acc-tpu-vllm-x.yaml: >-
+    No SIG owner assigned yet; schedule commented out. See the GKE GPU variant.
+  nightly-e2e-multimodal-serving-e-disaggregation-gke-acc-gpu-vllm-x.yaml: >-
+    No SIG owner assigned yet; schedule commented out. See the GKE GPU variant.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -37,6 +37,61 @@ workflow files:
   `v*` tag is pushed. Its badges are static, baked from the badge status captured at
   tag time, so the matrix records the state as of that release.
 
+## Slack notifications
+
+Alongside the badges, the result of every **scheduled** nightly is posted to the Slack channel of the SIG that owns it, by [`notify-slack-nightly.yaml`](notify-slack-nightly.yaml).
+
+This replaces the old `/github subscribe` integration, which had two limits that could not be worked around: it only supports one workflow per channel (so a channel like `#sig-router`, which owns 16 nightlies, could never be fully covered), and it also fired on manual `workflow_dispatch` runs, which was noise.
+
+### How routing works
+
+[`.github/slack-channels.yaml`](../slack-channels.yaml) is the source of truth. It maps each nightly to a channel, **keyed by workflow file name**, and lists the nightlies that are deliberately not notified (each with a reason).
+
+The `workflows:` list in the `workflow_run` trigger is *generated* from that file:
+
+```bash
+python scripts/sync-slack-channels.py --fix     # regenerate
+python scripts/sync-slack-channels.py --check   # verify (runs in pre-commit)
+python scripts/sync-slack-channels.py --audit   # print the routing table
+```
+
+Two different identifiers are in play, deliberately:
+
+* The **trigger** must use display names, because `workflow_run` matches on nothing else. That makes it the part that breaks silently — rename a nightly and the notifications just stop, with no error, which looks exactly like a quiet night. Generating the list means the rename turns CI red in the same PR that does the renaming.
+* **Runtime routing** uses the workflow *file* name (`workflow_run.path`), which is stable — it is already baked into `badge_name`, `release/README.md`, `/test-nightly` and the `consolidate-status-*` workflows. So a renamed display name can only stop notifications; it can never send them to the wrong channel.
+
+A nightly that is in neither `channels` nor `skip` fails the `sync-slack-channels` pre-commit hook. That check is the only place the mistake can be caught: an unrouted nightly is also absent from the generated trigger, so it never fires at all, and the symptom is *missing messages* — invisible by construction.
+
+### Deliberate decisions
+
+These are easy to mistake for bugs, so they are recorded here:
+
+* **Only `schedule` runs notify.** Manual dispatches and `/test-nightly` runs are filtered out via `github.event.workflow_run.event`. This is the whole reason the workflow exists.
+* **Re-runs of a scheduled run DO notify**, marked `(attempt N)`. When a SIG re-runs a nightly that failed on a transient cluster error, the re-run's result is the current truth about that guide — suppressing it would leave the channel showing an already-fixed failure as the last word.
+* **`cancelled` and `skipped` runs do not notify.** Every nightly sets `cancel-in-progress`, so dispatching one while a run is in flight cancels that run; that is not news for a channel. An all-skipped run means nothing exercised the guide, so there is no result to report.
+* **The guide's result is computed from the `nightly` jobs, not from the run's conclusion.** `update-badge` runs with `if: always()`, so a green test whose badge push to `gh-pages` failed comes out as a failed *run*. Reporting that verbatim would tell a channel its guide is broken when it is not, and credible false positives are what makes people stop trusting a channel. That case gets its own `test passed, update-badge failed` message instead.
+
+### Testing a change
+
+`workflow_run` **and** `workflow_dispatch` only work from the default branch, so the workflow itself cannot be exercised from a feature branch. Test the logic locally against any real run instead:
+
+```bash
+GH_TOKEN=$(gh auth token) python .github/scripts/notify-slack-nightly.py \
+    --repo llm-d/llm-d --run-id <run-id> --dry-run
+```
+
+Once merged, the workflow's `workflow_dispatch` inputs replay an existing run (`run_id`), optionally to a scratch channel (`channel_override`) and without posting (`dry_run`).
+
+### Slack app setup
+
+One-time, needs Slack workspace admin plus repo admin:
+
+1. Create an app at [api.slack.com/apps](https://api.slack.com/apps) → *From scratch* (e.g. `llm-d CI`).
+2. Under *OAuth & Permissions*, add the **`chat:write`** bot scope. Optionally add `channels:join` so the bot can add itself to public channels, which removes the `not_in_channel` failure mode. Do **not** add `chat:write.public` — it allows posting to any channel without membership, bypassing that control entirely.
+3. Install the app and copy the bot token (`xoxb-…`). A token is valid for one workspace only.
+4. **Invite the bot to every channel** in `slack-channels.yaml`, including `fallback_channel`: `/invite @llm-d CI`. This is manual and per-channel, and forgetting it is the most likely first-deploy failure — the posting step fails with `not_in_channel`.
+5. Add the token as the `SLACK_BOT_TOKEN` repository secret (*Settings → Secrets and variables → Actions*).
+
 ## Adding a new guide
 
 All nightly benchmark workflows rely heavily on these two "reusable" workflows on [`llm-d-infra`](https://github.com/llm-d/llm-d-infra):
@@ -45,6 +100,8 @@ All nightly benchmark workflows rely heavily on these two "reusable" workflows o
 * [`reusable-query-success-past-runs.yaml`](https://github.com/llm-d/llm-d-infra/blob/main/.github/workflows/reusable-query-success-past-runs.yaml).
 
 Developers aiming to add a new guide or testing an existing guide on a new cluster or with a new set of parameters should open a PR with **two** new workflows: one for the "nightly benchmark", and one for "consolidated status". Again, an illustratibe example using `optimized-baseline`:
+
+The same PR must also assign the new nightly a Slack channel in [`.github/slack-channels.yaml`](../slack-channels.yaml) (or add it to `skip` with a reason) and run `python scripts/sync-slack-channels.py --fix`; see [Slack notifications](#slack-notifications) above. The `sync-slack-channels` pre-commit hook fails until this is done.
 
 ```bash
 [llm-d]$ ls .github/workflows/*optimized-baseline*

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -86,10 +86,30 @@ Once merged, the workflow's `workflow_dispatch` inputs replay an existing run (`
 
 One-time, needs Slack workspace admin plus repo admin:
 
-1. Create an app at [api.slack.com/apps](https://api.slack.com/apps) → *From scratch* (e.g. `llm-d CI`).
+1. Create an app at [api.slack.com/apps](https://api.slack.com/apps). *From an app manifest* is the quickest route — paste the manifest below — or use *From scratch* and add the scope by hand in step 2.
+
+   ```yaml
+   display_information:
+     name: llm-d CI
+     description: Posts nightly CI results to the SIG channels that own each guide.
+   features:
+     bot_user:
+       display_name: llm-d-ci
+       always_online: false
+   oauth_config:
+     scopes:
+       bot:
+         - chat:write
+   settings:
+     org_deploy_enabled: false
+     socket_mode_enabled: false
+     token_rotation_enabled: false
+   ```
+
+   Note `bot_user.display_name` is the bot's handle and only accepts lowercase letters, digits, `-`, `_` and `.` — hence `llm-d-ci` rather than `llm-d CI`. That handle is what you type in step 4.
 2. Under *OAuth & Permissions*, add the **`chat:write`** bot scope. Optionally add `channels:join` so the bot can add itself to public channels, which removes the `not_in_channel` failure mode. Do **not** add `chat:write.public` — it allows posting to any channel without membership, bypassing that control entirely.
 3. Install the app and copy the bot token (`xoxb-…`). A token is valid for one workspace only.
-4. **Invite the bot to every channel** in `slack-channels.yaml`, including `fallback_channel`: `/invite @llm-d CI`. This is manual and per-channel, and forgetting it is the most likely first-deploy failure — the posting step fails with `not_in_channel`.
+4. **Invite the bot to every channel** in `slack-channels.yaml`, including `fallback_channel`: `/invite @llm-d-ci` (let Slack's autocomplete resolve the handle). For a private channel, a member has to do this from inside it. This is manual and per-channel, and forgetting it is the most likely first-deploy failure — the posting step fails with `not_in_channel`.
 5. Add the token as the `SLACK_BOT_TOKEN` repository secret (*Settings → Secrets and variables → Actions*).
 
 ## Adding a new guide

--- a/.github/workflows/notify-slack-nightly.yaml
+++ b/.github/workflows/notify-slack-nightly.yaml
@@ -1,0 +1,189 @@
+---
+name: Notify Slack - Nightly Results
+
+# Posts the result of every scheduled nightly to the Slack channel owned by the
+# SIG responsible for it.
+#
+# This replaces the `/github subscribe` integration, which had two limits we
+# could not work around: it only supports one workflow per channel (so a channel
+# like #sig-router, which owns 16 nightlies, could never be covered), and it
+# notifies on manual workflow_dispatch runs too, which was pure noise.
+#
+# Channel routing lives in .github/slack-channels.yaml -- that file is the
+# source of truth. The `workflows:` list below is GENERATED from it by
+#
+#     python scripts/sync-slack-channels.py --fix
+#
+# and verified on every PR by the `sync-slack-channels` pre-commit hook.
+# DO NOT edit that list by hand.
+#
+# Why the list is generated: workflow_run can only match on a workflow's display
+# name, and a display name is easy to change. Rename a nightly and the trigger
+# silently stops matching -- no error, just no more messages, which is
+# indistinguishable from a quiet night. Generating the list means the rename
+# turns CI red in the very PR that does the renaming.
+#
+# Note that routing at runtime keys off the workflow's FILE name
+# (workflow_run.path), not its display name, so a rename can only stop
+# notifications -- it can never send them to the wrong channel.
+
+on:
+  workflow_run:
+    types:
+      - completed
+    # Filters the branch of the *upstream* run. Scheduled runs always use the
+    # default branch, so this is belt-and-braces, but it does keep runs on the
+    # temporary test-nightly/pr-* branches from reaching this workflow.
+    branches:
+      - main
+    workflows:
+      # SLACK-WORKFLOWS-START
+      - "Nightly - Fast Model Actuation E2E (OCP GPU)"
+      - "Nightly - Flow Control E2E (GKE GPU)"
+      - "Nightly - Optimized Baseline E2E (AMD ROCM)"
+      - "Nightly - Optimized Baseline E2E (CKS GPU)"
+      - "Nightly - Optimized Baseline E2E (GKE GPU SGLang)"
+      - "Nightly - Optimized Baseline E2E (GKE GPU TensorRT-LLM)"
+      - "Nightly - Optimized Baseline E2E (GKE GPU)"
+      - "Nightly - Optimized Baseline E2E (GKE TPU)"
+      - "Nightly - Optimized Baseline E2E (Intel XPU)"
+      - "Nightly - Optimized Baseline E2E (OCP GPU)"
+      - "Nightly - PD Disaggregation E2E (AMD ROCM)"
+      - "Nightly - PD Disaggregation E2E (CKS GPU)"
+      - "Nightly - PD Disaggregation E2E (GKE GPU SGLang)"
+      - "Nightly - PD Disaggregation E2E (GKE GPU)"
+      - "Nightly - PD Disaggregation E2E (GKE TPU)"
+      - "Nightly - PD Disaggregation E2E (Intel XPU)"
+      - "Nightly - PD Disaggregation E2E (OCP GPU)"
+      - "Nightly - Precise Prefix Cache E2E (GKE TPU)"
+      - "Nightly - Precise Prefix Cache Routing E2E (AMD ROCM)"
+      - "Nightly - Precise Prefix Cache Routing E2E (CKS GPU)"
+      - "Nightly - Precise Prefix Cache Routing E2E (GKE GPU)"
+      - "Nightly - Precise Prefix Cache Routing E2E (Intel XPU)"
+      - "Nightly - Precise Prefix Cache Routing E2E (OCP GPU)"
+      - "Nightly - Predicted Latency Routing E2E (AMD ROCM)"
+      - "Nightly - Predicted Latency Routing E2E (CKS GPU)"
+      - "Nightly - Predicted Latency Routing E2E (GKE GPU)"
+      - "Nightly - Predicted Latency Routing E2E (OCP GPU)"
+      - "Nightly - Tiered Prefix Cache CPU Offloading E2E (GKE GPU)"
+      - "Nightly - Tiered Prefix Cache CPU Offloading E2E (Intel XPU)"
+      - "Nightly - Tiered Prefix Cache CPU Offloading E2E (OCP GPU)"
+      - "Nightly - Tiered Prefix Cache CPU Offloading LMCache E2E (GKE GPU)"
+      - "Nightly - Tiered Prefix Cache CPU Offloading LMCache E2E (Intel XPU)"
+      - "Nightly - Tiered Prefix Cache E2E (GKE TPU)"
+      - "Nightly - Wide EP LWS E2E (CKS GPU)"
+      - "Nightly - Wide EP LWS E2E (GKE GPU)"
+      - "Nightly - Wide EP LWS E2E (Intel XPU)"
+      - "Nightly - Wide EP LWS E2E (OCP GPU)"
+      - "Nightly - Workload Autoscaling E2E (CKS GPU)"
+      - "Nightly - Workload Autoscaling E2E (OCP GPU)"
+      - "Nightly - Workload Autoscaling KEDA+EPP Queue E2E (OCP GPU)"
+      # SLACK-WORKFLOWS-END
+
+  # Replays an existing nightly run through the notifier. Because workflow_run
+  # (and workflow_dispatch itself) only work from the default branch, this is
+  # the only way to exercise the real posting path once merged. Before merging,
+  # run .github/scripts/notify-slack-nightly.py locally instead -- see
+  # .github/workflows/README.md.
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'ID of an existing nightly run (the trailing number in its Actions URL)'
+        required: true
+        type: string
+      dry_run:
+        description: 'true = render the payload into the job summary without posting to Slack'
+        required: false
+        default: 'true'
+        type: string
+      channel_override:
+        description: 'Post to this channel instead of the mapped one (e.g. #llm-d-ci-test)'
+        required: false
+        default: ''
+        type: string
+
+# Deliberately minimal. A workflow_run-triggered workflow is handed secrets and a
+# privileged token even when the upstream run had neither, so it should ask for
+# no more than it uses: reading the mapping out of the repo, and reading the
+# upstream run and its jobs from the API.
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  # One group per upstream run. A global group would serialise 40 notifications
+  # behind each other; cancel-in-progress would drop a notification outright.
+  group: notify-slack-nightly-${{ github.event.workflow_run.id || inputs.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  notify:
+    # Three independent guards:
+    #   1. repository -- forks have no SLACK_BOT_TOKEN and must not try to post.
+    #   2. event == 'schedule' -- THE reason this workflow exists. Excludes
+    #      manual dispatches of a nightly and /test-nightly runs. Note this
+    #      cannot move into `on:`: workflow_run offers no filter on the upstream
+    #      run's own event, so we pay a ~2s empty run per manual dispatch.
+    #   3. conclusion -- see the list below.
+    #
+    # 'cancelled' is excluded on purpose and is the common case: every nightly
+    # sets cancel-in-progress, so dispatching one while a run is in flight
+    # cancels that run, and that is not news for a channel. 'skipped' and
+    # 'neutral' say nothing about guide health. 'timed_out' IS notified: it is a
+    # real failure with its own signature, usually a hung standup.
+    if: >-
+      github.repository == 'llm-d/llm-d' &&
+      (github.event_name == 'workflow_dispatch' ||
+       (github.event.workflow_run.event == 'schedule' &&
+        contains(fromJSON('["success", "failure", "timed_out"]'), github.event.workflow_run.conclusion)))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout mapping and script
+        uses: actions/checkout@v7
+        with:
+          # Only the two files this job reads, rather than the whole repo.
+          sparse-checkout: |
+            .github/slack-channels.yaml
+            .github/scripts/notify-slack-nightly.py
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install --disable-pip-version-check pyyaml
+
+      - name: Render Slack payload
+        id: render
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id || inputs.run_id }}
+          CHANNEL_OVERRIDE: ${{ inputs.channel_override }}
+        run: |
+          python .github/scripts/notify-slack-nightly.py \
+            --repo "${GITHUB_REPOSITORY}" \
+            --run-id "${RUN_ID}" \
+            ${CHANNEL_OVERRIDE:+--channel "${CHANNEL_OVERRIDE}"} \
+            --github-output
+
+      - name: Post to Slack
+        # An empty channel means the render step decided there is nothing to
+        # send. dry_run only applies to manual replays.
+        if: >-
+          steps.render.outputs.channel != '' &&
+          !(github.event_name == 'workflow_dispatch' && inputs.dry_run == 'true')
+        # Pinned by SHA: this is a third-party action in a job that holds
+        # SLACK_BOT_TOKEN. Dependabot already tracks github-actions and will
+        # propose bumps.
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          # Fail loudly when Slack rejects the call. The likely cause is the bot
+          # not being a member of the target channel ('not_in_channel'), which is
+          # broken configuration rather than operational noise.
+          errors: true
+          payload: ${{ steps.render.outputs.payload }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,6 +69,20 @@ repos:
         files: ^(release/README\.md|\.github/workflows/nightly-e2e-.*)$
         pass_filenames: false
 
+  # slack channel mapping sync
+  - repo: local
+    hooks:
+      - id: sync-slack-channels
+        name: sync slack channel mapping
+        language: python
+        entry: python scripts/sync-slack-channels.py --check
+        # Also triggers on nightly-* workflows because renaming one changes the
+        # generated workflow_run trigger, and on notify-slack-nightly.yaml itself
+        # to catch hand-edits of that generated list.
+        files: ^(\.github/slack-channels\.yaml|\.github/workflows/(nightly-.*|notify-slack-nightly)\.yaml)$
+        pass_filenames: false
+        additional_dependencies: [pyyaml]
+
   # yaml linting
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.37.1

--- a/scripts/sync-slack-channels.py
+++ b/scripts/sync-slack-channels.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Validate the Slack channel mapping and regenerate the notify workflow trigger.
+
+Usage:
+  python scripts/sync-slack-channels.py --check   # exit 1 if out of sync (default)
+  python scripts/sync-slack-channels.py --fix     # regenerate the trigger in-place
+  python scripts/sync-slack-channels.py --audit   # print the routing table
+
+.github/slack-channels.yaml is the source of truth: it routes each nightly
+workflow to a Slack channel, keyed by file name. The `workflows:` list in
+.github/workflows/notify-slack-nightly.yaml is derived from it.
+
+That list has to hold display names because `workflow_run` matches on them and
+offers nothing else, which makes it the one part that breaks silently: rename a
+workflow and the notifications simply stop, with no error anywhere. Generating
+the list -- and checking it here -- turns that silent break into a failure in
+the same PR that does the renaming.
+
+The workflow discovery helpers are shared with the testing matrices; see
+scripts/matrix_common.py.
+"""
+
+import argparse
+import difflib
+import re
+import sys
+from pathlib import Path
+
+import matrix_common as mc
+import yaml
+
+# ---------------------------------------------------------------------------
+# Paths and sentinels
+# ---------------------------------------------------------------------------
+
+MAPPING_PATH = mc.REPO_ROOT / ".github" / "slack-channels.yaml"
+NOTIFY_WORKFLOW_PATH = mc.REPO_ROOT / ".github" / "workflows" / "notify-slack-nightly.yaml"
+
+TRIGGER_START = "      # SLACK-WORKFLOWS-START"
+TRIGGER_END = "      # SLACK-WORKFLOWS-END"
+
+# Indentation of the generated list items inside `on.workflow_run.workflows`.
+ITEM_INDENT = "      "
+
+# Every nightly workflow must be routed or explicitly skipped. Globbing
+# `nightly-*` rather than matrix_common's `nightly-e2e-*` deliberately widens
+# the net: nightly-build-image.yaml is a nightly too, and forcing an explicit
+# decision about it is the point of the coverage check.
+NIGHTLY_GLOB = "nightly-*.yaml"
+
+CHANNEL_RE = re.compile(r"^#[a-z0-9][a-z0-9._-]*$")
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+
+def load_mapping() -> dict:
+    with MAPPING_PATH.open(encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+
+    for key in ("fallback_channel", "channels", "skip"):
+        if key not in data:
+            raise SystemExit(f"ERROR: {MAPPING_PATH} is missing the top-level '{key}' key.")
+
+    return data
+
+
+def workflow_display_name(path: Path) -> str | None:
+    """Return a workflow's display `name:`.
+
+    Only a top-level `name:` (column zero) is the workflow name; the same key
+    nested under jobs or steps names something else entirely.
+    """
+    m = re.search(r"^name:\s*(.+)$", path.read_text(encoding="utf-8"), re.MULTILINE)
+    return m.group(1).strip() if m else None
+
+
+def discover_nightly_names() -> dict[str, str]:
+    """Return {file_name: display_name} for every nightly workflow on disk."""
+    result = {}
+    for path in sorted(mc.WORKFLOWS_DIR.glob(NIGHTLY_GLOB)):
+        name = workflow_display_name(path)
+        if name is not None:
+            result[path.name] = name
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def validate(mapping: dict, on_disk: dict[str, str]) -> list[str]:
+    """Return a list of human-readable problems; empty means the mapping is sound."""
+    errors: list[str] = []
+    channels: dict[str, list[str]] = mapping["channels"] or {}
+    skip: dict[str, str] = mapping["skip"] or {}
+
+    # Channel naming, so a typo surfaces here rather than as a Slack API error
+    # at 3am. Slack channel names are lowercase by construction.
+    for channel in [mapping["fallback_channel"], *channels]:
+        if not CHANNEL_RE.match(channel or ""):
+            errors.append(f"'{channel}' is not a valid Slack channel name (expected e.g. '#sig-router').")
+
+    routed: dict[str, str] = {}
+    for channel, files in channels.items():
+        for file_name in files or []:
+            if file_name in routed:
+                errors.append(
+                    f"{file_name} is routed to both '{routed[file_name]}' and '{channel}'. "
+                    "A workflow can only notify one channel."
+                )
+            routed[file_name] = channel
+
+    # A file cannot be both routed and skipped -- that reads as a decision but
+    # is really a contradiction, and which one wins would be arbitrary.
+    for file_name in sorted(set(routed) & set(skip)):
+        errors.append(f"{file_name} appears in both 'channels' and 'skip'. Pick one.")
+
+    # Existence: catches renamed and deleted workflow files.
+    for file_name in sorted(set(routed) | set(skip)):
+        if file_name not in on_disk:
+            errors.append(
+                f"{file_name} is listed in {MAPPING_PATH.name} but no such workflow exists "
+                f"in {mc.WORKFLOWS_DIR.relative_to(mc.REPO_ROOT)}/."
+            )
+
+    # Coverage: the guardrail. A nightly missing from this file is also missing
+    # from the generated trigger, so it never fires and nobody notices.
+    for file_name in sorted(set(on_disk) - set(routed) - set(skip)):
+        errors.append(
+            f"{file_name} has no Slack channel assigned. Add it to 'channels' in "
+            f"{MAPPING_PATH.name}, or to 'skip' with a reason."
+        )
+
+    # A skip without a reason is indistinguishable from an oversight.
+    for file_name, reason in sorted(skip.items()):
+        if not (reason or "").strip():
+            errors.append(f"{file_name} is skipped without a reason. Say why it is not notified.")
+
+    # workflow_run matches on display names, so duplicates among routed
+    # workflows would fire this notifier twice for one upstream run.
+    seen: dict[str, str] = {}
+    for file_name in sorted(routed):
+        display = on_disk.get(file_name)
+        if display is None:
+            continue
+        if display in seen:
+            errors.append(
+                f"{file_name} and {seen[display]} share the display name '{display}'. "
+                "workflow_run cannot tell them apart; rename one."
+            )
+        seen[display] = file_name
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Trigger generation
+# ---------------------------------------------------------------------------
+
+
+def generate_trigger_list(mapping: dict, on_disk: dict[str, str]) -> str:
+    """Render the `workflows:` list items for the notify workflow's trigger.
+
+    Skipped workflows are omitted: keeping them would spend trigger entries on
+    runs the notifier then discards.
+
+    Names are quoted so a future workflow name containing ':' or '#' cannot
+    silently change the meaning of the generated YAML.
+    """
+    names = sorted(
+        on_disk[file_name]
+        for files in (mapping["channels"] or {}).values()
+        for file_name in (files or [])
+        if file_name in on_disk
+    )
+    return "\n".join(f'{ITEM_INDENT}- "{name}"' for name in names)
+
+
+def read_notify_workflow() -> str:
+    if not NOTIFY_WORKFLOW_PATH.exists():
+        raise SystemExit(f"ERROR: {NOTIFY_WORKFLOW_PATH} does not exist.")
+    return NOTIFY_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def run_audit(mapping: dict, on_disk: dict[str, str]) -> int:
+    channels: dict[str, list[str]] = mapping["channels"] or {}
+    skip: dict[str, str] = mapping["skip"] or {}
+
+    for channel in sorted(channels):
+        files = sorted(channels[channel] or [])
+        print(f"\n{channel}  ({len(files)})")
+        for file_name in files:
+            print(f"    {on_disk.get(file_name, '<MISSING WORKFLOW>')}")
+            print(f"        {file_name}")
+
+    print(f"\nnot notified  ({len(skip)})")
+    for file_name, reason in sorted(skip.items()):
+        print(f"    {file_name}")
+        print(f"        {' '.join((reason or '').split())}")
+
+    routed = sum(len(f or []) for f in channels.values())
+    print(f"\n{routed} routed + {len(skip)} skipped = {routed + len(skip)} of {len(on_disk)} nightly workflows")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--check", action="store_true", default=True, help="fail if out of sync (default)")
+    group.add_argument("--fix", action="store_true", help="regenerate the trigger list in the notify workflow")
+    group.add_argument("--audit", action="store_true", help="print the routing table for human review")
+    args = parser.parse_args()
+
+    mapping = load_mapping()
+    on_disk = discover_nightly_names()
+
+    if args.audit:
+        return run_audit(mapping, on_disk)
+
+    errors = validate(mapping, on_disk)
+    if errors:
+        print(f"ERROR: {MAPPING_PATH.relative_to(mc.REPO_ROOT)} is not valid.", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    content = read_notify_workflow()
+    current = mc.extract_matrix(content, TRIGGER_START, TRIGGER_END)
+    if current is None:
+        print(
+            f"ERROR: sentinel comments not found in {NOTIFY_WORKFLOW_PATH}.\n"
+            f"Add '{TRIGGER_START.strip()}' and '{TRIGGER_END.strip()}' around the workflows list.",
+            file=sys.stderr,
+        )
+        return 1
+
+    expected = generate_trigger_list(mapping, on_disk)
+
+    if current.strip("\n") == expected.strip("\n"):
+        print("Slack channel mapping is up to date.")
+        return 0
+
+    if args.fix:
+        updated = mc.replace_matrix(content, expected, TRIGGER_START, TRIGGER_END)
+        NOTIFY_WORKFLOW_PATH.write_text(updated, encoding="utf-8")
+        print(f"Updated the workflow_run trigger in {NOTIFY_WORKFLOW_PATH.relative_to(mc.REPO_ROOT)}")
+        return 0
+
+    diff = difflib.unified_diff(
+        current.strip("\n").splitlines(keepends=True),
+        expected.strip("\n").splitlines(keepends=True),
+        fromfile="notify-slack-nightly.yaml (current)",
+        tofile="notify-slack-nightly.yaml (expected)",
+        lineterm="",
+    )
+    print("ERROR: the workflow_run trigger in notify-slack-nightly.yaml is out of sync.", file=sys.stderr)
+    print("Run: python scripts/sync-slack-channels.py --fix", file=sys.stderr)
+    for line in diff:
+        print(line.rstrip("\n"), file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Posts the result of every **scheduled** nightly to the Slack channel of the SIG that owns it, from within the repo instead of via the GitHub app for Slack.

Closes #1548.

## Why

The GitHub app for Slack (`/github subscribe`) hit two limits we could not work around: it only supports **one workflow subscription per channel** (so `#sig-router`, which owns 16 nightlies, could never be covered), and it **also fired on manual `workflow_dispatch` runs**.

## How

```
.github/slack-channels.yaml          <- source of truth (keyed by workflow FILE name)
        |  scripts/sync-slack-channels.py --fix  (generates the `workflows:` list)
        v
.github/workflows/notify-slack-nightly.yaml   <- GENERATED list, do not hand-edit
        |  at runtime
        v
.github/scripts/notify-slack-nightly.py       <- routes on workflow_run.path
```

Two identifiers, deliberately: the **trigger** must use display names because `workflow_run` matches on nothing else, which makes it the part that breaks *silently* — rename a nightly and notifications just stop, indistinguishable from a quiet night. Generating that list turns the rename red in the same PR. **Runtime routing** uses the workflow *file* name, which is stable, so a rename can only stop notifications, never misroute them.

A nightly in neither `channels` nor `skip` fails the new `sync-slack-channels` pre-commit hook — the only place the mistake can be caught, since an unrouted nightly is also absent from the trigger and therefore never fires at all.

**Routing**: 40 nightlies across 7 channels, 4 explicitly skipped with a reason (= all 44 `nightly-*.yaml`). `#sig-router` 16, `#sig-kv-disaggregation` 7, `#llm-d-intel` 6, `#sig-pd-disaggregation` 5, `#sig-autoscaling` 3, `#sglang-collab` 2, `#fast-model-actuation` 1. Note SGLang and Intel XPU route by engine/accelerator rather than by guide, because that is who acts on a failure. Run `python scripts/sync-slack-channels.py --audit` for the full table.

## Decisions worth a look in review

- **Only `schedule` runs notify** — the whole point of the change. The filter must live in the job's `if:`; `workflow_run` cannot filter on the upstream run's own event.
- **Re-runs of a scheduled run DO notify**, marked `(attempt N)`: when a SIG re-runs a nightly that failed on a transient cluster error, that result is the current truth about the guide.
- **`cancelled` / `skipped` do not notify.** Every nightly sets `cancel-in-progress`, so dispatching one mid-flight cancels the previous run — not news for a channel.
- **The guide's result comes from the `nightly` jobs, not the run conclusion.** `update-badge` runs with `if: always()`, so a green test whose badge push failed surfaces as a failed *run*; reporting that verbatim would tell a channel its guide is broken when it is not. That case gets its own `test passed, update-badge failed` message.
- **Unrouted at runtime → `#llm-d-ci-alerts` + warning, not a failed job.** A red notifier is a second alert channel nobody watches.
- Slack action **pinned by SHA**; `permissions` limited to `contents: read` + `actions: read`, which matters because a `workflow_run` workflow gets secrets and a privileged token even when the upstream run had neither.

## Files

New: `.github/slack-channels.yaml`, `scripts/sync-slack-channels.py` (`--check`/`--fix`/`--audit`, modelled on `sync-nightly-matrix.py` and reusing `matrix_common.py`), `.github/workflows/notify-slack-nightly.yaml`, `.github/scripts/notify-slack-nightly.py`.

Modified: `.pre-commit-config.yaml` (new hook), `.github/workflows/README.md` (new "Slack notifications" section + a third step in "Adding a new guide").

No nightly workflow is touched, and nothing is needed in `llm-d-infra`.

## Testing

Validated against real runs (success, failure, cancelled), including `32211600170`, which renders identically to what the GitHub app posted for it:

```bash
GH_TOKEN=$(gh auth token) python .github/scripts/notify-slack-nightly.py \
    --repo llm-d/llm-d --run-id <run-id> --dry-run
```
A real test can be seen in `#llm-d-ci-alerts` where the app has posted a filing workflow using:
```
  GH_TOKEN=$(gh auth token) .venv/bin/python .github/scripts/notify-slack-nightly.py \
    --repo llm-d/llm-d --run-id 32737554939 --channel '#llm-d-ci-alerts' --json \
  | curl -s -X POST https://slack.com/api/chat.postMessage \
      -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
      -H 'Content-type: application/json; charset=utf-8' \
      --data-binary @- | jq '{ok, error, channel}'
```
Plus 25 unit checks over the pure functions, all five guardrail failure modes verified to fail actionably and be fixed by `--fix`.

## Required before this takes effect

Needs Slack + repo admin; full checklist with an app manifest is in `.github/workflows/README.md`.

- [x] Create and install the Slack app with the **`chat:write`** bot scope
- [x] Create `#llm-d-ci-alerts` (fallback channel)
- [x] `/invite @llm-d-ci` in all 8 channels — skipping this is the likely first-deploy failure (`not_in_channel`)
- [x] Add the `SLACK_BOT_TOKEN` repository secret

## Follow-ups

The 3 multimodal-serving nightlies need a SIG owner and a channel; they sit in `skip` until then. `nightly-build-image` is unrouted by design — happy to point it at a CI channel if reviewers prefer.

@llm-d/release-crew 