### PR TITLE
docs(observability): add batch-gateway dashboards and alerts to llm-d

### DIFF
--- a/docs/operations/observability/alerting.md
+++ b/docs/operations/observability/alerting.md
@@ -1,6 +1,6 @@
 # Alerting
 
-This page covers a default set of Prometheus alerting rules for the EPP (Endpoint Picker). For Prometheus and Grafana installation, see [Observability Setup](./setup.md) first, and for the metrics these alerts are built on, see [Metrics](./metrics.md).
+This page covers default sets of Prometheus alerting rules for the EPP (Endpoint Picker) and for the Batch Gateway. For Prometheus and Grafana installation, see [Observability Setup](./setup.md) first, and for the metrics these alerts are built on, see [Metrics](./metrics.md).
 
 The rules ship as a [`PrometheusRule`](https://prometheus-operator.dev/docs/getting-started/design/#prometheusrule) custom resource, so they require the Prometheus Operator (bundled with the kube-prometheus-stack installed by the [setup guide](./setup.md)).
 
@@ -80,6 +80,32 @@ The error-ratio alerts are `0/0`-safe: with no traffic the expression yields no 
 > [!NOTE]
 > `EPPExtProcStreamErrors` relies on opt-in metrics enabled by the EPP `--enable-grpc-stream-metrics` flag. When the flag is unset, the series are absent and the alert never fires. The matcher excludes `OK` and `Canceled` (a normal client disconnect) — adjust it for your environment.
 
+### Batch Gateway (`batch-gateway.rules`)
+
+These alerts cover the Batch Gateway processor and GC reconciler rather than the request path, so they are shipped as a separate `PrometheusRule` and are only relevant if you deployed the [Batch Gateway guide](../../../guides/batch-serving/batch-gateway/README.md).
+
+```bash
+kubectl apply -n ${NAMESPACE} -f guides/recipes/observability/alerts/batch-gateway-alerting-rules.yaml
+kubectl get prometheusrules -n ${NAMESPACE}
+```
+
+You should then see the `batch-gateway.rules` group under **Status → Rule Health** in the Prometheus UI.
+
+> [!IMPORTANT]
+> Every expression in this file is scoped with `namespace="batch-gateway"`, the namespace the Batch Gateway guide deploys into. The Batch Gateway metric names are unprefixed and generic (`jobs_processed_total`, `active_workers`), so an unscoped rule can pick up unrelated workloads. If you deployed into a different namespace, edit the matchers to match — applying the `PrometheusRule` into your namespace does **not** scope its queries.
+
+| Alert | Severity | Fires when | Why it matters |
+|-------|----------|-----------|----------------|
+| `BatchGatewayHighQueueWait` | warning | p95 `job_queue_wait_duration_seconds` > 300s for 15m | Jobs are backing up in the priority queue faster than workers drain it |
+| `BatchGatewayHighJobFailureRate` | warning | Failed share of `jobs_processed_total` > 10% for 10m | Job execution is failing at a rate users will notice |
+| `BatchGatewayExpiredJobsDetected` | warning | Expired share of `jobs_processed_total` > 3% for 10m | Jobs are aging out before execution — capacity or completion-window problem, not a code failure |
+| `BatchGatewayWorkersSaturated` | warning | `active_workers / total_workers` > 90% for 15m | The worker pool is the bottleneck; raise `NumWorkers` or add replicas |
+| `BatchReconcilerErrors` | warning | `batch_reconciler_errors_total` increased over 65m | The GC orphan reconciler is failing, so orphaned jobs are not being recovered |
+
+The two ratio alerts use `clamp_min` on the denominator, so they stay silent when no jobs are being processed rather than dividing by zero.
+
+`BatchReconcilerErrors` uses `increase()` over a 65m window rather than `rate()`: the reconciler runs on a 60m interval by default and increments the counter at most once per cycle, which is too sparse for a `rate()` threshold. If you shorten `reconciler.interval` in the GC config, shorten the window to match — a window shorter than the interval can miss a once-per-cycle failure, and a much longer one keeps the alert firing after the error has aged out.
+
 ## Customization
 
 These rules are a starting point, not a tuned policy. Common adjustments:
@@ -94,6 +120,7 @@ See the [PromQL Reference](./promql.md) for more queries you can promote into al
 
 ```bash
 kubectl delete -n ${NAMESPACE} -f guides/recipes/observability/alerts/epp-alerting-rules.yaml
+kubectl delete -n ${NAMESPACE} -f guides/recipes/observability/alerts/batch-gateway-alerting-rules.yaml
 ```
 
 ## Troubleshooting

--- a/docs/operations/observability/alerting.md
+++ b/docs/operations/observability/alerting.md
@@ -92,7 +92,7 @@ kubectl get prometheusrules -n ${NAMESPACE}
 You should then see the `batch-gateway.rules` group under **Status → Rule Health** in the Prometheus UI.
 
 > [!IMPORTANT]
-> Every expression in this file is scoped with `namespace="batch-gateway"`, the namespace the Batch Gateway guide deploys into. The Batch Gateway metric names are unprefixed and generic (`jobs_processed_total`, `active_workers`), so an unscoped rule can pick up unrelated workloads. If you deployed into a different namespace, edit the matchers to match — applying the `PrometheusRule` into your namespace does **not** scope its queries.
+> Every expression in this file is scoped with `namespace="batch-gateway"`, the namespace the Batch Gateway guide deploys into. The Batch Gateway metric names are unprefixed and generic (`jobs_processed_total`, `active_workers`), so an unscoped rule can pick up unrelated workloads. If you deployed into a different namespace, edit the matchers to match — applying the `PrometheusRule` into your namespace does **not** scope its queries. If you bring your own Prometheus, its `ruleSelector` must match this resource's label, `app: batch-gateway-metrics` (not `app: epp-metrics`, which is specific to the EPP rule).
 
 | Alert | Severity | Fires when | Why it matters |
 |-------|----------|-----------|----------------|

--- a/docs/operations/observability/metrics.md
+++ b/docs/operations/observability/metrics.md
@@ -209,6 +209,31 @@ When flow control is enabled (`flowControl` feature gate), these additional metr
 | `llm_d_epp_datalayer_poll_errors_total` | Data-source poll failures per source type | Signals failing telemetry scrapes from model servers |
 | `llm_d_epp_datalayer_extract_errors_total` | Extractor failures per source/extractor type | Signals parsing failures on scraped telemetry payloads |
 
+### Key Batch Gateway Metrics
+
+Only relevant if you deployed the [Batch Gateway guide](../../../guides/batch-serving/batch-gateway/README.md). These are the operationally useful series; the definitional source of truth for names, types, and labels is [`docs/guides/metrics.md`](https://github.com/llm-d/llm-d-batch-gateway/blob/main/docs/guides/metrics.md) in the component repo, which also documents the token, cancellation, and startup-recovery counters not listed here.
+
+Unlike the EPP and vLLM metrics above, these names carry no `llm_d_` prefix, so scope queries by `namespace` to avoid picking up unrelated workloads.
+
+| Metric | What it measures | Why it matters |
+|--------|-----------------|----------------|
+| `http_requests_total` | API server requests by method, path, and status | Baseline for API-side error rate — batch submission failures show up here, not in job metrics |
+| `http_request_duration_seconds` | API server request latency distribution | Submission and status-poll responsiveness |
+| `jobs_processed_total` | Jobs processed by `result` (`success`, `failed`, `skipped`, `re_enqueued`, `expired`) and `reason` | The primary outcome signal. `expired` means jobs aged out before running, which is a capacity problem rather than a failure |
+| `job_queue_wait_duration_seconds` | Time in the priority queue before pickup | Leading indicator of backlog; rises before end-to-end latency does |
+| `job_processing_duration_seconds` | End-to-end processing duration by `size_bucket` | Separates "large jobs are slow" from "everything is slow" |
+| `batch_job_e2e_latency_seconds` | Submission to terminal state, by `status` | What the user actually waits for, including queue time |
+| `active_workers` / `total_workers` | Active vs configured worker pool size | Their ratio is the saturation signal — sustained near 1.0 means the pool is the bottleneck |
+| `processor_inflight_requests` | In-flight inference requests during execution | Load the batch path is placing on the inference backends |
+| `batch_reconciler_errors_total` | GC reconciler cycle errors | Non-zero means orphaned jobs are not being recovered |
+| `batch_reconciler_orphans_recovered_total` | Orphans recovered by `action` | Sustained non-zero points at processor crashes upstream |
+| `file_storage_operations_total` | File storage operations by `operation`, `component`, and `status` | `status="exhausted"` means retries gave up — input or output data is inaccessible |
+
+> [!NOTE]
+> The Batch Gateway dashboards compute histogram quantiles by summing buckets across pods before applying `histogram_quantile`, which yields a fleet-wide approximate percentile rather than an exact one. This is acceptable because each job is processed by exactly one pod, but it can mask a single consistently-slow pod. Add `by (le, pod)` for a per-pod breakdown.
+
+For alerts built on these metrics, see [Alerting](./alerting.md#batch-gateway-batch-gatewayrules).
+
 ## Step 4: View Dashboards
 
 llm-d provides pre-built Grafana dashboards for common monitoring scenarios.
@@ -248,6 +273,9 @@ llm-d-failure-saturation-dashboard                1      30s
 llm-d-diagnostic-drilldown-dashboard              1      30s
 llm-d-performance-kv-cache                        1      30s
 llm-d-pd-coordinator-metrics                      1      30s
+llm-d-batch-gateway-apiserver                     1      30s
+llm-d-batch-gateway-processor                     1      30s
+llm-d-batch-gateway-gc                            1      30s
 ```
 
 Or import individual dashboard JSON files manually from `guides/recipes/observability/grafana/dashboards/`:
@@ -260,6 +288,11 @@ Or import individual dashboard JSON files manually from `guides/recipes/observab
 | `llm-d-diagnostic-drilldown-dashboard.json` | Detailed diagnostic metrics for troubleshooting |
 | `llm-d-performance-kv-cache.json` | Performance metrics including KV cache utilization |
 | `llm-d-pd-coordinator-metrics.json` | Prefill/decode disaggregation metrics |
+| `llm-d-batch-gateway-apiserver.json` | Batch Gateway API server request rate, latency, and in-flight requests |
+| `llm-d-batch-gateway-processor.json` | Batch Gateway job throughput, queue wait, worker saturation, and token usage |
+| `llm-d-batch-gateway-gc.json` | Batch Gateway GC reconciler cycles, orphan recovery, and errors |
+
+The three Batch Gateway dashboards are only useful if you deployed the [Batch Gateway guide](../../../guides/batch-serving/batch-gateway/README.md); each has a `namespace` variable to select the namespace it runs in.
 
 ## Step 5: Query Metrics
 

--- a/guides/batch-serving/batch-gateway/README.md
+++ b/guides/batch-serving/batch-gateway/README.md
@@ -195,6 +195,47 @@ OUTPUT_FILE_ID=$(curl -s \
 curl http://localhost:8000/v1/files/${OUTPUT_FILE_ID}/content > results.jsonl
 ```
 
+## Enable Monitoring
+
+Optional. Requires Prometheus and Grafana — see [Observability Setup](../../../docs/operations/observability/setup.md).
+
+1. Enable metrics scraping in the chart, so Prometheus discovers the three components:
+
+   ```bash
+   helm upgrade batch-gateway oci://ghcr.io/llm-d/charts/batch-gateway \
+     -n ${NAMESPACE} --reuse-values \
+     --set processor.podMonitor.enabled=true \
+     --set gc.podMonitor.enabled=true \
+     --set apiserver.serviceMonitor.enabled=true
+   ```
+
+   > [!NOTE]
+   > This step still uses the component chart's own `PodMonitor`/`ServiceMonitor` templates. Per [llm-d#1983](https://github.com/llm-d/llm-d/issues/1983) these scrape manifests should eventually live in this repo as standalone recipes; the target path is still being settled, so this guide uses the chart flags in the meantime. The alerts and dashboards below are already served from this repo.
+
+2. Apply the alerting rules:
+
+   ```bash
+   kubectl apply -n ${NAMESPACE} -f ../../recipes/observability/alerts/batch-gateway-alerting-rules.yaml
+   ```
+
+   These are scoped to `namespace="batch-gateway"`. If you changed `${NAMESPACE}`, edit the matchers first — see [Alerting](../../../docs/operations/observability/alerting.md#batch-gateway-batch-gatewayrules).
+
+3. Load the dashboards:
+
+   ```bash
+   ../../recipes/observability/load-llm-d-dashboards.sh
+   ```
+
+   This loads every llm-d dashboard, including `llm-d-batch-gateway-apiserver`, `-processor`, and `-gc`. Select your namespace with each dashboard's `namespace` variable.
+
+4. Verify:
+
+   ```bash
+   kubectl get podmonitors,servicemonitors,prometheusrules -n ${NAMESPACE}
+   ```
+
+For what the metrics mean and how to query them, see the [Batch Gateway metric reference](../../../docs/operations/observability/metrics.md#key-batch-gateway-metrics).
+
 ## Cleanup
 
 ```bash

--- a/guides/recipes/observability/alerts/batch-gateway-alerting-rules.yaml
+++ b/guides/recipes/observability/alerts/batch-gateway-alerting-rules.yaml
@@ -1,0 +1,79 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: batch-gateway-alerting-rules
+  labels:
+    app: batch-gateway-metrics
+spec:
+  groups:
+  # ---------------------------------------------------------------------------
+  # Batch Gateway processor and GC health
+  #
+  # Unlike epp-alerting-rules.yaml, every expression here carries a
+  # `namespace="batch-gateway"` matcher. The batch-gateway metric names
+  # (`jobs_processed_total`, `active_workers`, ...) are unprefixed and generic
+  # enough to collide with other workloads, so these rules must be scoped.
+  # Change the matcher if you deployed the guide with a different ${NAMESPACE}.
+  # ---------------------------------------------------------------------------
+  - name: batch-gateway.rules
+    rules:
+    - alert: BatchGatewayHighQueueWait
+      expr: |
+        histogram_quantile(
+          0.95,
+          sum(rate(job_queue_wait_duration_seconds_bucket{namespace="batch-gateway"}[5m])) by (le)
+        ) > 300
+      for: 15m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Batch Gateway queue wait time is high"
+        description: "p95 queue wait time has been above 300 seconds for 15m."
+    - alert: BatchGatewayHighJobFailureRate
+      # clamp_min keeps this silent rather than dividing by zero when no jobs
+      # are being processed.
+      expr: |
+        sum(rate(jobs_processed_total{namespace="batch-gateway", result="failed"}[10m]))
+          / clamp_min(sum(rate(jobs_processed_total{namespace="batch-gateway"}[10m])), 0.001)
+          > 0.1
+      for: 10m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Batch Gateway job failure rate is high"
+        description: "Failed jobs have exceeded 10% of processed jobs for 10m (current {{ $value | humanizePercentage }})."
+    - alert: BatchGatewayExpiredJobsDetected
+      expr: |
+        sum(rate(jobs_processed_total{namespace="batch-gateway", result="expired"}[10m]))
+          / clamp_min(sum(rate(jobs_processed_total{namespace="batch-gateway"}[10m])), 0.001)
+          > 0.03
+      for: 10m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Batch Gateway expired job rate is high"
+        description: "Expired jobs have exceeded 3% of processed jobs for 10m (current {{ $value | humanizePercentage }})."
+    - alert: BatchGatewayWorkersSaturated
+      expr: |
+        sum(active_workers{namespace="batch-gateway"})
+          / clamp_min(sum(total_workers{namespace="batch-gateway"}), 1)
+          > 0.9
+      for: 15m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Batch Gateway workers are saturated"
+        description: "Worker utilization has been above 90% for 15m (current {{ $value | humanizePercentage }})."
+    - alert: BatchReconcilerErrors
+      # increase(), not rate(): the GC orphan reconciler runs on an interval
+      # (60m by default) so errors arrive at most once per cycle. The 65m window
+      # is that interval plus a scrape buffer — shorten it if you shortened the
+      # reconciler interval, or the alert will not see a full cycle.
+      expr: |
+        increase(batch_reconciler_errors_total{namespace="batch-gateway"}[65m]) > 0
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Batch reconciler is encountering errors"
+        description: "The GC orphan reconciler encountered errors in the last 65m."

--- a/guides/recipes/observability/grafana/dashboards/llm-d-batch-gateway-apiserver.json
+++ b/guides/recipes/observability/grafana/dashboards/llm-d-batch-gateway-apiserver.json
@@ -1,0 +1,183 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(http_requests_total{namespace=\"$namespace\"}[5m])) by (method, path, status)",
+          "legendFormat": "{{method}} {{path}} {{status}}"
+        }
+      ],
+      "title": "Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(http_requests_total{namespace=\"$namespace\", status=~\"4..|5..\"}[5m])) by (status)",
+          "legendFormat": "{{status}}"
+        }
+      ],
+      "title": "Error Rate (4xx + 5xx)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le))",
+          "legendFormat": "p50"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le))",
+          "legendFormat": "p95"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le))",
+          "legendFormat": "p99"
+        }
+      ],
+      "title": "Request Latency (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(http_requests_in_flight{namespace=\"$namespace\"})",
+          "legendFormat": "in-flight"
+        }
+      ],
+      "title": "In-Flight Requests",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [
+    "batch-gateway",
+    "apiserver"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(http_requests_total, namespace)",
+        "includeAll": false,
+        "multi": false,
+        "name": "namespace",
+        "refresh": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "title": "Batch Gateway \u2014 Apiserver",
+  "uid": "batch-gateway-apiserver"
+}

