### PR TITLE
Fix: Remove GKE-specific node selectors from diffusion-serving guides

### DIFF
--- a/guides/diffusion-serving/image-to-image/modelserver/gpu/sglang/base/patch-sglang.yaml
+++ b/guides/diffusion-serving/image-to-image/modelserver/gpu/sglang/base/patch-sglang.yaml
@@ -6,8 +6,6 @@ spec:
   replicas: 3
   template:
     spec:
-      nodeSelector:
-        cloud.google.com/gke-accelerator: nvidia-h100-80gb
       tolerations:
         - key: nvidia.com/gpu
           operator: Exists

--- a/guides/diffusion-serving/image-to-image/modelserver/gpu/vllmomni/base/patch-vllm-omni-edit.yaml
+++ b/guides/diffusion-serving/image-to-image/modelserver/gpu/vllmomni/base/patch-vllm-omni-edit.yaml
@@ -6,8 +6,6 @@ spec:
   replicas: 3
   template:
     spec:
-      nodeSelector:
-        cloud.google.com/gke-accelerator: nvidia-h100-80gb
       tolerations:
         - key: nvidia.com/gpu
           operator: Exists

--- a/guides/diffusion-serving/text-to-image/modelserver/gpu/sglang/base/patch-sglang.yaml
+++ b/guides/diffusion-serving/text-to-image/modelserver/gpu/sglang/base/patch-sglang.yaml
@@ -6,8 +6,6 @@ spec:
   replicas: 3
   template:
     spec:
-      nodeSelector:
-        cloud.google.com/gke-accelerator: nvidia-h100-80gb
       tolerations:
         - key: nvidia.com/gpu
           operator: Exists

--- a/guides/diffusion-serving/text-to-image/modelserver/gpu/vllmomni/base/patch-vllm-omni.yaml
+++ b/guides/diffusion-serving/text-to-image/modelserver/gpu/vllmomni/base/patch-vllm-omni.yaml
@@ -6,8 +6,6 @@ spec:
   replicas: 3
   template:
     spec:
-      nodeSelector:
-        cloud.google.com/gke-accelerator: nvidia-h100-80gb
       tolerations:
         - key: nvidia.com/gpu
           operator: Exists


### PR DESCRIPTION
Remove the GKE-specific  nodeSelector from the image-to-image and text-to-image diffusion-serving modelserver guides.

The selector was added accidentally. Removing it keeps the guide configurations portable across platforms.
