### PR TITLE
fix(autoscaling): plot reconstructed desired replicas

### DIFF
--- a/guides/workload-autoscaling/slo-aware/benchmark-templates/plot_run.py
+++ b/guides/workload-autoscaling/slo-aware/benchmark-templates/plot_run.py
@@ -176,6 +176,8 @@ def main():
 
     ax[3].plot(mins(n_s), vals(n_s), color=BLUE, lw=2, drawstyle="steps-post", label="provisioned")
     ax[3].plot(mins(r_s), vals(r_s), color=AQUA, lw=2, ls=":", drawstyle="steps-post", label="ready")
+    ax[3].plot([(t - t0) / 60 for t in ts_d], desired, color=AMBER, lw=1.5,
+               ls="--", drawstyle="steps-post", label="formula desired")
     ax[3].set_ylabel("replicas")
     ax[3].set_ylim(NMIN - 0.5, NMAX + 0.5)
     ax[3].legend(loc="upper left", frameon=False, ncol=2)


### PR DESCRIPTION
The scored-run plotting script computes desired replicas from the control formula, but the replicas panel only draws provisioned and ready counts. Plot the reconstructed desired series using its aligned timestamps so the panel matches the documented actual/ready/desired view.

Validation: Ran main() with mocked Prometheus data, verified desired values and minute offsets on the plotted line, and confirmed both PNG outputs were generated.
Changed-file pre-commit checks passed.
