### PR TITLE
fix(guides): validate environment variable names

### DIFF
--- a/scripts/guide.py
+++ b/scripts/guide.py
@@ -380,6 +380,12 @@ def _check_env(env: Any, f: Findings) -> set[str]:
         return declared
 
     for var, spec in static.items():
+        if not isinstance(var, str) or not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", var):
+            f.error(
+                f"env.static.{var}: variable name must be a shell identifier "
+                f"matching [A-Za-z_][A-Za-z0-9_]*"
+            )
+            continue
         declared.add(var)
         if not isinstance(spec, dict):
             if spec is None or isinstance(spec, bool):

--- a/scripts/tests/test_guide.py
+++ b/scripts/tests/test_guide.py
@@ -111,6 +111,18 @@ def test_non_bool_sensitive_flag_fails_validation():
     assert any("TOKEN" in str(f) and "boolean" in str(f) for f in findings)
 
 
+def test_invalid_env_var_name_fails_validation():
+    data = _minimal()
+    data["env"]["static"]["BAD-NAME"] = "value"
+    findings = guide.Guide.from_text(yaml_text=yaml.safe_dump(data)).check()
+    assert any("BAD-NAME" in str(f) and "identifier" in str(f) for f in findings)
+
+    data["env"]["static"].pop("BAD-NAME")
+    data["env"]["static"]["lowercase_is_valid"] = "value"
+    findings = guide.Guide.from_text(yaml_text=yaml.safe_dump(data)).check()
+    assert findings.ok()
+
+
 def test_provenance_records_var_names_not_values():
     out = guide.emit_script(_minimal(), ["env"], {"SECRET_TOKEN": "hunter2"})
     header = out.split("# === ")[0]


### PR DESCRIPTION
Guide validation accepts invalid `env.static` names such as `BAD-NAME`, which later render as malformed shell assignments.

Require shell identifiers matching `[A-Za-z_][A-Za-z0-9_]*`, report invalid names as findings, and exclude them from the declared-variable set. Regression coverage includes invalid hyphenated names and valid lowercase names.

## Reproduction

On the unmodified `main` branch:

```text
findings.ok() == True
export BAD-NAME=value
```

After this change:

```text
findings.ok() == False
env.static.BAD-NAME: variable name must be a shell identifier matching [A-Za-z_][A-Za-z0-9_]*
```

## Validation

```bash
PYTHONDONTWRITEBYTECODE=1 python -m pytest -p no:cacheprovider -q \
  scripts/tests/test_guide.py
PYTHONDONTWRITEBYTECODE=1 python scripts/guide.py check guides/*/
PYTHONDONTWRITEBYTECODE=1 python scripts/guide.py render guides/*/ --check
git diff --check upstream/main...HEAD
```

All commands passed: `28 passed`, all four guides validated, and all generated READMEs are up to date.
