### PR TITLE
fix: correct always-true AWS credential check in setup-sccache.sh

### DIFF
--- a/docker/scripts/common/setup-sccache.sh
+++ b/docker/scripts/common/setup-sccache.sh
@@ -54,6 +54,6 @@ if [ "${USE_SCCACHE}" = "true" ]; then
     echo "  - Region: ${SCCACHE_REGION}"
     echo "  - Key prefix: ${SCCACHE_S3_KEY_PREFIX}"
     echo "  - Socket: ${SCCACHE_SERVER_UDS}"
-    echo "  - AWS credentials: $([ -n \"${AWS_ACCESS_KEY_ID:-}\" ] && echo 'set' || echo 'NOT SET')"
+    echo "  - AWS credentials: $([ -n "${AWS_ACCESS_KEY_ID:-}" ] && echo 'set' || echo 'NOT SET')"
     /usr/local/bin/sccache --show-stats 2>&1 | head -5
 fi


### PR DESCRIPTION
## Summary

`docker/scripts/common/setup-sccache.sh` logs a diagnostic line reporting whether AWS credentials were detected for the sccache S3 backend. The check was broken and always printed `set`, regardless of whether `AWS_ACCESS_KEY_ID` was actually present.

The backslash-escaped quotes inside the `$(...)` command substitution were unescaped by the *outer* double-quoted string before the substitution's command was parsed, so `[ -n ... ]` ended up testing a literal, always-non-empty string (`"${AWS_ACCESS_KEY_ID:-}"` including the quote characters) instead of the variable's actual value. `shellcheck` flags this directly (SC2070, SC2157).

This is a small piece of the puzzle behind #2225 (sccache S3 credentials being invalid on every CUDA build): the build log's own self-reported credential status was unconditionally wrong, giving false confidence that credentials were present even when missing entirely.

## Changes

- `docker/scripts/common/setup-sccache.sh`: drop the unnecessary backslash-escaping so the nested `[ -n "..." ]` check quotes the variable correctly.

Fixes #2411

## Test plan

- [x] Reproduced the bug locally: with `AWS_ACCESS_KEY_ID` unset, the old line printed `AWS credentials: set`; the fixed line correctly prints `NOT SET`
- [x] `shellcheck docker/scripts/common/setup-sccache.sh` passes clean (previously reported SC2070/SC2157)
- [x] `bash -n docker/scripts/common/setup-sccache.sh` — syntax OK