### PR TITLE
docs: add token-aware autoscaling guide (KEDA + EPP token backlog)

### DIFF
--- a/guides/workload-autoscaling/README.md
+++ b/guides/workload-autoscaling/README.md
@@ -56,9 +56,17 @@ Adapter.
 
 The [Saturation-based Autoscaling](./keda-epp-saturation/README.md) path has KEDA query Prometheus directly for InferencePool-scoped saturation and running-request metrics, then scale the model server Deployment. KEDA consumes two EPP metrics — pool saturation level (0.0–1.0+, normalized measure of how loaded the pool is) and active in-flight request count — and drives scaling decisions. Well-suited for simple homogeneous deployments where each model scales independently and you want minimal operational overhead.
 
+#### Token-Aware Autoscaling
+
+The [Token-Aware Autoscaling](./keda-epp-token-aware/README.md) path scales on **tokens of outstanding work** rather than a count of requests. An 8192-token prompt is 16x the prefill work of a 512-token one, and a request or queue-depth counter rates them the same, so the same request rate can mean a third of a replica or three replicas of prefill work.
+
+This path measures each phase in its own unit: prefill divides the EPP's in-flight token backlog by a calibrated `peakPrefillThroughput` to get **seconds of queue wait**, comparable directly against a share of your TTFT SLO, while decode reads per-pod KV cache occupancy. Overlays are provided for both topologies: P+D co-located (both phases in one pod) and P/D-disaggregated (split across pods). Best when prompt sizes vary widely, or when you want the prefill threshold derived from a latency target rather than tuned by trial. Requires one calibration run per hardware/model combination.
+
 #### SLO-Aware Autoscaling (KEDA + estimated latency)
 
