### PR TITLE
docs(scheduling): remove deprecated pd-profile-handler reference

### DIFF
--- a/docs/architecture/core/router/epp/scheduling.md
+++ b/docs/architecture/core/router/epp/scheduling.md
@@ -113,10 +113,7 @@ When a profile runs, it first filters the candidate endpoints. If any remain, it
 * **[`disagg-profile-handler`](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/profilehandler/disagg)**: Runs two scheduling profiles, one for prefill and one for decode. The **decode endpoint** is set as the primary destination for the proxy to forward the original request, while the **prefill endpoint** is injected into the request as a specialized header.
 
 > [!NOTE]
-> Two older handlers are **deprecated** and kept only for backward compatibility:
->
-> * `pd-profile-handler` — use `disagg-profile-handler` instead.
-> * `data-parallel-profile-handler` — use `single-profile-handler` instead.
+> An older handler, `data-parallel-profile-handler`, is **deprecated** and kept only for backward compatibility, use `single-profile-handler` instead.
 
 ---
 


### PR DESCRIPTION
## Summary

Removes the `pd-profile-handler` entry from the deprecated-handlers note in
`docs/architecture/core/router/epp/scheduling.md`. The plugin itself was
removed in llm-d/llm-d-router#2509 ("epp: remove code deprecated since
v0.7.0"), so documenting it as a deprecated-but-present option is now
inaccurate; `disagg-profile-handler` is the only supported replacement.

The other deprecated handler mentioned in the same note,
`data-parallel-profile-handler`, is left as-is: llm-d-router#2509
intentionally kept it (no formal removal schedule yet, and an e2e test still
depends on its behavior).