### PR TITLE
fix(wide-ep-lws): serve render endpoints on precise prefill pods

### DIFF
--- a/guides/wide-ep-lws/README.precise-prefix-cache-routing.md
+++ b/guides/wide-ep-lws/README.precise-prefix-cache-routing.md
@@ -111,7 +111,10 @@ helm install ${GUIDE_NAME} \
 #### Deploy using LeaderWorkerSet
 
 The overlay contains the complete tested modelserver and render-Service
-configuration:
+configuration. Its `render-endpoints` component sets
+`VLLM_ENABLE_SCALE_OUT_ENDPOINTS=1` on the prefill pods: vLLM serves the
+`/v1/*/render` endpoints only when that is set, and the render Service has no
+pods of its own, so without it every `token-producer` call returns 404:
 
 ```bash
 kubectl apply -n ${NAMESPACE} \
@@ -175,7 +178,9 @@ curl -X POST http://${IP}/v1/completions \
 
 ### 3. Verify Precise Routing
 
-The render Service must return token IDs:
+The render Service must return token IDs. A 404 here means the model server
+is not exposing vLLM's scale-out endpoints, so precise routing is inert while
+requests still return 200 from the remaining scorers:
 
 ```bash
 kubectl run render-check --rm -i --restart=Never \

--- a/guides/wide-ep-lws/modelserver/gpu/vllm-glm-5.2/components/render-endpoints/kustomization.yaml
+++ b/guides/wide-ep-lws/modelserver/gpu/vllm-glm-5.2/components/render-endpoints/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+# Expose vLLM's /v1/*/render endpoints on the prefill pods that the render
+# Service (../../../../../render) fronts, for the precise prefix-cache router
+# variant (see ../../../../../README.precise-prefix-cache-routing.md).
+#
+# vLLM serves the scale-out endpoints (/render, /derender,
+# /inference/v1/generate) only when VLLM_ENABLE_SCALE_OUT_ENDPOINTS is 1.
+# Without it the EPP token-producer's render call returns 404, so no request
+# carries token IDs, the precise producer never runs, and requests are still
+# answered 200 by the remaining scorers - the router degrades silently rather
+# than failing.
+#
+# Builds that predate the opt-in ignore the variable and serve the endpoints
+# unconditionally, so setting it is safe across versions.
+patches:
+  - target:
+      kind: LeaderWorkerSet
+      name: ".*-prefill"
+    patch: |-
+      - op: add
+        path: /spec/leaderWorkerTemplate/workerTemplate/spec/containers/0/env/-
+        value:
+          name: VLLM_ENABLE_SCALE_OUT_ENDPOINTS
+          value: "1"

--- a/guides/wide-ep-lws/modelserver/gpu/vllm-glm-5.2/deployments/p2w1d1w1-precise/kustomization.yaml
+++ b/guides/wide-ep-lws/modelserver/gpu/vllm-glm-5.2/deployments/p2w1d1w1-precise/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - ../../../../../render
 components:
   - ../../components/kv-events
+  - ../../components/render-endpoints
 patches:
   - path: delete-evictor.yaml

--- a/guides/wide-ep-lws/render/kustomization.yaml
+++ b/guides/wide-ep-lws/render/kustomization.yaml
@@ -3,7 +3,10 @@ kind: Kustomization
 
 # Render (tokenizer) Service for the precise prefix-cache routing variant.
 # Pairs with the token-producer `vllm.url` in
-# ../router/precise-routing.values.yaml.
+# ../router/precise-routing.values.yaml, and with the modelserver
+# `render-endpoints` component, which opts the prefill pods into vLLM's
+# scale-out endpoints so the /v1/*/render calls this Service forwards are
+# served.
 namePrefix: wide-ep-lws-
 
 resources:

--- a/guides/wide-ep-lws/render/service.yaml
+++ b/guides/wide-ep-lws/render/service.yaml
@@ -7,8 +7,10 @@ metadata:
 spec:
   # This Service owns no pods of its own: it fronts the prefill model server
   # pods deployed by ../modelserver/, so the EPP `token-producer` tokenizes
-  # prompts on the same vLLM pods that serve inference. `vllm serve` already
-  # exposes the /v1/*/render endpoints, so no model-server flag is needed.
+  # prompts on the same vLLM pods that serve inference. `vllm serve` exposes
+  # the /v1/*/render endpoints only with VLLM_ENABLE_SCALE_OUT_ENDPOINTS=1,
+  # which the modelserver `render-endpoints` component sets; without it every
+  # render call returns 404.
   #
   # Prefill pods are selected rather than decode because the decode pods'
   # port 8000 belongs to the routing-proxy sidecar, not vLLM. Only Ready


### PR DESCRIPTION
Fixes #2439.

The `wide-ep-lws` precise variant fronts the prefill pods with a Service that owns no pods of its own and forwards `/v1/*/render` for the EPP `token-producer`. vLLM serves those scale-out endpoints only when `VLLM_ENABLE_SCALE_OUT_ENDPOINTS=1` ([vllm-project/vllm#54579](https://github.com/vllm-project/vllm/pull/54579), merged 2026-09-02, after v0.28.0), and this guide deploys `vllm/vllm-openai:nightly`, so every render call returns 404.

The failure is silent: no request carries token IDs, the precise producer never runs and the index stays empty, but pods are `Ready`, the EPP holds all its KV-event subscriptions, and requests still return 200 from the remaining scorers. On a GLM-5.3 cell the same workload completed 2,269 requests with rendering broken against 2,853 with it working.

This sets the opt-in through a modelserver component applied by the precise overlay, on prefill only since that is what the render Service selects. Builds that predate the gate ignore the variable, so it is version-safe. The render manifests and the README no longer say that no model-server flag is needed, and the README's render verification step now says what a 404 there means.

`precise-prefix-cache-routing` uses the same podless Service pattern but pins a released image that predates the gate, so it is unaffected today and left alone.

### Verification

- `kubectl kustomize modelserver/gpu/vllm-glm-5.2/deployments/p2w1d1w1-precise` puts the variable on the prefill LeaderWorkerSet only, not on decode, which matches the Service selector.
- The 404 and a working render path were observed live on a GLM-5.3 wide-EP cell. The opt-in itself is from vLLM's route registration and renderer docs, not run, since that cell is torn down.

### Known follow-ups, not in this PR

- Tokenization runs only on prefill rank 0. Fronting decode as well needs a shared port name across roles, since decode's `8000` is the routing sidecar whose catch-all returns unknown paths to the gateway rather than the local engine.
- The `kv-events` component patches decode too, but the decode profile has no prefix producer, so those events only consume per-key LRU capacity and ingestion CPU.

Note that [vllm-project/vllm#55176](https://github.com/vllm-project/vllm/pull/55176) proposes replacing the variable with an `--enable-scale-out` flag, so this may need revisiting.
