### PR TITLE
feat(guides): add Kueue-based replica rebalancing to workload-autoscaling

### DIFF
--- a/.github/scripts/install-kueue-crds.sh
+++ b/.github/scripts/install-kueue-crds.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Install Kueue CRDs for CI validation of the Kueue-based rebalancing guide.
+#
+# On real clusters Kueue is installed as an operator (or via its Helm chart).
+# This script installs only the CRDs so kubectl dry-run can validate
+# ResourceFlavor, ClusterQueue and LocalQueue resources without deploying the
+# controller and its webhooks.
+#
+# Kueue publishes no CRD-only release asset, so the CRDs are rendered from the
+# chart's own templates with --show-only.
+
+set -euo pipefail
+
+KUEUE_VERSION=${KUEUE_VERSION:-"0.19.1"}
+KUEUE_CHART=${KUEUE_CHART:-"oci://registry.k8s.io/kueue/charts/kueue"}
+
+# Only the kinds the guide's overlays declare, plus Workload, which is what the
+# guide's verification commands read.
+CRDS=(
+  clusterqueues
+  localqueues
+  resourceflavors
+  workloads
+)
+
+show_only=()
+for crd in "${CRDS[@]}"; do
+  show_only+=(-s "templates/crd/kueue.x-k8s.io_${crd}.yaml")
+done
+
+echo "Installing Kueue CRDs (v${KUEUE_VERSION})..."
+helm template kueue "${KUEUE_CHART}" \
+  --version "${KUEUE_VERSION}" \
+  -n kueue-system \
+  "${show_only[@]}" \
+  | kubectl apply --server-side -f -
+
+echo "Kueue CRDs installed."

--- a/.github/workflows/ci-kustomize-dry-run.yaml
+++ b/.github/workflows/ci-kustomize-dry-run.yaml
@@ -54,6 +54,9 @@ jobs:
       - name: Install KEDA CRDs
         run: .github/scripts/install-keda-crds.sh
 
+      - name: Install Kueue CRDs
+        run: .github/scripts/install-kueue-crds.sh
+
       - name: Install Envoy Gateway CRDs
         run: .github/scripts/install-envoy-gateway-crds.sh
 

--- a/guides/workload-autoscaling/README.md
+++ b/guides/workload-autoscaling/README.md
@@ -109,3 +109,15 @@ annotated HPAs when multiple models share a GPU budget. Integration with
 KEDA-generated HPAs requires annotation-propagation support and is not covered
 by the KEDA+EPP guide. The feature is a proof of concept and is not
 production-ready; use it only in test or development environments.
