### PR TITLE
fix: select highest NIXL wheel version

### DIFF
--- a/docker/scripts/cpu/install_nixl.py
+++ b/docker/scripts/cpu/install_nixl.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import argparse
 import glob
+from packaging.utils import InvalidWheelFilename, parse_wheel_filename
 
 # --- Configuration ---
 WHEELS_CACHE_HOME = os.environ.get("WHEELS_CACHE_HOME", "/workspace/wheels_cache")
@@ -34,12 +35,15 @@ def find_nixl_wheel_in_cache(cache_dir):
     """Finds a nixl wheel file in the specified cache directory."""
     # The repaired wheel will have a 'manylinux' tag, but this glob still works.
     search_pattern = os.path.join(cache_dir, "nixl*.whl")
-    wheels = glob.glob(search_pattern)
-    if wheels:
-        # Sort to get the most recent/highest version if multiple exist
-        wheels.sort()
-        return wheels[-1]
-    return None
+    wheels = []
+    for wheel in glob.glob(search_pattern):
+        try:
+            name, version, _, _ = parse_wheel_filename(os.path.basename(wheel))
+        except InvalidWheelFilename:
+            continue
+        if name == "nixl":
+            wheels.append((version, wheel))
+    return max(wheels)[1] if wheels else None
 
 
 def install_system_dependencies():

--- a/docker/scripts/cpu/test_install_nixl.py
+++ b/docker/scripts/cpu/test_install_nixl.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+import install_nixl
+import pytest
+
+
+def test_find_nixl_wheel_uses_version_order(tmp_path: Path) -> None:
+    for name in (
+        "nixl-0.9.0-cp312-cp312-linux_x86_64.whl",
+        "nixl-0.10.0-cp312-cp312-linux_x86_64.whl",
+        "nixl-0.6.1-cp312-cp312-linux_x86_64.whl",
+    ):
+        (tmp_path / name).touch()
+
+    selected = install_nixl.find_nixl_wheel_in_cache(str(tmp_path))
+
+    assert Path(selected).name == "nixl-0.10.0-cp312-cp312-linux_x86_64.whl"
+
+
+@pytest.mark.parametrize(
+    ("versions", "expected"),
+    [
+        (("0.10.0rc1", "0.10.0"), "0.10.0"),
+        (("0.9.0", "0.10.0.dev1"), "0.10.0.dev1"),
+        (("0.10.0", "0.10.0.post1"), "0.10.0.post1"),
+    ],
+)
+def test_find_nixl_wheel_uses_pep440_order(tmp_path, versions, expected):
+    for version in versions:
+        (tmp_path / f"nixl-{version}-cp312-cp312-linux_x86_64.whl").touch()
+
+    selected = install_nixl.find_nixl_wheel_in_cache(str(tmp_path))
+
+    assert Path(selected).name == f"nixl-{expected}-cp312-cp312-linux_x86_64.whl"
+
+
+def test_find_nixl_wheel_ignores_unrelated_or_invalid_wheels(tmp_path):
+    for name in ("nixl-invalid.whl", "nixl_extra-99.0-py3-none-any.whl"):
+        (tmp_path / name).touch()
+
+    assert install_nixl.find_nixl_wheel_in_cache(str(tmp_path)) is None


### PR DESCRIPTION
The CPU installer sorts cached wheel filenames lexicographically, so `nixl-0.9.0` can win over `nixl-0.10.0`. Parse wheel metadata and compare PEP 440 versions using packaging, which is already installed by the CPU vLLM build requirements before this script runs. Ignore malformed wheel names and other distributions sharing the nixl prefix.

Validation: `python -m pytest -q docker/scripts/cpu/test_install_nixl.py`: 5 passed, covering numeric versions, prerelease/final/dev/postrelease ordering, and unrelated or invalid wheels.
Changed-file pre-commit checks passed.
