### PR TITLE
Add deployment guide for Flagos-cuda using vLLM

### DIFF
--- a/guides/optimized-baseline/README.md
+++ b/guides/optimized-baseline/README.md
@@ -41,6 +41,7 @@ This guide includes configurations for the following accelerators:
 | Google TPU v6e      | `tpu/v6`           | GKE TPU                                                         |
 | Google TPU v7       | `tpu/v7`           | GKE TPU                                                         |
 | CPU                 | `cpu`              | x86 with bf16 acceleration                                      |
+| NVIDIA GPU (FlagOS) | `flagos-cuda`      | vLLM + FlagOS unified backend                                   |
 
 > [!NOTE]
 > "x86 with bf16 acceleration": AMX or AVX512-BF16 (Intel Sapphire Rapids+ / GCP C3, AMD Zen 4+); 64 cores + 64GB RAM per replica. Older CPUs without AMX/AVX512-BF16 (e.g. Cascade/Ice Lake) crash on the bf16 model unless run with `--dtype=float32`
@@ -82,7 +83,7 @@ export HF_TOKEN=HF_TOKEN_PLACEHOLDER
 ```bash
 export MONITORING_VALUES=
 export PROVIDER_NAME=none # options: none, gke, agentgateway, istio
-export ACCELERATOR_TYPE=gpu # options: gpu, amd, xpu, hpu, tpu/v6, tpu/v7, cpu
+export ACCELERATOR_TYPE=gpu # options: gpu, amd, xpu, hpu, tpu/v6, tpu/v7, cpu, flagos-cuda
 export MODEL_SERVER=vllm # options: vllm, sglang, trtllm
 export INFRA_PROVIDER=base # options: base, gke
 export MODEL=Qwen/Qwen3-32B

--- a/guides/optimized-baseline/modelserver/flagos-cuda/vllm/kustomization.yaml
+++ b/guides/optimized-baseline/modelserver/flagos-cuda/vllm/kustomization.yaml
@@ -1,0 +1,52 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../recipes/modelserver/base/single-host/default
+
+namePrefix: optimized-baseline-flagos-cuda-vllm-
+
+images:
+  - name: REPLACE_MODEL_SERVER_IMAGE
+    newName: ghcr.io/llm-d/llm-d-flagos-cuda
+    newTag: latest
+
+labels:
+  - pairs:
+      llm-d.ai/model: Qwen3-32B
+      llm-d.ai/guide: optimized-baseline
+      llm-d.ai/accelerator-variant: flagos-cuda
+      llm-d.ai/accelerator-vendor: nvidia
+    includeSelectors: true
+    includeTemplates: true
+    fields:
+      - version: v1
+        kind: ServiceAccount
+        path: metadata/labels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: metadata/labels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: spec/selector/matchLabels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: spec/template/metadata/labels
+        create: true
+      - group: monitoring.coreos.com
+        version: v1
+        kind: PodMonitor
+        path: metadata/labels
+        create: true
+      - group: monitoring.coreos.com
+        version: v1
+        kind: PodMonitor
+        path: spec/selector/matchLabels
+        create: true
+patches:
+  - path: patch-vllm.yaml

--- a/guides/optimized-baseline/modelserver/flagos-cuda/vllm/patch-vllm.yaml
+++ b/guides/optimized-baseline/modelserver/flagos-cuda/vllm/patch-vllm.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: modelserver
+          command: ["vllm", "serve"]
+          args:
+            - "Qwen/Qwen3-32B"
+            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+            - "--tensor-parallel-size=2"
+            - "--gpu-memory-utilization=0.95"
+          env:
+            - name: VLLM_PLUGINS
+              value: "fl"
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
+          resources:
+            limits:
+              cpu: '16'
+              memory: 128Gi
+              nvidia.com/gpu: 2
+            requests:
+              cpu: '8'
+              memory: 96Gi
+              nvidia.com/gpu: 2
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /home/vllm/.cache
+              name: torch-compile-cache
+            - mountPath: /home/vllm/.triton
+              name: triton-cache
+            - mountPath: /home/vllm/.config
+              name: vllm-config
+          startupProbe:
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 120
+          livenessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 20Gi
+        - name: torch-compile-cache
+          emptyDir: {}
+        - name: triton-cache
+          emptyDir: {}
+        - name: vllm-config
+          emptyDir: {}


### PR DESCRIPTION
Depends on #1624 for the image(ghcr.io/llm-d/llm-d-flagos-cuda) 

This PR adds a deployment guide for the flagos-cuda variant. 

Summary of changes:
1. guides/optimized-baseline/modelserver/flagos-cuda/vllm/kustomization.yaml
    - Kustomize overlay modeled after the existing GPU variant
    - Points to the ghcr.io/llm-d/llm-d-flagos-cuda image
    - Adds labels: accelerator-variant: flagos-cuda, accelerator-vendor: nvidia

2. guides/optimized-baseline/modelserver/flagos-cuda/vllm/patch-vllm.yaml
    - Deployment patch for the decode pods
    - 2 replicas (reduced from 8 since this is a new variant being validated)
    - Same model/resources as GPU variant: Qwen3-32B, TP=2, 2x nvidia.com/gpu
    - Adds VLLM_PLUGINS=fl env var — the one key difference that enables FlagOS

3. guides/optimized-baseline/README.md 
    - Added FlagOS row to the Supported Hardware Backends table
    - Added flagos-cuda to the ACCELERATOR_TYPE options list

Once PR #1624 merges (providing the image), users can deploy FlagOS CUDA with:
  ```
export ACCELERATOR_TYPE=flagos-cuda
  export MODEL_SERVER=vllm
  kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/${ACCELERATOR_TYPE}/${MODEL_SERVER}/
```