### PR TITLE
Fix sglang image tag v0.5.16.0 -> v0.5.16

### DIFF
--- a/guides/recipes/modelserver/components/images/gpu-sglang/release/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/gpu-sglang/release/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Component
 images:
   - name: REPLACE_MODEL_SERVER_IMAGE
     newName: docker.io/lmsysorg/sglang
-    newTag: v0.5.16.0
+    newTag: v0.5.16


### PR DESCRIPTION
The tag docker.io/lmsysorg/sglang:v0.5.16.0 does not exist on Docker Hub (the correct tag is v0.5.16), which makes all GPU sglang guide pods fail with `ErrImagePull`.

fixes nightly benchmark failure for sglang: https://github.com/llm-d/llm-d/actions/workflows/nightly-e2e-optimized-baseline-gke-acc-gpu-sglang-x.yaml