### PR TITLE
feat(guides): add MetaX C500X vLLM P/D disaggregation overlay

### DIFF
--- a/docs/getting-started/accelerators.md
+++ b/docs/getting-started/accelerators.md
@@ -12,6 +12,7 @@ Maintainers for each accelerator type are listed below. See our well-lit path gu
 | CPU | x86_64 | Hongming Zheng (@ZhengHongming888, <hongming.zheng@intel.com>) |
 | Google | [TPU](../infrastructure/providers/gke/README.md#llm-d-on-google-kubernetes-engine-gke) | Edwin Hernandez (@Edwinhr716), Cong Liu (@liu-cong, <congliu.thu@gmail.com>) |
 | Intel | XPU | Yuan Wu (@yuanwu2017, <yuan.wu@intel.com>) |
+| MetaX | C500X GPU | Lianjie Zhang (@lianjiezh, <lianjie.zhang@metax-tech.com>), Mengxuan Li (@archlitchi, <mengxuan.li@dynamia.ai>) |
 | NVIDIA | GPU | Will Eaton (<weaton@redhat.com>), Greg (<grpereir@redhat.com>) |
 | Rebellions | NPU | Jinmoo Seok (@rebel-jinmoo, <jinmoo_seok@rebellions.ai>), Minwook Ahn (@rebel-minwook, <minwook.ahn@rebellions.ai>) |
 
@@ -74,6 +75,10 @@ For P/D disaggregation with RDMA-accelerated KV-cache transfer on Intel XPU, the
 - UCX transport configured with `ib,rc,ze_copy`.
 
 The RDMA overlay (`modelserver/xpu/vllm-rdma/`) reuses the standard XPU vLLM base and adds one RDMA DRA claim per pod plus RDMA-specific UCX transport settings. See the [P/D Disaggregation guide](../../guides/pd-disaggregation/README.md) for deployment instructions.
+
+## MetaX C500X
+
+MetaX C500X GPUs are supported for community-contributed well-lit paths. The device plugin must expose `metax-tech.com/gpu`. P/D disaggregation uses vLLM `NixlConnector` over TCP; see the [P/D Disaggregation guide](../../guides/pd-disaggregation/README.md) MetaX overlay (`modelserver/metax/vllm/`).
 
 ## CPU Inferencing
 

--- a/guides/pd-disaggregation/README.md
+++ b/guides/pd-disaggregation/README.md
@@ -53,6 +53,7 @@ This guide includes configuration for the following accelerators:
 | NVIDIA GPU (SGLang) | `modelserver/gpu/sglang/`  | SGLang, validated each release                           |
 | Google TPU          | `modelserver/tpu/v6/vllm/` & `modelserver/tpu/v7/vllm/` | GKE TPU (v6e & v7x), see [TPU Guide](./README.tpu.md) |
 | AMD GPU             | `modelserver/amd/vllm/`    | AMD GPU, community contributed                           |
+| MetaX GPU           | `modelserver/metax/vllm/`  | MetaX C500X, community contributed. Reduced 1P+1D / Qwen3-14B / TP=1 for compatibility checks. |
 | Intel XPU           | `modelserver/xpu/vllm/`    | Intel Data Center GPU Max 1550+, community contributed   |
 | Intel XPU + RDMA    | `modelserver/xpu/vllm-rdma/` | Intel XPU with RDMA via UCX (`ib,rc,ze_copy`), requires RDMA DRA driver |
 
@@ -271,8 +272,30 @@ SGLang-specific notes:
 >
 > * Disaggregation lives in the llm-d Router (EPP) and is engine-agnostic, so SGLang P/D composes with the same prefix-cache-aware and load-aware routing as vLLM.
 > * SGLang P/D is **validated each release** on NVIDIA GPU but is not yet part of the nightly E2E CI that covers the vLLM path (the badges above).
-> * The SGLang P/D overlays are **NVIDIA GPU only** today; the AMD overlay (`modelserver/amd/vllm/`) provides vLLM P/D only.
+> * The SGLang P/D overlays are **NVIDIA GPU only** today; the AMD overlay (`modelserver/amd/vllm/`) and MetaX overlay (`modelserver/metax/vllm/`) provide vLLM P/D only.
 > * On the NIXL transfer backend, SGLang has no explicit prefill-side free-notification (as vLLM does) and no prefill-side reclaim timeout, so a request cancelled before the decode initiates the transfer can strand KV cache on the prefill until the pod restarts. See the [SGLang operations doc](../../docs/operations/disaggregation/sglang.md).
+
+<details>
+<summary><h4>Deploying on MetaX C500X</h4></summary>
+
+This overlay is a reduced compatibility configuration: **1 Prefill + 1 Decode**, each `TP=1` on `metax-tech.com/gpu`, serving `Qwen/Qwen3-14B` over `NixlConnector` and the llm-d routing sidecar (`nixlv2`). It is not a production xPyD sizing example.
+
+Prerequisites:
+
+* MetaX device plugin exposing `metax-tech.com/gpu`.
+* Public MetaX vLLM image (`ghcr.io/project-hami/vllm-metax`). Air-gapped sites can retag the same bits from a private registry.
+* HuggingFace token secret `llm-d-hf-token` (or replace the model args with a local `hostPath` mount).
+* Pod network allowing Prefill↔Decode **TCP 5600** (NIXL side channel) in addition to HTTP 8000/8200. There is no RDMA requirement; TCP is enough for functional validation.
+
+```bash
+kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/metax/vllm
+```
+
+Re-measure `peakPrefillThroughput` in the router values for this model and card before performance work. An aggregated C500X / Qwen3-14B / TP=1 calibration was **5773** tok/s; the default `pd-disaggregation.values.yaml` figure is for gpt-oss-120b on NVIDIA and is not valid here.
+
+Qwen3 chat completions may emit a `<think>` channel unless the client sets `chat_template_kwargs.enable_thinking=false`. Verify P/D with Router `/v1/completions` or `/v1/chat/completions`, then confirm decode logs show an external prefix-cache hit / successful KV transfer rather than decode-only recompute.
+
+</details>
 
 ### 3. Enable Monitoring (optional)
 

--- a/guides/pd-disaggregation/modelserver/metax/vllm/kustomization.yaml
+++ b/guides/pd-disaggregation/modelserver/metax/vllm/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../recipes/modelserver/base/single-host/pd/vllm
+
+namePrefix: pd-disaggregation-metax-vllm-
+
+components:
+  - ../../../../recipes/modelserver/components/images/metax-vllm/release
+  - ../../../../recipes/modelserver/components/images/routing-sidecar/nightly
+
+labels:
+  - pairs:
+      llm-d.ai/model: Qwen3-14B
+      llm-d.ai/guide: pd-disaggregation
+      llm-d.ai/accelerator-variant: gpu
+      llm-d.ai/accelerator-vendor: metax
+      llm-d.ai/engine-type: vllm
+    includeSelectors: true
+    includeTemplates: true
+patches:
+  - path: patch-decode.yaml
+  - path: patch-prefill.yaml

--- a/guides/pd-disaggregation/modelserver/metax/vllm/patch-decode.yaml
+++ b/guides/pd-disaggregation/modelserver/metax/vllm/patch-decode.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: modelserver
+          command: ["vllm", "serve"]
+          args:
+            - "Qwen/Qwen3-14B"
+            - "--host"
+            - "0.0.0.0"
+            - "--port"
+            - "8200"
+            - "--served-model-name"
+            - "Qwen/Qwen3-14B"
+            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+            - "--tensor-parallel-size=1"
+            - "--max-num-batched-tokens=8192"
+            - "--gpu-memory-utilization=0.55"
+            - "--kv-transfer-config"
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+          env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
+            - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+              value: "5600"
+            - name: VLLM_HTTP_TIMEOUT_KEEP_ALIVE
+              value: "120"
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
+            seccompProfile:
+              type: Unconfined
+          resources:
+            limits:
+              memory: 64Gi
+              metax-tech.com/gpu: "1"
+            requests:
+              cpu: "4"
+              memory: 16Gi
+              metax-tech.com/gpu: "1"
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /.cache
+              name: torch-compile-cache
+          startupProbe:
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 180
+          livenessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 100Gi
+        - name: torch-compile-cache
+          emptyDir: {}

--- a/guides/pd-disaggregation/modelserver/metax/vllm/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/metax/vllm/patch-prefill.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prefill
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: modelserver
+          command: ["vllm", "serve"]
+          args:
+            - "Qwen/Qwen3-14B"
+            - "--host"
+            - "0.0.0.0"
+            - "--port"
+            - "8000"
+            - "--served-model-name"
+            - "Qwen/Qwen3-14B"
+            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+            - "--tensor-parallel-size=1"
+            - "--max-num-batched-tokens=8192"
+            # 14B on C500X (64 GiB) peaks near 93% VRAM in aggregated serving;
+            # leave headroom for NIXL KV registration on the P/D path.
+            - "--gpu-memory-utilization=0.55"
+            - "--kv-transfer-config"
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+          env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
+            - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+              value: "5600"
+            # Default vLLM keep-alive (5s) is shorter than llm-d-routing-sidecar's default idle
+            # conn timeout (90s, from Go http.Transport), causing TCP RSTs on reuse.
+            - name: VLLM_HTTP_TIMEOUT_KEEP_ALIVE
+              value: "120"
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
+            seccompProfile:
+              type: Unconfined
+          resources:
+            limits:
+              memory: 64Gi
+              metax-tech.com/gpu: "1"
+            requests:
+              cpu: "4"
+              memory: 16Gi
+              metax-tech.com/gpu: "1"
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /.cache
+              name: torch-compile-cache
+          startupProbe:
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 180
+          livenessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 100Gi
+        - name: torch-compile-cache
+          emptyDir: {}

--- a/guides/recipes/modelserver/components/images/README.md
+++ b/guides/recipes/modelserver/components/images/README.md
@@ -36,6 +36,8 @@ This directory contains Kustomize Components that define the **default container
 │   └── release
 ├── gpu-vllm-omni
 │   └── release
+├── metax-vllm
+│   └── release
 ├── routing-sidecar
 │   ├── nightly
 │   └── release

--- a/guides/recipes/modelserver/components/images/metax-vllm/release/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/metax-vllm/release/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+images:
+  - name: REPLACE_MODEL_SERVER_IMAGE
+    newName: ghcr.io/project-hami/vllm-metax
+    newTag: 0.24.0-maca.ai3.8.2.5-torch2.10-py310-ubuntu22.04-amd64


### PR DESCRIPTION
## Summary

- Add a community-contributed MetaX C500X P/D overlay (`guides/pd-disaggregation/modelserver/metax/vllm/`) as a reduced compatibility config: 1 Prefill + 1 Decode, `TP=1`, `Qwen/Qwen3-14B`, `NixlConnector` + routing sidecar `nixlv2`.
- Pin the public MetaX vLLM image via `metax-vllm/release` (`ghcr.io/project-hami/vllm-metax:0.24.0-maca.ai3.8.2.5-torch2.10-py310-ubuntu22.04-amd64`).
- Document cluster prerequisites (device plugin `metax-tech.com/gpu`, TCP 5600 NIXL, keep-alive / `IPC_LOCK` / shm) and that `peakPrefillThroughput` must be re-measured (aggregated C500X / 14B / TP=1 calibration was 5773 tok/s).

This was validated on a MetaX C500X node with 1P+1D, sidecar `nixlv2`, and decode logs showing external prefix-cache hits / successful NIXL transfers. No vendor CI is included (no community MetaX cluster).

## Test plan

- [x] `kubectl kustomize guides/pd-disaggregation/modelserver/metax/vllm` renders decode on port 8200, sidecar `nixlv2` on 8000, prefill on 8000, `metax-tech.com/gpu: "1"`, NIXL port 5600
- [ ] On a MetaX cluster: apply the overlay with `llm-d-hf-token`, deploy the llm-d Router for this guide, hit `/v1/completions` or `/v1/chat/completions` via Gateway
- [ ] Confirm decode logs show external prefix cache hit / successful KV transfer (not decode-only recompute)
- [ ] Re-calibrate `peakPrefillThroughput` before any performance work; do not use the default gpt-oss NVIDIA figure


Made with [Cursor](https://cursor.com)