### PR TITLE
fix(guides): report unhashable YAML mapping keys

### DIFF
--- a/scripts/guide.py
+++ b/scripts/guide.py
@@ -181,7 +181,16 @@ def _no_duplicate_keys(loader: yaml.SafeLoader, node: yaml.MappingNode, deep: bo
     seen: dict[object, yaml.Node] = {}
     for key_node, _value_node in node.value:
         key = loader.construct_object(key_node, deep=deep)
-        if key in seen:
+        try:
+            duplicate = key in seen
+        except TypeError:
+            raise yaml.constructor.ConstructorError(
+                None,
+                None,
+                "unhashable mapping key; YAML mapping keys must be hashable",
+                key_node.start_mark,
+            )
+        if duplicate:
             first_line = seen[key].start_mark.line + 1
             dup_line = key_node.start_mark.line + 1
             raise yaml.constructor.ConstructorError(

--- a/scripts/tests/test_guide.py
+++ b/scripts/tests/test_guide.py
@@ -213,6 +213,13 @@ def test_emitting_parent_section_concatenates_all_subgroups():
     assert "echo gateway" in out
 
 
+def test_unhashable_yaml_key_is_reported_as_finding():
+    data, finding = guide.parse_guide_yaml("{[a, b]: c}\n")
+    assert data is None
+    assert finding is not None
+    assert "unhashable" in finding.message
+
+
 def test_cli_refuses_invalid_yaml(tmp_path, capsys):
     bad_yaml = "name: broken\nenv: {static: {}}\n"  # missing required deploy
     bad = tmp_path / "guide.yaml"


### PR DESCRIPTION
A sequence used as a YAML mapping key makes `_no_duplicate_keys()` raise an uncaught `TypeError` during dictionary membership checking.

Convert that error to a `ConstructorError` with the source location so `parse_guide_yaml()` returns a normal validation finding. A regression test covers sequence mapping keys.

## Reproduction

On the unmodified `main` branch:

```text
TypeError: unhashable type: 'list'
```

After this change:

```text
line 1: unhashable mapping key; YAML mapping keys must be hashable
```

The parser returns `(None, finding)` instead of raising an uncaught exception.

## Validation

```bash
PYTHONDONTWRITEBYTECODE=1 python -m pytest -p no:cacheprovider -q \
  scripts/tests/test_guide.py
PYTHONDONTWRITEBYTECODE=1 python scripts/guide.py check guides/*/
PYTHONDONTWRITEBYTECODE=1 python scripts/guide.py render guides/*/ --check
git diff --check upstream/main...HEAD
```

All commands passed: `28 passed`, all four guides validated, and all generated READMEs are up to date. This change was also merge-tested with #2405; the combined guide test suite reports `29 passed`.
