### PR TITLE
fix: handle malformed metrics summaries

### DIFF
--- a/.github/scripts/nightly-e2e-verification/test_verify_helpers.py
+++ b/.github/scripts/nightly-e2e-verification/test_verify_helpers.py
@@ -274,6 +274,44 @@ class TestMetricsSummary(unittest.TestCase):
             (p / "metrics_summary.json").write_text("not-json{")
             self.assertIsNone(v.MetricsSummary.load(Path(td)))
 
+    def test_load_non_object_json(self):
+        with TemporaryDirectory() as td, patch("sys.stderr", io.StringIO()) as stderr:
+            p = Path(td) / "metrics" / "processed"
+            p.mkdir(parents=True)
+            (p / "metrics_summary.json").write_text("[]")
+            self.assertIsNone(v.MetricsSummary.load(Path(td)))
+            self.assertIn("JSON object", stderr.getvalue())
+
+    def test_load_invalid_aggregated_schema(self):
+        with TemporaryDirectory() as td, patch("sys.stderr", io.StringIO()) as stderr:
+            p = Path(td) / "metrics" / "processed"
+            p.mkdir(parents=True)
+            (p / "metrics_summary.json").write_text(
+                json.dumps({"_aggregated": []})
+            )
+            self.assertIsNone(v.MetricsSummary.load(Path(td)))
+            self.assertIn("_aggregated", stderr.getvalue())
+
+    def test_load_invalid_metric_stats_schema(self):
+        with TemporaryDirectory() as td, patch("sys.stderr", io.StringIO()) as stderr:
+            p = Path(td) / "metrics" / "processed"
+            p.mkdir(parents=True)
+            (p / "metrics_summary.json").write_text(json.dumps({
+                "_aggregated": {"metrics": {"m1": []}},
+            }))
+            self.assertIsNone(v.MetricsSummary.load(Path(td)))
+            self.assertIn("metric statistics", stderr.getvalue())
+
+    def test_load_invalid_pod_metrics_schema(self):
+        with TemporaryDirectory() as td, patch("sys.stderr", io.StringIO()) as stderr:
+            p = Path(td) / "metrics" / "processed"
+            p.mkdir(parents=True)
+            (p / "metrics_summary.json").write_text(json.dumps({
+                "pod-a": {"metrics": []},
+            }))
+            self.assertIsNone(v.MetricsSummary.load(Path(td)))
+            self.assertIn("pod-a", stderr.getvalue())
+
     def test_load_happy(self):
         with TemporaryDirectory() as td:
             p = Path(td) / "metrics" / "processed"
@@ -316,6 +354,14 @@ class TestCheckAggregated(unittest.TestCase):
         self.assertFalse(c.passed)
         self.assertIn("missing", c.detail)
 
+    def test_invalid_value_returns_failure(self):
+        ms = v.MetricsSummary({
+            "_aggregated": {"metrics": {"m1": {"p99": "not-a-number"}}},
+        })
+        c = ms.check_aggregated("m1", "p99", "<=", 2.0)
+        self.assertFalse(c.passed)
+        self.assertIn("not numeric", c.detail)
+
 
 class TestCheckPerPod(unittest.TestCase):
     def _ms(self):
@@ -348,6 +394,14 @@ class TestCheckPerPod(unittest.TestCase):
     def test_name_includes_reducer(self):
         c = self._ms().check_per_pod("m1", "max", ">", 0.0)
         self.assertIn("max", c.name)
+
+    def test_invalid_value_returns_failure(self):
+        ms = v.MetricsSummary({
+            "pod-a": {"metrics": {"m1": {"max": "not-a-number"}}},
+        })
+        c = ms.check_per_pod("m1", "max", ">", 0.0)
+        self.assertFalse(c.passed)
+        self.assertIn("not numeric", c.detail)
 
 
 class TestPrintChecksTable(unittest.TestCase):

--- a/.github/scripts/nightly-e2e-verification/verify_helpers.py
+++ b/.github/scripts/nightly-e2e-verification/verify_helpers.py
@@ -8,6 +8,7 @@ Aggregates produced by llm-d-benchmark's process_metrics.py _compute_stats:
 from __future__ import annotations
 
 import json
+import math
 import os
 import re
 import sys
@@ -174,10 +175,42 @@ class MetricsSummary:
             except json.JSONDecodeError as e:
                 error(f"{path} is not valid JSON: {e}")
                 return None
+
+        if not isinstance(raw, dict):
+            error(f"{path} must contain a JSON object")
+            return None
+
         info = raw.get("_info", {})
+        if not isinstance(info, dict):
+            error(f"{path} has an invalid _info object")
+            return None
         if info.get("status") == "no_data":
             error(f"metrics_summary.json has no data: {info.get('message')}")
             return None
+
+        aggregated = raw.get("_aggregated", {})
+        if not isinstance(aggregated, dict):
+            error(f"{path} has an invalid _aggregated object")
+            return None
+        metrics = aggregated.get("metrics", {})
+        if not isinstance(metrics, dict):
+            error(f"{path} has an invalid _aggregated.metrics object")
+            return None
+        if any(not isinstance(stats, dict) for stats in metrics.values()):
+            error(f"{path} has invalid metric statistics in _aggregated.metrics")
+            return None
+
+        for pod, data in raw.items():
+            if pod.startswith("_") or not isinstance(data, dict):
+                continue
+            pod_metrics = data.get("metrics", {})
+            if not isinstance(pod_metrics, dict):
+                error(f"{path} has invalid metrics for pod {pod!r}")
+                return None
+            if any(not isinstance(stats, dict) for stats in pod_metrics.values()):
+                error(f"{path} has invalid metric statistics for pod {pod!r}")
+                return None
+
         return cls(raw)
 
     @property
@@ -187,6 +220,15 @@ class MetricsSummary:
     @property
     def metric_count(self) -> int:
         return len(self.aggregated)
+
+    @staticmethod
+    def _coerce_metric_value(value: object) -> float | None:
+        """Return a finite metric value, or None for malformed data."""
+        try:
+            value = float(value)
+        except (TypeError, ValueError, OverflowError):
+            return None
+        return value if math.isfinite(value) else None
 
     # -- Check factories ----------------------------------------------------
 
@@ -208,7 +250,10 @@ class MetricsSummary:
         if actual is None:
             return Check(f"{metric}.{aggregate}", False,
                          detail=f"aggregate '{aggregate}' missing in data.")
-        actual = float(actual)
+        actual = self._coerce_metric_value(actual)
+        if actual is None:
+            return Check(f"{metric}.{aggregate}", False,
+                         detail=f"aggregate '{aggregate}' is not numeric")
         passed = OPS[op](actual, float(bound))
         return Check(
             name=f"{metric}.{aggregate}",
@@ -251,7 +296,11 @@ class MetricsSummary:
             v = stats.get(aggregate)
             if v is None:
                 continue
-            values.append(float(v))
+            value = self._coerce_metric_value(v)
+            if value is None:
+                return Check(name, False,
+                             detail=f"aggregate '{aggregate}' is not numeric")
+            values.append(value)
 
         if not values:
             return Check(name, False,


### PR DESCRIPTION
Nightly verification can crash when a metrics summary contains valid JSON with an unexpected object shape or a nonnumeric metric value. Validate the summary containers before using them and report a failed check for nonnumeric or nonfinite values. Regression tests cover malformed summary objects and aggregated/per-pod metric values.

Validation: `python -m pytest -q .github/scripts/nightly-e2e-verification/test_verify_helpers.py`: 57 passed.
Changed-file pre-commit checks passed.