+
+### Kueue-Based Replica Rebalancing (Experimental)
+
+The [Kueue-Based Replica Rebalancing guide](./kueue-rebalancing/README.md)
+enforces the same shared GPU budget with [Kueue](https://kueue.sigs.k8s.io/)
+instead of a control loop over HPAs. Each model gets a `ClusterQueue` with a
+guaranteed GPU floor in a shared cohort, and replica pods are admitted only when
+quota is free — so an idle model's GPUs are lent to a busy one and reclaimed by
+preemption. Enforcement happens below the HPA, so KEDA-generated HPAs work
+unmodified, but over-budget demand shows up as `Pending` pods rather than a
+lowered `maxReplicas`. Do not run this alongside the experimental replica
+rebalancer.

--- a/guides/workload-autoscaling/kueue-rebalancing/README.md
+++ b/guides/workload-autoscaling/kueue-rebalancing/README.md
@@ -33,23 +33,6 @@ when demand returns.
          admitted pods → scheduled    over-budget pods → gated (Pending)
 ```
 
-## How It Compares to the Replica Rebalancer
-
-| | Replica rebalancer | Kueue |
-|---|---|---|
-| Where the budget is enforced | above the HPA, by patching `maxReplicas` | below the HPA, by gating pods |
-| GPU budget defined as | `ResourceQuota` `requests.nvidia.com/gpu` | `ClusterQueue` `nominalQuota`, shared through a cohort |
-| Reaction time | the `COORDINATOR_INTERVAL` loop (default 15s) | event-driven, on pod creation and deletion |
-| Opt-in | `llm-d.ai/epp-inference-pool` annotation on the HPA | `kueue.x-k8s.io/queue-name` label on the Deployment |
-| GPUs per replica | computed by the controller | read from the pod's `resources.requests` |
-| KEDA-generated HPAs | needs annotation propagation, not covered | works unchanged — Kueue never reads the HPA |
-| Reclaiming lent capacity | not supported | `preemption.reclaimWithinCohort: Any` |
-| Over-budget demand | never created, because the ceiling drops | created and queued as gated pods |
-| Extra components | WVA controller with the coordinator enabled | Kueue |
-
-Both keep total GPU usage inside the budget. They must not run at the same time:
-each would react to the capacity the other freed.
-
 ## Prerequisites
 
 1. Multiple inference pools in one namespace, from the

--- a/guides/workload-autoscaling/kueue-rebalancing/README.md
+++ b/guides/workload-autoscaling/kueue-rebalancing/README.md
@@ -1,0 +1,358 @@
+# Kueue-Based Replica Rebalancing
+
+When several model deployments share one GPU budget, their HPAs scale
+independently and none of them knows what the others are consuming. Two models
+scaling up at the same time collectively ask for more GPUs than the budget
+holds.
+
+The [experimental replica rebalancer](../replica-rebalancing/README.md) solves
+this *above* the HPA: a control loop reads a `ResourceQuota` and patches
+`spec.maxReplicas` on annotated HPAs so the ceilings always sum to the budget.
+
+This guide solves it *below* the HPA with [Kueue](https://kueue.sigs.k8s.io/).
+With the `deployment` integration, every replica pod becomes its own Kueue
+`Workload`, and Kueue holds a pod at a scheduling gate until GPU quota is free
+for it. The HPA is never touched, so it needs no annotation and KEDA keeps sole
+ownership of the HPA it generates. Each model gets a guaranteed floor of GPUs,
+lends what it is not using to the others, and preempts to take its floor back
+when demand returns.
+
+```text
+      KEDA ScaledObject            KEDA ScaledObject
+              │                            │
+        HPA (model-a)                HPA (model-b)     ← untouched, unannotated
+              │  replicas                  │  replicas
+      Deployment model-a           Deployment model-b
+              │  pods                      │  pods
+      ┌───────┴───────────────────────────-┴───────┐
+      │            Kueue admission                 │
+      │  model-a-lq ─→ model-a-cq   floor 5 GPU    │
+      │  model-b-lq ─→ model-b-cq   floor 5 GPU    │
+      │            cohort llm-d-gpu (10 GPU)       │
+      └────────────────────────────────────────────┘
+         admitted pods → scheduled    over-budget pods → gated (Pending)
+```
+
+## How It Compares to the Replica Rebalancer
+
+| | Replica rebalancer | Kueue |
+|---|---|---|
+| Where the budget is enforced | above the HPA, by patching `maxReplicas` | below the HPA, by gating pods |
+| GPU budget defined as | `ResourceQuota` `requests.nvidia.com/gpu` | `ClusterQueue` `nominalQuota`, shared through a cohort |
+| Reaction time | the `COORDINATOR_INTERVAL` loop (default 15s) | event-driven, on pod creation and deletion |
+| Opt-in | `llm-d.ai/epp-inference-pool` annotation on the HPA | `kueue.x-k8s.io/queue-name` label on the Deployment |
+| GPUs per replica | computed by the controller | read from the pod's `resources.requests` |
+| KEDA-generated HPAs | needs annotation propagation, not covered | works unchanged — Kueue never reads the HPA |
+| Reclaiming lent capacity | not supported | `preemption.reclaimWithinCohort: Any` |
+| Over-budget demand | never created, because the ceiling drops | created and queued as gated pods |
+| Extra components | WVA controller with the coordinator enabled | Kueue |
+
+Both keep total GPU usage inside the budget. They must not run at the same time:
+each would react to the capacity the other freed.
+
+## Prerequisites
+
+1. Multiple inference pools in one namespace, from the
+   [Multi-Inference Pool Setup guide](../multi-inference-pool/README.md).
+2. An autoscaler per pool — either
+   [KEDA + EPP Metrics](../keda-epp-queue/README.md) or
+   [KEDA + WVA Metrics](../wva/README.md). Nothing in this guide changes that
+   configuration.
+3. The [experimental replica rebalancer](../replica-rebalancing/README.md) is
+   uninstalled. It enforces the same GPU budget from the other side of the
+   HPA, so the two must never run together. This guide assumes it is absent,
+   along with the hard `requests.nvidia.com/gpu` `ResourceQuota` it reads — a
+   gated pod still counts against a `ResourceQuota`, so one left in place would
+   stop the ReplicaSet from creating the very pod Kueue is meant to queue.
+4. Every model pod declares explicit GPU requests and limits. This is what Kueue
+   accounts against quota, so a pod without them is admitted for free:
+
+   ```yaml
+   resources:
+     requests:
+       nvidia.com/gpu: "1"
+     limits:
+       nvidia.com/gpu: "1"
+   ```
+
+5. `jq`, for the verification commands.
+
+Set the guide environment variables:
+
+<!-- guide:env.static start -->
+```bash
+export BRANCH=main
+export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
+export NAMESPACE=llm-d-optimized-baseline
+export KUEUE_NAMESPACE=kueue-system
+export KUEUE_VERSION=0.19.1
+export DEPLOYMENT_A=optimized-baseline-nvidia-gpu-vllm-decode
+export DEPLOYMENT_B=model-b-nvidia-gpu-vllm-decode
+export QUEUE_A=model-a-lq
+export QUEUE_B=model-b-lq
+export QUOTA_ROOT=${REPO_ROOT}/guides/workload-autoscaling/kueue-rebalancing/optimized-baseline
+```
+<!-- guide:env.static end -->
+
+Source the common guide environment variables:
+
+<!-- guide:env.source start -->
+```bash
+source ${REPO_ROOT}/guides/env.sh
+```
+<!-- guide:env.source end -->
+
+## Step 1: Install Kueue
+
+<!-- guide:prerequisites.kueue start -->
+```bash
+helm install kueue oci://registry.k8s.io/kueue/charts/kueue \
+  --version ${KUEUE_VERSION} \
+  -n ${KUEUE_NAMESPACE} --create-namespace --wait
+```
+<!-- guide:prerequisites.kueue end -->
+
+> [!NOTE]
+> On OpenShift, Kueue is also available as the Red Hat build of Kueue operator.
+> Install it instead of the upstream chart; the quota objects in this guide are
+> the same either way.
+
+Confirm the controller is running and that the `pod` and `deployment`
+integrations are enabled — they are on by default in 0.19.x, and without them
+the queue-name label is inert and no pod is ever gated:
+
+<!-- guide:prerequisites.integrations start -->
+```bash
+kubectl wait --for=condition=Available -n ${KUEUE_NAMESPACE} \
+  deploy/kueue-controller-manager --timeout=180s
+kubectl get cm kueue-manager-config -n ${KUEUE_NAMESPACE} \
+  -o jsonpath='{.data.controller_manager_config\.yaml}' \
+  | grep -A 20 'integrations:'
+```
+<!-- guide:prerequisites.integrations end -->
+
+## Step 2: Define the GPU Budget
+
+Five objects across three files, in
+[`kueue-rebalancing/optimized-baseline/base`](optimized-baseline/base/):
+
+| File | Object | Role |
+|---|---|---|
+| [`resourceflavor.yaml`](optimized-baseline/base/resourceflavor.yaml) | `ResourceFlavor` | the accelerator pool being rationed. One empty flavor for homogeneous nodes; one per GPU type, with `nodeLabels`, otherwise |
+| [`clusterqueues.yaml`](optimized-baseline/base/clusterqueues.yaml) | `ClusterQueue` ×2 | one per model. `nominalQuota` is that model's guaranteed floor; a shared `cohortName` makes the floors lendable |
+| [`localqueues.yaml`](optimized-baseline/base/localqueues.yaml) | `LocalQueue` ×2 | the namespaced handle each Deployment points at. A pod can only name a LocalQueue, never a ClusterQueue |
+
+The defaults describe 10 GPUs split into two floors of 5, replacing a
+`requests.nvidia.com/gpu: "10"` ResourceQuota. Before applying, set each
+`nominalQuota` to your own GPU count:
+
+```bash
+kubectl describe nodes | grep nvidia.com/gpu
+```
+
+Floors should sum to the physical GPU count. Kueue accounting is nominal — quota
+larger than the cluster admits pods the scheduler cannot place, which then sit
+`Pending` as unschedulable instead of gated. Summing to less than capacity
+simply leaves GPUs unused.
+
+Apply them:
+
+<!-- guide:deploy.quota start -->
+```bash
+kubectl apply -k ${QUOTA_ROOT}/base
+```
+<!-- guide:deploy.quota end -->
+
+## Step 3: Opt Each Deployment In
+
+One label per Deployment, replacing the rebalancer's HPA annotation:
+
+<!-- guide:deploy.optin start -->
+```bash
+for pair in "${DEPLOYMENT_A}:${QUEUE_A}" "${DEPLOYMENT_B}:${QUEUE_B}"; do
+  deployment=${pair%%:*}; queue=${pair##*:}
+  kubectl patch deployment "${deployment}" -n ${NAMESPACE} --type=merge -p \
+    "{\"metadata\":{\"labels\":{\"kueue.x-k8s.io/queue-name\":\"${queue}\"}},\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"kueue.x-k8s.io/queue-name\":\"${queue}\"}}}}}"
+done
+```
+<!-- guide:deploy.optin end -->
+
+The label on the Deployment is Kueue's documented opt-in surface, and its
+webhook copies the label to the pod template; the patch sets it on the template
+too, so the opt-in is explicit in the object rather than a webhook side effect.
+Every replica the HPA creates inherits it and becomes its own Workload.
+Deployments without the label are untouched by Kueue.
+
+To make the opt-in part of the model server's own Kustomize overlay rather than
+a live patch, add it there instead:
+
+```yaml
+labels:
+  - pairs:
+      kueue.x-k8s.io/queue-name: model-a-lq
+    includeSelectors: false   # the pod selector must not change
+    includeTemplates: true    # every replica pod needs the label
+```
+
+Finally, roll out with no surge. At full quota a surge pod has no GPU to claim,
+so it is gated and the rollout waits behind it:
+
+<!-- guide:deploy.rollout_strategy start -->
+```bash
+for deployment in ${DEPLOYMENT_A} ${DEPLOYMENT_B}; do
+  kubectl patch deployment "${deployment}" -n ${NAMESPACE} --type=merge \
+    -p '{"spec":{"strategy":{"rollingUpdate":{"maxSurge":0,"maxUnavailable":1}}}}'
+done
+```
+<!-- guide:deploy.rollout_strategy end -->
+
+## Step 4: Verify
+
+`ClusterQueue` status is the whole picture — admitted GPUs per model, how many
+of them are borrowed from the cohort, and how many workloads are waiting:
+
+<!-- guide:verify.tests.queues start -->
+```bash
+kubectl get clusterqueues -o wide
+kubectl get localqueues -n ${NAMESPACE}
+```
+<!-- guide:verify.tests.queues end -->
+
+There is one Workload per replica pod. Pods beyond the budget stay `Pending`
+behind a scheduling gate instead of being scheduled onto GPUs that do not
+exist:
+
+<!-- guide:verify.tests.workloads start -->
+```bash
+kubectl get workloads -n ${NAMESPACE}
+kubectl get pods -n ${NAMESPACE} \
+  -l kueue.x-k8s.io/queue-name --show-labels
+kubectl get pods -n ${NAMESPACE} -o json \
+  | jq -r '.items[] | select((.spec.schedulingGates // []) | length > 0)
+           | "gated: \(.metadata.name) \([.spec.schedulingGates[].name] | join(","))"'
+```
+<!-- guide:verify.tests.workloads end -->
+
+A gated pod explains itself through its Workload — which queue it is in, and
+which resource the cohort could not satisfy:
+
+<!-- guide:verify.tests.gated start -->
+```bash
+for w in $(kubectl get workloads -n ${NAMESPACE} -o json \
+  | jq -r '.items[] | select((.status.conditions // [])
+           | any(.type=="QuotaReserved" and .status!="True")) | .metadata.name'); do
+  kubectl get workload "$w" -n ${NAMESPACE} -o json \
+    | jq -r '"workload: \(.metadata.name)  queue: \(.spec.queueName)",
+             (.status.conditions[]? | "  \(.type)=\(.status) reason=\(.reason)\n    \(.message)")'
+done
+```
+<!-- guide:verify.tests.gated end -->
+
+```text
+QuotaReserved=False  reason=Pending
+  couldn't assign flavors to pod set main: insufficient unused quota for
+  nvidia.com/gpu in flavor gpu-default, 1 more needed
+```
+
+Preemption is visible in namespace events:
+
+```bash
+kubectl get events -n ${NAMESPACE} --field-selector reason=Preempted
+```
+
+## How It Interacts With the HPA
+
+| Layer | Actor | What it controls |
+|---|---|---|
+| Demand signal | Prometheus / EPP metrics | when to scale |
+| Replica count | HPA (owned by KEDA) | how many replicas are requested |
+| GPU budget | Kueue | which of those replicas get a GPU now |
+
+The HPA still makes every scaling decision. Kueue admits the resulting pods in
+budget order, so `maxReplicas` becomes a physical ceiling that nothing rewrites.
+
+Two consequences worth planning for:
+
+- **Desired and ready replicas legitimately differ.** Alerts on
+  "replicas != desired" now fire by design. Retarget them at
+  `kueue_pending_workloads`.
+- **A preempted replica is a deleted serving pod.** Check that
+  `terminationGracePeriodSeconds` is long enough to drain in-flight requests.
+
+KEDA's `AverageValue` triggers divide an aggregate metric by the per-replica
+target rather than by live pod count, so gated pods do not skew the HPA's
+arithmetic. Re-check this if you switch a trigger to `Utilization`.
+
+## Perceived Effects
+
+| Condition | Replica rebalancer | Kueue |
+|---|---|---|
+| Demand rises, budget full | lowers `spec.maxReplicas` on the next loop | extra pods are created and gated |
+| Demand drops | raises `maxReplicas` back toward the manifest value | pods are deleted, quota is released within seconds |
+| One model idle | its unused GPUs raise the other's ceiling | the other ClusterQueue borrows above its own floor |
+| Idle model wakes up | waits for the next loop, no preemption | preempts a borrowed replica immediately |
+
+## Why Contention Settles on the Floors
+
+The rule Kueue enforces is: **you may preempt to reach your own floor, never to
+go beyond it.** Above your floor you can only take what is idle. Two separate
+settings produce that:
+
+- `reclaimWithinCohort: Any` applies only when the incoming pod fits inside its
+  own `nominalQuota`. That is what lets a model evict the borrowed replicas of a
+  peer to get back to its own floor.
+- `borrowWithinCohort` governs preemption *by* a pod that must itself borrow. It
+  defaults to `Never` and this guide leaves it there, so a borrowing pod never
+  evicts anyone — it waits for someone to go idle.
+
+So when both models want more than their floor at once, and the floors already
+sum to capacity, there is by definition nothing idle left to borrow: each model
+sits on its floor and the surplus stays gated. That is exactly the
+over-provisioning the replica rebalancer existed to prevent, except the surplus
+queues instead of the cluster being oversubscribed.
+
+## Tuning
+
+The floors are the dial. Beyond them:
+
+- **Asymmetric floors** — a 7/3 split guarantees one model more capacity under
+  contention while both still borrow freely when the other is idle.
+- **`lendingLimit: 0`** on a latency-critical model's GPU quota means peers can
+  never borrow its floor, so it scales out without waiting for a preemption
+  round trip.
+- **`WorkloadPriorityClass`** (for example `prod: 1000`, `dev: 100`) plus the
+  `kueue.x-k8s.io/priority-class` label on the pod template chooses *which*
+  replicas get evicted, instead of newest-first.
+- **Fair sharing instead of floors** — put the whole budget on a `Cohort`
+  object, give each ClusterQueue `nominalQuota: 0` and a
+  `fairSharing.weight`, and enable `fairSharing` in the Kueue manager config.
+  Fully elastic, with no guaranteed floor.
+
+## Limitations
+
+- **Nominal accounting.** Kueue admits against the quota you declare, not
+  against live node capacity. Quota above physical capacity produces
+  unschedulable pods rather than gated ones.
+- **Gated pods accumulate.** Keep `maxReplicaCount` at a sane physical ceiling;
+  every replica the HPA asks for and cannot place stays as a `Pending` pod.
+- **Rollouts need slack.** With `maxSurge: 0` a rollout terminates before it
+  creates, which is slower; the alternative is to leave one replica of budget
+  free.
+- **Same-namespace routing needs one LocalQueue per model.** ClusterQueue
+  `namespaceSelector` cannot distinguish two models in one namespace.
+
+## Cleanup
+
+<!-- guide:cleanup start -->
+```bash
+for deployment in ${DEPLOYMENT_A} ${DEPLOYMENT_B}; do
+  kubectl patch deployment "${deployment}" -n ${NAMESPACE} --type=merge -p \
+    '{"metadata":{"labels":{"kueue.x-k8s.io/queue-name":null}},"spec":{"template":{"metadata":{"labels":{"kueue.x-k8s.io/queue-name":null}}}}}'
+done
+
+kubectl delete -k ${QUOTA_ROOT}/base --ignore-not-found=true
+```
+<!-- guide:cleanup end -->
+
+Removing the label stops Kueue managing pods created from then on; pods already
+admitted keep running.

--- a/guides/workload-autoscaling/kueue-rebalancing/guide.yaml
+++ b/guides/workload-autoscaling/kueue-rebalancing/guide.yaml
@@ -1,0 +1,123 @@
+name: kueue-rebalancing
+
+env:
+  static:
+    BRANCH: main
+    REPO_ROOT: $(realpath $(git rev-parse --show-toplevel))
+
+    NAMESPACE:       llm-d-optimized-baseline
+    KUEUE_NAMESPACE: kueue-system
+
+    # Kueue chart version. 0.19.x serves the v1beta2 API used by the quota
+    # overlay, and enables the `pod` and `deployment` integrations by default.
+    KUEUE_VERSION: { default: "0.19.1" }
+
+    # The two model server Deployments that share one GPU budget. Model A is the
+    # optimized-baseline decode Deployment; model B is the second pool added by
+    # the multi-inference-pool guide. Set these to your own Deployment names.
+    DEPLOYMENT_A: { default: "optimized-baseline-nvidia-gpu-vllm-decode" }
+    DEPLOYMENT_B: { default: "model-b-nvidia-gpu-vllm-decode" }
+
+    # LocalQueue each Deployment opts into, from the quota overlay below.
+    QUEUE_A: { default: "model-a-lq" }
+    QUEUE_B: { default: "model-b-lq" }
+
+    # Quota overlay for this guide (ResourceFlavor, ClusterQueues, LocalQueues).
+    QUOTA_ROOT: ${REPO_ROOT}/guides/workload-autoscaling/kueue-rebalancing/optimized-baseline
+
+  source: ["${REPO_ROOT}/guides/env.sh"]
+
+prerequisites:
+  # Install Kueue. The chart is published as an OCI artifact; --wait blocks until
+  # the controller manager and its webhooks are serving, which the quota objects
+  # below depend on.
+  kueue:
+    - run: |
+        helm install kueue oci://registry.k8s.io/kueue/charts/kueue \
+          --version ${KUEUE_VERSION} \
+          -n ${KUEUE_NAMESPACE} --create-namespace --wait
+
+  # Confirm the controller is up and that the `pod` and `deployment` integrations
+  # are active. They are on by default in 0.19.x; without them the queue-name
+  # label is inert and no pod is ever gated.
+  integrations:
+    - run: |
+        kubectl wait --for=condition=Available -n ${KUEUE_NAMESPACE} \
+          deploy/kueue-controller-manager --timeout=180s
+        kubectl get cm kueue-manager-config -n ${KUEUE_NAMESPACE} \
+          -o jsonpath='{.data.controller_manager_config\.yaml}' \
+          | grep -A 20 'integrations:'
+
+deploy:
+  # Apply the quota objects: one ResourceFlavor, one ClusterQueue per model in a
+  # shared cohort, and one LocalQueue per model in the workload namespace.
+  # Edit the nominalQuota floors to match your GPU count before applying.
+  quota:
+    - run: kubectl apply -k ${QUOTA_ROOT}/base
+
+  # Opt each Deployment in with the queue-name label. On the Deployment it is the
+  # documented opt-in surface, and Kueue's webhook copies it to the pod template;
+  # setting it on the template too makes the opt-in explicit and independent of
+  # that propagation. Every replica the HPA creates inherits it and becomes its
+  # own Kueue Workload. Deployments without the label are untouched by Kueue.
+  optin:
+    - run: |
+        for pair in "${DEPLOYMENT_A}:${QUEUE_A}" "${DEPLOYMENT_B}:${QUEUE_B}"; do
+          deployment=${pair%%:*}; queue=${pair##*:}
+          kubectl patch deployment "${deployment}" -n ${NAMESPACE} --type=merge -p \
+            "{\"metadata\":{\"labels\":{\"kueue.x-k8s.io/queue-name\":\"${queue}\"}},\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"kueue.x-k8s.io/queue-name\":\"${queue}\"}}}}}"
+        done
+
+  # Roll out with no surge. At full quota a surge pod has no GPU to claim, so it
+  # is gated and the rollout stalls behind it; terminating first keeps rollouts
+  # moving. The alternative is to keep one replica of slack in the budget.
+  rollout_strategy:
+    - run: |
+        for deployment in ${DEPLOYMENT_A} ${DEPLOYMENT_B}; do
+          kubectl patch deployment "${deployment}" -n ${NAMESPACE} --type=merge \
+            -p '{"spec":{"strategy":{"rollingUpdate":{"maxSurge":0,"maxUnavailable":1}}}}'
+        done
+
+verify:
+  tests:
+    # ClusterQueue status is the whole picture: admitted GPUs per model, how many
+    # are borrowed from the cohort, and how many workloads are waiting. The
+    # LocalQueues give the same per-model view from inside the namespace.
+    queues:
+      - run: |
+          kubectl get clusterqueues -o wide
+          kubectl get localqueues -n ${NAMESPACE}
+
+    # One Workload per replica pod, and pods above quota sitting Pending behind a
+    # scheduling gate rather than being scheduled onto GPUs that do not exist.
+    workloads:
+      - run: |
+          kubectl get workloads -n ${NAMESPACE}
+          kubectl get pods -n ${NAMESPACE} \
+            -l kueue.x-k8s.io/queue-name --show-labels
+          kubectl get pods -n ${NAMESPACE} -o json \
+            | jq -r '.items[] | select((.spec.schedulingGates // []) | length > 0)
+                     | "gated: \(.metadata.name) \([.spec.schedulingGates[].name] | join(","))"'
+
+    # A gated pod explains itself through its Workload: which queue it is in, and
+    # exactly which resource the cohort could not satisfy.
+    gated:
+      - run: |
+          for w in $(kubectl get workloads -n ${NAMESPACE} -o json \
+            | jq -r '.items[] | select((.status.conditions // [])
+                     | any(.type=="QuotaReserved" and .status!="True")) | .metadata.name'); do
+            kubectl get workload "$w" -n ${NAMESPACE} -o json \
+              | jq -r '"workload: \(.metadata.name)  queue: \(.spec.queueName)",
+                       (.status.conditions[]? | "  \(.type)=\(.status) reason=\(.reason)\n    \(.message)")'
+          done
+
+cleanup:
+  # Removing the label stops Kueue managing pods created from then on; pods
+  # already admitted keep running. Do this before deleting the quota objects, so
+  # no replica is left gated with no ClusterQueue to admit it.
+  - run: |
+      for deployment in ${DEPLOYMENT_A} ${DEPLOYMENT_B}; do
+        kubectl patch deployment "${deployment}" -n ${NAMESPACE} --type=merge -p \
+          '{"metadata":{"labels":{"kueue.x-k8s.io/queue-name":null}},"spec":{"template":{"metadata":{"labels":{"kueue.x-k8s.io/queue-name":null}}}}}'
+      done
+  - run: kubectl delete -k ${QUOTA_ROOT}/base --ignore-not-found=true

--- a/guides/workload-autoscaling/kueue-rebalancing/optimized-baseline/base/clusterqueues.yaml
+++ b/guides/workload-autoscaling/kueue-rebalancing/optimized-baseline/base/clusterqueues.yaml
@@ -1,0 +1,63 @@
+# One ClusterQueue per model, both in the same cohort.
+#
+#   nominalQuota  the model's guaranteed floor - it can always reclaim this much
+#   cohortName    the pool the floors are lent into and borrowed from
+#
+# The floors sum to the physical GPU count (5 + 5 = 10), replacing the
+# `requests.nvidia.com/gpu: "10"` ResourceQuota used by the replica rebalancer.
+# Set them to the GPUs actually installed: `kubectl describe nodes | grep nvidia.com/gpu`.
+#
+# Kueue accounting is nominal, not physical. Quota larger than the cluster admits
+# pods the scheduler then cannot place, so they sit Pending as Unschedulable
+# instead of gated.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: model-a-cq
+spec:
+  # Same cohort in both queues: idle GPUs are lent across models.
+  cohortName: llm-d-gpu
+  namespaceSelector: {}
+  resourceGroups:
+    - coveredResources: ["nvidia.com/gpu", "cpu", "memory"]
+      flavors:
+        - name: gpu-default
+          resources:
+            # model-a's guaranteed floor; it borrows above this when model-b is idle.
+            - name: "nvidia.com/gpu"
+              nominalQuota: 5
+            # cpu and memory are deliberately generous. Every resource a pod
+            # requests must be covered by the ClusterQueue or its Workload is
+            # inadmissible, and GPU must stay the only binding constraint.
+            - name: "cpu"
+              nominalQuota: 200
+            - name: "memory"
+              nominalQuota: 2000Gi
+  preemption:
+    # Take lent GPUs back on demand: a pod that fits inside its own floor may
+    # preempt a pod from another queue in the cohort that is over its floor.
+    reclaimWithinCohort: Any
+    # Within one model, evict the newest replica first.
+    withinClusterQueue: LowerOrNewerEqualPriority
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: model-b-cq
+spec:
+  cohortName: llm-d-gpu
+  namespaceSelector: {}
+  resourceGroups:
+    - coveredResources: ["nvidia.com/gpu", "cpu", "memory"]
+      flavors:
+        - name: gpu-default
+          resources:
+            - name: "nvidia.com/gpu"
+              nominalQuota: 5
+            - name: "cpu"
+              nominalQuota: 200
+            - name: "memory"
+              nominalQuota: 2000Gi
+  preemption:
+    reclaimWithinCohort: Any
+    withinClusterQueue: LowerOrNewerEqualPriority

--- a/guides/workload-autoscaling/kueue-rebalancing/optimized-baseline/base/kustomization.yaml
+++ b/guides/workload-autoscaling/kueue-rebalancing/optimized-baseline/base/kustomization.yaml
@@ -1,0 +1,13 @@
+# Kueue quota objects for GPU-budget rebalancing across model deployments.
+#
+# ResourceFlavor and ClusterQueue are cluster-scoped, so this overlay is applied
+# once per cluster; LocalQueue is namespaced and pins the workload namespace.
+# Rename the queues before applying if another namespace on the same cluster
+# already uses these ClusterQueue names.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - resourceflavor.yaml
+  - clusterqueues.yaml
+  - localqueues.yaml

--- a/guides/workload-autoscaling/kueue-rebalancing/optimized-baseline/base/localqueues.yaml
+++ b/guides/workload-autoscaling/kueue-rebalancing/optimized-baseline/base/localqueues.yaml
@@ -1,0 +1,22 @@
+# A pod can only name a LocalQueue in its own namespace, never a ClusterQueue,
+# so one LocalQueue per model is the required indirection. When both models live
+# in the same namespace these are also the only thing routing each model's pods
+# to its own ClusterQueue - namespaceSelector cannot tell them apart.
+#
+# They double as the per-model view: `kubectl get localqueue -n <namespace>`
+# reports pending and admitted workloads per model.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: model-a-lq
+  namespace: llm-d-optimized-baseline
+spec:
+  clusterQueue: model-a-cq
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: model-b-lq
+  namespace: llm-d-optimized-baseline
+spec:
+  clusterQueue: model-b-cq

--- a/guides/workload-autoscaling/kueue-rebalancing/optimized-baseline/base/resourceflavor.yaml
+++ b/guides/workload-autoscaling/kueue-rebalancing/optimized-baseline/base/resourceflavor.yaml
@@ -1,0 +1,10 @@
+# One homogeneous accelerator pool. An empty spec matches every node, so quota
+# is enforced on the GPU count alone.
+#
+# For heterogeneous hardware, define one ResourceFlavor per GPU type with
+# nodeLabels (for example nvidia.com/gpu.product: NVIDIA-A100-SXM4-80GB) and
+# give each flavor its own nominalQuota in the ClusterQueues below.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: gpu-default


### PR DESCRIPTION
## What

Adds a second replica-rebalancing path to the workload-autoscaling guide that
enforces a shared GPU budget with [Kueue](https://kueue.sigs.k8s.io/) instead of
a control loop over HPAs.

Each model gets a `ClusterQueue` with a guaranteed GPU floor, all of them in one
cohort, and with Kueue's `deployment` integration every replica pod becomes a
`Workload` that is admitted only when quota is free. Enforcement therefore
happens *below* the HPA, on the pods it creates:

- the HPA needs no annotation, and KEDA keeps sole ownership of the HPA it
  generates — so this works with KEDA-generated HPAs as they are
- an idle model's GPUs are lent to a busy one, and a model reclaims its floor by
  preemption (`preemption.reclaimWithinCohort: Any`)
- over-budget demand becomes gated `Pending` pods rather than a lowered
  `maxReplicas`, so "desired" and "ready" replicas legitimately differ

This does not change the existing
[experimental replica rebalancer](https://github.com/llm-d/llm-d/tree/main/guides/workload-autoscaling/replica-rebalancing);
it sits alongside it as a second Features entry. The two enforce the same budget
from opposite sides of the HPA and must never run at the same time, so the new
guide assumes the rebalancer is uninstalled and that the hard
`requests.nvidia.com/gpu` `ResourceQuota` it reads is gone (a gated pod still
counts against a `ResourceQuota`, which would stop the ReplicaSet from creating
the very pod Kueue is meant to queue).

## Files changed

| File | Change |
|---|---|
| `guides/workload-autoscaling/README.md` | new `### Kueue-Based Replica Rebalancing (Experimental)` entry under Features, next to the existing rebalancer entry |
| `guides/workload-autoscaling/kueue-rebalancing/guide.yaml` | new — machine-readable guide source: env, Kueue install, quota apply, opt-in, rollout strategy, verification and cleanup steps |
| `guides/workload-autoscaling/kueue-rebalancing/README.md` | new — the guide itself, with every bash block rendered from `guide.yaml` by `scripts/guide.py` |
| `guides/workload-autoscaling/kueue-rebalancing/kueue.values.yaml` | new — Kueue chart overrides that confine the controller and its webhooks to the model namespace |
| `guides/workload-autoscaling/kueue-rebalancing/optimized-baseline/base/kustomization.yaml` | new — quota overlay |
| `.../base/resourceflavor.yaml` | new — one `ResourceFlavor` for the accelerator pool being rationed |
| `.../base/clusterqueues.yaml` | new — two `ClusterQueue`s (floors of 5 + 5 across 10 GPUs) sharing cohort `llm-d-gpu`, with `reclaimWithinCohort: Any` |
| `.../base/localqueues.yaml` | new — one `LocalQueue` per model in the workload namespace |
| `.github/scripts/install-kueue-crds.sh` | new — installs the Kueue CRDs for the dry-run job |
| `.github/workflows/ci-kustomize-dry-run.yaml` | one step added to run the above |

All objects use `kueue.x-k8s.io/v1beta2`, the storage version since Kueue 0.16.
The guide pins the chart at 0.19.1.

## CI

The `dry-run` job auto-discovers every `kustomization.yaml` under `guides/*/`, so
it picks up the new quota overlay with no workflow change — but it would have
failed without the Kueue CRDs, since the objects are all custom resources. Kueue
publishes no CRD-only release asset and the chart's CRD templates contain Helm
directives, so `install-kueue-crds.sh` renders them from the chart the same way
the other per-operator installers work:

```bash
helm template kueue oci://registry.k8s.io/kueue/charts/kueue \
  --version "${KUEUE_VERSION}" -n kueue-system \
  -s templates/crd/kueue.x-k8s.io_clusterqueues.yaml \
  -s templates/crd/kueue.x-k8s.io_localqueues.yaml \
  -s templates/crd/kueue.x-k8s.io_resourceflavors.yaml \
  -s templates/crd/kueue.x-k8s.io_workloads.yaml \
  | kubectl apply --server-side -f -
```

The step is placed alongside the other CRD installers in
`ci-kustomize-dry-run.yaml`, so the new overlay is `kustomize build`-ed and
server dry-run like every other overlay in `guides/`.

## Validation

Static checks:

- `kustomize build` on the quota overlay — 5 objects
- every Kueue object checked field-by-field against the `v1beta2` CRD OpenAPI
  schemas rendered from the 0.19.1 chart (field names, enums, required fields)
- `scripts/guide.py render --recursive --check guides` passes, so `README.md` and
  `guide.yaml` are in sync as CI requires
- yamllint and markdownlint with the repo's configs; relative links and anchors
  resolve; `bash -n` on the new script

End to end on a kind cluster (Kueue 0.19.1, k8s 1.32, one node advertising 10
emulated `nvidia.com/gpu`, the shipped floors of 5 + 5), running every bash block
rendered in `README.md` in order and unedited — install, quota apply, rollout
strategy, opt-in, all four verification tests, cleanup. All exited 0, and:

- installing with `kueue.values.yaml` left `mpod.kb.io` selecting only the model
  namespace; a pod labelled `kueue.x-k8s.io/queue-name` in an unrelated namespace
  ran ungated with no `Workload` created
- the pod-template opt-in produced one `Workload` per replica, and cleanup removed
  the label and rolled both Deployments back with no quota objects or `Workload`s
  left behind
- model A scaled to 6 against a floor of 5 → 6 admitted, `borrowed=1`
- model B then scaled to 5 → A's borrowed replica preempted (`due to reclamation
  within the cohort`), A's replacement pod `Pending` behind
  `kueue.x-k8s.io/admission,kueue.x-k8s.io/topology`, `borrowed` back to 0; both
  queues settled on their floors when scaled back down
- with the chart-default `maxSurge: 25%` at full quota the opt-in rollout stalls on
  a gated surge pod and `kubectl rollout status` exits 1; with `maxSurge: 0`
  applied first the same rollout completes — which is why the guide sets the
  strategy before opting in
- the new `verify` assertion exits 0 on a healthy cluster and 1 both when the
  queues cannot be reconciled and when `cohortName` is removed from one
  `ClusterQueue`

## Not tested on OpenShift

This has only been validated on upstream Kubernetes (kind). It has **not** been
tested on OpenShift, and specifically not with the Red Hat build of Kueue
operator, which the guide mentions as an alternative to the upstream chart. The
quota objects should be identical either way, but that path needs confirmation
before anyone relies on it.

The OpenShift path also differs materially: the Red Hat build of Kueue is
installed as an operator with a cluster-scoped `Kueue` CR rather than this Helm
chart, so `kueue.values.yaml` does not apply there, `integrations.frameworks` must
be set explicitly on the CR, and namespaces need `kueue.openshift.io/managed=true`.
The README documents that route, but it needs verification by someone with a
cluster.

