### PR TITLE
fix(interactive-pod): scope gateway discovery to namespace

### DIFF
--- a/helpers/interactive-pod/build/prepare-inference.sh
+++ b/helpers/interactive-pod/build/prepare-inference.sh
@@ -57,8 +57,8 @@ if (( VERBOSE )); then
 fi
 
 NAMESPACE="${NAMESPACE:-$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace 2>/dev/null || echo default)}"
-GATEWAY_OBJECT=$(kubectl get gateway --no-headers | grep "inference-gateway")
-GATEWAY_SERVICE=$(kubectl get services --no-headers | grep "inference-gateway" | awk '{print $1}')
+GATEWAY_OBJECT=$(kubectl get gateway -n "${NAMESPACE}" --no-headers | grep "inference-gateway")
+GATEWAY_SERVICE=$(kubectl get services -n "${NAMESPACE}" --no-headers | grep "inference-gateway" | awk '{print $1}')
 
 if [[ -z "${GATEWAY_OBJECT}" ]]; then
     echo "Error, could not find the Gateway"

--- a/helpers/interactive-pod/build/tests/test-namespace-queries.sh
+++ b/helpers/interactive-pod/build/tests/test-namespace-queries.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+kubectl() {
+  case "$*" in
+    'get gateway -n target-ns --no-headers') printf '%s\n' 'inference-gateway ClusterIP 10.0.0.1' ;;
+    'get services -n target-ns --no-headers') printf '%s\n' 'inference-gateway ClusterIP 10.0.0.2' ;;
+    *)
+      printf 'unexpected kubectl arguments: %s\n' "$*" >&2
+      return 1
+      ;;
+  esac
+}
+export -f kubectl
+
+curl() {
+  printf '%s\n' '{"data":[{"id":"served-model"}]}'
+}
+export -f curl
+
+result="$(SCRIPT_DIR="${SCRIPT_DIR}" NAMESPACE=target-ns bash -c '
+  source "${SCRIPT_DIR}/prepare-inference.sh" >/dev/null
+  printf "%s|%s" "${GATEWAY_NAME}" "${GATEWAY_SERVICE_ENDPOINT}"
+')"
+
+[[ "${result}" == "inference-gateway|http://inference-gateway.target-ns.svc.cluster.local" ]]


### PR DESCRIPTION
`prepare-inference.sh` uses `NAMESPACE` to construct the service endpoint but omits it from the Gateway and Service queries. Discovery fails when the configured namespace differs from the current kubectl context.

Pass `-n "${NAMESPACE}"` to both queries. The shell regression test rejects unnamespaced queries and checks the discovered endpoint.

## Reproduction

With `NAMESPACE=target-ns` and kubectl requiring an explicit namespace, the unmodified `main` branch reports:

```text
exit=1
Error, could not find the Gateway
```

After this change:

```text
exit=0
GATEWAY_SERVICE_ENDPOINT=http://inference-gateway.target-ns.svc.cluster.local
```

## Validation

```bash
bash helpers/interactive-pod/build/tests/test-namespace-queries.sh
bash -n helpers/interactive-pod/build/prepare-inference.sh \
  helpers/interactive-pod/build/tests/test-namespace-queries.sh
shellcheck helpers/interactive-pod/build/prepare-inference.sh \
  helpers/interactive-pod/build/tests/test-namespace-queries.sh
git diff --check upstream/main...HEAD
```

All commands passed. This change was also merge-tested with #2400; both interactive-pod regression tests pass on the combined tree.
