### PR TITLE
fix: merge duplicate env blocks in lmcache connector patch

### DIFF
--- a/guides/tiered-prefix-cache/modelserver/gpu/vllm/lmcache-connector/cpu/base/patch-vllm.yaml
+++ b/guides/tiered-prefix-cache/modelserver/gpu/vllm/lmcache-connector/cpu/base/patch-vllm.yaml
@@ -14,18 +14,17 @@ spec:
             - "--kv-transfer-config"
             - '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'
             - "--max-num-seq=1024"
-          env:
-            - name: HF_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: llm-d-hf-token
-                  key: HF_TOKEN
           resources:
             limits:
               memory: 500Gi
             requests:
               memory: 500Gi
           env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
             - name: LMCACHE_MAX_LOCAL_CPU_SIZE
               value: "100.0"
             - name: PYTHONHASHSEED


### PR DESCRIPTION
Merge the duplicate `env` blocks in the lmcache connector [patch-vllm.yaml](https://github.com/llm-d/llm-d/blob/main/guides/tiered-prefix-cache/modelserver/gpu/vllm/lmcache-connector/cpu/base/patch-vllm.yaml). This preserves the `HF_TOKEN` environment variable alongside the existing environment variables.

fixes: #2356 