### PR TITLE
feat(modelexpress-p2p): add Intel XPU (B60) host-staged transport guide

### DIFF
--- a/guides/README.md
+++ b/guides/README.md
@@ -115,4 +115,4 @@ instructions — deliberately not repeated here, so the two cannot drift apart.
 Our supporting guides address common operational challenges with model serving at scale:
 
 * [Benchmark](../helpers/benchmark.md) demonstrates how to use automation for running benchmarks against the llm-d stack.
-* [ModelExpress P2P Weight Transfer](./modelexpress-p2p/README.md) loads one model replica from storage and transfers weights to peer replicas over GPU-to-GPU RDMA for faster cold scale-outs.
+* [ModelExpress P2P Weight Transfer](./modelexpress-p2p/README.md) loads one model replica from storage and transfers weights to peer replicas over GPU-to-GPU RDMA, or through the correctness-first host-staged Intel XPU path, for faster cold scale-outs.

--- a/guides/modelexpress-p2p/README.md
+++ b/guides/modelexpress-p2p/README.md
@@ -2,7 +2,10 @@
 
 ## Overview
 
-This guide adds [NVIDIA ModelExpress](https://github.com/ai-dynamo/modelexpress) to the [Optimized Baseline](../optimized-baseline/README.md) deployment. It moves cold-start weight loading off disk and onto **GPU-to-GPU NIXL/RDMA**. One pod in the inference pool loads weights from HuggingFace. Every other pod gets the same weights directly from that pod's HBM over the RDMA fabric, and none of them touch disk.
+This guide adds [NVIDIA ModelExpress](https://github.com/ai-dynamo/modelexpress) to the [Optimized Baseline](../optimized-baseline/README.md) deployment. The default NVIDIA configuration moves cold-start weight loading off disk and onto **GPU-to-GPU NIXL/RDMA**. One pod in the inference pool loads weights from HuggingFace. Every other pod gets the same weights directly from that pod's HBM over the RDMA fabric, and none of them touch disk.
+
+An [Intel XPU variant](./README.xpu.md) is also available. It uses ModelExpress with host-staged
+TCP and Level Zero copies instead of GPU-direct RDMA.
 
 A central-coordinator ModelExpress server (it runs with the `kubernetes` metadata backend) brokers the metadata exchange. It tracks which pods are READY sources for which `mx_source_id`, and gives target pods the NIXL agent and tensor-manifest endpoints they need to start an RDMA pull. The server itself never touches weight bytes.
 
@@ -55,6 +58,9 @@ For workload-specific guidance (RL training rollouts, elastic bin-packed racks),
 | Image | Shared GPU vLLM image + ModelExpress client baked in (build it yourself, see [Image](#image-building-a-modelexpress-enabled-model-server-image)) |
 | MX backend | `kubernetes` (CRDs, no Redis) |
 | Weight transport | NIXL/RDMA, GPU HBM -> GPU HBM |
+
+The table above describes the default NVIDIA deployment. See [Intel XPU
+ModelExpress](./README.xpu.md) for the Qwen3-0.6B, Intel GPU DRA, and `tcp,ze_copy` configuration.
 
 ## Prerequisites
 
@@ -424,6 +430,8 @@ These are environment-specific observations, not official NVIDIA benchmark resul
 
 ## Going Further
 
+* [Running ModelExpress on Intel XPU](./README.xpu.md): deploy the Qwen3-0.6B, Intel GPU DRA, and
+  `tcp,ze_copy` configuration.
 * [Measuring storage-backed loading paths](./measuring-storage-paths.md): time fastsafetensors from NFS and local NVMe against P2P in your own cluster.
 * [Reusing JIT compile caches across pods](./compile-cache.md): once weight transfer is sub-second, cut the `torch.compile` cost with P2P artifact transfer (0.5.0+, measured 20.1 s → 3.4 s) or a shared RWX PVC.
 * [Locking down the metadata broker](./security.md): Istio mTLS plus an AuthorizationPolicy for shared clusters.

--- a/guides/modelexpress-p2p/README.xpu.md
+++ b/guides/modelexpress-p2p/README.xpu.md
@@ -1,0 +1,177 @@
+# Intel XPU ModelExpress
+
+For a comprehensive overview of ModelExpress P2P weight transfer, see the
+[ModelExpress P2P guide](./README.md). This guide covers the Intel XPU variant: it distributes
+ModelExpress weights between Intel Arc Pro B60 pods through host-staged TCP and Level Zero copies:
+
+```text
+source XPU -> ze_copy -> host -> TCP -> host -> ze_copy -> destination XPU
+```
+
+This overlay validates **functional XPU P2P** over TCP, not XPU-direct RDMA. Do not add `rc_mlx5`,
+`rc`, `dc`, `ib`, or another verbs transport to `UCX_TLS` or `NIXL_UCX_TLS`.
+
+## Validated stack
+
+The XPU image recipe pins the stack that passed the B60 functional tests:
+
+| Component | Version |
+| --- | --- |
+| Base image | `docker.io/vllm/vllm-openai-xpu:v0.26.0` |
+| PyTorch | `2.12.0+xpu` |
+| vLLM | `0.26.0+xpu` |
+| UCX | commit `940c1c1d948873d64cba05adc756bae645eb618f`, built with verbs and Level Zero |
+| NIXL | `1.3.0`, commit `5949ccf9f55ad60f6d7f79c28200bde152cbb203` |
+| ModelExpress | `0.5.0`, commit `0406ac16d5daeef985de1bf4d09c9f0a5e188c1a` |
+
+`image/Dockerfile.xpu` validates package versions, the ModelExpress XPU backend, UCX Level Zero
+modules, and NIXL plugin linkage during the image build.
+
+## Prerequisites
+
+In addition to the main guide prerequisites:
+
+- Kubernetes 1.35 or newer with DRA `resource.k8s.io/v1`.
+- Intel Resource Driver for Kubernetes exposing the `gpu.intel.com` DeviceClass.
+- At least two Intel XPU nodes for the default cross-node one-seed/one-receiver deployment.
+- Pod-to-pod TCP connectivity between the model-server pods.
+
+The overlay uses one GPU DRA claim per pod. It deliberately does not request an RDMA NIC or
+verbs device.
+
+## Build the XPU image
+
+```bash
+export REPO_ROOT=$(realpath "$(git rev-parse --show-toplevel)")
+export GUIDE_NAME=modelexpress-p2p
+export MODELSERVER_IMAGE=<your-registry>/modelexpress-p2p-vllm-xpu:latest
+
+DOCKER_BUILDKIT=1 docker build \
+  -f "${REPO_ROOT}/guides/${GUIDE_NAME}/image/Dockerfile.xpu" \
+  -t "${MODELSERVER_IMAGE}" \
+  "${REPO_ROOT}/guides/${GUIDE_NAME}/image"
+docker push "${MODELSERVER_IMAGE}"
+```
+
+Point the XPU overlay at the resulting image:
+
+```bash
+cd "${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/xpu/vllm/base"
+kustomize edit set image REPLACE_MODEL_SERVER_IMAGE="${MODELSERVER_IMAGE}"
+cd -
+```
+
+## Deploy
+
+Follow the main guide to create the namespace, install ModelExpress CRDs and server, create the
+Hugging Face secret, and optionally deploy the router. Use Qwen3-0.6B for this XPU overlay:
+
+```bash
+export MODEL=Qwen/Qwen3-0.6B
+
+kubectl apply -n "${NAMESPACE}" -k \
+  "${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/xpu/vllm/base"
+kubectl rollout status -n "${NAMESPACE}" \
+  deploy/modelexpress-p2p-intel-xpu-vllm-decode \
+  --timeout=30m
+```
+
+The portable `base` overlay uses the default Kubernetes pod network. On clusters whose management
+network is slow, use the optional DRANET overlay to attach the high-speed NIC while retaining the
+safe host-staged transport:
+
+```bash
+kubectl apply -n "${NAMESPACE}" -k \
+  "${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/xpu/vllm/dranet"
+```
+
+The DRANET overlay requires a `dranet-rdma` DeviceClass. It retains the base Intel XPU claim and
+allocates the RDMA-capable NIC through a separate claim. The host-staged path does not require
+GPU/NIC peer-DMA alignment. Its startup wrapper selects the fastest UP interface and exports that
+interface as `UCX_NET_DEVICES`; the selected DRANET device must have a usable cross-node IP
+configuration.
+
+The overlay recreates `/dev/dri/by-path` symlinks for only the XPU render devices allocated to the
+Pod. This keeps oneCCL device discovery working after the network DRA injection without mounting
+the host's complete device directory.
+
+`UCX_TLS=tcp,ze_copy` remains unchanged: the NIC carries TCP and never reads XPU VRAM directly.
+
+The selector prints the chosen interface and link speed before vLLM starts. If a site has multiple
+equally fast data interfaces, replace the selector with an explicit `UCX_NET_DEVICES` value in a
+site-specific overlay. Do not add a verbs transport.
+
+The overlay sets:
+
+```text
+NIXL_UCX_TLS=tcp,ze_copy
+UCX_TLS=tcp,ze_copy
+UCX_MEMTYPE_CACHE=0
+UCX_TCP_TX_SEG_SIZE=16M
+UCX_TCP_RX_SEG_SIZE=16M
+```
+
+`UCX_MEMTYPE_CACHE=0` is required for reliable B60 memory-type detection. The larger TCP segments
+avoid excessive synchronous Level Zero copy submissions.
+
+### Restricted-egress clusters
+
+The seed must read the checkpoint before it can publish tensors. If model-server pods cannot reach
+Hugging Face, either pre-populate a read-only model volume or add `HTTP_PROXY`, `HTTPS_PROXY`, and
+`NO_PROXY` to the model-server container. `NO_PROXY` must include the Kubernetes service domain,
+service CIDR, pod CIDR, loopback addresses, and the ModelExpress server so metadata and P2P traffic
+do not traverse the external proxy.
+
+For an offline P2P validation, start one seed with the complete checkpoint and wait for its
+ModelMetadata status to become Ready. Then scale to two with only config and tokenizer files
+available to the receiver. The receiver must log a P2P transfer; do not copy the weight file to its
+model volume.
+
+## Verify
+
+Confirm that both replicas are Ready and each received one XPU:
+
+```bash
+kubectl get pods -n "${NAMESPACE}" \
+  -l llm-d.ai/guide=modelexpress-p2p,llm-d.ai/accelerator-variant=xpu
+kubectl get resourceclaims -n "${NAMESPACE}"
+```
+
+Find the newer pod, which is normally the receiver, and inspect its transfer:
+
+```bash
+RECEIVER=$(kubectl get pods -n "${NAMESPACE}" \
+  -l llm-d.ai/guide=modelexpress-p2p,llm-d.ai/accelerator-variant=xpu \
+  --sort-by=.metadata.creationTimestamp \
+  -o jsonpath='{.items[-1].metadata.name}')
+
+kubectl logs -n "${NAMESPACE}" "${RECEIVER}" -c modelserver \
+  | grep -E "MxModelLoader|Receiving|Transfer complete|Loading weights from disk"
+```
+
+Acceptance criteria:
+
+1. The source publishes READY metadata and the receiver selects the ModelExpress P2P strategy.
+2. The receiver logs `Transfer complete` and does not load model weights from disk.
+3. UCX configuration contains only `tcp,ze_copy`; no `rma(rc_mlx5/...)` data lane is present.
+4. Both pods return successful inference for `Qwen/Qwen3-0.6B`.
+5. Both pods remain Ready with zero restarts and each sees exactly one assigned XPU.
+
+The portable GPU-only DRA overlay transferred 339 Qwen3-0.6B tensors (1.20 GB) across two B60
+nodes in 10.73 seconds, or 0.9 Gbps, through a 1 Gbps management network. The DRANET path avoids
+that line-rate ceiling: the same transfer completed in 2.20 seconds, or 4.4 Gbps, on the 400 Gbps
+interface. Both are functional results, not direct-RDMA bandwidth.
+
+ModelExpress currently calls its P2P loader strategy `rdma` even when NIXL/UCX is restricted to
+TCP. Use the selected UCX lanes and environment, not the strategy name alone, to identify the
+actual transport.
+
+## Cleanup
+
+```bash
+kubectl delete -n "${NAMESPACE}" -k \
+  "${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/xpu/vllm/base"
+```
+
+Use `modelserver/xpu/vllm/dranet` instead of `base` in the cleanup command if that overlay was
+deployed.

--- a/guides/modelexpress-p2p/image/Dockerfile.xpu
+++ b/guides/modelexpress-p2p/image/Dockerfile.xpu
@@ -1,0 +1,174 @@
+ARG BASE_IMAGE=docker.io/vllm/vllm-openai-xpu:v0.26.0
+
+FROM ${BASE_IMAGE} AS native-transfer-build
+
+ARG UCX_COMMIT=940c1c1d948873d64cba05adc756bae645eb618f
+ARG NIXL_COMMIT=5949ccf9f55ad60f6d7f79c28200bde152cbb203
+ARG MODELEXPRESS_COMMIT=0406ac16d5daeef985de1bf4d09c9f0a5e188c1a
+
+USER root
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
+        build-essential \
+        cmake \
+        libibverbs-dev \
+        librdmacm-dev \
+        libtool \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --upgrade \
+        meson \
+        meson-python \
+        ninja \
+        patchelf \
+        pybind11 \
+        pyyaml \
+        tomlkit \
+        types-pyyaml \
+        "setuptools>=80.9.0"
+
+RUN git clone https://github.com/openucx/ucx.git /tmp/ucx-source \
+    && cd /tmp/ucx-source \
+    && git checkout "${UCX_COMMIT}" \
+    && ./autogen.sh \
+    && ./configure \
+        --prefix=/opt/ucx-native-xpu \
+        --disable-static \
+        --enable-mt \
+        --enable-shared \
+        --with-verbs \
+        --with-ze=yes \
+    && make -j"$(nproc)" \
+    && make install
+
+ENV PKG_CONFIG_PATH=/opt/ucx-native-xpu/lib/pkgconfig
+ENV LD_LIBRARY_PATH=/opt/ucx-native-xpu/lib
+
+# NIXL v1.3.0 was tagged before these two package versions were updated.
+RUN git clone https://github.com/ai-dynamo/nixl.git /tmp/nixl-source \
+    && cd /tmp/nixl-source \
+    && git checkout "${NIXL_COMMIT}" \
+    && sed -i "s/version: '1.2.0'/version: '1.3.0'/" meson.build \
+    && sed -i 's/version = "1.2.0"/version = "1.3.0"/' pyproject.toml \
+    && ./contrib/tomlutil.py --wheel-name nixl-cu12 pyproject.toml \
+    && python -m pip wheel \
+        --no-build-isolation \
+        --no-deps \
+        -Csetup-args=-Ducx_path=/opt/ucx-native-xpu \
+        -Csetup-args=-Denable_plugins=UCX \
+        -Csetup-args=-Dwheel_variant=cu12 \
+        . \
+        --wheel-dir /tmp/wheels \
+    && mkdir -p /tmp/nixl-meta/nixl \
+    && cp -a src/bindings/python/nixl-meta/nixl/. /tmp/nixl-meta/nixl/ \
+    && printf '%s\n' \
+        '[build-system]' \
+        'requires = ["setuptools>=80.9.0", "wheel"]' \
+        'build-backend = "setuptools.build_meta"' \
+        '' \
+        '[project]' \
+        'name = "nixl"' \
+        'version = "1.3.0"' \
+        'description = "NIXL Python API meta package for the native XPU build"' \
+        'requires-python = ">=3.10"' \
+        'dependencies = ["nixl-cu12==1.3.0"]' \
+        '' \
+        '[tool.setuptools]' \
+        'packages = ["nixl"]' \
+        > /tmp/nixl-meta/pyproject.toml \
+    && python -m pip wheel \
+        --no-build-isolation \
+        --no-deps \
+        /tmp/nixl-meta \
+        --wheel-dir /tmp/wheels
+
+RUN git clone https://github.com/ai-dynamo/modelexpress.git /tmp/modelexpress-source \
+    && cd /tmp/modelexpress-source \
+    && git checkout "${MODELEXPRESS_COMMIT}" \
+    && MX_SKIP_EXT=1 python -m pip wheel \
+        --no-build-isolation \
+        --no-deps \
+        modelexpress_client/python \
+        --wheel-dir /tmp/wheels
+
+RUN /opt/ucx-native-xpu/bin/ucx_info -v \
+    | grep -q -- '--with-ze=yes' \
+    && find /opt/ucx-native-xpu/lib/ucx -name '*ze*' -print -quit \
+    | grep -q . \
+    && ls -l /tmp/wheels/nixl_cu12-1.3.0-*.whl \
+               /tmp/wheels/nixl-1.3.0-*.whl \
+               /tmp/wheels/modelexpress-0.5.0-*.whl
+
+FROM ${BASE_IMAGE}
+
+ARG UCX_COMMIT=940c1c1d948873d64cba05adc756bae645eb618f
+ARG NIXL_COMMIT=5949ccf9f55ad60f6d7f79c28200bde152cbb203
+ARG MODELEXPRESS_COMMIT=0406ac16d5daeef985de1bf4d09c9f0a5e188c1a
+
+LABEL org.opencontainers.image.description="llm-d XPU image with native UCX/ZE, NIXL 1.3.0, and ModelExpress 0.5.0"
+LABEL io.llm-d.xpu.ucx.commit="${UCX_COMMIT}"
+LABEL io.llm-d.xpu.nixl.commit="${NIXL_COMMIT}"
+LABEL io.llm-d.xpu.modelexpress.commit="${MODELEXPRESS_COMMIT}"
+
+USER root
+
+COPY --from=native-transfer-build /opt/ucx-native-xpu /opt/ucx-native-xpu
+COPY --from=native-transfer-build /tmp/wheels /tmp/native-xpu-wheels
+
+ENV UCX_HOME=/opt/ucx-native-xpu
+ENV PATH=/opt/ucx-native-xpu/bin:${PATH}
+ENV PKG_CONFIG_PATH=/opt/ucx-native-xpu/lib/pkgconfig
+ENV LD_LIBRARY_PATH=/opt/ucx-native-xpu/lib:/opt/intel/oneapi/umf/latest/lib:${LD_LIBRARY_PATH}
+ENV UCX_MODULE_DIR=/opt/ucx-native-xpu/lib/ucx
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip uninstall nixl nixl-cu12 nixl-cu13 \
+    && uv pip install --no-deps \
+        /tmp/native-xpu-wheels/nixl_cu12-1.3.0-*.whl \
+        /tmp/native-xpu-wheels/nixl-1.3.0-*.whl \
+        /tmp/native-xpu-wheels/modelexpress-0.5.0-*.whl \
+    && uv pip install \
+        google-crc32c==1.8.0 \
+        "protobuf>=5.27.0,<6.0.0" \
+    && rm -rf /tmp/native-xpu-wheels
+
+RUN python - <<'PY'
+import importlib.metadata as metadata
+
+expected = {
+    "torch": "2.12.0+xpu",
+    "vllm": "0.26.0+xpu",
+    "nixl": "1.3.0",
+    "nixl-cu12": "1.3.0",
+    "modelexpress": "0.5.0",
+    "google-crc32c": "1.8.0",
+}
+actual = {name: metadata.version(name) for name in expected}
+for name, version in expected.items():
+    if actual[name] != version:
+        raise RuntimeError(f"{name}: expected {version}, found {actual[name]}")
+
+import nixl
+from modelexpress.accelerators import XpuAcceleratorBackend
+
+agent = nixl.nixl_agent("native-xpu-build-check")
+if XpuAcceleratorBackend().name != "xpu":
+    raise RuntimeError("ModelExpress XPU backend is unavailable")
+print(actual)
+print(f"nixl_module={nixl.__file__}")
+PY
+
+RUN plugin="$(find /opt/venv -name libplugin_UCX.so -print -quit)" \
+    && test -n "${plugin}" \
+    && ! ldd "${plugin}" | grep -q 'not found' \
+    && ldd "${plugin}" | grep -q '/opt/ucx-native-xpu/lib/libucp.so' \
+    && ucx_info -v | grep -q -- '--with-ze=yes' \
+    && find /opt/ucx-native-xpu/lib/ucx -name '*ze*' -print -quit \
+    | grep -q .
+
+# Inherit ENTRYPOINT/CMD from ${BASE_IMAGE} (vllm serve); the Deployment
+# manifests in this guide always set an explicit `command`.

--- a/guides/modelexpress-p2p/modelserver/xpu/vllm/base/kustomization.yaml
+++ b/guides/modelexpress-p2p/modelserver/xpu/vllm/base/kustomization.yaml
@@ -1,0 +1,57 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../../recipes/modelserver/base/single-host/default
+  - resource-claim-template.yaml
+
+namePrefix: modelexpress-p2p-intel-xpu-vllm-
+
+configurations:
+  - namereference.yaml
+
+images:
+  - name: REPLACE_MODEL_SERVER_IMAGE
+    newName: <your-registry>/modelexpress-p2p-vllm-xpu
+    newTag: latest
+
+labels:
+  - pairs:
+      llm-d.ai/model: Qwen3-0.6B
+      llm-d.ai/guide: modelexpress-p2p
+      llm-d.ai/accelerator-variant: xpu
+      llm-d.ai/accelerator-vendor: intel
+    includeSelectors: true
+    includeTemplates: true
+    fields:
+      - version: v1
+        kind: ServiceAccount
+        path: metadata/labels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: metadata/labels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: spec/selector/matchLabels
+        create: true
+      - group: apps
+        version: v1
+        kind: Deployment
+        path: spec/template/metadata/labels
+        create: true
+      - group: monitoring.coreos.com
+        version: v1
+        kind: PodMonitor
+        path: metadata/labels
+        create: true
+      - group: monitoring.coreos.com
+        version: v1
+        kind: PodMonitor
+        path: spec/selector/matchLabels
+        create: true
+
+patches:
+  - path: patch-vllm.yaml

--- a/guides/modelexpress-p2p/modelserver/xpu/vllm/base/namereference.yaml
+++ b/guides/modelexpress-p2p/modelserver/xpu/vllm/base/namereference.yaml
@@ -1,0 +1,6 @@
+nameReference:
+  - kind: ResourceClaimTemplate
+    group: resource.k8s.io
+    fieldSpecs:
+      - path: spec/template/spec/resourceClaims/resourceClaimTemplateName
+        kind: Deployment

--- a/guides/modelexpress-p2p/modelserver/xpu/vllm/base/patch-vllm.yaml
+++ b/guides/modelexpress-p2p/modelserver/xpu/vllm/base/patch-vllm.yaml
@@ -1,0 +1,130 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  # One seed and one receiver is the smallest real P2P transfer.
+  replicas: 2
+  # DRA devices are reserved for a pod's lifetime. Avoid a surge pod that
+  # cannot acquire an XPU while the old replica still owns it.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  template:
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 107
+        supplementalGroups:
+          - 107
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              llm-d.ai/guide: modelexpress-p2p
+              llm-d.ai/accelerator-variant: xpu
+      containers:
+        - name: modelserver
+          command: ["vllm", "serve"]
+          args:
+            - "Qwen/Qwen3-0.6B"
+            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+            - "--tensor-parallel-size=1"
+            - "--dtype=bfloat16"
+            - "--max-model-len=2048"
+            - "--gpu-memory-utilization=0.50"
+            - "--max-num-seqs=8"
+            - "--enforce-eager"
+            - "--load-format=mx"
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+              add: [IPC_LOCK]
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: USER
+              value: llm-d
+            - name: TORCH_LLM_ALLREDUCE
+              value: "1"
+            - name: VLLM_PLUGINS
+              value: modelexpress
+            - name: MX_SERVER_ADDRESS
+              value: modelexpress-server:8001
+            - name: MX_METADATA_PORT
+              value: "5555"
+            - name: MX_WORKER_GRPC_PORT
+              value: "6555"
+            - name: MX_NIXL_BACKEND
+              value: UCX
+            # Correctness-first XPU path. Do not add rc_mlx5: direct mlx5
+            # reads from compressible B60 VRAM regions can corrupt bytes.
+            - name: NIXL_UCX_TLS
+              value: tcp,ze_copy
+            - name: UCX_TLS
+              value: tcp,ze_copy
+            - name: UCX_MEMTYPE_CACHE
+              value: "0"
+            - name: UCX_TCP_TX_SEG_SIZE
+              value: 16M
+            - name: UCX_TCP_RX_SEG_SIZE
+              value: 16M
+            - name: HF_HUB_CACHE
+              value: /models
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
+          resources:
+            limits:
+              cpu: "16"
+              memory: 48Gi
+            requests:
+              cpu: "8"
+              memory: 24Gi
+            claims:
+              - name: intel-xpu
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /root/.cache
+              name: torch-compile-cache
+            - mountPath: /root/.config
+              name: vllm-config
+            - mountPath: /models
+              name: model-cache
+          startupProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 60
+          livenessProbe:
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 20
+          readinessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+      resourceClaims:
+        - name: intel-xpu
+          resourceClaimTemplateName: intel-xpu-claim
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 4Gi
+        - name: torch-compile-cache
+          emptyDir: {}
+        - name: vllm-config
+          emptyDir: {}
+        - name: model-cache
+          emptyDir:
+            sizeLimit: 8Gi

--- a/guides/modelexpress-p2p/modelserver/xpu/vllm/base/resource-claim-template.yaml
+++ b/guides/modelexpress-p2p/modelserver/xpu/vllm/base/resource-claim-template.yaml
@@ -1,0 +1,12 @@
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: intel-xpu-claim
+spec:
+  spec:
+    devices:
+      requests:
+        - name: intel
+          exactly:
+            deviceClassName: gpu.intel.com
+            count: 1

--- a/guides/modelexpress-p2p/modelserver/xpu/vllm/dranet/data-nic-claim-template.yaml
+++ b/guides/modelexpress-p2p/modelserver/xpu/vllm/dranet/data-nic-claim-template.yaml
@@ -1,0 +1,15 @@
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: modelexpress-p2p-intel-xpu-vllm-xpu-data-nic
+spec:
+  spec:
+    devices:
+      requests:
+        - name: nic
+          exactly:
+            deviceClassName: dranet-rdma
+            count: 1
+            selectors:
+              - cel:
+                  expression: device.attributes["dra.net"].rdma == true

--- a/guides/modelexpress-p2p/modelserver/xpu/vllm/dranet/kustomization.yaml
+++ b/guides/modelexpress-p2p/modelserver/xpu/vllm/dranet/kustomization.yaml
@@ -1,0 +1,45 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - data-nic-claim-template.yaml
+  - select-data-nic.yaml
+
+patches:
+  - target:
+      kind: Deployment
+      name: decode
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: decode
+      spec:
+        template:
+          spec:
+            containers:
+              - name: modelserver
+                command:
+                  - /xpu-data-nic/select-xpu-data-nic.sh
+                resources:
+                  claims:
+                    - name: intel-xpu
+                    - name: xpu-data-nic
+                volumeMounts:
+                  - name: xpu-data-nic-selector
+                    mountPath: /xpu-data-nic
+                    readOnly: true
+                  - name: xpu-dri-by-path
+                    mountPath: /dev/dri/by-path
+            resourceClaims:
+              - name: intel-xpu
+                resourceClaimTemplateName: intel-xpu-claim
+              - name: xpu-data-nic
+                resourceClaimTemplateName: modelexpress-p2p-intel-xpu-vllm-xpu-data-nic
+            volumes:
+              - name: xpu-data-nic-selector
+                configMap:
+                  name: modelexpress-p2p-intel-xpu-vllm-xpu-data-nic-selector
+                  defaultMode: 0555
+              - name: xpu-dri-by-path
+                emptyDir: {}

--- a/guides/modelexpress-p2p/modelserver/xpu/vllm/dranet/select-data-nic.yaml
+++ b/guides/modelexpress-p2p/modelserver/xpu/vllm/dranet/select-data-nic.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: modelexpress-p2p-intel-xpu-vllm-xpu-data-nic-selector
+data:
+  select-xpu-data-nic.sh: |
+    #!/bin/bash
+    set -euo pipefail
+
+    found_render_device=false
+    for render_device in /dev/dri/renderD*; do
+      [[ -e ${render_device} ]] || continue
+      render_name=${render_device##*/}
+      pci_device=$(basename "$(readlink -f "/sys/class/drm/${render_name}/device")")
+      ln -sfn "../${render_name}" "/dev/dri/by-path/pci-${pci_device}-render"
+      found_render_device=true
+    done
+    if [[ ${found_render_device} != true ]]; then
+      echo "no allocated XPU render device found" >&2
+      exit 1
+    fi
+
+    best_iface=
+    best_speed=0
+    for speed_file in /sys/class/net/*/speed; do
+      iface=${speed_file%/speed}
+      iface=${iface##*/}
+      [[ ${iface} == lo ]] && continue
+      [[ $(<"/sys/class/net/${iface}/operstate") == up ]] || continue
+      speed=$(<"${speed_file}")
+      if ((speed > best_speed)); then
+        best_iface=${iface}
+        best_speed=${speed}
+      fi
+    done
+
+    if [[ -z ${best_iface} ]]; then
+      echo "no UP data interface with a reported link speed" >&2
+      exit 1
+    fi
+
+    export UCX_NET_DEVICES=${best_iface}
+    echo "Selected UCX TCP interface ${UCX_NET_DEVICES} (${best_speed} Mb/s)"
+    exec vllm serve "$@"


### PR DESCRIPTION
## Summary

- Add an Intel XPU (Arc Pro B60) variant of the ModelExpress P2P guide (`guides/modelexpress-p2p/README.xpu.md`), following the repo's existing `README.<variant>.md` naming convention (e.g. `pd-disaggregation/README.tpu.md`, `workload-autoscaling/README.hpa-epp.md`) rather than a bare `xpu.md`.
- Add a build image (`image/Dockerfile.xpu`) pinning PyTorch `2.12.0+xpu`, vLLM `0.26.0+xpu`, UCX (built with verbs + Level Zero support), NIXL `1.3.0`, and ModelExpress `0.5.0`, with build-time checks that the ZE modules, NIXL UCX plugin linkage, and package versions all match. The image inherits its `ENTRYPOINT`/`CMD` from the base image; every Deployment in this guide sets an explicit `command`.
- Add `base` and `dranet` kustomize overlays under `modelserver/xpu/vllm/` for a cross-node one-seed/one-receiver Qwen3-0.6B deployment: `base` requests one Intel GPU DRA claim per pod on the default pod network, `dranet` additionally requests an RDMA-capable NIC DRA claim to carry the transfer over a faster fabric. The `dranet`-only `ConfigMap`/`ResourceClaimTemplate` are name-prefixed the same way as the guide's other resources to avoid collisions with other guides sharing a namespace.
- Update `guides/modelexpress-p2p/README.md` and `guides/README.md` to link the new Intel XPU variant.

The guide validates only `UCX_TLS`/`NIXL_UCX_TLS=tcp,ze_copy` and explicitly avoids
`rc_mlx5`/`rc`/`dc`/`ib`, because direct `rc_mlx5` reads from B60 device memory silently corrupt
content-dependent regions: the RDMA operation completes with `UCS_OK`, but bytes read from
compressible/constant/repetitive source regions (padding, sparse, and quantized values are common
in model weights) come back wrong, while random regions in the same allocation pass SHA-256
verification. This reproduces for both GET and PUT, on multiple workers, and even with same-node
forced RC — it is not a network/IOMMU/firmware/routing configuration issue.

## Why this is a draft

This PR ships only the TCP-based configuration above, which is correct and safe to merge as-is —
it does not itself depend on any external fix. It is marked draft because it tracks an in-flight
upstream dependency that changes what happens next:

- [openucx/ucx#11903](https://github.com/openucx/ucx/pull/11903) (depends on
  [#11902](https://github.com/openucx/ucx/pull/11902)) targets the same failure mode — the
  `ze_copy` memory domain advertises DMA-BUF export support for `ze-device` memory without
  requesting an export descriptor at allocation time. Both PRs are currently open/draft and
  unmerged upstream.
- Plan: once a UCX release containing the fix is available, re-run the byte-for-byte checksum
  check (all-zero, constant, repeating, sparse, random, and mixed-content allocations, plus an
  independent checksum for every Qwen3-0.6B tensor) on this cluster's B60/ConnectX-7 hardware with
  direct RDMA enabled. If it passes, this PR is updated (or followed up) to switch the guide's
  default to direct XPU RDMA before it comes out of draft.

## Testing

- `npx markdownlint-cli2 guides/modelexpress-p2p/README.xpu.md guides/modelexpress-p2p/README.md`: 0 errors.
- `kubectl kustomize guides/modelexpress-p2p/modelserver/xpu/vllm/base` and `.../dranet` both render cleanly, with all resource names and cross-references (`resourceClaimTemplateName`, `configMap.name`) resolving correctly, no double-prefixed or dangling references.
- `pytest scripts/tests/`: 36 passed, 1 skipped (unchanged baseline).
- `scripts/sync-nightly-matrix.py --check`: no diff (no CI workflow changes in this PR).
- Deployed end-to-end on a 2-node Intel Arc Pro B60 cluster: the `base` overlay transferred 339 Qwen3-0.6B tensors (1.20 GB) in 10.73 s (0.9 Gbps) over a 1 Gbps management network; the `dranet` overlay completed the same transfer in 2.20 s (4.4 Gbps) over a 400 Gbps fabric while still forcing `tcp,ze_copy` (no verbs data lane). Both replicas stayed Ready with zero restarts, and inference output matched between seed and receiver.
