### PR TITLE
fix: recognize RUN command environment variables

### DIFF
--- a/scripts/lint-dockerfile-envvars.py
+++ b/scripts/lint-dockerfile-envvars.py
@@ -99,8 +99,34 @@ class DockerfileParser:
         return self.stages[stage]['ARG'] | self.stages[stage]['ENV']
 
 
-def find_script_runs(dockerfile_content: str) -> List[Tuple[str, str, int]]:
-    """find all RUN commands that execute scripts, return (stage, script_path, line_num)"""
+_RUN_ASSIGNMENT = re.compile(r'([A-Z_][A-Z0-9_]*)=.*')
+
+
+def _run_environment(command_prefix: str) -> Set[str]:
+    """Return environment assignments immediately before a script command."""
+    # Only inspect the current shell command.  Assignments in an earlier
+    # command (for example, ``echo x=1 &&``) do not affect the script.
+    command = re.split(r'&&|\|\||;', command_prefix)[-1].strip()
+    tokens = command.split()
+
+    # Docker's RUN flags are not shell environment assignments.
+    while tokens and tokens[0].startswith('--'):
+        tokens.pop(0)
+    if tokens and tokens[0] == 'env':
+        tokens.pop(0)
+
+    assignments: Set[str] = set()
+    while tokens:
+        match = _RUN_ASSIGNMENT.fullmatch(tokens[0])
+        if not match:
+            break
+        assignments.add(match.group(1))
+        tokens.pop(0)
+    return assignments
+
+
+def find_script_runs(dockerfile_content: str) -> List[Tuple[str, str, int, Set[str]]]:
+    """Find RUN scripts and command-level environment assignments."""
     runs = []
     current_stage = None
     line_num = 0
@@ -120,11 +146,17 @@ def find_script_runs(dockerfile_content: str) -> List[Tuple[str, str, int]]:
         # find script executions
         if stripped.upper().startswith('RUN'):
             # match: RUN /path/to/script.sh or RUN chmod ... && /path/to/script.sh
-            script_matches = re.findall(r'(/[^\s]+\.sh)', stripped)
-            for script in script_matches:
+            command = stripped[3:].strip()
+            for match in re.finditer(r'(/[^\s]+\.sh)', command):
+                script = match.group(1)
                 # normalize path (remove /tmp/ prefix if present)
                 script_name = Path(script).name
-                runs.append((current_stage, script_name, line_num))
+                runs.append((
+                    current_stage,
+                    script_name,
+                    line_num,
+                    _run_environment(command[:match.start()]),
+                ))
 
     return runs
 
@@ -138,7 +170,7 @@ def lint_dockerfile(dockerfile_path: Path, scripts_dir: Path) -> Tuple[bool, Lis
 
     errors = []
 
-    for stage, script_name, line_num in script_runs:
+    for stage, script_name, line_num, run_env in script_runs:
         # find the script file
         script_path = None
         for candidate in scripts_dir.rglob(script_name):
@@ -154,7 +186,7 @@ def lint_dockerfile(dockerfile_path: Path, scripts_dir: Path) -> Tuple[bool, Lis
             continue  # no requirements declared
 
         # get available vars in this stage
-        available_vars = parser.get_available_vars(stage)
+        available_vars = parser.get_available_vars(stage) | run_env
 
         # check for missing vars
         missing = required_vars - available_vars

--- a/scripts/tests/test_lint_dockerfile_run_env.py
+++ b/scripts/tests/test_lint_dockerfile_run_env.py
@@ -1,0 +1,30 @@
+"""Regression tests for Dockerfile RUN environment tracking."""
+
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).parents[1] / "lint-dockerfile-envvars.py"
+SPEC = importlib.util.spec_from_file_location("lint_dockerfile_envvars", MODULE_PATH)
+assert SPEC and SPEC.loader
+lint = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(lint)
+
+
+def test_run_command_environment_satisfies_script_requirement(tmp_path):
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "check.sh").write_text(
+        "#!/bin/sh\n"
+        "# Required environment variables:\n"
+        "# - UCCL_DEVICE: selected build device\n"
+    )
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        "FROM ubuntu:22.04 AS build\n"
+        "RUN UCCL_DEVICE=rocm /tmp/check.sh\n"
+    )
+
+    ok, errors = lint.lint_dockerfile(dockerfile, scripts_dir)
+
+    assert ok, errors


### PR DESCRIPTION
A Dockerfile command such as `RUN UCCL_DEVICE=rocm /tmp/build.sh` supplies the variable to the script, but the environment linter only checks stage ARG/ENV declarations and incorrectly reports it missing. Include environment assignments from the current RUN command when validating script requirements. Assignments remain local to that invocation.

Validation: `python -m pytest -q scripts/tests`: 29 passed.
Changed-file pre-commit checks passed.
