### PR TITLE
[ROCM] add ATOM MoRIIO P/D support

### DIFF
--- a/.github/workflows/consolidate-status-pd-disaggregation-amd-ci-acc-rocm-atom-moriio.yaml
+++ b/.github/workflows/consolidate-status-pd-disaggregation-amd-ci-acc-rocm-atom-moriio.yaml
@@ -1,0 +1,36 @@
+name: Past Status - PD Disaggregation E2E (AMD ROCM ATOM MoRIIO)
+
+on:
+  workflow_dispatch:
+    inputs:
+      workflow_name_query:
+        description: 'Name of the workflow to be queried'
+        required: false
+        type: 'string'
+        default: 'nightly-e2e-pd-disaggregation-amd-ci-acc-rocm-atom-moriio.yaml'
+      time_window_query:
+        description: 'How many days in the past to query'
+        required: true
+        type: 'string'
+        default: '5'
+      branch_query:
+        description: 'Branch to be queried'
+        required: false
+        type: string
+        default: 'main'
+
+#  push:
+#    branches:
+#      - main
+
+  schedule:
+    - cron: '00 8 * * *'  # 08:00 UTC daily
+
+jobs:
+  check_for_success:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-query-success-past-runs.yaml@main
+    with:
+      workflow_name_query: ${{ inputs.workflow_name_query || 'nightly-e2e-pd-disaggregation-amd-ci-acc-rocm-atom-moriio.yaml' }}
+      time_window_query: ${{ inputs.time_window_query || '5' }}
+      branch_query: ${{ inputs.branch_query || 'main' }}
+    secrets: inherit

--- a/.github/workflows/nightly-e2e-pd-disaggregation-amd-ci-acc-rocm-atom-moriio.yaml
+++ b/.github/workflows/nightly-e2e-pd-disaggregation-amd-ci-acc-rocm-atom-moriio.yaml
@@ -1,0 +1,108 @@
+name: Nightly - PD Disaggregation E2E (AMD ROCM ATOM MoRIIO)
+
+on:
+  workflow_dispatch:
+    inputs:
+      decode_pods:
+        description: 'Number of decode (atom "standalone") pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      prefill_pods:
+        description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      gateway_class:
+        description: 'Class of gateway used ("istio", "agentgateway", "epponly" (i.e., "standalone"), "none")'
+        required: false
+        default: 'epponly'
+      monitoring_enabled:
+        description: 'Enabled monitoring ("true", "false")'
+        required: true
+        type: 'string'
+        default: 'false'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode ("true", "false")'
+        required: false
+        default: 'false'
+      verbose:
+        description: 'Execute workflow in "verbose" mode ("true", "false")'
+        required: false
+        default: 'false'
+        type: 'string'
+      harness:
+        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
+        required: false
+        default: 'inference-perf'
+        type: 'string'
+      workload:
+        description: 'Workload profile to be used during "run" operation (check list under "workload/profiles")'
+        required: false
+        default: 'sanity_random.yaml'
+#        default: 'guide_pd-disaggregation_1.yaml'
+        type: 'string'
+      cleanup:
+        description: 'Cleanup the llm-d stack stood up by this workflow'
+        required: false
+        default: 'true'
+        type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
+
+#  push:
+#    branches:
+#      - main
+
+  schedule:
+    - cron: '43 4 * * *'  # 04:43 UTC daily
+
+permissions:
+  contents: write
+  actions: read
+
+concurrency:
+  group: nightly-e2e-pd-disaggregation-amd-atom-moriio
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
+    with:
+      scenario_dir: ${{ inputs.scenario_dir || 'guides' }}
+      standup_method: ${{ inputs.standup_method || 'kustomize' }}
+      standup_scenario: ${{ inputs.standup_scenario || 'pd-disaggregation' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'amd' }}
+      backend_type: ${{ inputs.backend_type || 'atom' }}
+      connector: ${{ inputs.connector || 'moriio' }}
+      infra_provider: ${{ inputs.infra_provider || 'amd-ci' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-pd-disaggregation-amd-rocm-atom-moriio' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-amd-atom' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdk-amd-atom' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions/pd-disaggregation' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'sanity_random.yaml' }}
+      cleanup: ${{ inputs.cleanup || 'true' }}
+    secrets: inherit
+
+  update-badge:
+    needs: [nightly]
+    if: always() && inputs.update_badge != 'false'
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
+    with:
+      badge_name: pd-disaggregation-amd-atom-moriio
+      badge_label: "ATOM MoRIIO ROCm"
+      result: ${{ needs.nightly.result }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}

--- a/guides/pd-disaggregation/modelserver/amd/atom/moriio/amd-ci/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/atom/moriio/amd-ci/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+
+components:
+  - ../../../../../../recipes/modelserver/components/model-cache
+
+patches:
+  - path: patch-amd-ci.yaml

