### PR TITLE
fix: patch GLM no-MTP environment variable

### DIFF
--- a/guides/wide-ep-lws/modelserver/gpu/vllm-glm-5.2/components/no-mtp/kustomization.yaml
+++ b/guides/wide-ep-lws/modelserver/gpu/vllm-glm-5.2/components/no-mtp/kustomization.yaml
@@ -5,7 +5,7 @@ patches:
       kind: LeaderWorkerSet
     patch: |-
       - op: replace
-        path: /spec/leaderWorkerTemplate/workerTemplate/spec/containers/0/env/5
+        path: /spec/leaderWorkerTemplate/workerTemplate/spec/containers/0/env/6
         value:
           name: ENABLE_MTP
           value: "0"

--- a/guides/wide-ep-lws/modelserver/gpu/vllm-glm-5.2/components/no-mtp/test-no-mtp.sh
+++ b/guides/wide-ep-lws/modelserver/gpu/vllm-glm-5.2/components/no-mtp/test-no-mtp.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+OVERLAY="${REPO_ROOT}/guides/wide-ep-lws/modelserver/gpu/vllm-glm-5.2/deployments/benchmark/baseline/p1w1d1w1"
+MANIFEST="$(mktemp)"
+trap 'rm -f "${MANIFEST}"' EXIT
+
+kustomize build "${OVERLAY}" >"${MANIFEST}"
+
+# The no-mtp component must modify ENABLE_MTP in place.  A duplicate env name
+# is rejected by the LeaderWorkerSet CRD during server-side validation.
+yq -o=json '.' "${MANIFEST}" | jq -s -e '
+  [ .[]
+    | select(.kind == "LeaderWorkerSet")
+    | .spec.leaderWorkerTemplate.workerTemplate.spec.containers[0].env
+    | map(select(.name == "ENABLE_MTP"))
+    | select(length != 1 or .[0].value != "0")
+  ] | length == 0
+' >/dev/null


### PR DESCRIPTION
The no-MTP JSON patch replaces env entry 5, which is no longer `ENABLE_MTP`. This overwrites another variable and leaves duplicate ENABLE_MTP entries instead of disabling MTP. Target the current ENABLE_MTP entry at index 6 and add a regression that renders the benchmark overlay and verifies exactly one disabled ENABLE_MTP value per LeaderWorkerSet.

Validation: `bash guides/wide-ep-lws/modelserver/gpu/vllm-glm-5.2/components/no-mtp/test-no-mtp.sh`: passed.
Changed-file pre-commit checks passed.
