### PR TITLE
fix nightly wide-ep-lws workflows after guide directory rename

### DIFF
--- a/.github/workflows/nightly-e2e-wide-ep-lws-cks-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-cks-acc-gpu-vllm-x.yaml
@@ -78,7 +78,7 @@ jobs:
       decode_pods: ${{ inputs.decode_pods || 'auto' }}
       prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
       accelerator_type: ${{ inputs.accelerator_type || 'gpu' }}
-      backend_type: ${{ inputs.backend_type || 'vllm' }}
+      backend_type: ${{ inputs.backend_type || 'vllm-deepseek-r1-0528' }}
       infra_provider: ${{ inputs.infra_provider || 'coreweave' }}
       connector: ${{ inputs.connector || '' }}
       cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-wide-ep-lws-cks-gpu' }}

--- a/.github/workflows/nightly-e2e-wide-ep-lws-gke-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-gke-acc-gpu-vllm-x.yaml
@@ -78,7 +78,7 @@ jobs:
       decode_pods: ${{ inputs.decode_pods || 'auto' }}
       prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
       accelerator_type: ${{ inputs.accelerator_type || 'gpu' }}
-      backend_type: ${{ inputs.backend_type || 'vllm' }}
+      backend_type: ${{ inputs.backend_type || 'vllm-deepseek-r1-0528' }}
       infra_provider: ${{ inputs.infra_provider || 'gke' }}
       connector: ${{ inputs.connector || '' }}
       cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-wide-ep-lws-gke-gpu' }}

--- a/.github/workflows/nightly-e2e-wide-ep-lws-ibm-acc-gpu-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-wide-ep-lws-ibm-acc-gpu-vllm-x.yaml
@@ -77,7 +77,7 @@ jobs:
       decode_pods: ${{ inputs.decode_pods || 'auto' }}
       prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
       accelerator_type: ${{ inputs.accelerator_type || 'gpu' }}
-      backend_type: ${{ inputs.backend_type || 'vllm' }}
+      backend_type: ${{ inputs.backend_type || 'vllm-deepseek-r1-0528' }}
       infra_provider: ${{ inputs.infra_provider || 'base' }}
       connector: ${{ inputs.connector || '' }}
       cluster_namespace: ${{ inputs.cluster_namespace || 'llm-d-nightly-wide-ep-lws-ibm-gpu' }}


### PR DESCRIPTION
The GPU wide-ep-lws nightlies fail because https://github.com/llm-d/llm-d/pull/2186 renamed `guides/wide-ep-lws/modelserver/gpu/vllm` to `gpu/vllm-deepseek-r1-0528` while the workflows still build the kustomize path with backend `vllm` (example failure: https://github.com/llm-d/llm-d/actions/runs/33033991347/job/98392648726). This changes the default `backend_type` to `vllm-deepseek-r1-0528` in the gke, cks, and ibm workflows.