--- a/guides/pd-disaggregation/modelserver/amd/atom/moriio/amd-ci/patch-amd-ci.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/atom/moriio/amd-ci/patch-amd-ci.yaml
@@ -1,0 +1,71 @@
+# AMD CI overlay: adds Multus CNI network annotations for RDMA NICs (amd.com/vnic)
+# and the dockerhub pull secret. The 8 net* interfaces map to the 8 ionic RDMA
+# devices (ionic_0..ionic_7) exposed by the AMD Pensando NIC device plugin.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prefill
+spec:
+  template:
+    metadata:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: |
+          [
+            {"name":"amd-host-device-nad","namespace":"default","interface":"net1"},
+            {"name":"amd-host-device-nad","namespace":"default","interface":"net2"},
+            {"name":"amd-host-device-nad","namespace":"default","interface":"net3"},
+            {"name":"amd-host-device-nad","namespace":"default","interface":"net4"},
+            {"name":"amd-host-device-nad","namespace":"default","interface":"net5"},
+            {"name":"amd-host-device-nad","namespace":"default","interface":"net6"},
+            {"name":"amd-host-device-nad","namespace":"default","interface":"net7"},
+            {"name":"amd-host-device-nad","namespace":"default","interface":"net8"}
+          ]
+    spec:
+      containers:
+        - name: modelserver
+          env:
+            - name: MORI_ENABLE_DMABUF_REG
+              value: "1"
+            - name: MORI_IB_GID_INDEX
+              value: "1"
+          resources:
+            limits:
+              amd.com/gpu: "8"
+              amd.com/vnic: "8"
+            requests:
+              amd.com/gpu: "8"
+              amd.com/vnic: "8"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  template:
+    metadata:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: |
+          [
+            {"name":"amd-host-device-nad","namespace":"default","interface":"net1"},
+            {"name":"amd-host-device-nad","namespace":"default","interface":"net2"},
+            {"name":"amd-host-device-nad","namespace":"default","interface":"net3"},
+            {"name":"amd-host-device-nad","namespace":"default","interface":"net4"},
+            {"name":"amd-host-device-nad","namespace":"default","interface":"net5"},
+            {"name":"amd-host-device-nad","namespace":"default","interface":"net6"},
+            {"name":"amd-host-device-nad","namespace":"default","interface":"net7"},
+            {"name":"amd-host-device-nad","namespace":"default","interface":"net8"}
+          ]
+    spec:
+      containers:
+        - name: modelserver
+          env:
+            - name: MORI_ENABLE_DMABUF_REG
+              value: "1"
+          resources:
+            limits:
+              amd.com/gpu: "8"
+              amd.com/vnic: "8"
+            requests:
+              amd.com/gpu: "8"
+              amd.com/vnic: "8"

--- a/guides/pd-disaggregation/modelserver/amd/atom/moriio/base/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/atom/moriio/base/kustomization.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../../../../recipes/modelserver/base/single-host/pd/atom
+
+namePrefix: pd-disaggregation-rocm-moriio-atom-
+
+components:
+  - ../../../../../../recipes/modelserver/components/images/amd-atom
+  - ../../../../../../recipes/modelserver/components/images/routing-sidecar/nightly
+
+images:
+  - name: ghcr.io/llm-d/llm-d-router-disagg-sidecar
+    newName: ghcr.io/vcave/llm-d/llm-d-router-disagg-sidecar
+    newTag: v0.1.0
+
+labels:
+  - pairs:
+      llm-d.ai/model: Qwen3-32B
+      llm-d.ai/guide: pd-disaggregation
+      llm-d.ai/accelerator-variant: gpu
+      llm-d.ai/accelerator-vendor: amd
+      llm-d.ai/kv-connector: atom
+      llm-d.ai/engine-type: atom
+    includeSelectors: true
+    includeTemplates: true
+
+patches:
+  - path: patch-prefill.yaml
+  - path: patch-decode.yaml

--- a/guides/pd-disaggregation/modelserver/amd/atom/moriio/base/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/atom/moriio/base/patch-decode.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: modelserver
+          imagePullPolicy: Always
+          command: ["python", "-m", "atom.entrypoints.openai_server"]
+          args:
+            - "--model=Qwen/Qwen3-32B"
+            - "--host=0.0.0.0"
+            - "--server-port=8200"
+            - "--tensor-parallel-size=8"
+            - "--gpu-memory-utilization=0.50"
+            - "--kv_cache_dtype=fp8"
+            - "--enable_prefix_caching"
+            - "--disable-uvicorn-access-log"
+            - "--kv-transfer-config"
+            # CONSUMER (decode) role: receives KV cache blocks from prefill via RDMA.
+            - '{"kv_connector":"moriio","kv_role":"kv_consumer","http_port":8200,"handshake_port":6301}'
+          env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
+          securityContext:
+            capabilities:
+              add: ["IPC_LOCK"]
+          ports:
+            - containerPort: 6301
+              name: mori-handshake
+              protocol: TCP
+          resources:
+            limits:
+              cpu: "64"
+              memory: 160Gi
+              amd.com/gpu: "8"
+            requests:
+              cpu: "32"
+              memory: 128Gi
+              amd.com/gpu: "8"
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: shm
+          startupProbe:
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 240
+          livenessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 12
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Gi
+

