### PR TITLE
fix: request 1 DRA claim for SGLang GKE prefill to match TP=1

### DIFF
--- a/guides/pd-disaggregation/modelserver/gpu/sglang/gke/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/sglang/gke/patch-prefill.yaml
@@ -11,15 +11,10 @@ spec:
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
-      # Request 4 GKE DRA RDMA claims for PCIe root switch rail-aligned RoCE inter-pod transfer
+      # Request 1 GKE DRA RDMA claim (1 GPU + 1 rail-aligned NIC) to match the
+      # prefill server's --tensor-parallel-size=1
       resourceClaims:
-        - name: gke-rdma-claim-0
-          resourceClaimTemplateName: gke-rdma-template
-        - name: gke-rdma-claim-1
-          resourceClaimTemplateName: gke-rdma-template
-        - name: gke-rdma-claim-2
-          resourceClaimTemplateName: gke-rdma-template
-        - name: gke-rdma-claim-3
+        - name: gke-rdma-claim
           resourceClaimTemplateName: gke-rdma-template
       containers:
         - name: modelserver
@@ -40,12 +35,9 @@ spec:
             requests:
               cpu: "32"
               memory: "128Gi"
-            # Bind the 4 GKE DRA claims to the modelserver container
+            # Bind the GKE DRA claim to the modelserver container
             claims:
-              - name: gke-rdma-claim-0
-              - name: gke-rdma-claim-1
-              - name: gke-rdma-claim-2
-              - name: gke-rdma-claim-3
+              - name: gke-rdma-claim
           volumeMounts:
             # Mount a persistent volume for huggingface cache, so that the cache is shared across restarts
             - mountPath: /root/.cache/huggingface


### PR DESCRIPTION
The SGLang GKE prefill patch attaches 4 DRA claims per pod, but prefill runs with `--tensor-parallel-size=1`, so each pod allocates 4 GPUs and uses only 1. With 8 replicas the guide asks for 40 GPUs instead of 16, which is part of why the GKE GPU SGLang nightly cannot schedule.

Reduce prefill to 1 claim, matching the vLLM GKE overlays (`gpu/vllm/gke/base`, `gpu/vllm-ds/gke`). Decode keeps 4 claims for its TP=4.