### PR TITLE
docs(observability): document NIXL transfer metrics

### DIFF
--- a/docs/operations/observability/metrics.md
+++ b/docs/operations/observability/metrics.md
@@ -60,6 +60,23 @@ prefill-podmonitor      5m
 | `vllm:prompt_tokens_total` | Total input tokens processed | Use `rate()` to get tokens/sec per pod. Compare across pods to spot uneven load distribution |
 | `vllm:generation_tokens_total` | Total output tokens generated | Use `rate()` alongside prompt tokens to get total throughput. A drop signals degraded model performance |
 
+#### vLLM NIXL KV Transfer Metrics
+
+When vLLM uses `NixlConnector` for disaggregated serving, it exports metrics for the KV cache transfers between workers. See the [vLLM NixlConnector usage guide](https://docs.vllm.ai/en/latest/features/nixl_connector_usage/) for configuration details.
+
+| Metric | What it measures | Why it matters |
+|--------|------------------|----------------|
+| `vllm:nixl_xfer_time_seconds` (histogram) | Time from posting a transfer until the backend reports completion, including submission and data movement | High tail latency can indicate network congestion, large transfers, or backend delays |
+| `vllm:nixl_post_time_seconds` (histogram) | Synchronous time spent submitting a transfer to the backend | A high value with otherwise normal transfer time points to descriptor setup or submission overhead |
+| `vllm:nixl_bytes_transferred` (histogram) | Bytes moved per transfer observation | Shows transfer size and KV cache data volume |
+| `vllm:nixl_num_descriptors` (histogram) | Memory descriptor count per transfer observation | High counts can indicate fragmented or large KV cache allocations |
+| `vllm:nixl_num_failed_transfers` (counter) | Failed NIXL KV cache transfers | Transfer failures can prevent the consumer from using remote KV blocks |
+| `vllm:nixl_num_failed_notifications` (counter) | Failed transfer completion notifications | Notification failures can prevent a peer from learning that a transfer completed |
+| `vllm:nixl_num_kv_expired_reqs` (counter) | Requests whose KV blocks expired before the decoder read them; recorded on the prefill instance | Sustained increases can indicate that `kv_lease_duration` is too short for the workload or network |
+
+> [!NOTE]
+> With tensor parallelism, vLLM pools transfer observations from all TP ranks before exporting them. Histogram counts therefore represent rank-level transfer observations, not inference requests, and byte values do not represent the total size of one request across all ranks. These are aggregate Prometheus metrics and are not correlated with individual request or trace IDs.
+
 ### Key SGLang Metrics
 
 | Metric | What it measures | Why it matters |

--- a/docs/operations/observability/promql.md
+++ b/docs/operations/observability/promql.md
@@ -69,6 +69,15 @@ Start here when something looks wrong.
 | **Prefill worker utilization (SGLang)** | `avg by(pod) (sglang_num_running_reqs{pod=~".*prefill.*"})` |
 | **Decode KV cache utilization** | `avg by(pod) (vllm:kv_cache_usage_perc{pod=~".*decode.*"})` |
 | **Disaggregation decision ratio** | `sum(rate(llm_d_epp_disagg_decision_total{decision_type="prefill-decode"}[5m])) / sum(rate(llm_d_epp_disagg_decision_total[5m]))` |
+| **Average NIXL transfer time (ms)** | `sum(rate(vllm:nixl_xfer_time_seconds_sum[5m])) / sum(rate(vllm:nixl_xfer_time_seconds_count[5m])) * 1000` |
+| **NIXL transfer time P95 (ms)** | `histogram_quantile(0.95, sum by(le) (rate(vllm:nixl_xfer_time_seconds_bucket[5m]))) * 1000` |
+| **Average NIXL transfer size (MiB)** | `sum(rate(vllm:nixl_bytes_transferred_sum[5m])) / sum(rate(vllm:nixl_bytes_transferred_count[5m])) / 1048576` |
+| **NIXL transfer data volume (MiB/sec)** | `sum(rate(vllm:nixl_bytes_transferred_sum[5m])) / 1048576` |
+| **Failed NIXL transfers in 5m** | `sum(increase(vllm:nixl_num_failed_transfers[5m]))` |
+| **Failed NIXL notifications in 5m** | `sum(increase(vllm:nixl_num_failed_notifications[5m]))` |
+| **Expired prefill KV requests in 5m** | `sum(increase(vllm:nixl_num_kv_expired_reqs[5m]))` |
+
+NIXL histogram observations are pooled across tensor-parallel ranks. Their counts and average sizes describe rank-level transfer observations, not inference requests or whole-request KV cache sizes.
 
 ### Flow Control
 


### PR DESCRIPTION
Expose the existing vLLM NIXL metric semantics and PromQL in the central observability docs so operators can diagnose P/D transfers without reverse engineering the dashboard. Clarify TP-rank aggregation and that the metrics are not correlated with individual requests.

see https://github.com/llm-d/llm-d/issues/2269#issuecomment-5392973593 for more details.