### PR TITLE
docs(epp): document saturationDetector nested under flowControl

### DIFF
--- a/docs/architecture/core/router/epp/configuration.md
+++ b/docs/architecture/core/router/epp/configuration.md
@@ -16,8 +16,6 @@ parser:
   ...
 flowControl:
   ...
-saturationDetector:
-  ...
 schedulingProfiles:
 - ....
 - ....
@@ -32,7 +30,7 @@ dataLayer:
 - **Plugins**: Defines the set of plugins that will be instantiated and their parameters.
 - **Feature Gates**: Enables or disables specific experimental or optional features (such as Flow Control).
 - **Request Handling**: Manages the full lifecycle of requests around the scheduling phase, spanning protocol parsing, state preparation via data producers, and final admission decisions.
-- **Flow Control**: Manages pool defense and multi-tenancy by queuing requests at the gateway to enforce priority and fairness, while evaluating pool saturation to prevent overload (combines `flowControl` and `saturationDetector` fields).
+- **Flow Control**: Manages pool defense and multi-tenancy by queuing requests at the gateway to enforce priority and fairness, while evaluating pool saturation to prevent overload (configured via the `flowControl` field, including its nested `saturationDetector`).
 - **Scheduling**: Defines the profiles and plugins used to select the optimal model server candidate for each request (via Filter -> Score -> Pick lifecycle).
 - **Data Layer**: Configures the backend sources and metrics collection used for smart scheduling decisions and observability.
 
@@ -51,7 +49,7 @@ This design allows you to define a plugin once and reuse it across multiple prof
 
 To ensure the integrity of this graph, the following **validation rules** apply across all layers:
 
-- **Valid References**: Any field that references a plugin (e.g., `pluginRef` in `schedulingProfiles` or `saturationDetector`) must reference a valid name defined in the top-level `plugins` section.
+- **Valid References**: Any field that references a plugin (e.g., `pluginRef` in `schedulingProfiles` or `flowControl.saturationDetector`) must reference a valid name defined in the top-level `plugins` section.
 - **Unique Names**: All instances within lists that require naming (like `schedulingProfiles`) must have unique, non-empty names.
 - **Data Dependencies**: The system validates that metrics extractors form a Directed Acyclic Graph (DAG) without circular dependencies, ensuring correct execution order.
 
