### PR TITLE
fix: align modelexpress-p2p PROVIDER_NAME default with optimized-baseline

### DIFF
--- a/guides/modelexpress-p2p/README.md
+++ b/guides/modelexpress-p2p/README.md
@@ -88,7 +88,7 @@ export HF_TOKEN=HF_TOKEN_PLACEHOLDER
 <!-- llm-d-cicd:skip end -->
 ```bash
 export MODEL=openai/gpt-oss-120b
-export PROVIDER_NAME=gke # options: none, gke, agentgateway, istio
+export PROVIDER_NAME=none # options: none, gke, agentgateway, istio
 export INFRA_PROVIDER=coreweave # options: base, coreweave
 export CURL_TEST_IMAGE=cfmanteiga/alpine-bash-curl-jq:latest
 ```
@@ -230,6 +230,9 @@ To use a Kubernetes Gateway managed proxy instead of the standalone version, fol
 
 1. _Deploy a Kubernetes Gateway_ by following one of [the gateway guides](../../docs/infrastructure/gateway).
 2. _Deploy the llm-d router and an HTTPRoute_ that connects it to the Gateway as follows:
+
+> [!IMPORTANT]
+> Set `PROVIDER_NAME` to the gateway provider you deployed in step 1 (e.g. `gke`, `istio`). The default, `none`, renders no provider-specific resources — on GKE that means no `HealthCheckPolicy`, so the Gateway marks the backends unhealthy and requests fail with 503s.
 
 <!-- guide:deploy.gateway start -->
 ```bash

--- a/guides/modelexpress-p2p/guide.yaml
+++ b/guides/modelexpress-p2p/guide.yaml
@@ -16,7 +16,7 @@ env:
 
     MODEL: {default: "openai/gpt-oss-120b"}
 
-    PROVIDER_NAME: {default: gke, values: [none, gke, agentgateway, istio]}
+    PROVIDER_NAME: {default: none, values: [none, gke, agentgateway, istio]}
     INFRA_PROVIDER: {default: coreweave, values: [base, coreweave]}
 
     # VERIFICATION


### PR DESCRIPTION
## Summary

`guides/modelexpress-p2p/guide.yaml` defaulted `PROVIDER_NAME` to `gke`, while `guides/optimized-baseline/guide.yaml` defaults it to `none` (per #2260). Both guides pass this value to the same `--set provider.name=` flag on the router gateway install, so the two guides documented conflicting defaults for the same knob.

The `gke` default was actively wrong for this guide's own default path: `modelexpress-p2p`'s `INFRA_PROVIDER` defaults to `coreweave`, not `gke`, so a user following the guide's defaults would apply GKE-only router resources on a non-GKE cluster, which fail to apply.

## Changes

- `guides/modelexpress-p2p/guide.yaml`: `PROVIDER_NAME` default changed from `gke` to `none`, matching `optimized-baseline`.
- `guides/modelexpress-p2p/README.md`: re-rendered via `scripts/guide.py render` to reflect the new default, and added the same `[!IMPORTANT]` tradeoff note that `optimized-baseline` has, explaining that the `none` default renders no provider-specific resources (e.g. no `HealthCheckPolicy` on GKE) and that users should override `PROVIDER_NAME` to match their deployed gateway.

Fixes #2330

## Test plan

- [x] `python scripts/guide.py check guides/modelexpress-p2p` passes
- [x] `python scripts/guide.py render guides/modelexpress-p2p --check` confirms README is up to date with guide.yaml
- [x] `python -m pytest scripts/tests/` passes (27 passed)