### PR TITLE
docs(api): document requestHandler.parsers as a list

### DIFF
--- a/docs/api-reference/endpointpickerconfig.md
+++ b/docs/api-reference/endpointpickerconfig.md
@@ -74,7 +74,7 @@ Configures request handling behavior.
 
 | Field | Description |
 | --- | --- |
-| `parser` | [ParserConfig](#parserconfig) <br/> Specifies the parsing logic for protocol messages. |
+| `parsers` | [][ParserConfig](#parserconfig) <br/> List of parsing plugins used to process protocol messages. If unspecified, `openai-parser`, `anthropic-parser`, and `vllmhttp-parser` are configured by default. |
 
 ## DataLayerConfig
 
@@ -99,4 +99,4 @@ Configures request handling behavior.
 
 | Field | Description |
 | --- | --- |
-| `pluginRef` | `string` <br/> **Required** <br/> Reference to a parser plugin (default: `openai-parser`). |
+| `pluginRef` | `string` <br/> **Required** <br/> Reference to a parser plugin instance. |

--- a/docs/architecture/core/router/epp/configuration.md
+++ b/docs/architecture/core/router/epp/configuration.md
@@ -12,7 +12,7 @@ plugins:
 - ....
 featureGates:
   ...
-parser:
+requestHandler:
   ...
 flowControl:
   ...
@@ -169,18 +169,22 @@ This section covers components that process requests and responses before they r
 
 #### Parsers
 
-The `parser` section configures how the EPP understands protocol messages (e.g., OpenAI or vLLM payloads). To use a non-default parser, you must first instantiate it in the `plugins` section and then reference its name in the `parser` field:
+The `requestHandler.parsers` section configures how the EPP understands protocol messages (e.g., OpenAI or vLLM payloads). By default, when `requestHandler.parsers` is unspecified, the EPP configures three built-in parsers, `openai-parser`, `anthropic-parser`, and `vllmhttp-parser`, instantiated automatically without `plugins` entries. A request is handled by the first configured parser that claims its path (for example `/v1/chat/completions` by `openai-parser`, `/v1/messages` by `anthropic-parser`, `/inference/v1/generate` by `vllmhttp-parser`).
+
+Setting `parsers` replaces this default list. To use a non-default parser, you must first instantiate it in the `plugins` section and then reference its name in an entry of the `parsers` list:
 
 ```yaml
 plugins:
 - name: myParser
   type: vllmgrpc-parser
 # ...
-parser:
-  pluginRef: myParser
+requestHandler:
+  parsers:
+  - pluginRef: myParser
 ```
 
-If unspecified, `openai-parser` is used by default.
+> [!NOTE]
+> The top-level `parser` field (a single object) is deprecated in favor of the `requestHandler.parsers` list. If both are set, `requestHandler.parsers` is used. See [llm-d-router#1308](https://github.com/llm-d/llm-d-router/issues/1308).
 
 #### Admitters & Data Producers
 


### PR DESCRIPTION
## Summary
`docs/api-reference/endpointpickerconfig.md` documented `requestHandler.parser` as a single object while `docs/api-reference/epp-grpc-apis.md` shows `requestHandler.parsers` as a list. The schema defines only the list form inside `requestHandler`. The configuration guide also presented the deprecated top-level `parser` field as current.

Fixes #2355

## Changes
- `docs/api-reference/endpointpickerconfig.md`: `RequestHandlerConfig` table row `parser` ([ParserConfig]) replaced with `parsers` ([][ParserConfig]).
- `docs/architecture/core/router/epp/configuration.md`: top-level structure sketch lists `requestHandler` instead of the deprecated `parser`; the Parsers section example now uses the `requestHandler.parsers` list form; added a note that the top-level `parser` field is deprecated, with the precedence rule.
- `docs/api-reference/epp-grpc-apis.md` already uses the list form and is unchanged.

## Validation
- Schema checked in llm-d/llm-d-router at tag `v0.10.0` (commit `0b43c187`), file `apix/config/v1alpha1/endpointpickerconfig_types.go`:
  - lines 320-325: `RequestHandlerConfig` has a single field `Parsers []ParserConfig` with JSON tag `parsers,omitempty`.
  - lines 72-78: top-level `Parser *ParserConfig` (JSON tag `parser,omitempty`) is marked Deprecated, the new field wins when both are set, tracked in llm-d-router#1308.
  - Same shape at llm-d-router `main` (commit `d3248497`, lines 361-366).
- `markdownlint-cli@0.47.0` (version pinned in `.pre-commit-config.yaml`) with the repo `.markdownlint.json` over both changed files: no new findings. The single reported error (MD051 at `endpointpickerconfig.md:90`, broken `#datalayerextractor` fragment) exists on `main` before this change.