### PR TITLE
docs(scripts): fix swapped argument order in lint-dockerfile-envvars.py examples

### DIFF
--- a/scripts/ENVVARS.md
+++ b/scripts/ENVVARS.md
@@ -70,11 +70,11 @@ declare all environment variables required by scripts they execute.
 
 ```bash
 # check specific dockerfile
-./scripts/lint-dockerfile-envvars.py docker/Dockerfile.cuda docker/scripts
+./scripts/lint-dockerfile-envvars.py docker/scripts docker/Dockerfile.cuda
 
 # check all dockerfiles
 for df in docker/Dockerfile.*; do
-  ./scripts/lint-dockerfile-envvars.py "$df" docker/scripts
+  ./scripts/lint-dockerfile-envvars.py docker/scripts "$df"
 done
 ```
 


### PR DESCRIPTION
## Summary

`scripts/ENVVARS.md`'s documented manual-usage examples for `lint-dockerfile-envvars.py` have the arguments in the wrong order. Running them exactly as written crashes.

## Detail

`lint-dockerfile-envvars.py`'s `main()` reads `argv` as `<scripts-dir> <Dockerfile> [<Dockerfile>...]` — which matches how `.pre-commit-config.yaml` actually invokes it (`args: [docker/scripts]`, with the changed Dockerfile paths appended by `pass_filenames: true`).

The doc's examples had it backwards (`Dockerfile` first, `docker/scripts` second):

```bash
./scripts/lint-dockerfile-envvars.py docker/Dockerfile.cuda docker/scripts
```

Running that verbatim:

```
Traceback (most recent call last):
  ...
    self.content = dockerfile_path.read_text()
IsADirectoryError: [Errno 21] Is a directory: 'docker/scripts'
```

because the script tries to open `docker/scripts` (a directory) as if it were the Dockerfile.

## Fix

Swapped both examples in `ENVVARS.md` to the correct order, matching the real (and pre-commit-hook-verified) argument order.

## Testing
- Ran the corrected examples verbatim:
  - `./scripts/lint-dockerfile-envvars.py docker/scripts docker/Dockerfile.cuda` → succeeds
  - The corrected `for df in docker/Dockerfile.*; do ... done` loop → runs without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
