### PR TITLE
feat(guides): add diffusion-serving text-to-speech guide

### DIFF
--- a/guides/README.md
+++ b/guides/README.md
@@ -35,7 +35,7 @@ Workload-centric guides — each provides the recommended, cohesive deployment f
 
 * [Agentic Serving](./agentic-serving/README.md) - serve long, multi-turn, tool-using agentic workloads (e.g. coding agents) by composing prefix-aware routing, KV-cache offloading, and P/D disaggregation.
 * [Multimodal Serving](./multimodal-serving/README.md) - Deploy multimodal model serving (e.g., image/audio/video) using either aggregated routing or dedicated encode disaggregation topologies.
-* [Diffusion Serving](./diffusion-serving/README.md) - serve text-to-image diffusion models on vLLM-Omni or SGLang.diffusion-serving/text-to-image
+* [Diffusion Serving](./diffusion-serving/README.md) - serve media generation models (text-to-image, image-to-image, text-to-speech) on vLLM-Omni or SGLang.
 * [Reinforcement Learning](./rl/README.md) - Accelerate RL rollout by delegating rollout routing to llm-d's EPP and scheduler, bringing prefix-cache-aware routing and P/D disaggregation to RLHF/GRPO/PPO training on Ray or Slurm.
 * [Batch Serving](./batch-serving/README.md) - Deploy batch and asynchronous inference processing using an OpenAI-compatible Batch API or lightweight queue-based dispatchers with dynamic metric gating.
 

--- a/guides/diffusion-serving/README.md
+++ b/guides/diffusion-serving/README.md
@@ -11,3 +11,4 @@ Diffusion models generate media such as images, audio, and video by iterative de
 
 * **[Text-to-Image Guide](./text-to-image/README.md)**: Generate images from text prompts over the OpenAI-compatible `POST /v1/images/generations` endpoint, serving on vLLM-Omni or SGLang.
 * **[Image-to-Image Guide](./image-to-image/README.md)**: Edit an uploaded image over the OpenAI-compatible `POST /v1/images/edits` endpoint, which carries `multipart/form-data`, serving on vLLM-Omni or SGLang.
+* **[Text-to-Speech Guide](./text-to-speech/README.md)**: Generate speech from text over the OpenAI-compatible `POST /v1/audio/speech` endpoint, which returns binary audio or streamed audio chunks, serving on vLLM-Omni.

