### PR TITLE
fix(interactive-pod): unquote discovered model name

### DIFF
--- a/helpers/interactive-pod/build/prepare-inference.sh
+++ b/helpers/interactive-pod/build/prepare-inference.sh
@@ -83,7 +83,7 @@ if [[ "${MODELS_ENDPOINT_CURL_STATUS}" != 0 ]]; then
     exit 1
 
 else
-    MODEL_NAME=$(echo "${MODELS_ENDPOINT_CURL}" | jq '.data[0].id' )
+    MODEL_NAME=$(echo "${MODELS_ENDPOINT_CURL}" | jq -r '.data[0].id // empty' )
     if [[ -z "${MODEL_NAME}" || "${MODEL_NAME}" == "null"  ]]; then
         echo "Could not discover model name from vLLM server"
         exit 1

--- a/helpers/interactive-pod/build/tests/test-model-name.sh
+++ b/helpers/interactive-pod/build/tests/test-model-name.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+kubectl() {
+  case "${1-} ${2-}" in
+    'get gateway') printf '%s\n' 'inference-gateway ClusterIP 10.0.0.1' ;;
+    'get services') printf '%s\n' 'inference-gateway ClusterIP 10.0.0.2' ;;
+    *) return 1 ;;
+  esac
+}
+export -f kubectl
+
+curl() {
+  printf '%s\n' '{"data":[{"id":"served-model"}]}'
+}
+export -f curl
+
+model_name="$(SCRIPT_DIR="${SCRIPT_DIR}" NAMESPACE=test-ns bash -c '
+  source "${SCRIPT_DIR}/prepare-inference.sh" >/dev/null
+  printf "%s" "${MODEL_NAME}"
+')"
+
+[[ "${model_name}" == "served-model" ]]


### PR DESCRIPTION
`prepare-inference.sh` reads the served model ID with `jq` without raw output, leaving literal quotes in `MODEL_NAME`. The value passed to guidellm therefore differs from the served model name.

Use `jq -r` to extract the raw ID, retaining the existing error for a missing or empty ID. A shell regression test covers automatic discovery.

## Reproduction

On the unmodified `main` branch, the mock `/v1/models` response produces a shell value containing literal quotes:

```text
<"served-model">
```

After this change, the same response produces:

```text
<served-model>
```

## Validation

```bash
bash helpers/interactive-pod/build/tests/test-model-name.sh
bash -n helpers/interactive-pod/build/prepare-inference.sh \
  helpers/interactive-pod/build/tests/test-model-name.sh
shellcheck helpers/interactive-pod/build/prepare-inference.sh \
  helpers/interactive-pod/build/tests/test-model-name.sh
git diff --check upstream/main...HEAD
```

All commands passed. The regression test fails against the unmodified `main` implementation and passes with this change.