--- a/guides/pd-disaggregation/modelserver/amd/atom/moriio/base/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/atom/moriio/base/patch-prefill.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prefill
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: modelserver
+          imagePullPolicy: Always
+          command: ["python", "-m", "atom.entrypoints.openai_server"]
+          args:
+            - "--model=Qwen/Qwen3-32B"
+            - "--host=0.0.0.0"
+            - "--server-port=8000"
+            - "--tensor-parallel-size=8"
+            - "--gpu-memory-utilization=0.50"
+            - "--kv_cache_dtype=fp8"
+            - "--enable_prefix_caching"
+            - "--disable-uvicorn-access-log"
+            - "--kv-transfer-config"
+            # PRODUCER (prefill) role: sends KV cache blocks via RDMA to decode.
+            # proxy_ip intentionally omitted; peer discovery is via the routing sidecar.
+            - '{"kv_connector":"moriio","kv_role":"kv_producer","http_port":8000,"handshake_port":6301}'
+          env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
+          securityContext:
+            capabilities:
+              add: ["IPC_LOCK"]
+          ports:
+            - containerPort: 6301
+              name: mori-handshake
+              protocol: TCP
+          resources:
+            limits:
+              cpu: "64"
+              memory: 160Gi
+              amd.com/gpu: "8"
+            requests:
+              cpu: "32"
+              memory: 128Gi
+              amd.com/gpu: "8"
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: shm
+          startupProbe:
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 240
+          livenessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 12
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Gi

--- a/guides/pd-disaggregation/modelserver/amd/atom/moriio/router-atom.values.yaml
+++ b/guides/pd-disaggregation/modelserver/amd/atom/moriio/router-atom.values.yaml
@@ -1,0 +1,13 @@
+# Use PR-2476 that teaches EPP to read ATOM metrics
+#
+# Usage:
+#   helm install ... \
+#     -f guides/pd-disaggregation/router/pd-disaggregation.values.yaml \
+#     -f guides/pd-disaggregation/modelserver/amd/atom/moriio/router-atom.values.yaml
+
+router:
+  epp:
+    image:
+      registry: ghcr.io/vcave/llm-d
+      repository: llm-d-router-endpoint-picker
+      tag: "pr-2476"

--- a/guides/recipes/modelserver/base/single-host/pd/atom/kustomization.yaml
+++ b/guides/recipes/modelserver/base/single-host/pd/atom/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+
+patches:
+  # Add routing sidecar to the decode deployment
+  - path: patch-sidecar.yaml
+    target:
+      kind: Deployment
+      name: decode

--- a/guides/recipes/modelserver/base/single-host/pd/atom/patch-sidecar.yaml
+++ b/guides/recipes/modelserver/base/single-host/pd/atom/patch-sidecar.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: routing-proxy
+          image: REPLACE_ROUTING_SIDECAR_IMAGE
+          imagePullPolicy: IfNotPresent
+          # ATOM P/D connector: injects data_parallel_rank into the request body
+          # for both prefill and decode legs, matching ATOM's DP routing convention.
+          # kv_transfer_params are passed through unchanged (ATOM-to-ATOM compatible).
+          args:
+            - --port=8000
+            - --model-server-port=8200
+            - --kv-connector=atom
+            - --atom-dp-size=1
+            - --zap-log-level=1
+            - --secure-proxy=false
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          ports:
+            - containerPort: 8000
+              name: sidecar
+              protocol: TCP
+          resources: {}
+          restartPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true

--- a/guides/recipes/modelserver/components/images/amd-atom/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/amd-atom/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+images:
+  - name: REPLACE_MODEL_SERVER_IMAGE
+    newName: ghcr.io/vcave/rocm/atom-dev
+    newTag: "20260819-ionic1-125"


### PR DESCRIPTION
Add Prefill/Decode disaggregation configuration for ATOM inference engines using MoRIIO RDMA and pull-based KV cache transfer on AMD GPUs.

Key components:
- Base kustomization with prefill/decode deployments using ATOM
- MoRIIO connector configuration for RDMA KV transfer
- Sidecar patch to use atom protocol
- Disable EPP metrics query (no /metrics endpoint)
- AMD CI overlay for AINIC-based CI

Limitations:
- Known issue when gpu util > 0.50 when TP=8
- Requires custom llm-d-router image (until upstream patch is merged)