### PR TITLE
ci(async-e2e): dump pod diagnostics when the kind e2e fails

### DIFF
--- a/guides/batch-serving/asynchronous-processing/test/kind-e2e.sh
+++ b/guides/batch-serving/asynchronous-processing/test/kind-e2e.sh
@@ -66,6 +66,26 @@ log()  { printf '\033[1;34m[%s]\033[0m %s\n' "$(date +%H:%M:%S)" "$*"; }
 ok()   { printf '\033[1;32m[ OK ]\033[0m %s\n' "$*"; }
 fail() { printf '\033[1;31m[FAIL]\033[0m %s\n' "$*" >&2; }
 
+# Dump everything needed to diagnose a failure post-mortem from CI logs: pod
+# list, recent events, and per-pod describe + current and previous-crash logs.
+# The namespaces here hold only a handful of pods, so dump all of them.
+dump_debug() {
+  local ns="$1"
+  log "---- debug dump: namespace ${ns} ----"
+  kubectl get pods -n "${ns}" -o wide || true
+  kubectl get events -n "${ns}" --sort-by=.lastTimestamp 2>/dev/null | tail -n 40 || true
+  local pod
+  for pod in $(kubectl get pods -n "${ns}" -o name); do
+    log "describe ${pod}"
+    kubectl describe -n "${ns}" "${pod}" | tail -n 40 || true
+    log "logs ${pod} (current)"
+    kubectl logs -n "${ns}" "${pod}" --all-containers --tail=100 2>/dev/null || true
+    log "logs ${pod} (previous crash)"
+    kubectl logs -n "${ns}" "${pod}" --all-containers --previous --tail=100 2>/dev/null || true
+  done
+  log "---- end debug dump: namespace ${ns} ----"
+}
+
 cleanup() {
   local rc=$?
   if [ "$KEEP" = "1" ]; then
@@ -171,7 +191,7 @@ log "Waiting up to ${BASELINE_TIMEOUT}s for the baseline stack to become ready"
 if ! kubectl wait --for=condition=available --timeout="${BASELINE_TIMEOUT}s" \
       deployment --all -n "${BASELINE_NAMESPACE}"; then
   fail "Baseline stack did not become ready"
-  kubectl get pods -n "${BASELINE_NAMESPACE}"
+  dump_debug "${BASELINE_NAMESPACE}"
   exit 1
 fi
 ok "Baseline stack ready"
@@ -205,7 +225,7 @@ helm install llm-d-async \
 if ! kubectl wait --for=condition=available --timeout=300s \
       deployment --all -n "${NAMESPACE}"; then
   fail "Async Processor did not become ready"
-  kubectl get pods -n "${NAMESPACE}"
+  dump_debug "${NAMESPACE}"
   exit 1
 fi
 ok "Async Processor ready"
@@ -227,8 +247,10 @@ if kubectl run async-smoketest --rm -i --restart=Never --image=redis -- \
   ok "Smoke test PASSED — async result returned"
 else
   fail "Smoke test FAILED — no result on result-list"
-  log "Async Processor logs (tail):"
-  kubectl logs -n "${NAMESPACE}" deployment/llm-d-async --tail=50 2>/dev/null || true
+  # A smoke-test timeout can also be the backing stack's fault (EPP or model
+  # server), so dump both namespaces.
+  dump_debug "${NAMESPACE}"
+  dump_debug "${BASELINE_NAMESPACE}"
   exit 1
 fi
 


### PR DESCRIPTION
## What

When the async kind e2e fails, the script now dumps full diagnostics before the cluster is torn down, instead of just `kubectl get pods`. A new `dump_debug <namespace>` helper prints:

- the pod list (`-o wide`) and the last 40 namespace events,
- per pod: the `describe` tail (Last State, exit codes, events), current container logs, and `--previous` crash logs.

It is called from all three failure paths: baseline-stack readiness, Async Processor readiness, and the smoke test (which also dumps the baseline namespace, since a result timeout can be the backing stack's fault).

## Why

Both failures of this check to date — run [32280577396](https://github.com/llm-d/llm-d/actions/runs/32280577396) (2026-08-19) and its re-run (2026-08-31) — ended with the CPU vLLM decode pod in `CrashLoopBackOff` after 7 restarts, and nothing else. The crash reason (HF download throttling? OOM? something else) is unrecoverable from the CI logs because the cluster is deleted on exit. This change makes the next occurrence diagnosable in one look, and is a prerequisite for choosing the right deflake fix (HF token, model cache volume, or memory bump) based on evidence rather than guesswork.

## Notes

- No behavior change on the success path.
- `bash -n` clean; the repo shellcheck hook scopes to `docker/scripts/` only.