### PR TITLE
fix: inherit variables between Dockerfile stages

### DIFF
--- a/scripts/lint-dockerfile-envvars.py
+++ b/scripts/lint-dockerfile-envvars.py
@@ -64,14 +64,25 @@ class DockerfileParser:
 
             # detect new build stage
             if line.upper().startswith('FROM'):
-                match = re.match(r'FROM\s+.*?\s+AS\s+(\w+)', line, re.IGNORECASE)
+                match = re.match(
+                    r'FROM\s+(?:(?:--\S+)\s+)*(?P<base>\S+)'
+                    r'(?:\s+AS\s+(?P<stage>\w+))?',
+                    line,
+                    re.IGNORECASE,
+                )
                 if match:
-                    self.current_stage = match.group(1)
+                    base_stage = match.group('base')
+                    self.current_stage = match.group('stage') or 'default'
                 else:
+                    base_stage = None
                     self.current_stage = 'default'
 
                 if self.current_stage not in self.stages:
-                    self.stages[self.current_stage] = {'ARG': set(), 'ENV': set()}
+                    inherited = self.stages.get(base_stage, {}) if base_stage else {}
+                    self.stages[self.current_stage] = {
+                        'ARG': set(inherited.get('ARG', set())),
+                        'ENV': set(inherited.get('ENV', set())),
+                    }
 
             # track ARG declarations
             elif line.upper().startswith('ARG'):

--- a/scripts/tests/test_lint_dockerfile_envvars.py
+++ b/scripts/tests/test_lint_dockerfile_envvars.py
@@ -1,0 +1,34 @@
+"""Regression tests for Dockerfile stage variable tracking."""
+
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).parents[1] / "lint-dockerfile-envvars.py"
+SPEC = importlib.util.spec_from_file_location("lint_dockerfile_envvars", MODULE_PATH)
+assert SPEC and SPEC.loader
+lint = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(lint)
+
+
+def test_child_stage_inherits_base_arg_and_env(tmp_path):
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "check.sh").write_text(
+        "#!/bin/sh\n"
+        "# Required environment variables:\n"
+        "# - INHERITED_ARG: declared by the base stage\n"
+        "# - INHERITED_ENV: declared by the base stage\n"
+    )
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        "FROM ubuntu:22.04 AS base\n"
+        "ARG INHERITED_ARG=value\n"
+        "ENV INHERITED_ENV=value\n"
+        "FROM base AS build\n"
+        "RUN /tmp/check.sh\n"
+    )
+
+    ok, errors = lint.lint_dockerfile(dockerfile, scripts_dir)
+
+    assert ok, errors


### PR DESCRIPTION
When a Dockerfile uses `FROM base AS build`, ARG and ENV variables declared in `base` are available in `build`. The linter currently starts the child stage with empty variable sets and reports inherited script requirements as missing. Copy the base-stage declarations into the child stage and add a regression for both ARG and ENV inheritance.

Validation: `python -m pytest -q scripts/tests`: 29 passed.
Changed-file pre-commit checks passed.