--- a/guides/recipes/observability/grafana/dashboards/llm-d-batch-gateway-gc.json
+++ b/guides/recipes/observability/grafana/dashboards/llm-d-batch-gateway-gc.json
@@ -198,11 +198,7 @@
         "type": "datasource"
       },
       {
-        "current": {
-          "selected": false,
-          "text": "default",
-          "value": "default"
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
@@ -211,7 +207,7 @@
         "includeAll": false,
         "multi": false,
         "name": "namespace",
-        "refresh": 2,
+        "refresh": 1,
         "type": "query"
       }
     ]

--- a/guides/recipes/observability/grafana/dashboards/llm-d-batch-gateway-gc.json
+++ b/guides/recipes/observability/grafana/dashboards/llm-d-batch-gateway-gc.json
@@ -1,0 +1,225 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(batch_reconciler_orphans_recovered_total{namespace=\"$namespace\"}[5m])) by (action)",
+          "legendFormat": "{{action}}"
+        }
+      ],
+      "title": "Orphans Recovered (rate)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(batch_reconciler_cycle_duration_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le))",
+          "legendFormat": "p50"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(batch_reconciler_cycle_duration_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le))",
+          "legendFormat": "p95"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(batch_reconciler_cycle_duration_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le))",
+          "legendFormat": "p99"
+        }
+      ],
+      "title": "Cycle Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(batch_reconciler_errors_total{namespace=\"$namespace\"}[5m])",
+          "legendFormat": "errors"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(batch_reconciler_cas_conflicts_total{namespace=\"$namespace\"}[5m])",
+          "legendFormat": "CAS conflicts"
+        }
+      ],
+      "title": "Errors & CAS Conflicts (rate)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(batch_reconciler_stale_cleanup_total{namespace=\"$namespace\"}[5m])",
+          "legendFormat": "stale cleanup"
+        }
+      ],
+      "title": "Stale In-Flight Cleanup (rate)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(batch_reconciler_orphans_recovered_total{namespace=\"$namespace\"}) by (action)",
+          "legendFormat": "{{action}}"
+        }
+      ],
+      "title": "Orphans Recovered (cumulative)",
+      "type": "stat"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [
+    "batch-gateway",
+    "gc",
+    "reconciler"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(batch_reconciler_cycle_duration_seconds_count, namespace)",
+        "includeAll": false,
+        "multi": false,
+        "name": "namespace",
+        "refresh": 2,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "title": "Batch Gateway \u2014 GC Reconciler",
+  "uid": "batch-gateway-gc"
+}

