### PR TITLE
fix: normalize abbreviated vLLM versions

### DIFF
--- a/.github/scripts/nightly-e2e-verification/test_verify_helpers.py
+++ b/.github/scripts/nightly-e2e-verification/test_verify_helpers.py
@@ -199,6 +199,12 @@ class TestGetVllmVersion(unittest.TestCase):
         self.assertEqual(v.get_vllm_version("ns", "pod"), (0, 24, 0))
 
     @patch("verify_helpers.kubectl")
+    def test_normalizes_abbreviated_rc_version(self, mock_kubectl):
+        # vLLM may omit the patch component when reporting a release candidate.
+        mock_kubectl.return_value = "0.24rc1"
+        self.assertEqual(v.get_vllm_version("ns", "pod"), (0, 24, 0))
+
+    @patch("verify_helpers.kubectl")
     def test_stops_at_non_digit_segment(self, mock_kubectl):
         # First non-digit-led segment stops the parse entirely.
         mock_kubectl.return_value = "0.24.dev0"

--- a/.github/scripts/nightly-e2e-verification/verify_helpers.py
+++ b/.github/scripts/nightly-e2e-verification/verify_helpers.py
@@ -124,12 +124,19 @@ def get_vllm_version(namespace: str, pod: str) -> tuple[int, ...] | None:
     ).strip()
     if not out:
         return None
+    segments = out.split(".")
     parts: list[int] = []
-    for seg in out.split("."):
+    for seg in segments:
         m = re.match(r"\d+", seg)
         if not m:
             break
         parts.append(int(m.group()))
+    # PEP 440 permits omitting a trailing zero, e.g. ``0.24rc1``.  Keep the
+    # tuple shape stable for callers that compare it with ``(major, minor,
+    # patch)``.  A dotted pre-release such as ``0.24.dev0`` deliberately keeps
+    # its two-part tuple so it remains below the corresponding final release.
+    if len(parts) == 2 and len(segments) == 2:
+        parts.append(0)
     return tuple(parts) if parts else None
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
An abbreviated release such as `0.24rc1` becomes `(0, 24)`, which compares below the `(0, 24, 0)` metric-version threshold, while `0.24.0rc1` selects the new metric family. Normalize two-component release strings with a trailing zero and preserve the existing dotted development-version handling.

Validation: `python -m pytest -q .github/scripts/nightly-e2e-verification/test_verify_helpers.py`: 52 passed.
Changed-file pre-commit checks passed.
