### PR TITLE
fix(observability): start P/D traffic statistics at zero

### DIFF
--- a/guides/recipes/observability/generate-traffic-pd.sh
+++ b/guides/recipes/observability/generate-traffic-pd.sh
@@ -29,9 +29,9 @@ MODEL_NAME="${MODEL_NAME:-meta-llama/Llama-3.1-8B-Instruct}"
 # Shared counter for statistics (macOS-compatible)
 STATS_DIR="/tmp/load_gen_stats_$$"
 mkdir -p "$STATS_DIR"
-echo "0" > "$STATS_DIR/total"
-echo "0" > "$STATS_DIR/success"
-echo "0" > "$STATS_DIR/fail"
+: > "$STATS_DIR/total"
+: > "$STATS_DIR/success"
+: > "$STATS_DIR/fail"
 
 increment_stat() {
     local stat_type=$1  # total, success, or failure

--- a/scripts/tests/test_pd_traffic_stats.py
+++ b/scripts/tests/test_pd_traffic_stats.py
@@ -1,0 +1,38 @@
+"""Regression tests for the P/D observability traffic generator."""
+
+import os
+from pathlib import Path
+import re
+import subprocess
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "guides/recipes/observability/generate-traffic-pd.sh"
+
+
+def test_statistics_start_at_zero(tmp_path: Path) -> None:
+    source = SCRIPT.read_text()
+    start = source.index('STATS_DIR="/tmp/load_gen_stats_$$"')
+    end = source.index('\necho "============================================================"', start)
+    stats_setup = source[start:end]
+    stats_setup = re.sub(
+        r'^STATS_DIR=.*$',
+        'STATS_DIR="${TEST_STATS_DIR}"',
+        stats_setup,
+        count=1,
+        flags=re.MULTILINE,
+    )
+
+    env = os.environ.copy()
+    env["TEST_STATS_DIR"] = str(tmp_path)
+    result = subprocess.run(
+        ["bash"],
+        input=f"{stats_setup}\nget_stats\n",
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "0 0 0"


### PR DESCRIPTION
## Summary

Initialize the P/D traffic generator statistics files as empty counters so an idle run reports zero requests.

## Root Cause

The statistics are calculated by counting lines in the counter files. The initial `echo "0"` writes one line to each file, so the generator reports one total, one successful request, and one failed request before any request has been sent.

## Changes

- Truncate the total, success, and failure counter files without writing an initial marker line.
- Add a regression test covering the initial statistics state.

## Reproduction

On the unmodified `main` branch, before sending any requests:

```text
1 1 1
```

After this change:

```text
0 0 0
```

## Validation

```bash
PYTHONDONTWRITEBYTECODE=1 python -m pytest -p no:cacheprovider -q \
  scripts/tests/test_pd_traffic_stats.py
bash -n guides/recipes/observability/generate-traffic-pd.sh
shellcheck --severity=error -x \
  guides/recipes/observability/generate-traffic-pd.sh
git diff --check upstream/main...HEAD
```

All commands passed. The regression test reports `1 passed`.

## Scope

This only changes counter initialization. Per-request counter updates and final statistics aggregation are unchanged.
