### PR TITLE
fix(nightly-e2e-verification): reject empty benchmark workspaces

### DIFF
--- a/.github/scripts/nightly-e2e-verification/test_verify_helpers.py
+++ b/.github/scripts/nightly-e2e-verification/test_verify_helpers.py
@@ -91,8 +91,14 @@ class TestFindResultsDirs(unittest.TestCase):
         return exp
 
     def test_empty_workspace_returns_none(self):
-        with patch("sys.stderr", io.StringIO()):
-            self.assertIsNone(v.find_results_dirs("", "ns"))
+        with TemporaryDirectory() as td, patch("sys.stderr", io.StringIO()):
+            old_cwd = os.getcwd()
+            os.chdir(td)
+            try:
+                self._make_run(Path("."), "user-1", "exp", "ns")
+                self.assertIsNone(v.find_results_dirs("", "ns"))
+            finally:
+                os.chdir(old_cwd)
 
     def test_empty_namespace_returns_none(self):
         with TemporaryDirectory() as td, patch("sys.stderr", io.StringIO()):

--- a/.github/scripts/nightly-e2e-verification/verify_helpers.py
+++ b/.github/scripts/nightly-e2e-verification/verify_helpers.py
@@ -93,6 +93,9 @@ def find_results_dirs(workspace: str, namespace: str) -> list[Path] | None:
     All experiments belonging to the winning run are returned (a single
     `llmdbenchmark run` invocation can produce multiple `<exp>/` subdirs).
     """
+    if not isinstance(workspace, str) or not workspace.strip():
+        error("LLMDBENCH_WORKSPACE is empty; refusing to search the current directory")
+        return None
     ws = Path(workspace)
     matches: list[Path] = []
     for meta in ws.rglob("run_metadata.yaml"):


### PR DESCRIPTION
## Summary

Reject an empty `LLMDBENCH_WORKSPACE` before searching for benchmark results.

## Root Cause

`Path("")` resolves to the current working directory. If `LLMDBENCH_WORKSPACE` was unset and the current directory happened to contain matching `run_metadata.yaml` files, `find_results_dirs()` could select unrelated results instead of reporting that the workspace was missing.

## Changes

- Validate that `workspace` is a non-empty string in `find_results_dirs()`.
- Return `None` with an explicit error instead of recursively scanning the current directory.
- Strengthen the regression test by placing matching metadata in a temporary current directory.

## Reproduction

On the unmodified `main` branch, an empty workspace can search the current directory and return unrelated results:

```text
result=[PosixPath('user-1/results/exp')]
```

After this change:

```text
LLMDBENCH_WORKSPACE is empty; refusing to search the current directory
result=None
```

## Validation

```bash
PYTHONDONTWRITEBYTECODE=1 python -m pytest -p no:cacheprovider -q \
  .github/scripts/nightly-e2e-verification/test_verify_helpers.py
git diff --check upstream/main...HEAD
```

All commands passed. The test suite reports `51 passed`.

## Scope

This only changes handling of missing or blank workspace input. Valid workspace paths and result selection behavior are unchanged.