@@ -221,7 +219,7 @@ The `flowControl` section configures the EPP's Flow Control layer, which acts as
 
 When flow control is enabled (via the `FlowControl` feature gate), incoming requests are queued in memory and dispatched according to configured priority bands, fairness policies, and ordering policies. When the pool is saturated (as determined by the [saturation detector](#saturation-detector)), requests are held in the queue until capacity frees up.
 
-The following example demonstrates a complete `EndpointPickerConfig` with flow control enabled, showing how to configure the `featureGates`, `plugins`, `saturationDetector`, and `flowControl` sections to work together.
+The following example demonstrates a complete `EndpointPickerConfig` with flow control enabled, showing how to configure the `featureGates`, `plugins`, and `flowControl` sections (including the nested `saturationDetector`) to work together.
 
 ```yaml
 apiVersion: llm-d.ai/v1alpha1
@@ -237,14 +235,14 @@ plugins:
 - type: utilization-detector
 # ... other plugins ...
 
-saturationDetector:
-  pluginRef: utilization-detector # Default
-
 flowControl:
   maxBytes: 0 # Default: unlimited
   maxRequests: 0 # Default: unlimited
   defaultRequestTTL: "0s" # Default: uses client context deadline
   enableEviction: false # Default: in-flight eviction disabled
+
+  saturationDetector:
+    pluginRef: utilization-detector # Default
 
   defaultPriorityBand:
     maxBytes: "1Gi" # Default
@@ -288,17 +286,16 @@ For a full list of available Fairness and Ordering policies, see the [Flow Contr
 
 #### Saturation Detector
 
-> [!NOTE]
-> While `saturationDetector` is presented here conceptually as part of Flow Control, it is a **top-level field** in the YAML schema, at the same level as `flowControl`.
-
-The `saturationDetector` section configures the mechanism that evaluates whether the backend InferencePool is overloaded.
-
-The `saturationDetector` section has the following form:
+The `saturationDetector` section configures the mechanism that evaluates whether the backend InferencePool is overloaded. It is nested under `flowControl` and has the following form:
 
 ```yaml
-saturationDetector:
-  pluginRef: utilization-detector # Default
+flowControl:
+  saturationDetector:
+    pluginRef: utilization-detector # Default
 ```
+
+> [!NOTE]
+> The top-level `saturationDetector` field is deprecated in favor of `flowControl.saturationDetector`. If both are set, `flowControl.saturationDetector` is used. See [llm-d-router#1308](https://github.com/llm-d/llm-d-router/issues/1308).
 
 ##### Fields
 

--- a/docs/architecture/core/router/epp/flow-control.md
+++ b/docs/architecture/core/router/epp/flow-control.md
@@ -211,10 +211,10 @@ plugins:
     headroom: 0.0
 # ... other plugins ...
 
-saturationDetector:
-  pluginRef: concurrency-detector
-
 flowControl:
+  saturationDetector:
+    pluginRef: concurrency-detector
+
   maxBytes: "10Gi"
   maxRequests: "1k"
   defaultRequestTTL: "60s"

--- a/guides/flow-control/tuning.md
+++ b/guides/flow-control/tuning.md
@@ -127,10 +127,10 @@ plugins:
     maxConcurrency: <N_active + B> # From wizard output
     headroom: 0.0
 
-saturationDetector:
-  pluginRef: concurrency-detector
-
 flowControl:
+  saturationDetector:
+    pluginRef: concurrency-detector
+
   maxRequests: 200 # Set a healthy burst queue limit
   maxBytes: "10Gi" # Adjust to protect host memory
 ```


### PR DESCRIPTION
## Summary
The EPP configuration reference documented `saturationDetector` as a top-level field of `EndpointPickerConfig`, with a NOTE asserting that placement. In the schema the top-level field is deprecated: the current field is `flowControl.saturationDetector`, and the nested field wins when both are set. The shipped guide values already use the nested form.

Fixes #2352

## Changes
- `docs/architecture/core/router/epp/configuration.md`: removed `saturationDetector` from the top-level structure sketch; moved it under `flowControl` in the complete flow control example; the Saturation Detector section now shows the nested form, and the NOTE is replaced with a deprecation note stating the precedence rule and linking llm-d-router#1308; two prose references updated to `flowControl.saturationDetector`.
- `docs/architecture/core/router/epp/flow-control.md`: EPP configuration example moves `saturationDetector` under `flowControl`.
- `guides/flow-control/tuning.md`: gateway configuration example moves `saturationDetector` under `flowControl`.
- `guides/flow-control/router/flow-control.values.yaml` already nests it and is unchanged.

## Validation
- Schema checked in llm-d/llm-d-router at tag `v0.10.0` (commit `0b43c187`), file `apix/config/v1alpha1/endpointpickerconfig_types.go`:
  - lines 66-71: top-level `SaturationDetector *SaturationDetectorConfig` is marked `Deprecated: use flowControl.saturationDetector instead. If both are set, the new field is used.` Tracked in llm-d-router#1308.
  - lines 419-422: `FlowControlConfig.SaturationDetector` (JSON tag `saturationDetector,omitempty`) is the current field.
  - Same shape at llm-d-router `main` (commit `d3248497`).
- All edited YAML example blocks parse (PyYAML) and nest `saturationDetector` under `flowControl`. The two illustrative `apps/v1` snippets that do not parse are unchanged from `main`.
- `markdownlint-cli@0.47.0` (version pinned in `.pre-commit-config.yaml`) with the repo `.markdownlint.json` over the three changed files: identical findings before and after (22 pre-existing in `flow-control.md`, all outside the edited region; `configuration.md` and `tuning.md` clean).