-A specialization of this path drives the HPA from the pool's **latency** rather than its queue depth. The [SLO-Aware Autoscaling](./slo-aware/README.md) sub-path scales directly against latency SLOs, using the EPP's **estimated** TTFT/TPOT as the signal — either its ML-predicted latency (from the online-trained predictor) or the actual measured latency aggregated in real time when the predictor isn't enabled. A Prometheus recording rule turns that estimate into a single saturation ratio (latency ÷ SLO), and a KEDA `ScaledObject` with an [expr-lang](https://expr-lang.org/) formula computes the desired replica count and drives a standard HPA — no custom controller. With the ML predictor, capacity is added as pressure builds rather than after the queue has already formed. Best when clients express per-request latency SLOs and you want scaling driven by the objective itself rather than a proxy metric.
+A specialization of this path drives the HPA from the pool's **latency** rather than its queue depth. The [SLO-Aware Autoscaling](./slo-aware/README.md) sub-path scales directly against latency SLOs, using the EPP's **estimated** TTFT/TPOT as the signal — either its ML-predicted latency (from the online-trained predictor) or the actual measured latency aggregated in real time when the predictor isn't enabled.
+
+A Prometheus recording rule turns that estimate into a single saturation ratio (latency ÷ SLO), and a KEDA `ScaledObject` with an [expr-lang](https://expr-lang.org/) formula computes the desired replica count and drives a standard HPA — no custom controller. With the ML predictor, capacity is added as pressure builds rather than after the queue has already formed. Best when clients express per-request latency SLOs and you want scaling driven by the objective itself rather than a proxy metric.
 
 ### KEDA + WVA Metrics (Legacy)
 
@@ -68,22 +76,24 @@ WVA is designed for operators running multiple variants of the same model across
 
 ## Choosing a Scaling Signal
 
-| | [Queue-based Autoscaling](./keda-epp-queue/README.md) | [Saturation-based Autoscaling](./keda-epp-saturation/README.md) | [SLO-Aware Autoscaling](./slo-aware/README.md) | [KEDA + WVA Metrics](./wva/README.md) |
-|---|---|---|---|---|
-| **Best for** | Homogeneous deployments; scale on absolute queue depth / running requests (lagging, per-deployment thresholds, no over-provisioning) | Homogeneous deployments; scale on a normalized saturation ratio (leading, more portable thresholds, can potentially over-provision) | Single-pool deployments with per-request latency SLOs, scaled on predicted latency | Multi-variant deployments with cost-aware placement across heterogeneous hardware |
-| **Scaling signal** | EPP metrics such as queue depth and running request count | normalized pool saturation level (0.0–1.0+) and running request count | EPP estimated TTFT/TPOT (ML-predicted, or measured) vs the SLO | KV cache utilization, queue depth, performance budgets |
-| **Cost optimization** | None — scales based on load signals only | None — scales based on load signals only | Minimizes replicas needed to meet the SLO | Optimizes across variants by preferring lower-cost hardware |
-| **Additional components** | KEDA and Prometheus only | KEDA and Prometheus only | KEDA + one Prometheus recording rule | KEDA and WVA controller |
-| **Scale to zero** | Supported | Supported (Needs Validation) | Supported (via KEDA) | Supported |
+| | [Queue-based Autoscaling](./keda-epp-queue/README.md) | [Saturation-based Autoscaling](./keda-epp-saturation/README.md) | [Token-Aware Autoscaling](./keda-epp-token-aware/README.md) | [SLO-Aware Autoscaling](./slo-aware/README.md) | [KEDA + WVA Metrics](./wva/README.md) |
+| --- | --- | --- | --- | --- | --- |
+| **Best for** | Homogeneous deployments; scale on absolute queue depth / running requests (lagging, per-deployment thresholds, no over-provisioning) | Homogeneous deployments; scale on a normalized saturation ratio (leading, more portable thresholds, can potentially over-provision) | Deployments with heterogeneous prompt sizes; scale on token backlog, with the prefill threshold derived from a TTFT SLO | Single-pool deployments with per-request latency SLOs, scaled on predicted latency | Multi-variant deployments with cost-aware placement across heterogeneous hardware |
+| **Scaling signal** | EPP metrics such as queue depth and running request count | normalized pool saturation level (0.0–1.0+) and running request count | EPP in-flight tokens ÷ calibrated prefill throughput (seconds of backlog), and per-pod KV cache occupancy | EPP estimated TTFT/TPOT (ML-predicted, or measured) vs the SLO | KV cache utilization, queue depth, performance budgets |
+| **Cost optimization** | None — scales based on load signals only | None — scales based on load signals only | None — scales based on load signals only | Minimizes replicas needed to meet the SLO | Optimizes across variants by preferring lower-cost hardware |
+| **Additional components** | KEDA and Prometheus only | KEDA and Prometheus only | KEDA and Prometheus, plus one `peakPrefillThroughput` calibration run | KEDA + one Prometheus recording rule | KEDA and WVA controller |
+| **Scale to zero** | Supported | Supported (Needs Validation) | Supported (Needs Validation) | Supported (via KEDA) | Supported |
 
 ## Observability & Troubleshooting
 
-Autoscaling is a closed loop, so the useful view is not a single metric but the **composed signal** across the model servers, the autoscaler, and the resulting pool. Watch the loop end to end: a demand signal rises, the autoscaler raises a replica target, new replicas become ready, and the demand signal comes back down. When scaling misbehaves, the break is almost always at one of those handoffs. Full definitions for the model-server and EPP signals live in the [metric reference](../../docs/operations/observability/metrics.md) and [PromQL reference](../../docs/operations/observability/promql.md); WVA's own metrics are defined in the [WVA Prometheus reference](https://github.com/llm-d/llm-d-workload-variant-autoscaler/blob/main/docs/developer-guide/prometheus.md).
+Autoscaling is a closed loop, so the useful view is not a single metric but the **composed signal** across the model servers, the autoscaler, and the resulting pool. Watch the loop end to end: a demand signal rises, the autoscaler raises a replica target, new replicas become ready, and the demand signal comes back down. When scaling misbehaves, the break is almost always at one of those handoffs.
 
-#### Key metrics for this path
+Full definitions for the model-server and EPP signals live in the [metric reference](../../docs/operations/observability/metrics.md) and [PromQL reference](../../docs/operations/observability/promql.md); WVA's own metrics are defined in the [WVA Prometheus reference](https://github.com/llm-d/llm-d-workload-variant-autoscaler/blob/main/docs/developer-guide/prometheus.md).
+
+### Key metrics for this path
 
 | Stage in the loop | Signal | Why it matters |
-|-------------------|--------|----------------|
+| ------------------- | -------- | ---------------- |
 | Demand | `vllm:num_requests_waiting`, `vllm:kv_cache_usage_perc` ([PromQL → Basic Model Serving](../../docs/operations/observability/promql.md#basic-model-serving)) | The leading indicators autoscaling exists to react to. Queue depth and KV pressure rise before latency does |
 | Demand (EPP view) | `llm_d_epp_request_running` ([Metrics → EPP](../../docs/operations/observability/metrics.md#key-llm-d-router-epp-metrics)) | On the KEDA + EPP path this is the scaling signal itself. Compare it against replica count to see whether scaling is tracking demand |
 | Decision (WVA) | `wva_desired_replicas`, `wva_current_replicas`, `wva_saturation_utilization` | WVA's replica target vs. what is running. A gap that persists means the decision is made but not being actuated |
@@ -91,7 +101,7 @@ Autoscaling is a closed loop, so the useful view is not a single metric but the 
 | Convergence | `llm_d_epp_ready_endpoints` ([Metrics → EPP](../../docs/operations/observability/metrics.md#key-llm-d-router-epp-metrics)) | The pool the router can actually route to. If desired replicas climb but ready endpoints do not follow, new pods are not becoming Ready |
 | Outcome | `vllm:time_to_first_token_seconds`, `vllm:num_requests_waiting` ([Metrics → vLLM](../../docs/operations/observability/metrics.md#key-vllm-metrics)) | Confirms the loop closed: after capacity lands, queue depth and TTFT should recover. If they do not, you scaled on the wrong signal |
 
-#### Common failure modes
+### Common failure modes
 
 * **Demand signal saturated but replicas flat** — the autoscaler is not reacting. On the WVA path check `wva_metrics_freshness_status` and `wva_desired_replicas` for the variant; on the KEDA + EPP path check that the `ScaledObject` is Ready and the external metric is resolving. See the metric-plumbing steps in the [KEDA + EPP troubleshooting](./keda-epp-queue/README.md#troubleshooting) section.
 * **Replica target climbs but the pool does not grow** — `wva_desired_replicas` (or the HPA desired count) rises while `wva_current_replicas` / `llm_d_epp_ready_endpoints` lag. New pods are not scheduling or not passing readiness, usually GPU quota or image pull. See [Desired replicas increase but new replicas are not Ready](./keda-epp-queue/README.md#desired-replicas-increase-but-new-replicas-are-not-ready).

--- a/guides/workload-autoscaling/keda-epp-token-aware/README.md
+++ b/guides/workload-autoscaling/keda-epp-token-aware/README.md
@@ -1,0 +1,332 @@
+# [Experimental] Token-Aware Autoscaling
+
+KEDA queries Prometheus directly for two signals — one EPP-emitted, one vLLM-emitted — and scales your model servers on **tokens of outstanding work** rather than a count of requests. No WVA controller, no Prometheus Adapter — just KEDA, Prometheus, and your model servers.
+
+> [!WARNING]
+> This guide is experimental and subject to change. The metrics, configurations, and APIs may evolve as the feature matures. Use in development and test environments only.
+
+**Why tokens.** An 8192-token prompt is 16× the prefill work of a 512-token one, and a request counter rates them the same. Queue depth and running-request signals ([keda-epp-queue](../keda-epp-queue/README.md), [keda-epp-saturation](../keda-epp-saturation/README.md)) therefore hold well when prompt sizes are homogeneous and drift when they are not: the same request rate can be a third of a replica or three replicas of prefill work. This path closes that gap by counting the tokens themselves.
+
+## How it works
+
+The two phases of inference are bound by different resources, so they are measured in different units and each trigger is built differently.
+
+Three symbols recur throughout this guide:
+
+| Symbol | Full name | What it is |
+| --- | --- | --- |
+| `V_P` | `peakPrefillThroughput` | Your **prefill token velocity**: how many prompt tokens one replica can prefill per second, measured on your own hardware. The one hardware-specific constant this design needs. `V` is for velocity, after the [token-velocity](#references) approach this guide follows. |
+| `ISL` | input sequence length | The **uncached** prompt tokens in a request. "Uncached" matters: a prefix already in the KV cache is not prefilled again, so prefix caching lowers the effective `ISL` without changing the request. |
+| `TTFT` | time to first token | How long a client waits before the first output token arrives. The latency SLO this guide's prefill threshold is derived from. |
+
+`ISL / V_P` is therefore "seconds to prefill one request", and it turns up repeatedly below.
+
+**Prefill is a rate problem.** The EPP publishes the tokens it has dispatched to each endpoint but not yet finished prefilling. Dividing that backlog by **`peakPrefillThroughput`** converts tokens into **seconds of queue wait**, which is directly comparable to a share of your time-to-first-token (TTFT) budget:
+
+```text
+replicas = ceil(  queued_tokens ÷ peakPrefillThroughput  ÷  threshold  )
+                 └──── converts tokens → seconds ────┘   └ seconds of queue budget ┘
+```
+
+`peakPrefillThroughput` is **not** the KEDA threshold. It lives inside the PromQL, where it is a unit conversion; the threshold is the number of seconds of backlog you are willing to tolerate per replica. KEDA has no arithmetic of its own, which is why the division has to be in the query.
+
+**Decode is an occupancy problem.** It has no equivalent measured rate. `vllm:kv_cache_usage_perc` is already a fraction of capacity, so the threshold is compared against it directly and the unit is "pods' worth of full KV cache". When a pod's KV cache fills, vLLM stops admitting requests outright, so you act before that — `0.8` means "act at 80 % full".
+
+### The two topologies
+
+| | [P+D co-located](./optimized-baseline/) | [P/D-disaggregated](./pd-disaggregation/) |
+| --- | --- | --- |
+| **Base guide** | [optimized-baseline](../../optimized-baseline/README.md) | [pd-disaggregation](../../pd-disaggregation/README.md) |
+| **Objects** | one `ScaledObject`, two triggers, one Deployment | one `ScaledObject` per role, two Deployments |
+| **Scaling rule** | `max(ceil(backlog_s / 1.5), ceil(kv / 0.8))` — the current bottleneck wins | prefill and decode scale independently |
+| **Trade-off** | simpler: one calibration, one object. A prompt-heavy burst and a generation-heavy burst both scale the whole pod | tracks lopsided load between phases, at the cost of two objects and a calibration through the KV-transfer path |
+
+The token math is identical across both. Only the query *shape* (role selectors) and the *number* of `ScaledObject`s differ.
+
+## Metrics
+
+| Metric | Type | Description | Labels used |
+| --- | --- | --- | --- |
+| `llm_d_epp_inflight_tokens` | Gauge | Uncached prompt tokens dispatched to an endpoint but not yet prefilled — the prefill backlog. | `namespace`, `producer_name`, `endpoint_name` |
+| `vllm:kv_cache_usage_perc` | Gauge | Per-pod KV cache occupancy (0.0–1.0). | `namespace`, `pod` |
+
+For details on these metrics, see:
+
+- [EPP Request Handling Metrics](../../../docs/architecture/core/router/epp/request-handling.md)
+- [EPP Scheduling Metrics](../../../docs/architecture/core/router/epp/scheduling.md)
+- [Metric reference](../../../docs/operations/observability/metrics.md) and [PromQL reference](../../../docs/operations/observability/promql.md)
+
+### Endpoint-removal note for older EPP images
+
+`llm_d_epp_inflight_tokens` is a `GaugeVec` whose series were historically **not pruned when an endpoint was removed**, so a scaled-down pod left a series frozen at its last non-zero value and `sum()` could never fall back — the fleet would scale up but not down. That was [llm-d-router#2529](https://github.com/llm-d/llm-d-router/issues/2529), **fixed by [llm-d-router#2577](https://github.com/llm-d/llm-d-router/pull/2577)**, and the plain `sum()` queries in this guide rely on that fix.
+
+The fix is on `main` — which is what `ROUTER_EPP_VERSION` defaults to — but it merged after `v0.10.0`, so it is **not in a tagged release yet**. If you pin `ROUTER_EPP_VERSION` to `v0.10.0` or earlier and see prefill scale up but never back down, either move to `main` or intersect the numerator against a metric that *is* rebuilt from live endpoints each scrape, which filters the stale series out:
+
+```promql
+    label_replace(llm_d_epp_inflight_tokens{...}, "target_pod", "$1", "endpoint_name", "(.+)")
+  and on (target_pod)
+    label_replace(llm_d_epp_per_endpoint_queue_size{name="<your-pool>"},
+                  "target_pod", "$1", "model_server_endpoint", "(.+)")
+```
+
+`and on (...)` is a set intersection, not arithmetic — it contributes no value, only liveness. The two `label_replace` calls are plumbing, because the metrics label the same pod as `endpoint_name` and `model_server_endpoint` respectively.
+
+## Prerequisites
+
+Before proceeding, ensure you have:
+
+1. **Monitoring stack with Prometheus over HTTPS** — See [autoscaling prerequisites](../README.md#prerequisites) and [Prometheus Setup Guide](../../../docs/operations/observability/setup.md). This includes KEDA installation. The decode trigger additionally needs the model servers scraped, so apply your base guide's monitoring component (`recipes/modelserver/components/monitoring`, or `monitoring-pd` for P/D) — without it `vllm:kv_cache_usage_perc` never reaches Prometheus and that trigger reads 0 forever.
+
+2. **A deployed base guide** — complete either the [optimized-baseline guide](../../optimized-baseline/README.md) (P+D co-located) or the [pd-disaggregation guide](../../pd-disaggregation/README.md) (P/D-disaggregated), and set `TOPOLOGY` below to match.
+
+3. **The EPP plugins that emit the prefill signal** — `inflight-load-producer` (publishes `llm_d_epp_inflight_tokens`) and `prefix-cache-affinity-filter` (carries `peakPrefillThroughput`). **Both base guides already register these in their shipped router values**, so no EPP change is required beyond step 4. If you built your own router config, add them.
+
+   > [!NOTE]
+   > Keep the EPP at a single replica. The `inflight-load-producer`'s token accounting is local to each EPP process, so multiple replicas would each see — and publish — only a fraction of the per-endpoint load. The `pd-disaggregation` router values pin `replicas: 1` for this reason.
+
+4. **A calibrated `peakPrefillThroughput`** — this is the one hardware-specific constant the design needs, and the shipped values are reference figures (`15928` for Qwen3-32B / H100-80GB / TP=2; `33821` for the P/D guide's gpt-oss-120b / H200 fleet). Measure your own:
+
+<!-- guide:prerequisites.calibration start -->
+```bash
+GUIDE_NAME=${TOPOLOGY} \
+NAMESPACE=${NAMESPACE} \
+MODEL_NAME=${MODEL} \
+CHUNK_SIZE=8192 \
+${REPO_ROOT}/guides/recipes/router/calibration/calibrate.sh
+```
+<!-- guide:prerequisites.calibration end -->
+
+   `calibrate.sh` computes `V_P = CHUNK_SIZE / median(TTFT)` on an idle stack and **only prints** the value — see the [calibration guide](../../recipes/router/calibration/README.md) and the [configuration matrix](../../recipes/router/calibration/configuration-matrix.md). Because TTFT is time-to-*first*-token, the figure already includes the KV transfer to decode and the first decode step on the P/D path. `CHUNK_SIZE` must match vLLM's effective `--max-num-batched-tokens` or the result is silently wrong.
+
+   Measure through the path you will serve on. Do not borrow a published figure: the same GPU and model measured through a P/D path with a slow KV fabric can be several times slower than on the aggregated path, and the divisor changes when prefill scales — one reference stack asked for 8 replicas at `V_P = 2696` and 3 at `V_P = 15928` under identical load.
+
+## Set Namespaces
+
+Set the guide environment variables:
+
+<!-- guide:env.static start -->
+```bash
+export BRANCH=main
+export REPO_ROOT=$(realpath $(git rev-parse --show-toplevel))
+export NAMESPACE=llm-d-optimized-baseline # options: llm-d-optimized-baseline, llm-d-pd-disaggregation
+export MONITORING_NAMESPACE=llm-d-monitoring
+export MODEL=Qwen/Qwen3-32B
+export ENV=existing # options: existing, ocp
+export TOPOLOGY=optimized-baseline # options: optimized-baseline, pd-disaggregation
+export OVERLAY_ROOT=${REPO_ROOT}/guides/workload-autoscaling/keda-epp-token-aware/${TOPOLOGY}
+```
+<!-- guide:env.static end -->
+
+Source the common guide environment variables:
+
+<!-- guide:env.source start -->
+```bash
+source ${REPO_ROOT}/guides/env.sh
+```
+<!-- guide:env.source end -->
+
+## Configure
+
+### 1. Create TriggerAuthentication Secret (generic Kubernetes only)
+
+> On **OpenShift**, skip this step — the `ocp` overlay provisions a dedicated
+> ServiceAccount and token Secret automatically (see [OpenShift](#openshift) below).
+
+For the bundled kube-prometheus-stack on generic Kubernetes, KEDA needs a bearer token and CA certificate to authenticate with Prometheus. Extract these from the Prometheus ServiceAccount's auto-generated token secret and create a new `prometheus-token` secret in the workload namespace:
+
+<!-- guide:deploy.prometheus_auth start -->
+```bash
+# only when ENV=existing:
+SERVICEACCOUNT_SECRET=$(kubectl get serviceaccount prometheus -n ${MONITORING_NAMESPACE} -o jsonpath='{.secrets[0].name}')
+TOKEN=$(kubectl get secret ${SERVICEACCOUNT_SECRET} -n ${MONITORING_NAMESPACE} -o jsonpath='{.data.token}' | base64 -d)
+CA_CRT=$(kubectl get secret ${SERVICEACCOUNT_SECRET} -n ${MONITORING_NAMESPACE} -o jsonpath='{.data.ca\.crt}' | base64 -d)
+kubectl create secret generic prometheus-token \
+  --from-literal=token="${TOKEN}" \
+  --from-literal=ca.crt="${CA_CRT}" \
+  --dry-run=client -o yaml | kubectl apply -f - -n ${NAMESPACE}
+```
+<!-- guide:deploy.prometheus_auth end -->
+
+This creates a secret named `prometheus-token` containing:
+
+- `token`: bearer token for Prometheus authentication
+- `ca.crt`: CA certificate for TLS verification
+
+### 2. Set your calibrated `peakPrefillThroughput`
+
+The value measured in Prerequisites step 4 goes in **two places**, and they are read by different components:
+
+| Where | Read by | Effect |
+| --- | --- | --- |
+| `prefix-cache-affinity-filter.parameters.peakPrefillThroughput` in your guide's router values | the EPP router | prices recomputing a prompt against reusing a cached prefix when picking a pod |
+| the `/ <V_P>` divisor in this overlay's prefill query | the KEDA trigger | converts queued tokens into seconds of backlog |
+
+For the router side, edit your base guide's router values file and re-apply, then restart the EPP:
+
+```bash
+kubectl rollout restart -n ${NAMESPACE} deployment/${TOPOLOGY}-epp
+```
+
+For the trigger side, edit the divisor in the overlay's `scaledobject.yaml` (`optimized-baseline/base/scaledobject.yaml`, or `pd-disaggregation/base/prefill-scaledobject.yaml`). Kustomize cannot reach inside a PromQL string, so this — like the label selectors — is a hand edit.
+
+### 3. Apply the ScaledObject(s) and TriggerAuthentication
+
+On generic Kubernetes with the bundled kube-prometheus-stack, apply the `k8s` overlay:
+
+<!-- guide:deploy.apply_k8s start -->
+```bash
+# only when ENV=existing:
+kubectl apply -k ${OVERLAY_ROOT}/k8s -n ${NAMESPACE}
+```
+<!-- guide:deploy.apply_k8s end -->
+
+On OpenShift, apply the `ocp` overlay instead (see [OpenShift](#openshift) — it handles authentication for you):
+
+<!-- guide:deploy.apply_ocp start -->
+```bash
+# only when ENV=ocp:
+kubectl apply -k ${OVERLAY_ROOT}/ocp -n ${NAMESPACE}
+```
+<!-- guide:deploy.apply_ocp end -->
+
+Before applying, edit the manifests to match your deployment:
+
+- **the `/ <V_P>` divisor** in the prefill query — your calibrated figure (step 2)
+- **`namespace`** in every query, to your deployment's namespace. Both queries pin it: on a cluster-wide store (OpenShift Thanos, or any Prometheus scraping several namespaces) an unpinned query silently aggregates every EPP on the cluster, so a shared-cluster deployment would scale on other tenants' traffic
+- **the `.*prefill.*` / `.*decode.*` selectors** (P/D overlay only) if your Deployments are named differently
+- **`threshold`** on each trigger — see [Choosing the two thresholds](#choosing-the-two-thresholds)
+- **`minReplicaCount`, `maxReplicaCount`**
+- **`serverAddress`** in every trigger, if your Prometheus is not the bundled llm-d stack
+
+### Choosing the two thresholds
+
+#### Prefill: seconds of queue budget, from your TTFT SLO
+
+The prefill threshold is **not measured from anything**. It is the share of your time-to-first-token budget you are willing to spend waiting in the prefill queue — the budget left after the irreducible floor of your workload (`V_P`, `ISL` and `TTFT` are defined under [How it works](#how-it-works)):
+
+```text
+threshold ≈ TTFT_SLO − (ISL_uncached / V_P)        [seconds]
+            └ product target ┘  └ the idle floor ┘
+```
+
+**The idle floor is the TTFT you get when nothing is queued** — one request alone on an unloaded stack. It is the time the pod needs to actually prefill that prompt, and no amount of scaling removes it: adding replicas shortens the *line*, never the work at the front of it. So the floor is what your SLO pays first, and the threshold is whatever is left over.
+
+`ISL/V_P` **is** the whole idle TTFT for that prompt — `V_P` was measured as `CHUNK_SIZE / median(TTFT)` through the router, and TTFT already contains the KV transfer and the first decode step, so do not add a transfer term or you double-count. Autoscaling removes *queueing*; it can never take you below this floor. If `TTFT_SLO ≤ floor`, no threshold meets it — raise `V_P` (faster accelerators, larger prefill chunk) or shrink the *uncached* ISL (prefix caching) instead of scaling.
+
+Worked against three workload shapes at two very different values of `V_P`, to show how much the constant matters. Both `V_P` columns are real calibrations of the same model class: **15928 tok/s** is the plugin's shipped default (Qwen3-32B on H100-80GB, TP=2, measured on the aggregated path), and **2696 tok/s** was measured on comparable hardware through a P/D path, where TTFT also pays the KV transfer to the decode pod. Every cell is the same two steps — `floor = ISL / V_P`, then `threshold = SLO - floor` — so only the constant changes:
+
+| workload | ISL | idle floor at `V_P` = 2696 tok/s | idle floor at `V_P` = 15928 tok/s | example TTFT SLO | threshold at `V_P` = 2696 | threshold at `V_P` = 15928 |
+| --- | --- | --- | --- | --- | --- | --- |
+| prefill-heavy | 8192 | 3.04 s | 0.51 s | 8 s | **~5.0 s** | **~7.5 s** |
+| symmetrical | 2048 | 0.76 s | 0.13 s | 3 s | **~2.2 s** | **~2.9 s** |
+| decode-heavy | 256 | 0.09 s | 0.02 s | trivially met | prefill moot — **decode KV governs** | prefill moot — **decode KV governs** |
+
+Every cell above is two divisions and a subtraction. Spelled out for the prefill-heavy row:
+
+```text
+                    V_P = 2696                  V_P = 15928
+floor     = ISL/V_P    8192 / 2696 = 3.04 s       8192 / 15928 = 0.51 s
+threshold = SLO-floor  8 - 3.04    = 4.96 s       8 - 0.51     = 7.49 s
+                                   ≈ 5.0 s                     ≈ 7.5 s
+```
+
+The thresholds are rounded to one decimal because the SLO they come from is itself a judgement call — carrying 4.96 would imply precision the input does not have.
+
+The same workload against the same SLO wants a threshold 50 % apart across those two columns. That is the argument for calibrating `V_P` on your own serving path rather than borrowing a published figure.
+
+Two adjustments before committing a number:
+
+- **Tail, not mean.** `metricType: AverageValue` makes the signal a per-replica *average*, so roughly half of requests wait longer than the threshold. For a p90/p99 SLO, shave to ~60–70 % of the formula result.
+- **Serving margin.** The calibrated floor is a median on an idle stack; real serving runs higher. One reference cluster measured 4.2 s mean TTFT against a 3.0 s calibrated floor at low rate.
+
+The shipped `1.5` suits interactive / short-context traffic (small ISL, ~2 s SLO). Lower it to scale earlier and hold more prefill pods; raise it to tolerate more queueing and run leaner. Being a little off costs slower first tokens, not failures — prefill latency degrades gradually.
+
+#### Decode: how much KV headroom you keep
+
+`0.8` is compared directly against occupancy and means "act at 80 % full". Lower it for more margin, raise it to run hotter. Unlike prefill, the failure mode here is abrupt: past a full cache vLLM refuses admission, and because decode holds each request for its whole generation, the fleet recovers a full generation-time *behind* the traffic.
+
+### How offered load becomes a replica count
+
+At `V_P = 2696` tok/s with every request at ISL 8192, one replica retires `V_P ÷ ISL = 0.33` req/s of prefill, and load in replica-equivalents is `(r × 8192) ÷ 2696`:
+
+| rate `r` (req/s) | tokens/s | replica-equivalents | `ceil(÷ 1.5)`, cap 4 |
+| --- | --- | --- | --- |
+| 0.15 | 1229 | 0.46 | 1 |
+| 0.30 | 2458 | 0.91 | 1 |
+| 0.50 | 4096 | 1.52 | 2 ← the knee |
+| 1.40 | 11469 | 4.25 | 4 (at cap, real backlog builds) |
+
+The knee lands where the math predicts: 0.50 req/s is the first stage past one replica's 0.33 req/s ceiling. Note that the trigger does not watch offered rate — it watches *measured* backlog, so observed replicas can lead this table during a transient.
+
+### Platform-specific notes
+
+#### OpenShift
+
+On OpenShift, apply the `ocp` overlay (skip Configure step 1 — this overlay handles authentication for you):
+
+```bash
+kubectl apply -k ${OVERLAY_ROOT}/ocp -n ${NAMESPACE}
+```
+
+The overlay:
+
+- Points every trigger at `thanos-querier.openshift-monitoring.svc.cluster.local:9091` and enables `authModes: bearer`. Thanos rejects unauthenticated queries with a 401, and KEDA silently serves `fallback` replicas when a trigger errors, so unauthenticated autoscaling looks healthy while doing nothing.
+- Provisions a dedicated `keda-epp-metrics-reader` ServiceAccount granted the `cluster-monitoring-view` ClusterRole, and repoints the `TriggerAuthentication` at that SA's token Secret. On OpenShift the service-ca operator injects `service-ca.crt` (the CA that signs Thanos's serving certificate) into the token Secret automatically, so no `prometheus-token` copy is required.
+- Renames the `cluster-monitoring-view` ClusterRoleBinding per namespace. The binding is cluster-scoped and the recipe is shared with `keda-epp-queue` and `keda-epp-saturation`, so a fixed name would collide across namespaces or guides. If you deploy to a namespace other than the overlay's default, update that patch too.
+
+## Verify
+
+Check that the ScaledObject(s) are ready and KEDA has created its HPA:
+
+<!-- guide:verify.tests.scaledobject_hpa start -->
+```bash
+kubectl get scaledobject -n ${NAMESPACE}
+kubectl wait --for=condition=Ready scaledobject --all -n ${NAMESPACE} --timeout=120s
+kubectl get hpa -n ${NAMESPACE}
+```
+<!-- guide:verify.tests.scaledobject_hpa end -->
+
+Expected output on the P+D co-located topology (one ScaledObject; P/D yields two, one per role):
+
+```text
+NAME                                              READY   ACTIVE   AGE
+optimized-baseline-nvidia-gpu-vllm-token-aware    True    True     1m
+
+NAME                                                       REFERENCE                                           TARGETS          MINPODS   MAXPODS   REPLICAS   AGE
+keda-hpa-optimized-baseline-nvidia-gpu-vllm-token-aware    Deployment/optimized-baseline-nvidia-gpu-vllm-decode 0/1500m, 0/800m  1         10        1          1m
+```
+
+> [!NOTE]
+> KEDA creates its own HPA object from the ScaledObject. Do **not** apply a separate `hpa.yaml` — doing so will cause conflicts.
+
+`Ready=True` only proves the scaler *config* parses. Confirm the queries actually resolve — a trigger that errors is suppressed by KEDA, which then serves `fallback` replicas while looking healthy:
+
+<!-- guide:verify.tests.trigger_metrics start -->
+```bash
+kubectl get hpa -n ${NAMESPACE} -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .status.conditions[?(@.type=="ScalingActive")]}{.status}{" "}{.reason}{end}{"\n"}{end}'
+kubectl describe hpa -n ${NAMESPACE} | grep -A2 "External metric"
+```
+<!-- guide:verify.tests.trigger_metrics end -->
+
+Every HPA should report `True ValidMetricFound`.
+
+## Cleanup
+
+<!-- guide:cleanup start -->
+```bash
+# only when ENV=existing:
+kubectl delete -k ${OVERLAY_ROOT}/k8s -n ${NAMESPACE} --ignore-not-found=true
+
+# only when ENV=ocp:
+kubectl delete -k ${OVERLAY_ROOT}/ocp -n ${NAMESPACE} --ignore-not-found=true
+
+# only when ENV=existing:
+kubectl delete secret prometheus-token -n ${NAMESPACE} --ignore-not-found=true
+```
+<!-- guide:cleanup end -->
+
+## References
+
+The token-velocity approach — sizing each role by dividing a token rate by that role's token throughput, so prefill and decode share a common denominator in tokens/s — follows:
+
+> Ruiqi Lai, Hongrui Liu, Chengzhi Lu, Zonghao Liu, Siyu Cao, Siyang Shao, Yixin Zhang, Luo Mai, and Dmitrii Ustiugov. **"TokenScale: Timely and Accurate Autoscaling for Disaggregated LLM Serving with Token Velocity."** arXiv:2512.03416 [cs.DC], December 2025. <https://arxiv.org/abs/2512.03416>

--- a/guides/workload-autoscaling/keda-epp-token-aware/guide.yaml
+++ b/guides/workload-autoscaling/keda-epp-token-aware/guide.yaml
@@ -1,0 +1,106 @@
+name: keda-epp-token-aware
+
+env:
+  static:
+    BRANCH: main
+    REPO_ROOT: $(realpath $(git rev-parse --show-toplevel))
+
+    # Namespace of the base deployment this guide autoscales. Switch it with
+    # TOPOLOGY: llm-d-optimized-baseline for the P+D co-located path,
+    # llm-d-pd-disaggregation for the P/D path.
+    NAMESPACE:
+      default: llm-d-optimized-baseline
+      values: [llm-d-optimized-baseline, llm-d-pd-disaggregation]
+    MONITORING_NAMESPACE: llm-d-monitoring
+
+    MODEL: {default: "Qwen/Qwen3-32B"}
+
+    # Target platform. `existing` = generic Kubernetes with the bundled
+    # kube-prometheus-stack (the `k8s` overlay). `ocp` = OpenShift with Thanos
+    # Querier (the `ocp` overlay, which reuses recipes/autoscaling/metrics-reader).
+    # Rendered as an annotation only — it does not gate execution.
+    ENV: {default: existing, values: [existing, ocp]}
+
+    # Serving topology of the deployment being autoscaled. `optimized-baseline` is
+    # P+D co-located (kv_both, one InferencePool, one Deployment) and gets ONE
+    # ScaledObject with both triggers. `pd-disaggregation` splits prefill and decode
+    # across Deployments and gets one ScaledObject per role.
+    TOPOLOGY: {default: optimized-baseline, values: [optimized-baseline, pd-disaggregation]}
+
+    # Autoscaling overlays for this guide (<strategy>/<topology>).
+    OVERLAY_ROOT: ${REPO_ROOT}/guides/workload-autoscaling/keda-epp-token-aware/${TOPOLOGY}
+
+  source: ["${REPO_ROOT}/guides/env.sh"]
+
+prerequisites:
+  # peakPrefillThroughput (V_P) is the one hardware-specific constant this design
+  # needs: the prefill trigger divides queued tokens by it to get SECONDS of
+  # backlog. Measure it on YOUR hardware through YOUR serving path — the shipped
+  # defaults are reference figures, and a wrong divisor silently changes when
+  # prefill scales. calibrate.sh only measures and prints; you set the value in two
+  # places (see Configure step 2).
+  calibration:
+    - run: |
+        GUIDE_NAME=${TOPOLOGY} \
+        NAMESPACE=${NAMESPACE} \
+        MODEL_NAME=${MODEL} \
+        CHUNK_SIZE=8192 \
+        ${REPO_ROOT}/guides/recipes/router/calibration/calibrate.sh
+
+deploy:
+  # Generic Kubernetes only: KEDA needs a bearer token + CA to reach the bundled
+  # kube-prometheus-stack over HTTPS. Extract them from the Prometheus
+  # ServiceAccount's token Secret and create the prometheus-token Secret in the
+  # workload namespace. On OpenShift the ocp overlay provisions its own SA token,
+  # so this step is skipped.
+  prometheus_auth:
+    - when: {ENV: [existing]}
+      run: |
+        SERVICEACCOUNT_SECRET=$(kubectl get serviceaccount prometheus -n ${MONITORING_NAMESPACE} -o jsonpath='{.secrets[0].name}')
+        TOKEN=$(kubectl get secret ${SERVICEACCOUNT_SECRET} -n ${MONITORING_NAMESPACE} -o jsonpath='{.data.token}' | base64 -d)
+        CA_CRT=$(kubectl get secret ${SERVICEACCOUNT_SECRET} -n ${MONITORING_NAMESPACE} -o jsonpath='{.data.ca\.crt}' | base64 -d)
+        kubectl create secret generic prometheus-token \
+          --from-literal=token="${TOKEN}" \
+          --from-literal=ca.crt="${CA_CRT}" \
+          --dry-run=client -o yaml | kubectl apply -f - -n ${NAMESPACE}
+
+  # Apply the ScaledObject(s) and TriggerAuthentication overlay for the platform.
+  # Generic Kubernetes (bundled kube-prometheus-stack):
+  apply_k8s:
+    - when: {ENV: [existing]}
+      run: kubectl apply -k ${OVERLAY_ROOT}/k8s -n ${NAMESPACE}
+  # OpenShift (Thanos Querier + the shared recipes/autoscaling/metrics-reader auth):
+  apply_ocp:
+    - when: {ENV: [ocp]}
+      run: kubectl apply -k ${OVERLAY_ROOT}/ocp -n ${NAMESPACE}
+
+verify:
+  tests:
+    # ScaledObject Ready=True confirms the scaler config is valid; KEDA then creates
+    # its own HPA. Do not apply a separate hpa.yaml — KEDA owns the generated HPA.
+    # The P+D co-located topology yields one ScaledObject, P/D yields two.
+    scaledobject_hpa:
+      - run: |
+          kubectl get scaledobject -n ${NAMESPACE}
+          kubectl wait --for=condition=Ready scaledobject --all -n ${NAMESPACE} --timeout=120s
+          kubectl get hpa -n ${NAMESPACE}
+
+    # A Ready ScaledObject only means the CONFIG parses. When a trigger query
+    # errors — a 401 from Thanos, a typo'd label, a metric that does not exist —
+    # KEDA suppresses the error and serves `fallback` replicas, so autoscaling
+    # looks healthy while doing nothing. ScalingActive=True with reason
+    # ValidMetricFound is the check that the queries actually resolve.
+    trigger_metrics:
+      - run: |
+          kubectl get hpa -n ${NAMESPACE} -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .status.conditions[?(@.type=="ScalingActive")]}{.status}{" "}{.reason}{end}{"\n"}{end}'
+          kubectl describe hpa -n ${NAMESPACE} | grep -A2 "External metric"
+
+cleanup:
+  # Deleting the ScaledObject also removes the KEDA-managed HPA. It does not delete
+  # the target Deployment or reset its replica count.
+  - when: {ENV: [existing]}
+    run: kubectl delete -k ${OVERLAY_ROOT}/k8s -n ${NAMESPACE} --ignore-not-found=true
+  - when: {ENV: [ocp]}
+    run: kubectl delete -k ${OVERLAY_ROOT}/ocp -n ${NAMESPACE} --ignore-not-found=true
+  - when: {ENV: [existing]}
+    run: kubectl delete secret prometheus-token -n ${NAMESPACE} --ignore-not-found=true

--- a/guides/workload-autoscaling/keda-epp-token-aware/optimized-baseline/base/kustomization.yaml
+++ b/guides/workload-autoscaling/keda-epp-token-aware/optimized-baseline/base/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# EPP configuration is deliberately absent here, for two reasons.
+#
+# First, EndpointPickerConfig is the EPP binary's config schema (group
+# llm-d.ai/v1alpha1), not a Kubernetes API type — there is no CRD to apply it
+# against. It is a key inside the <release>-epp ConfigMap.
+#
+# Second, this guide needs no EPP change at all: the optimized-baseline guide's
+# router values already register `inflight-load-producer` (which publishes the
+# prefill trigger's metric) and `prefix-cache-affinity-filter` (which carries
+# peakPrefillThroughput). The only EPP-side work is setting that parameter to
+# YOUR calibrated value — see Prerequisites in the README.
+resources:
+  - scaledobject.yaml
+  - triggerauthentication.yaml

--- a/guides/workload-autoscaling/keda-epp-token-aware/optimized-baseline/base/scaledobject.yaml
+++ b/guides/workload-autoscaling/keda-epp-token-aware/optimized-baseline/base/scaledobject.yaml
@@ -1,0 +1,134 @@
+# Token-aware KEDA autoscaling for the P+D co-located (kv_both) topology.
+#
+# "P+D co-located" = prefill and decode run together in the SAME pod, as opposed
+# to P/D-disaggregated, where they are split across separate pods.
+#
+# One ScaledObject, two triggers, one Deployment. P+D co-located pods run both
+# phases, so there is nothing to scale independently: KEDA evaluates both
+# triggers and scales the Deployment to the MAX of their desired replica counts,
+#
+#   replicas = max( ceil(prefill_backlog_s / 1.5) , ceil(kv_pods_worth / 0.8) )
+#
+# so whichever phase is the current bottleneck wins. The trade-off against the
+# pd-disaggregation overlay is that a prompt-heavy burst and a generation-heavy
+# burst both scale the whole pod.
+#
+# Before applying, update:
+#   - peakPrefillThroughput — the `/ 15928` divisor in the prefill query. This is
+#     the ONE hardware-specific constant the design needs, and the shipped value
+#     is calibrated for Qwen3-32B / H100-80GB / TP=2. Measure your own with
+#     guides/recipes/router/calibration/calibrate.sh. A wrong divisor silently
+#     changes when prefill scales — the same offered load asked for 8 replicas at
+#     2696 tok/s and 3 replicas at 15928 tok/s on one reference stack.
+#   - namespace in both queries, to your deployment's namespace
+#   - threshold on each trigger (the prefill one is workload-dependent — see
+#     "Choosing the two thresholds" in the README)
+#   - minReplicaCount / maxReplicaCount
+#   - serverAddress if your Prometheus is not the bundled llm-d stack (see ../ocp)
+#
+# Both queries pin `namespace`. On a cluster-wide store (OpenShift Thanos, or any
+# Prometheus scraping several namespaces) an unpinned query silently aggregates
+# every EPP on the cluster, so a shared-cluster deployment would scale on other
+# tenants' traffic. Kustomize cannot reach inside these PromQL strings, so the
+# label must be edited by hand to match the target namespace.
+#
+# KEDA will create its own HPA from this ScaledObject. Do NOT apply a separate hpa.yaml.
+
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: optimized-baseline-nvidia-gpu-vllm-token-aware
+  labels:
+    app.kubernetes.io/part-of: keda-epp-token-aware
+    app: optimized-baseline-nvidia-gpu-vllm-decode
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: optimized-baseline-nvidia-gpu-vllm-decode
+  minReplicaCount: 1
+  maxReplicaCount: 10
+  pollingInterval: 15
+  triggers:
+    # ── PREFILL: seconds of uncached prefill backlog ────────────────────────────
+    # inflight_tokens is a token count; dividing by peakPrefillThroughput turns it
+    # into SECONDS of prefill backlog, which is what `threshold` is denominated in.
+    # KEDA has no arithmetic of its own, so the division must live in the PromQL.
+    #
+    # A plain sum() is correct as of llm-d-router#2577, which prunes inflight_tokens
+    # series when an endpoint is removed (llm-d-router#2529). That fix is on `main`
+    # — the ROUTER_EPP_VERSION default — but landed after v0.10.0, so on an EPP
+    # pinned to v0.10.0 or earlier a scaled-down pod strands a frozen series and the
+    # sum never falls back. See "Endpoint-removal note for older EPP images" in the
+    # README for the liveness-intersection workaround if you are pinned to a release.
+    #
+    # sum(), not max(): with metricType AverageValue the HPA computes
+    # ceil(value / threshold), so the numerator must GROW with the pool or the
+    # replica count is structurally capped. sum() also guarantees an empty label
+    # set, which is what lets `or vector(0)` collapse to the single series KEDA
+    # requires — without it the result keeps its pod labels, `or` appends a second
+    # {} series, and KEDA fails with FailedGetExternalMetric.
+    - type: prometheus
+      name: prefill-backlog-seconds
+      metricType: AverageValue
+      metadata:
+        serverAddress: "https://llmd-kube-prometheus-stack-prometheus.llm-d-monitoring.svc.cluster.local:9090"
+        query: |
+          (
+            sum(llm_d_epp_inflight_tokens{namespace="llm-d-optimized-baseline",
+                                          producer_name="inflight-load-producer"}) / 15928
+          ) or vector(0)
+        # Seconds of prefill queue wait tolerated per replica. This is a share of
+        # your TTFT budget, not a measured quantity: threshold ~= TTFT_SLO - ISL/V_P.
+        # 1.5 suits interactive / short-context traffic (~2 s TTFT SLO); long-context
+        # serving needs more. See the README.
+        threshold: "1.5"
+        activationThreshold: "0"
+        unsafeSsl: "false"
+      authenticationRef:
+        name: prometheus-auth
+    # ── DECODE: pods' worth of full KV cache ────────────────────────────────────
+    # kv_cache_usage_perc is already a fraction of capacity, so no unit conversion
+    # is needed and the threshold is compared to it directly. When a pod's KV cache
+    # fills, vLLM stops admitting requests outright, so you act before that: 0.8
+    # means "one replica per 0.8 pods' worth of occupied cache".
+    #
+    # sum(), not avg(), for the same reason as above: avg() cannot exceed ~1.0 no
+    # matter how many pods are full, so ceil(avg / 0.8) pins the Deployment at 2
+    # replicas forever. sum() grows with the pool, and AverageValue divides it back
+    # out per replica, which is what makes 0.8 mean "80 % full per pod".
+    #
+    # vllm:* is scraped from each pod's own /metrics, so a removed pod's scrape
+    # target disappears and its series goes stale on its own.
+    - type: prometheus
+      name: decode-kv-utilization
+      metricType: AverageValue
+      metadata:
+        serverAddress: "https://llmd-kube-prometheus-stack-prometheus.llm-d-monitoring.svc.cluster.local:9090"
+        query: |
+          sum(vllm:kv_cache_usage_perc{namespace="llm-d-optimized-baseline"}) or vector(0)
+        # Pods' worth of full KV cache per replica. Lower keeps more headroom,
+        # higher runs hotter.
+        threshold: "0.8"
+        activationThreshold: "0"
+        unsafeSsl: "false"
+      authenticationRef:
+        name: prometheus-auth
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        # Model weights take minutes to load, so a replica bought on a burst that
+        # drains in seconds is pure cost. Add at most one pod per 3 min and remove
+        # at most one per 5 min, with a 5 min scale-down stabilization window.
+        scaleUp:
+          stabilizationWindowSeconds: 0
+          policies:
+            - type: Pods
+              value: 1
+              periodSeconds: 180
+        scaleDown:
+          stabilizationWindowSeconds: 300
+          policies:
+            - type: Pods
+              value: 1
+              periodSeconds: 300

--- a/guides/workload-autoscaling/keda-epp-token-aware/optimized-baseline/base/triggerauthentication.yaml
+++ b/guides/workload-autoscaling/keda-epp-token-aware/optimized-baseline/base/triggerauthentication.yaml
@@ -1,0 +1,22 @@
+# KEDA TriggerAuthentication for Prometheus bearer token access.
+#
+# References the `prometheus-token` Secret that the guide's Configure step copies
+# from the monitoring namespace into the workload namespace — it carries both the
+# bearer token and the CA certificate needed to reach the bundled
+# kube-prometheus-stack over HTTPS.
+#
+# On OpenShift the ../ocp overlay repoints this at the auto-provisioned
+# metrics-reader ServiceAccount token instead, so the copy step is not needed.
+
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: prometheus-auth
+spec:
+  secretTargetRef:
+    - parameter: bearerToken
+      name: prometheus-token
+      key: token
+    - parameter: ca
+      name: prometheus-token
+      key: ca.crt

--- a/guides/workload-autoscaling/keda-epp-token-aware/optimized-baseline/k8s/kustomization.yaml
+++ b/guides/workload-autoscaling/keda-epp-token-aware/optimized-baseline/k8s/kustomization.yaml
@@ -1,0 +1,10 @@
+# Generic Kubernetes overlay for token-aware autoscaling on the P+D co-located
+# (kv_both) topology. The base ScaledObject already targets the bundled
+# kube-prometheus-stack with a bearer TriggerAuthentication (prometheus-token,
+# copied per the guide's Configure step), so this is a passthrough. Apply this on
+# non-OpenShift clusters; use ../ocp on OpenShift.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base

--- a/guides/workload-autoscaling/keda-epp-token-aware/optimized-baseline/ocp/kustomization.yaml
+++ b/guides/workload-autoscaling/keda-epp-token-aware/optimized-baseline/ocp/kustomization.yaml
@@ -1,0 +1,83 @@
+# OpenShift overlay for token-aware autoscaling on the P+D co-located (kv_both) topology.
+#
+# On OpenShift, metrics live in Thanos Querier, whose :9091 endpoint rejects
+# unauthenticated queries with a 401 — and KEDA suppresses that error and silently
+# serves `fallback` replicas, so an unauthenticated trigger looks healthy while
+# autoscaling does nothing. This overlay makes the token-aware path work on
+# OpenShift by:
+#   - pointing both triggers at Thanos Querier and enabling bearer auth, and
+#   - provisioning a dedicated ServiceAccount (keda-epp-metrics-reader) granted
+#     cluster-monitoring-view, then repointing the TriggerAuthentication at that
+#     SA's token Secret. On OpenShift the service-ca operator injects
+#     `service-ca.crt` (the CA that signs Thanos's serving cert) into the token
+#     Secret automatically — so the guide's manual prometheus-token copy step is
+#     not needed on OpenShift.
+#
+# The decode trigger reads vllm:kv_cache_usage_perc, which reaches Thanos only if
+# the model servers are scraped by user-workload monitoring — apply the guide's
+# modelserver monitoring component before relying on it.
+#
+# Build:  kubectl kustomize ocp
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Default namespace for the guide; override per deployment. The namespace
+# transformer also rewrites the base ScaledObject/TriggerAuthentication namespace
+# and the ServiceAccount subject in the ClusterRoleBinding, keeping them aligned.
+# NOTE: the PromQL label selectors inside the trigger queries are opaque strings
+# the transformer cannot reach — edit them, and the peakPrefillThroughput divisor,
+# to match your EPP pool/namespace and calibrated token rate.
+namespace: llm-d-optimized-baseline
+
+resources:
+  - ../base
+
+# Shared OCP metrics-reader auth (SA + ClusterRoleBinding + token Secret).
+components:
+  - ../../../../recipes/autoscaling/metrics-reader
+
+patches:
+  # Repoint the TriggerAuthentication from the manually-copied prometheus-token
+  # Secret to the auto-provisioned ServiceAccount token Secret. On OpenShift its
+  # `service-ca.crt` is the CA that signs the Thanos serving cert (the base's
+  # ca.crt is the bundled-Prometheus CA and does not verify Thanos).
+  - patch: |-
+      - op: replace
+        path: /spec/secretTargetRef
+        value:
+          - parameter: bearerToken
+            name: keda-epp-metrics-reader-token
+            key: token
+          - parameter: ca
+            name: keda-epp-metrics-reader-token
+            key: service-ca.crt
+    target:
+      kind: TriggerAuthentication
+      name: prometheus-auth
+  # Point both triggers at Thanos Querier and enable bearer authentication.
+  - patch: |-
+      - op: replace
+        path: /spec/triggers/0/metadata/serverAddress
+        value: "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"
+      - op: add
+        path: /spec/triggers/0/metadata/authModes
+        value: "bearer"
+      - op: replace
+        path: /spec/triggers/1/metadata/serverAddress
+        value: "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"
+      - op: add
+        path: /spec/triggers/1/metadata/authModes
+        value: "bearer"
+    target:
+      kind: ScaledObject
+      name: optimized-baseline-nvidia-gpu-vllm-token-aware
+  # The ClusterRoleBinding from the metrics-reader component is cluster-scoped, so
+  # its name must be unique per namespace or two deployments of this guide (or of
+  # keda-epp-saturation / keda-epp-queue, which share the recipe) collide on it.
+  - patch: |-
+      - op: replace
+        path: /metadata/name
+        value: keda-epp-metrics-reader-monitoring-view-llm-d-optimized-baseline
+    target:
+      kind: ClusterRoleBinding
+      name: keda-epp-metrics-reader-monitoring-view

--- a/guides/workload-autoscaling/keda-epp-token-aware/pd-disaggregation/base/decode-scaledobject.yaml
+++ b/guides/workload-autoscaling/keda-epp-token-aware/pd-disaggregation/base/decode-scaledobject.yaml
@@ -1,0 +1,87 @@
+# Token-aware KEDA autoscaling for the DECODE role of a P/D-disaggregated topology.
+#
+# Decode has no equivalent of peakPrefillThroughput — no measured rate, no unit
+# conversion. Its query returns KV cache occupancy, which is already a fraction of
+# capacity, so the threshold is compared to it directly. The unit is "pods' worth
+# of full KV cache".
+#
+# Before applying, update:
+#   - namespace in the query, to your deployment's namespace
+#   - the .*decode.* pod selector if your Deployments are named differently
+#   - threshold, minReplicaCount, maxReplicaCount
+#   - serverAddress if your Prometheus is not the bundled llm-d stack (see ../ocp)
+#
+# KEDA will create its own HPA from this ScaledObject. Do NOT apply a separate hpa.yaml.
+
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: pd-disaggregation-nvidia-gpu-vllm-decode-token-aware
+  labels:
+    app.kubernetes.io/part-of: keda-epp-token-aware
+    llm-d.ai/role: decode
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: pd-disaggregation-nvidia-gpu-vllm-decode
+  minReplicaCount: 1
+  maxReplicaCount: 10
+  pollingInterval: 15
+  triggers:
+    # DECODE: pods' worth of full KV cache, summed over decode pods.
+    #
+    # When a decode pod's KV cache fills, vLLM stops admitting requests outright, so
+    # you act before that: 0.8 means "one replica per 0.8 pods' worth of occupied
+    # cache".
+    #
+    # This is a vLLM metric rather than an EPP one on purpose. The autoscaler needs a
+    # KV reading PER POD so it can filter to decode pods and sum them; vLLM reports
+    # exactly that. The EPP's only KV metric is a single pool-wide average covering
+    # both roles, which cannot be split by role.
+    #
+    # The pod=~".*decode.*" filter is load-bearing: without it the query sums prefill
+    # KV usage into the decode replica count.
+    #
+    # sum(), not avg() or max(): with metricType AverageValue the HPA computes
+    # ceil(value / threshold), so the numerator must grow with the pool. A per-pod
+    # average cannot exceed ~1.0 however many pods are full, which would pin decode
+    # at 2 replicas forever. sum() also guarantees the empty label set that lets
+    # `or vector(0)` collapse to the single series KEDA requires.
+    #
+    # vllm:* is scraped from each pod's own /metrics, so a removed pod's scrape target
+    # disappears and its series goes stale on its own — this trigger was never exposed
+    # to the EPP gauge-pruning issue (llm-d-router#2529) the prefill one was.
+    - type: prometheus
+      name: decode-kv-utilization
+      metricType: AverageValue
+      metadata:
+        serverAddress: "https://llmd-kube-prometheus-stack-prometheus.llm-d-monitoring.svc.cluster.local:9090"
+        query: |
+          sum(vllm:kv_cache_usage_perc{namespace="llm-d-pd-disaggregation",
+                                       pod=~".*decode.*"}) or vector(0)
+        # Pods' worth of full KV cache per replica. Lower keeps more headroom,
+        # higher runs hotter.
+        threshold: "0.8"
+        activationThreshold: "0"
+        unsafeSsl: "false"
+      authenticationRef:
+        name: prometheus-auth
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        # Decode holds each request for its whole generation, so its scale-down is
+        # deliberately slower than its scale-up: removing a pod mid-generation
+        # costs in-flight requests.
+        scaleUp:
+          stabilizationWindowSeconds: 0
+          policies:
+            - type: Pods
+              value: 1
+              periodSeconds: 180
+        scaleDown:
+          stabilizationWindowSeconds: 300
+          policies:
+            - type: Pods
+              value: 1
+              periodSeconds: 300

--- a/guides/workload-autoscaling/keda-epp-token-aware/pd-disaggregation/base/kustomization.yaml
+++ b/guides/workload-autoscaling/keda-epp-token-aware/pd-disaggregation/base/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# EPP configuration is deliberately absent here, for two reasons.
+#
+# First, EndpointPickerConfig is the EPP binary's config schema (group
+# llm-d.ai/v1alpha1), not a Kubernetes API type — there is no CRD to apply it
+# against. It is a key inside the <release>-epp ConfigMap.
+#
+# Second, this guide needs no EPP change at all: the pd-disaggregation guide's
+# router values already register `inflight-load-producer` (which publishes the
+# prefill trigger's metric) and `prefix-cache-affinity-filter` (which carries
+# peakPrefillThroughput). The only EPP-side work is setting that parameter to
+# YOUR calibrated value — see Prerequisites in the README.
+#
+# Two ScaledObjects, one per role: prefill and decode are separate Deployments
+# bound by different resources, so they scale independently.
+resources:
+  - prefill-scaledobject.yaml
+  - decode-scaledobject.yaml
+  - triggerauthentication.yaml

--- a/guides/workload-autoscaling/keda-epp-token-aware/pd-disaggregation/base/prefill-scaledobject.yaml
+++ b/guides/workload-autoscaling/keda-epp-token-aware/pd-disaggregation/base/prefill-scaledobject.yaml
@@ -1,0 +1,103 @@
+# Token-aware KEDA autoscaling for the PREFILL role of a P/D-disaggregated topology.
+#
+# Prefill and decode are separate Deployments bound by different resources —
+# prefill is compute-bound on the prompt pass, decode is memory-bound for the
+# request's whole lifetime — so each gets its own ScaledObject and scales
+# independently. This is the difference from the ../../optimized-baseline overlay,
+# where one ScaledObject with both triggers drives a single P+D co-located Deployment.
+#
+# Before applying, update:
+#   - peakPrefillThroughput — the `/ 33821` divisor. This is the ONE
+#     hardware-specific constant the design needs, and the shipped value is the
+#     pd-disaggregation guide's reference figure (gpt-oss-120b, 8x prefill TP=1 on
+#     H200, chunk 8192), measured THROUGH the full P/D path. Measure your own with
+#     guides/recipes/router/calibration/calibrate.sh: through a P/D path with a
+#     slow KV fabric it can be several times lower than the aggregated-path figure
+#     for the same GPU, and a wrong divisor silently changes when prefill scales.
+#   - namespace in the query, to your deployment's namespace
+#   - the .*prefill.* endpoint selectors if your Deployments are named differently
+#   - threshold (workload-dependent — see "Choosing the two thresholds" in the README)
+#   - minReplicaCount / maxReplicaCount
+#   - serverAddress if your Prometheus is not the bundled llm-d stack (see ../ocp)
+#
+# The query pins `namespace`. On a cluster-wide store (OpenShift Thanos, or any
+# Prometheus scraping several namespaces) an unpinned query silently aggregates
+# every EPP on the cluster, so a shared-cluster deployment would scale on other
+# tenants' traffic. Kustomize cannot reach inside these PromQL strings, so the
+# label must be edited by hand to match the target namespace.
+#
+# KEDA will create its own HPA from this ScaledObject. Do NOT apply a separate hpa.yaml.
+
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: pd-disaggregation-nvidia-gpu-vllm-prefill-token-aware
+  labels:
+    app.kubernetes.io/part-of: keda-epp-token-aware
+    llm-d.ai/role: prefill
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: pd-disaggregation-nvidia-gpu-vllm-prefill
+  minReplicaCount: 1
+  maxReplicaCount: 10
+  pollingInterval: 15
+  triggers:
+    # PREFILL: seconds of uncached prefill backlog on live prefill pods.
+    #
+    # inflight_tokens is a token count; dividing by peakPrefillThroughput turns it
+    # into SECONDS of prefill backlog, which is what `threshold` is denominated in.
+    # KEDA has no arithmetic of its own, so the division must live in the PromQL.
+    #
+    # A plain sum() is correct as of llm-d-router#2577, which prunes inflight_tokens
+    # series when an endpoint is removed (llm-d-router#2529). That fix is on `main`
+    # — the ROUTER_EPP_VERSION default — but landed after v0.10.0, so on an EPP
+    # pinned to v0.10.0 or earlier scaling prefill 4 -> 1 strands three frozen
+    # series and the sum never falls back. See "Endpoint-removal note for older EPP
+    # images" in the README for the liveness-intersection workaround.
+    #
+    # sum(), not max(): with metricType AverageValue the HPA computes
+    # ceil(value / threshold), so the numerator must GROW with the pool or the
+    # replica count is structurally capped. sum() also guarantees an empty label
+    # set, which is what lets `or vector(0)` collapse to the single series KEDA
+    # requires — without it the result keeps its pod labels, `or` appends a second
+    # {} series, and KEDA fails with FailedGetExternalMetric.
+    - type: prometheus
+      name: prefill-backlog-seconds
+      metricType: AverageValue
+      metadata:
+        serverAddress: "https://llmd-kube-prometheus-stack-prometheus.llm-d-monitoring.svc.cluster.local:9090"
+        query: |
+          (
+            sum(llm_d_epp_inflight_tokens{namespace="llm-d-pd-disaggregation",
+                                          producer_name="inflight-load-producer",
+                                          endpoint_name=~".*prefill.*"}) / 33821
+          ) or vector(0)
+        # Seconds of prefill queue wait tolerated per replica. This is a share of
+        # your TTFT budget, not a measured quantity: threshold ~= TTFT_SLO - ISL/V_P.
+        # 1.5 suits interactive / short-context traffic (~2 s TTFT SLO); long-context
+        # serving needs more. See the README.
+        threshold: "1.5"
+        activationThreshold: "0"
+        unsafeSsl: "false"
+      authenticationRef:
+        name: prometheus-auth
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        # Model weights take minutes to load, so a replica bought on a burst that
+        # drains in seconds is pure cost. Add at most one pod per 3 min and remove
+        # at most one per 5 min, with a 5 min scale-down stabilization window.
+        scaleUp:
+          stabilizationWindowSeconds: 0
+          policies:
+            - type: Pods
+              value: 1
+              periodSeconds: 180
+        scaleDown:
+          stabilizationWindowSeconds: 300
+          policies:
+            - type: Pods
+              value: 1
+              periodSeconds: 300

--- a/guides/workload-autoscaling/keda-epp-token-aware/pd-disaggregation/base/triggerauthentication.yaml
+++ b/guides/workload-autoscaling/keda-epp-token-aware/pd-disaggregation/base/triggerauthentication.yaml
@@ -1,0 +1,22 @@
+# KEDA TriggerAuthentication for Prometheus bearer token access.
+#
+# Shared by both ScaledObjects in this overlay. References the `prometheus-token`
+# Secret that the guide's Configure step copies from the monitoring namespace into
+# the workload namespace — it carries both the bearer token and the CA certificate
+# needed to reach the bundled kube-prometheus-stack over HTTPS.
+#
+# On OpenShift the ../ocp overlay repoints this at the auto-provisioned
+# metrics-reader ServiceAccount token instead, so the copy step is not needed.
+
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: prometheus-auth
+spec:
+  secretTargetRef:
+    - parameter: bearerToken
+      name: prometheus-token
+      key: token
+    - parameter: ca
+      name: prometheus-token
+      key: ca.crt

--- a/guides/workload-autoscaling/keda-epp-token-aware/pd-disaggregation/k8s/kustomization.yaml
+++ b/guides/workload-autoscaling/keda-epp-token-aware/pd-disaggregation/k8s/kustomization.yaml
@@ -1,0 +1,10 @@
+# Generic Kubernetes overlay for token-aware autoscaling on the P/D-disaggregated
+# topology. The base ScaledObjects already target the bundled kube-prometheus-stack
+# with a bearer TriggerAuthentication (prometheus-token, copied per the guide's
+# Configure step), so this is a passthrough. Apply this on non-OpenShift clusters;
+# use ../ocp on OpenShift.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base

--- a/guides/workload-autoscaling/keda-epp-token-aware/pd-disaggregation/ocp/kustomization.yaml
+++ b/guides/workload-autoscaling/keda-epp-token-aware/pd-disaggregation/ocp/kustomization.yaml
@@ -1,0 +1,89 @@
+# OpenShift overlay for token-aware autoscaling on the P/D-disaggregated topology.
+#
+# On OpenShift, metrics live in Thanos Querier, whose :9091 endpoint rejects
+# unauthenticated queries with a 401 — and KEDA suppresses that error and silently
+# serves `fallback` replicas, so an unauthenticated trigger looks healthy while
+# autoscaling does nothing. This overlay makes the token-aware path work on
+# OpenShift by:
+#   - pointing both roles' triggers at Thanos Querier and enabling bearer auth, and
+#   - provisioning a dedicated ServiceAccount (keda-epp-metrics-reader) granted
+#     cluster-monitoring-view, then repointing the TriggerAuthentication at that
+#     SA's token Secret. On OpenShift the service-ca operator injects
+#     `service-ca.crt` (the CA that signs Thanos's serving cert) into the token
+#     Secret automatically — so the guide's manual prometheus-token copy step is
+#     not needed on OpenShift.
+#
+# The decode trigger reads vllm:kv_cache_usage_perc, which reaches Thanos only if
+# the model servers are scraped by user-workload monitoring — apply the P/D
+# monitoring component (recipes/modelserver/components/monitoring-pd) before
+# relying on it.
+#
+# Build:  kubectl kustomize ocp
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Default namespace for the guide; override per deployment. The namespace
+# transformer also rewrites the base ScaledObjects'/TriggerAuthentication namespace
+# and the ServiceAccount subject in the ClusterRoleBinding, keeping them aligned.
+# NOTE: the PromQL label selectors inside the trigger queries are opaque strings
+# the transformer cannot reach — edit them, and the peakPrefillThroughput divisor,
+# to match your EPP pool/namespace and calibrated token rate.
+namespace: llm-d-pd-disaggregation
+
+resources:
+  - ../base
+
+# Shared OCP metrics-reader auth (SA + ClusterRoleBinding + token Secret).
+components:
+  - ../../../../recipes/autoscaling/metrics-reader
+
+patches:
+  # Repoint the TriggerAuthentication from the manually-copied prometheus-token
+  # Secret to the auto-provisioned ServiceAccount token Secret. On OpenShift its
+  # `service-ca.crt` is the CA that signs the Thanos serving cert (the base's
+  # ca.crt is the bundled-Prometheus CA and does not verify Thanos).
+  - patch: |-
+      - op: replace
+        path: /spec/secretTargetRef
+        value:
+          - parameter: bearerToken
+            name: keda-epp-metrics-reader-token
+            key: token
+          - parameter: ca
+            name: keda-epp-metrics-reader-token
+            key: service-ca.crt
+    target:
+      kind: TriggerAuthentication
+      name: prometheus-auth
+  # Point the prefill trigger at Thanos Querier and enable bearer authentication.
+  - patch: |-
+      - op: replace
+        path: /spec/triggers/0/metadata/serverAddress
+        value: "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"
+      - op: add
+        path: /spec/triggers/0/metadata/authModes
+        value: "bearer"
+    target:
+      kind: ScaledObject
+      name: pd-disaggregation-nvidia-gpu-vllm-prefill-token-aware
+  # Same for the decode trigger.
+  - patch: |-
+      - op: replace
+        path: /spec/triggers/0/metadata/serverAddress
+        value: "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"
+      - op: add
+        path: /spec/triggers/0/metadata/authModes
+        value: "bearer"
+    target:
+      kind: ScaledObject
+      name: pd-disaggregation-nvidia-gpu-vllm-decode-token-aware
+  # The ClusterRoleBinding from the metrics-reader component is cluster-scoped, so
+  # its name must be unique per namespace or two deployments of this guide (or of
+  # keda-epp-saturation / keda-epp-queue, which share the recipe) collide on it.
+  - patch: |-
+      - op: replace
+        path: /metadata/name
+        value: keda-epp-metrics-reader-monitoring-view-llm-d-pd-disaggregation
+    target:
+      kind: ClusterRoleBinding
+      name: keda-epp-metrics-reader-monitoring-view


### PR DESCRIPTION
## Summary

Adds a new autoscaling path under `guides/workload-autoscaling/`: **token-aware autoscaling**, where KEDA scales model servers on *tokens of outstanding work* rather than a count of requests.

The existing KEDA + EPP paths (`keda-epp-queue`, `keda-epp-saturation`) scale on request-shaped signals — queue depth, running requests, pool saturation. Those hold well when prompt sizes are homogeneous and drift when they are not: an 8192-token prompt is 16× the prefill work of a 512-token one, and a request counter rates them the same, so the same request rate can represent a third of a replica or three replicas of prefill work. This path counts the tokens themselves.

It needs no new components — KEDA and Prometheus only, same as the sibling guides — and no EPP config change, because both base guides already register the plugins it reads from.

## How it works

Each phase is measured in its own unit, because they are bound by different resources.

**Prefill is a rate problem.** `llm_d_epp_inflight_tokens` is a token backlog; dividing it by the calibrated `peakPrefillThroughput` converts tokens into **seconds of queue wait**:

```promql
(
  sum(llm_d_epp_inflight_tokens{namespace="llm-d-optimized-baseline",
                                producer_name="inflight-load-producer"}) / 15928
) or vector(0)
```

The useful consequence is that the threshold becomes **derivable from a latency target** instead of tuned by trial:

```text
threshold ≈ TTFT_SLO − (ISL / V_P)
            └ product ┘  └ idle floor ┘
```

`ISL / V_P` is the irreducible idle TTFT for a prompt. Autoscaling only ever removes *queueing*, so the threshold is whatever the SLO has left after that floor. The guide works this through for three workload shapes and shows the arithmetic. It also flags the case where `TTFT_SLO ≤ floor`, in which no threshold can meet the SLO and scaling is the wrong lever — you need a higher `V_P` or a smaller uncached ISL.

**Decode is an occupancy problem.** No measured rate exists for it. `vllm:kv_cache_usage_perc` is already a fraction of capacity, so the threshold is compared to it directly and `0.8` reads as "act at 80 % full":

```promql
sum(vllm:kv_cache_usage_perc{namespace="llm-d-pd-disaggregation", pod=~".*decode.*"}) or vector(0)
```

This is a vLLM metric rather than an EPP one deliberately: the autoscaler needs a KV reading **per pod** so it can filter by role and aggregate. The EPP's only KV metric is a single pool-wide average covering both roles, which cannot be split.

## Layout

Follows the `<strategy>/<topology>` layout of `keda-epp-saturation`, with `base` / `k8s` / `ocp` under each topology:

```
keda-epp-token-aware/
├── README.md
├── guide.yaml
├── optimized-baseline/      # P+D co-located (kv_both)
│   └── base/ k8s/ ocp/
└── pd-disaggregation/       # prefill and decode split across pods
    └── base/ k8s/ ocp/
```

| | P+D co-located | P/D-disaggregated |
|---|---|---|
| Objects | one `ScaledObject`, two triggers | one `ScaledObject` per role |
| Scaling rule | `max(ceil(backlog_s / 1.5), ceil(kv / 0.8))` — the current bottleneck wins | prefill and decode scale independently |
| Trade-off | one calibration, one object; a prompt-heavy and a generation-heavy burst both scale the whole pod | tracks lopsided load between phases, at the cost of two objects |

The token math is identical in both. Only the query shape (role selectors) and the number of `ScaledObject`s differ.

The `ocp` overlays reuse `recipes/autoscaling/metrics-reader` for Thanos bearer auth, matching the sibling guides, and give the cluster-scoped `ClusterRoleBinding` a namespace-unique name so deployments do not collide across namespaces or across the guides sharing that recipe.

## Points worth reviewer attention

**Both triggers use `sum()`, never `avg()` or `max()`.** With `metricType: AverageValue` the HPA computes `ceil(value / threshold)`, so the numerator must grow with the pool. A per-pod average cannot exceed ~1.0 regardless of fleet size, so `ceil(avg / 0.8)` pins a Deployment at 2 replicas — and worse, the average *drops* each time a replica is added, so it oscillates rather than holding. `sum()` grows with the pool and `AverageValue` divides it back out per replica, which is what makes `0.8` mean "80 % full per pod".

**The plain `sum()` prefill query depends on llm-d-router#2577.** Before that fix, `inflight_tokens` series were not pruned when an endpoint was removed (llm-d-router#2529), so a scaled-down pod stranded a frozen series and the sum could never fall back — scale-up worked, scale-down did not. #2577 is on `main`, which is what `ROUTER_EPP_VERSION` defaults to, but it merged after `v0.10.0`, so it is not in a tagged release yet. The guide therefore keeps a short subsection documenting the liveness-intersection workaround for anyone pinned to `v0.10.0` or earlier. **That subsection can be dropped if a release carrying #2577 ships before this merges** — happy to do so on request.

**`peakPrefillThroughput` appears in two places** and is read by different components: on `prefix-cache-affinity-filter` (the EPP router, for prefix-cache-aware routing) and as the divisor inside the trigger PromQL (KEDA, for the unit conversion). The guide is explicit that these are separate and that kustomize cannot reach inside a PromQL string, so the divisor is a documented hand edit — same as the label selectors in `keda-epp-saturation`.

## Validation

Done locally against this branch:

- `scripts/guide.py check` passes; `scripts/guide.py render --check` reports the README up to date, so the marker rendering is idempotent
- `kubectl kustomize` builds all six overlay directories; the rendered `ocp` output was inspected to confirm the PromQL backreferences survive, the namespace transformer rewrites the `ClusterRoleBinding` subject, and both triggers are repointed at Thanos with `authModes: bearer`
- `pre-commit` passes on every changed file, including `markdownlint` and `yamllint`
- all relative links and internal anchors in the new README resolve
- every numeric cell in the threshold table was re-derived from `ISL`, `V_P` and the SLO and checked against the rendered text

**Not yet done: an end-to-end run on a cluster.** The queries and the design are ported from a working deployment, but this specific overlay set has not been applied to a live cluster and driven through a scaling event. Treating this as a draft for that reason. Marking the guide `[Experimental]` in the title, consistent with `keda-epp-saturation`.

The guide is not added to the CI dry-run exclusions, so the kustomize dry-run job will cover all six overlays.

## Also in this PR

`guides/workload-autoscaling/README.md` gains the new path in the Paths section and a column in the Choosing a Scaling Signal table.

That file also carried three pre-existing `markdownlint` violations (two `MD013` long lines, one `MD001` heading-increment). Since CI lints changed files, touching the file made them blocking, so they are fixed here: two paragraphs split at sentence boundaries with no wording changed, and two `####` headings under an `##` corrected to `###`. Heading anchors are text-derived, so no inbound links change. Called out to explain the otherwise-unrelated moved lines.

## Reference

The token-velocity framing — sizing each role by dividing a token rate by that role's token throughput, so both phases share a denominator in tokens/s — follows *"TokenScale: Timely and Accurate Autoscaling for Disaggregated LLM Serving with Token Velocity"* ([arXiv:2512.03416](https://arxiv.org/abs/2512.03416)), cited in the guide.