--- a/guides/recipes/observability/grafana/dashboards/llm-d-batch-gateway-processor.json
+++ b/guides/recipes/observability/grafana/dashboards/llm-d-batch-gateway-processor.json
@@ -1,0 +1,618 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(jobs_processed_total{namespace=\"$namespace\"}[5m])) by (result, reason)",
+          "legendFormat": "{{result}} / {{reason}}"
+        }
+      ],
+      "title": "Job Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(job_processing_duration_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le))",
+          "legendFormat": "p50"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(job_processing_duration_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le))",
+          "legendFormat": "p95"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(job_processing_duration_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le))",
+          "legendFormat": "p99"
+        }
+      ],
+      "title": "Job Processing Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(job_queue_wait_duration_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le))",
+          "legendFormat": "p50"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(job_queue_wait_duration_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le))",
+          "legendFormat": "p95"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(job_queue_wait_duration_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le))",
+          "legendFormat": "p99"
+        }
+      ],
+      "title": "Queue Wait Time (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "max": 1,
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(active_workers{namespace=\"$namespace\"}) / sum(total_workers{namespace=\"$namespace\"})",
+          "legendFormat": "utilization"
+        }
+      ],
+      "title": "Worker Utilization",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(processor_inflight_requests{namespace=\"$namespace\"}) / sum(processor_max_inflight_concurrency{namespace=\"$namespace\"})",
+          "legendFormat": "utilization"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(processor_inflight_requests{namespace=\"$namespace\"})",
+          "legendFormat": "in-flight"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(processor_max_inflight_concurrency{namespace=\"$namespace\"})",
+          "legendFormat": "max"
+        }
+      ],
+      "title": "Inflight Concurrency Utilization",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(model_inflight_requests{namespace=\"$namespace\"}) by (model)",
+          "legendFormat": "{{model}}"
+        }
+      ],
+      "title": "Per-Model Inflight Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(model_request_execution_duration_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le, model))",
+          "legendFormat": "{{model}} p95"
+        }
+      ],
+      "title": "Per-Model Execution Duration (p95)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(request_errors_by_model_total{namespace=\"$namespace\"}[5m])) by (model)",
+          "legendFormat": "{{model}}"
+        }
+      ],
+      "title": "Error Rate by Model",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(plan_build_duration_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le))",
+          "legendFormat": "p50"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(plan_build_duration_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le))",
+          "legendFormat": "p95"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(plan_build_duration_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le))",
+          "legendFormat": "p99"
+        }
+      ],
+      "title": "Plan Build Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(file_storage_operations_total{namespace=\"$namespace\", status=\"retry\", component=\"processor\"}[5m])) by (operation)",
+          "legendFormat": "{{operation}} retry/s"
+        }
+      ],
+      "title": "File storage operations (retry)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(batch_startup_recovery_total{namespace=\"$namespace\"}) by (status, action)",
+          "legendFormat": "{{status}} / {{action}}"
+        }
+      ],
+      "title": "Startup Recovery",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 48
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(batch_request_prompt_tokens_total{namespace=\"$namespace\"}[5m])) by (model)",
+          "legendFormat": "{{model}} prompt tok/s"
+        }
+      ],
+      "title": "Token Throughput (prompt)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 48
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(batch_request_generation_tokens_total{namespace=\"$namespace\"}[5m])) by (model)",
+          "legendFormat": "{{model}} gen tok/s"
+        }
+      ],
+      "title": "Token Throughput (generation)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 56
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(batch_cancellation_total{namespace=\"$namespace\"}[5m])) by (phase)",
+          "legendFormat": "{{phase}}"
+        }
+      ],
+      "title": "Cancellation Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 56
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(batch_job_e2e_latency_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le, status))",
+          "legendFormat": "{{status}} p50"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(batch_job_e2e_latency_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le, status))",
+          "legendFormat": "{{status}} p95"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(batch_job_e2e_latency_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le, status))",
+          "legendFormat": "{{status}} p99"
+        }
+      ],
+      "title": "Job E2E Latency (p50 / p95 / p99 by status)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 64
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "batch_processor_aimd_concurrency_limit{namespace=\"$namespace\"}",
+          "legendFormat": "{{endpoint}}"
+        }
+      ],
+      "title": "AIMD Concurrency Limit per Endpoint",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 64
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(batch_processor_aimd_decreases_total{namespace=\"$namespace\"}[5m])) by (endpoint, signal)",
+          "legendFormat": "{{endpoint}} decrease ({{signal}})"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(batch_processor_aimd_increases_total{namespace=\"$namespace\"}[5m])) by (endpoint)",
+          "legendFormat": "{{endpoint}} increase"
+        }
+      ],
+      "title": "AIMD Signals (decreases / increases)",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [
+    "batch-gateway",
+    "processor"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(jobs_processed_total, namespace)",
+        "includeAll": false,
+        "multi": false,
+        "name": "namespace",
+        "refresh": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "title": "Batch Gateway \u2014 Processor",
+  "uid": "batch-gateway-processor"
+}


### PR DESCRIPTION
## What this PR does

Moves the Batch Gateway's user-facing observability assets into `llm-d/llm-d`, per the [observability-integration proposal](https://github.com/llm-d/llm-d/blob/main/proposals/observability-integration.md) and #1983. This is the llm-d half of [batch-gateway#619](https://github.com/llm-d/llm-d-batch-gateway/issues/619); the cleanup PR in the component repo follows once this lands.

It follows the pattern of #2363 (the WVA slice) rather than inventing a layout — dashboards alongside the existing seven, the `PrometheusRule` as a sibling of `epp-alerting-rules.yaml`.

**Added:**

| File | Source in batch-gateway |
|---|---|
| `guides/recipes/observability/grafana/dashboards/llm-d-batch-gateway-apiserver.json` | `charts/batch-gateway/dashboards/apiserver.json` (4 panels) |
| `guides/recipes/observability/grafana/dashboards/llm-d-batch-gateway-processor.json` | `charts/batch-gateway/dashboards/processor.json` (17 panels) |
| `guides/recipes/observability/grafana/dashboards/llm-d-batch-gateway-gc.json` | `charts/batch-gateway/dashboards/gc.json` (5 panels) |
| `guides/recipes/observability/alerts/batch-gateway-alerting-rules.yaml` | `charts/batch-gateway/templates/prometheus-rule.yaml` (5 alerts) |

## The dashboards are not copied verbatim

Same class of problem #2363 hit, more severe here. None of the three dashboards had a datasource template variable, and none of their datasource references carried a `uid` — each file had exactly one `{"type": "prometheus"}` reference, on the `namespace` query variable, with the panels carrying no datasource at all. Copied across unchanged they would load and render empty, binding to whatever Grafana had set as default.

Every dashboard already here uses `${DS_PROMETHEUS}` with a standard `datasource`-type template variable. All three were given that variable and had every panel and target bound to it — **71 datasource references in total** (11 / 46 / 14). `load-llm-d-dashboards.sh` globs `*.json`, so no registration was needed.

Panel content, queries, and dashboard `uid`s are untouched; the `uid`s are stable so existing links keep working.

## Alerts

The chart's `PrometheusRule` is a Helm template, so it was rendered to static YAML using the chart's own `values.yaml` defaults (300s queue wait, 10% failure ratio, 3% expired ratio, 90% worker saturation, 65m reconciler window). Renamed to `batch-gateway-alerting-rules` and relabelled `app: batch-gateway-metrics`, matching `epp-alerting-rules.yaml`.

**One deliberate deviation from `epp-alerting-rules.yaml`, worth a maintainer's eye:** every expression keeps a `namespace="batch-gateway"` matcher. The EPP rules carry no namespace matcher because `llm_d_epp_*` names are unambiguous; the batch-gateway names are not (`jobs_processed_total`, `active_workers`, `total_workers`), and an unscoped rule would silently aggregate unrelated workloads. `batch-gateway` is the namespace the guide's `export NAMESPACE=batch-gateway` creates. Applying the `PrometheusRule` into a namespace does not scope its queries, so this can't be left to `kubectl apply -n`. Called out in both a file comment and an `IMPORTANT` note in `alerting.md`. Happy to drop the matcher if you'd rather match the EPP file exactly.

The `ruleSelector` caveat already documented in `alerting.md` Step 1 applies here identically — I have not changed that behaviour.

## Docs

- `alerting.md` — intro now covers both components, plus a Batch Gateway section with apply/verify steps and a reference table for the five `batch-gateway.rules` alerts. These fire on batch job throughput and GC reconciler health rather than request-path health, which the section calls out.
- `metrics.md` — a "Key Batch Gateway Metrics" section (11 operationally useful series), the two new dashboard entries in the `kubectl get configmaps` sample output and the manual-import table.
- `guides/batch-serving/batch-gateway/README.md` — the 4-step "Enable Monitoring" section #619 asks for, which the guide was missing entirely.

On the metric reference: rather than copy the component's 126-line `docs/guides/metrics.md` across (which would drift), the new section is a table of the operationally relevant series in the same style as the vLLM/SGLang/EPP tables, linking the component doc as the definitional source of truth for names, types, and labels. Say the word if you want the full doc mirrored instead.

## What is deliberately not here

The `PodMonitor`s and `ServiceMonitor`. #619 targets them at `guides/recipes/batch-gateway/monitoring/` "(or equivalent)", and #2363 raised the same open question for the WVA scrape manifest — whether these belong under the per-guide directory or the shared recipe directory — which is still unanswered. I would rather not guess and have it moved twice. Step 1 of the new guide section therefore still uses the chart's `podMonitor.enabled` / `serviceMonitor.enabled` flags, with an in-tree note saying so and pointing at #1983. Happy to add the standalone manifests here in a follow-up once the path is settled.

**Path note:** #619 refers to `llm-d/guides/batch-gateway/README.md`, which no longer exists — the guide has since moved to `guides/batch-serving/batch-gateway/README.md`. That is the file this PR edits.

## Testing

- All three dashboards parse as valid JSON and retain their panel counts (4 / 17 / 5) and `uid`s; no unbound datasource references remain.
- The `PrometheusRule` parses as valid YAML, retains all five alerts in the single `batch-gateway.rules` group, and contains no unrendered Helm template expressions.
- `python scripts/guide.py render guides/*/ --check` passes (the batch-gateway guide has no `guide.yaml`, so its README is hand-maintained — this edit does not desync a rendered file).
- `markdownlint-cli` 0.47.0 and `yamllint` at the repo's pinned versions/config report only findings that are already present on `main` — MD060 fires 70 times on `metrics.md` before this change, and the existing `epp-alerting-rules.yaml` produces the identical yamllint indentation output, so the new YAML matches established style.

I have not applied these to a live cluster — I don't have a Prometheus/Grafana stack with the Batch Gateway running to hand, so the datasource rebinding is verified structurally rather than by rendering. Worth a look from someone who can load them.

---

*Disclosure: prepared with AI assistance. The asset inventory, the datasource-convention mismatch, the chart's default thresholds, and the guide's namespace were checked against both repositories before writing.*