### PR TITLE
fix(docker): correct always-true AWS credential check in sccache log

### DIFF
--- a/docker/scripts/common/setup-sccache.sh
+++ b/docker/scripts/common/setup-sccache.sh
@@ -49,11 +49,14 @@ if [ "${USE_SCCACHE}" = "true" ]; then
         return 0
     fi
 
+    aws_creds_status="NOT SET"
+    [ -n "${AWS_ACCESS_KEY_ID:-}" ] && aws_creds_status="set"
+
     echo "sccache successfully configured:"
     echo "  - Bucket: ${SCCACHE_BUCKET}"
     echo "  - Region: ${SCCACHE_REGION}"
     echo "  - Key prefix: ${SCCACHE_S3_KEY_PREFIX}"
     echo "  - Socket: ${SCCACHE_SERVER_UDS}"
-    echo "  - AWS credentials: $([ -n \"${AWS_ACCESS_KEY_ID:-}\" ] && echo 'set' || echo 'NOT SET')"
+    echo "  - AWS credentials: ${aws_creds_status}"
     /usr/local/bin/sccache --show-stats 2>&1 | head -5
 fi


### PR DESCRIPTION
## Summary

`docker/scripts/common/setup-sccache.sh` logs whether AWS credentials were picked up for the sccache S3 backend. That check was always reporting "set", even when no credentials were configured.

## The bug

```bash
echo "  - AWS credentials: $([ -n \"${AWS_ACCESS_KEY_ID:-}\" ] && echo 'set' || echo 'NOT SET')"
```

The `-n` test lives inside a string that's already double-quoted, so the `\"..\"` around `${AWS_ACCESS_KEY_ID:-}` is an *escaped literal quote character*, not a quote the shell removes. `[` receives the value with literal `"` characters glued to it, so the string is never empty and `-n` is always true — the log always prints `set`, regardless of whether credentials exist. `shellcheck -S warning` flags this directly (SC2070 / SC2157).

## Fix

Compute the status in a plain variable first, so the test isn't running on an already-quoted string:

```bash
aws_creds_status="NOT SET"
[ -n "${AWS_ACCESS_KEY_ID:-}" ] && aws_creds_status="set"
...
echo "  - AWS credentials: ${aws_creds_status}"
```

## Testing
- `shellcheck -S warning docker/scripts/common/setup-sccache.sh` — clean (was previously flagging 2 errors on this line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