--- a/guides/diffusion-serving/text-to-speech/README.md
+++ b/guides/diffusion-serving/text-to-speech/README.md
@@ -1,0 +1,244 @@
+# [Experimental] Text-to-Speech Guide
+
+This guide deploys a text-to-speech (TTS) model behind the llm-d router and serves it over the OpenAI-compatible `POST /v1/audio/speech` endpoint.
+
+> [!NOTE]
+> Parsing `/v1/audio/speech` requests in the EPP landed in [llm-d-router#2484](https://github.com/llm-d/llm-d-router/pull/2484) after the v0.10.0 release, so EPP images up to v0.10.0 cannot route this guide's requests. The default chart version used below (`${ROUTER_CHART_VERSION}` = `v0`) deploys the `main`-tagged EPP image, which includes the change. Once a router release newer than v0.10.0 is available, pin that instead.
+
+Currently, this guide routes on load: the EPP tracks how many requests it has dispatched to each endpoint and not yet seen complete, and prefers the least busy one. The Qwen3-TTS talker stage is autoregressive, so prefix-cache-aware routing is possible in principle and is tracked as follow-up work in [llm-d-router#2483](https://github.com/llm-d/llm-d-router/issues/2483).
+
+---
+
+## Default Configuration
+
+| Parameter        | Value                                                                                               |
+| ---------------- | --------------------------------------------------------------------------------------------------- |
+| Default Model    | [Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice)  |
+| Replicas         | 3                                                                                                     |
+| GPUs per replica | 1                                                                                                     |
+| Total GPUs       | 3                                                                                                     |
+| Accelerator      | NVIDIA H100 80GB                                                                                      |
+
+Qwen3-TTS-12Hz-1.7B-CustomVoice is a ~1.7B autoregressive talker plus a 12Hz codec decoder. It is a small model and fits comfortably on a single GPU; the H100 is a default, not a requirement.
+
+### Supported Hardware Backends
+
+| Backend    | Directory                                     | Model                                  | Notes                                                            |
+| ---------- | --------------------------------------------- | -------------------------------------- | ---------------------------------------------------------------- |
+| NVIDIA GPU | `modelserver/gpu/vllmomni/${INFRA_PROVIDER}/` | `Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice` | Default configuration (`INFRA_PROVIDER` options: `base`, `gke`)   |
+
+---
+
+## Prerequisites
+
+1. Install the local client tooling using the [client setup guide](../../../helpers/client-setup/README.md).
+2. Clone and check out the llm-d repository:
+
+   ```bash
+   export branch="main" # branch, tag, or commit hash
+   git clone https://github.com/llm-d/llm-d.git && cd llm-d && git checkout ${branch}
+   export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
+   ```
+
+3. Set up environment variables:
+
+   ```bash
+   source ${REPO_ROOT}/guides/env.sh
+   export GUIDE_NAME="text-to-speech"
+   export NAMESPACE=llm-d-diffusion-tts
+   export ENGINE=vllmomni
+   export INFRA_PROVIDER=gke # base | gke
+   ```
+
+4. Install the Gateway API Inference Extension CRDs:
+
+   ```bash
+   # GAIE_URL is automatically calculated from GAIE_VERSION at ${REPO_ROOT}/guides/env.sh
+   kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/${GAIE_URL}/v1-manifests.yaml
+   ```
+
+5. Create the namespace:
+
+   ```bash
+   kubectl create namespace ${NAMESPACE}
+   ```
+
+6. [Create the `llm-d-hf-token` secret in your target namespace with the key `HF_TOKEN` matching a valid HuggingFace token](../../../helpers/hf-token.md) to pull models. Qwen3-TTS is Apache-2.0, so the token is optional for the default model.
+<!-- llm-d-cicd:skip start -->
+   ```bash
+   export HF_TOKEN=<your HuggingFace token>
+   kubectl create secret generic llm-d-hf-token \
+     --from-literal="HF_TOKEN=${HF_TOKEN}" \
+     --namespace "${NAMESPACE}" \
+     --dry-run=client -o yaml | kubectl apply -f -
+   ```
+<!-- llm-d-cicd:skip end -->
+
+---
+
+## Installation Instructions
+
+### 1. Deploy the llm-d Router
+
+#### Standalone Mode
+
+Deploy the llm-d Router in **Standalone Mode** overlaying router custom configurations:
+
+```bash
+# Run from the root of the llm-d repo
+helm install ${GUIDE_NAME} \
+    ${ROUTER_STANDALONE_CHART} \
+    -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
+    -f ${REPO_ROOT}/guides/diffusion-serving/${GUIDE_NAME}/router/values.yaml \
+    -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
+```
+
+<details>
+<summary><h4>Gateway Mode</h4></summary>
+
+To use a Kubernetes Gateway managed proxy rather than the standalone version, follow these steps:
+
+1. _Deploy a Kubernetes Gateway_ by following one of [the gateway guides](../../../docs/infrastructure/gateway).
+2. _Deploy the llm-d router and an HTTPRoute_ that connects it to the Gateway as follows:
+
+```bash
+export PROVIDER_NAME=gke # options: none, gke, agentgateway, istio
+helm install ${GUIDE_NAME} \
+    ${ROUTER_GATEWAY_CHART}  \
+    -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
+    -f ${REPO_ROOT}/guides/diffusion-serving/${GUIDE_NAME}/router/values.yaml \
+    --set provider.name=${PROVIDER_NAME} \
+    --set httpRoute.create=true \
+    --set httpRoute.inferenceGatewayName=llm-d-inference-gateway \
+    -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
+```
+
+</details>
+
+### 2. Deploy the Model Server
+
+Apply the Kustomize overlay:
+
+```bash
+export INFRA_PROVIDER=gke # base | gke
+kubectl apply -n ${NAMESPACE} -k ${REPO_ROOT}/guides/diffusion-serving/${GUIDE_NAME}/modelserver/gpu/${ENGINE}/${INFRA_PROVIDER}/
+```
+
+---
+
+## Verification
+
+### 1. Retrieve the Proxy Endpoint IP
+
+**Standalone Mode:**
+
+```bash
+export IP=$(kubectl get service ${GUIDE_NAME}-epp -n ${NAMESPACE} -o jsonpath='{.spec.clusterIP}')
+```
+
+<details>
+<summary><b>Gateway Mode:</b></summary>
+
+```bash
+export IP=$(kubectl get gateway llm-d-inference-gateway -n ${NAMESPACE} -o jsonpath='{.status.addresses[0].value}')
+```
+
+</details>
+
+### 2. Send a Text-to-Speech Test Request
+
+Open a debug container within the cluster namespace:
+
+```bash
+kubectl run curl-debug --rm -it \
+    --image=cfmanteiga/alpine-bash-curl-jq \
+    --env="IP=$IP" \
+    --env="NAMESPACE=$NAMESPACE" \
+    -- /bin/bash
+```
+
+Send an OpenAI-compatible speech request. Unlike the JSON-based image endpoints, a successful response body is the binary audio itself, so write it to a file:
+
+```bash
+curl -s -X POST http://${IP}/v1/audio/speech \
+    -H 'Content-Type: application/json' \
+    -D headers.txt \
+    -o speech.wav \
+    -d '{
+        "model": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
+        "input": "vLLM is a fast and easy-to-use library for LLM inference and serving.",
+        "voice": "vivian",
+        "response_format": "wav"
+    }'
+```
+
+Check that the response is a valid WAV file:
+
+```bash
+head -c 4 speech.wav; echo    # RIFF
+```
+
+vLLM-Omni also reports token usage for binary audio responses in headers (see the [vLLM-Omni speech API response format](https://docs.vllm.ai/projects/vllm-omni/en/latest/serving/speech_api/#response-format)):
+
+```bash
+grep -i x-vllm-omni headers.txt
+```
+
+Expected header shape:
+
+```text
+x-vllm-omni-input-tokens: 18
+x-vllm-omni-output-tokens: 52
+x-vllm-omni-total-tokens: 70
+```
+
+> [!NOTE]
+> The usage headers were added in vLLM-Omni v0.28.0. With the current default image (v0.26.0) the WAV file is returned but the `x-vllm-omni-*` headers are absent; usage is still reported in the `speech.audio.done` event when using `stream_format: "sse"`.
+
+### 3. Streaming Variants
+
+vLLM-Omni supports two streaming formats through the router.
+
+**SSE stream** (`stream_format: "sse"`) returns `speech.audio.delta` events with base64 audio chunks and a final `speech.audio.done` event carrying usage:
+
+```bash
+curl -s -N -X POST http://${IP}/v1/audio/speech \
+    -H 'Content-Type: application/json' \
+    -d '{
+        "model": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
+        "input": "Hello from llm-d.",
+        "voice": "vivian",
+        "stream_format": "sse"
+    }' | head -c 600
+```
+
+**Raw audio stream** (`stream_format: "audio"`) returns binary PCM chunks as they are generated, giving time-to-first-byte in the tens of milliseconds instead of seconds:
+
+```bash
+curl -s -N -X POST http://${IP}/v1/audio/speech \
+    -H 'Content-Type: application/json' \
+    -o speech-stream.pcm \
+    -d '{
+        "model": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
+        "input": "Hello from llm-d.",
+        "voice": "vivian",
+        "stream_format": "audio"
+    }'
+```
+
+---
+
+## Cleanup
+
+To tear down and clean up all deployed resources:
+
+```bash
+helm uninstall ${GUIDE_NAME} -n ${NAMESPACE}
+kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/diffusion-serving/${GUIDE_NAME}/modelserver/gpu/${ENGINE}/${INFRA_PROVIDER}/
+```
+
+<!-- llm-d-cicd:skip start -->
+```bash
+kubectl delete namespace ${NAMESPACE}
+```
+<!-- llm-d-cicd:skip end -->

--- a/guides/diffusion-serving/text-to-speech/modelserver/gpu/vllmomni/base/kustomization.yaml
+++ b/guides/diffusion-serving/text-to-speech/modelserver/gpu/vllmomni/base/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../../../recipes/modelserver/base/single-host/default
+
+namespace: llm-d-diffusion-tts
+
+namePrefix: diffusion-serving-tts-nvidia-gpu-vllm-omni-
+
+components:
+  - ../../../../../../recipes/modelserver/components/images/gpu-vllm-omni/release
+
+labels:
+  - pairs:
+      llm-d.ai/guide: diffusion-serving-tts
+      llm-d.ai/model: Qwen3-TTS-12Hz-1.7B-CustomVoice
+      llm-d.ai/accelerator-variant: gpu
+      llm-d.ai/accelerator-vendor: nvidia
+      llm-d.ai/engine-type: vllm-omni
+    includeSelectors: true
+    includeTemplates: true
+
+patches:
+  - path: patch-vllm-omni-tts.yaml

--- a/guides/diffusion-serving/text-to-speech/modelserver/gpu/vllmomni/base/patch-vllm-omni-tts.yaml
+++ b/guides/diffusion-serving/text-to-speech/modelserver/gpu/vllmomni/base/patch-vllm-omni-tts.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  replicas: 3
+  template:
+    spec:
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: modelserver
+          command: ["vllm", "serve"]
+          args:
+            - "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
+            - "--omni"
+            - "--trust-remote-code"
+            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+            - "--log-stats"
+          env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
+                  optional: true
+          resources:
+            limits:
+              cpu: '16'
+              memory: 128Gi
+              nvidia.com/gpu: 1
+            requests:
+              cpu: '8'
+              memory: 96Gi
+              nvidia.com/gpu: 1
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: dshm
+            - mountPath: /.cache
+              name: torch-compile-cache
+            - mountPath: /.triton
+              name: triton-cache
+            - mountPath: /.config
+              name: vllm-config
+          startupProbe:
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 120
+          livenessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi
+        - name: torch-compile-cache
+          emptyDir: {}
+        - name: triton-cache
+          emptyDir: {}
+        - name: vllm-config
+          emptyDir: {}

--- a/guides/diffusion-serving/text-to-speech/modelserver/gpu/vllmomni/gke/kustomization.yaml
+++ b/guides/diffusion-serving/text-to-speech/modelserver/gpu/vllmomni/gke/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+components:
+  - ../../../../../../recipes/modelserver/components/disable-gke-nccl-tuner-patch

--- a/guides/diffusion-serving/text-to-speech/router/values.yaml
+++ b/guides/diffusion-serving/text-to-speech/router/values.yaml
@@ -1,0 +1,33 @@
+router:
+  extraServicePorts:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8081
+
+  inferencePool:
+    failureMode: FailOpen
+
+  epp:
+    pluginsConfigFile: "tts.yaml"
+    pluginsCustomConfig:
+      tts.yaml: |
+        apiVersion: inference.networking.x-k8s.io/v1alpha1
+        kind: EndpointPickerConfig
+        plugins:
+        - name: activeRequest
+          type: active-request-scorer
+        - name: maxScore
+          type: max-score-picker
+        schedulingProfiles:
+        - name: default
+          plugins:
+          - pluginRef: activeRequest
+          - pluginRef: maxScore
+        dataLayer:
+          injectDefaults: false
+
+  modelServers:
+    matchLabels:
+      llm-d.ai/guide: "diffusion-serving-tts"
+    protocol: http


### PR DESCRIPTION
Adds a diffusion-serving text-to-speech guide: Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice on vLLM-Omni behind the llm-d router, served over the OpenAI-compatible POST /v1/audio/speech endpoint.

- Routes on load via active-request-scorer; prefix-cache-aware routing is follow-up work tracked in llm-d/llm-d-router#2483.
- Requires an EPP with /v1/audio/speech request parsing from llm-d/llm-d-router#2484 (landed after router v0.10.0).
- Verified end to end on GKE (1x H100 per replica): non-streaming WAV, SSE stream (usage in speech.audio.done), raw audio stream, and even load spread across replicas under a concurrent burst.
