### PR TITLE
fix(guides): configure CPU cache capacity for ECCPUConnector

### DIFF
--- a/guides/coord-disaggregation/modelserver/gpu/vllm/common/encode-deployment.yaml
+++ b/guides/coord-disaggregation/modelserver/gpu/vllm/common/encode-deployment.yaml
@@ -27,7 +27,9 @@ spec:
             - "--enforce-eager"
             - "--no-enable-prefix-caching"
             - "--ec-transfer-config"
-            - '{"ec_connector": "ECCPUConnector", "ec_role": "ec_producer"}'
+            # ec_cpu_bytes defines the capacity of the shared encoder cache in bytes.
+            # Increase it for workloads with large or numerous multimodal items.
+            - '{"ec_connector": "ECCPUConnector", "ec_role": "ec_producer", "ec_connector_extra_config": {"ec_cpu_bytes": 4294967296}}'
           env:
             - name: MODEL_NAME
               value: "Qwen/Qwen3-VL-32B-Instruct"

--- a/guides/coord-disaggregation/modelserver/gpu/vllm/common/prefill-deployment.yaml
+++ b/guides/coord-disaggregation/modelserver/gpu/vllm/common/prefill-deployment.yaml
@@ -29,7 +29,9 @@ spec:
             - '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}'
             - "--no-disable-hybrid-kv-cache-manager"
             - "--ec-transfer-config"
-            - '{"ec_connector": "ECCPUConnector", "ec_role": "ec_consumer"}'
+            # ec_cpu_bytes defines the capacity of the shared encoder cache in bytes.
+            # Increase it for workloads with large or numerous multimodal items.
+            - '{"ec_connector": "ECCPUConnector", "ec_role": "ec_consumer", "ec_connector_extra_config": {"ec_cpu_bytes": 4294967296}}'
           env:
             - name: MODEL_NAME
               value: "Qwen/Qwen3-VL-32B-Instruct"

--- a/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/encode-deployment.yaml
+++ b/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/encode-deployment.yaml
@@ -30,11 +30,9 @@ spec:
             - "--enforce-eager"
             - "--no-enable-prefix-caching"
             - "--ec-transfer-config"
-            # num_ec_blocks (Default: 100,000) defines the capacity of the shared encoder
-            # cache for multimodal items. Increase this value for workloads with large or
-            # numerous images to prevent cache evictions and costly re-encodings that
-            # degrade system performance.
-            - '{"ec_connector": "ECCPUConnector", "ec_role": "ec_producer", "ec_connector_extra_config": {"num_ec_blocks": 1000000}}'
+            # ec_cpu_bytes defines the capacity of the shared encoder cache in bytes.
+            # Increase it for workloads with large or numerous multimodal items.
+            - '{"ec_connector": "ECCPUConnector", "ec_role": "ec_producer", "ec_connector_extra_config": {"ec_cpu_bytes": 4294967296}}'
           env:
             - name: VLLM_EC_SIDE_CHANNEL_HOST
               valueFrom:

--- a/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/patch-prefill.yaml
+++ b/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-p-d/base/patch-prefill.yaml
@@ -20,11 +20,9 @@ spec:
             - "--no-disable-hybrid-kv-cache-manager"
             - "--gpu-memory-utilization=0.75"
             - "--ec-transfer-config"
-            # num_ec_blocks (Default: 100,000) defines the capacity of the shared encoder
-            # cache for multimodal items. Increase this value for workloads with large or
-            # numerous images to prevent cache evictions and costly re-encodings that
-            # degrade system performance.
-            - '{"ec_connector": "ECCPUConnector", "ec_role": "ec_consumer", "ec_connector_extra_config": {"num_ec_blocks": 1000000}}'
+            # ec_cpu_bytes defines the capacity of the shared encoder cache in bytes.
+            # Increase it for workloads with large or numerous multimodal items.
+            - '{"ec_connector": "ECCPUConnector", "ec_role": "ec_consumer", "ec_connector_extra_config": {"ec_cpu_bytes": 4294967296}}'
           env:
             - name: VLLM_NIXL_SIDE_CHANNEL_HOST
               valueFrom:

--- a/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-pd/base/patch-decode.yaml
+++ b/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-pd/base/patch-decode.yaml
@@ -36,7 +36,9 @@ spec:
             - "20"
             - "--port=8200"
             - "--ec-transfer-config"
-            - '{"ec_connector": "ECCPUConnector", "ec_role": "ec_consumer"}'
+            # ec_cpu_bytes defines the capacity of the shared encoder cache in bytes.
+            # Increase it for workloads with large or numerous multimodal items.
+            - '{"ec_connector": "ECCPUConnector", "ec_role": "ec_consumer", "ec_connector_extra_config": {"ec_cpu_bytes": 4294967296}}'
           env:
             - name: HF_TOKEN
               valueFrom:

--- a/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-pd/base/patch-encode.yaml
+++ b/guides/multimodal-serving/e-disaggregation/modelserver/gpu/vllm/e-pd/base/patch-encode.yaml
@@ -30,11 +30,9 @@ spec:
             - "--enforce-eager"
             - "--no-enable-prefix-caching"
             - "--ec-transfer-config"
-            # num_ec_blocks (Default: 100,000) defines the capacity of the shared encoder
-            # cache for multimodal items. Increase this value for workloads with large or
-            # numerous images to prevent cache evictions and costly re-encodings that
-            # degrade system performance.
-            - '{"ec_connector": "ECCPUConnector", "ec_role": "ec_producer", "ec_connector_extra_config": {"num_ec_blocks": 1000000}}'
+            # ec_cpu_bytes defines the capacity of the shared encoder cache in bytes.
+            # Increase it for workloads with large or numerous multimodal items.
+            - '{"ec_connector": "ECCPUConnector", "ec_role": "ec_producer", "ec_connector_extra_config": {"ec_cpu_bytes": 4294967296}}'
           env:
             - name: VLLM_EC_SIDE_CHANNEL_HOST
               valueFrom:


### PR DESCRIPTION
## Summary

Configure the CPU cache capacity required by vLLM's `ECCPUConnector` across the encoder disaggregation deployment examples.

## Changes

- Add `ec_connector_extra_config.ec_cpu_bytes` to ECCPUConnector producer and consumer configurations.
- Set the example CPU cache capacity to 4 GiB (`4294967296` bytes).
- Replace the unsupported `num_ec_blocks` setting with the required `ec_cpu_bytes` configuration.
- Document how to tune the cache capacity for larger multimodal workloads.

## Motivation

Recent vLLM versions require `ec_cpu_bytes` to be explicitly specified in `ec_connector_extra_config`. Without it, EngineCore fails during startup with:

`ValueError: ec_cpu_bytes must be specified in ec_connector_extra_config`

https://docs.vllm.ai/en/v0.28.0/api/vllm/distributed/ec_transfer/ec_connector/cpu/common/
<img width="798" height="564" alt="image" src="https://github.com/user-attachments/assets/7fbe02fa-22f0-469f-9f42-73043b60a892" />
