### PR TITLE
Update async guides + observability script

### DIFF
--- a/docs/api-reference/artifacts.md
+++ b/docs/api-reference/artifacts.md
@@ -149,15 +149,15 @@ The [Async Processor](https://github.com/llm-d/llm-d-async) is an optional compo
 
 | Chart | Version | OCI Registry | Description |
 |-------|---------|--------------|-------------|
-| **Async Processor** | v0.9.0 | `oci://ghcr.io/llm-d/charts/llm-d-async` | Deploys the async processor with its queue backend (GCP Pub/Sub or Redis), worker pools, and dispatch gates |
+| **Async Processor** | v0.9.1 | `oci://ghcr.io/llm-d/charts/llm-d-async` | Deploys the async processor with its queue backend (GCP Pub/Sub or Redis), worker pools, and dispatch gates |
 
 ### Images
 
 | Image | Description | Version |
 |-------|-------------|---------|
-| `ghcr.io/llm-d/llm-d-async` | Asynchronous dispatch processor for latency-insensitive traffic | v0.9.0 |
+| `ghcr.io/llm-d/llm-d-async` | Asynchronous dispatch processor for latency-insensitive traffic | v0.9.1 |
 
-Clients that publish requests or consume results can import the Go modules released alongside the image — `github.com/llm-d/llm-d-async/api`, `/pipeline`, and `/producer`, each tagged `v0.9.0`.
+Clients that publish requests or consume results can import the Go modules released alongside the image — `github.com/llm-d/llm-d-async/api`, `/pipeline`, and `/producer`, each tagged `v0.9.1`.
 
 > [!NOTE]
 > The chart was renamed from `async-processor` to `llm-d-async` in v0.8.0, and chart versions now

--- a/docs/architecture/advanced/batch/async-processor.md
+++ b/docs/architecture/advanced/batch/async-processor.md
@@ -68,7 +68,7 @@ The two supported global merge policies are:
 | Policy | Description |
 |--------|-------------|
 | `random-robin` | Default policy. Randomly picks messages from all queues configured for a each pool. |
-| `tier-priority` | Buckets requests into 6 strict priority lanes using routing tags (`(classification, tier)`). Within each bucket, it round-robins across different client channels and stamps the chosen priority header (`x-gateway-priority` by default). |
+| `tier-priority` | Buckets requests into 6 strict priority lanes using routing tags (`(classification, tier)`). Within each bucket, it round-robins across different client channels and stamps lane objectives (`x-llm-d-inference-objective`). |
 
 Because merging lanes are grouped and evaluated independently per worker pool, backpressure from one pool's merged channel only impacts its associated worker pool, maintaining multi-tenant isolation.
 

--- a/guides/batch-serving/asynchronous-processing/README.md
+++ b/guides/batch-serving/asynchronous-processing/README.md
@@ -64,12 +64,14 @@ Deploy the Async Processor using the selected queue implementation's configurati
 ```bash
 export NAMESPACE=llm-d-async
 export MQ_PROVIDER=gcp-pubsub # options are gcp-pubsub or redis
-export ASYNC_VERSION=v0.9.0   # latest llm-d-async release
+export ASYNC_VERSION=v0.9.1   # llm-d-async release
+
+[ "$MQ_PROVIDER" = "redis" ] && TARGET_KEY="ap.transportConfig.queues[0].igw_base_url" || TARGET_KEY="ap.transportConfig.topics[0].igw_base_url"
 
 helm install llm-d-async \
     oci://ghcr.io/llm-d/charts/llm-d-async \
     -f ${REPO_ROOT}/guides/batch-serving/asynchronous-processing/${MQ_PROVIDER}/values.yaml \
-    --set ap.igwBaseURL=http://${IP}:80 \
+    --set ${TARGET_KEY}=http://${IP}:80 \
     -n ${NAMESPACE} --create-namespace --version ${ASYNC_VERSION}
 ```
 

--- a/guides/batch-serving/asynchronous-processing/gcp-pubsub/README.md
+++ b/guides/batch-serving/asynchronous-processing/gcp-pubsub/README.md
@@ -64,10 +64,14 @@ Edit the `values.yaml` file with your specific GCP project and resources:
 
 ```yaml
 ap:
-  gcpPubSub:
-    projectId: "<your-project>"
-    requestSubscriberId: "projects/<your-project>/subscriptions/async-proc-requests-sub"
-    resultTopicId: "projects/<your-project>/topics/async-proc-results"
+  transport: "gcp-pubsub"
+  transportConfig:
+    project_id: "<your-project>"
+    result_topic_id: "projects/<your-project>/topics/async-proc-results"
+    topics:
+      - subscriber_id: "projects/<your-project>/subscriptions/async-proc-requests-sub"
+        request_path_url: "/v1/completions"
+        igw_base_url: "http://<igw-host>:80"
 ```
 
 For deployment instructions, please refer to the [main README](../README.md#installation).

--- a/guides/batch-serving/asynchronous-processing/gcp-pubsub/values.yaml
+++ b/guides/batch-serving/asynchronous-processing/gcp-pubsub/values.yaml
@@ -1,9 +1,10 @@
 ap:
-  messageQueueImpl: "gcp-pubsub"
-  gcpPubSub:
-    enabled: true
+  transport: "gcp-pubsub"
+  transportConfig:
     # Replace with your GCP project and resources
-    projectId: "REPLACE_WITH_YOUR_PROJECT"
-    requestSubscriberId: "projects/REPLACE_WITH_YOUR_PROJECT/subscriptions/async-proc-requests-sub"
-    resultTopicId: "projects/REPLACE_WITH_YOUR_PROJECT/topics/async-proc-results"
-    requestPathURL: "/v1/completions"
+    project_id: "REPLACE_WITH_YOUR_PROJECT"
+    result_topic_id: "projects/REPLACE_WITH_YOUR_PROJECT/topics/async-proc-results"
+    topics:
+      - subscriber_id: "projects/REPLACE_WITH_YOUR_PROJECT/subscriptions/async-proc-requests-sub"
+        request_path_url: "/v1/completions"
+        igw_base_url: "http://REPLACE_WITH_IGW_HOST:80"

--- a/guides/batch-serving/asynchronous-processing/multitenant/README.md
+++ b/guides/batch-serving/asynchronous-processing/multitenant/README.md
@@ -34,32 +34,72 @@ model — and within each pool three teams contend by **tier** and **quota**. Th
 
 The three dimensions:
 
-- **Model → pool isolation.** The publisher sends a request to the `(team, model)` queue and sets
-  `payload.model`; the gateway routes it to that model's `InferencePool`. Each pool has its own workers
-  and its own saturation gate, so one model saturating does not park the other.
+- **Model → pool isolation.** The publisher sets `payload.model`, which the gateway routes to that model's
+  `InferencePool`. Each model gets its own worker pool (`model-a`, `model-b`) and independent saturation gate,
+  so one model saturating does not park the other.
+- **Queue as the serving dimension (tier × model).** A queue represents a **serving SLA tier** for a target model
+  (e.g., interactive latency-sensitive, standard async, or batch throughput), **not a rigid single-tenant silo**.
+  In production, multiple distinct teams can publish into the **same queue** concurrently. The request payload
+  identifies the team via `metadata.team`.
 - **Team → reservation classification.** The per-team **`redis-quota`** gate runs in **`classifying`**
-  mode (keyed on `metadata.team`, with a **per-model prefix** so each `(team, model)` has its own
-  counter): within quota → `reserved` (org-guaranteed), over quota → `overflow` (admitted and
-  deprioritized, **not** nacked).
-- **Tier → priority.** A per-queue `tier` label: `interactive` (premium) > `async` (standard) > `batch`.
+  mode (keyed dynamically on `metadata.team`, with a **per-model prefix** such as `quota:a:team:<team>`):
+  each team maintains its own independent concurrency counter in Redis. When multiple teams share a serving queue,
+  one team exceeding its quota does not exhaust another team's budget: within quota → `reserved` (org-guaranteed),
+  over quota → `overflow` (admitted and deprioritized, **not** nacked).
+- **Tier → priority.** A per-queue `tier` label: `interactive` (premium SLA) > `async` (standard SLA) > `batch`.
 
 The [**tier-priority merge policy**](https://github.com/llm-d/llm-d-async/pull/294) runs
 **per pool independently**: within each model it buckets requests into **6 strict lanes** by
-`(classification, tier)`, dispatches them in order, and stamps **`x-gateway-priority`** (0 = highest …
-5 = lowest):
+`(classification, tier)`, dispatches them in order, and stamps both **`x-gateway-priority`** (0 = highest …
+5 = lowest) and **`x-llm-d-inference-objective`** via `lane_objectives`.
 
-| Lane | `x-gateway-priority` | Who (within one model) |
-| :-- | :-- | :-- |
-| reserved + interactive | 0 | premium within quota |
-| reserved + async | 1 | standard within quota |
-| reserved + batch | 2 | batch within quota |
-| overflow + interactive | 3 | premium over quota |
-| overflow + async | 4 | standard over quota |
-| overflow + batch | 5 | batch over quota |
+By defining matching [`InferenceObjective`](#1-apply-inferenceobjectives-and-deploy-flow-control-router)
+resources in the cluster, `llm-d-async` and `llm-d-router` Flow Control speak the exact same language.
+Requests carry the authoritative objective and tenant identity (`x-llm-d-inference-fairness-id`), allowing
+`llm-d-router` to enforce multi-tenant fairness and priority band admission at the gateway:
+
+| Lane | Objective (`lane_objectives`) | Header `x-llm-d-inference-objective` | Router Band Priority | Who (within one model) |
+| :-- | :-- | :-- | :-- | :-- |
+| reserved + interactive | `reserved-interactive` | `reserved-interactive` | 100 | premium within quota |
+| reserved + async | `reserved-async` | `reserved-async` | 60 | standard within quota |
+| reserved + batch | `reserved-batch` | `reserved-batch` | 30 | batch within quota |
+| overflow + interactive | `overflow-interactive` | `overflow-interactive` | 10 | premium over quota |
+| overflow + async | `overflow-async` | `overflow-async` | 0 | standard over quota |
+| overflow + batch | `overflow-batch` | `overflow-batch` | -10 | batch over quota |
 
 So within each model **all reserved traffic drains before any overflow** (org priority), tier-ordered
 within each class; and the two models are fully independent. On Redis SortedSet, within a lane dispatch
 is earliest-deadline-first (the deadline is the sorted-set score).
+
+### Priority Values: Flow Control ON vs. Flow Control OFF
+
+The system establishes two complementary priority representations:
+- **`x-gateway-priority` (0 to 5):** A scalar integer priority where **0 is highest and 5 is lowest**. This is standard for generic reverse proxies, HTTP load balancers, or Envoy ingress filters that order dispatch based on ascending integer rank.
+- **`x-llm-d-inference-objective` & Router Band Priority (100 to -10):** The Kubernetes [`InferenceObjective`](#1-apply-inferenceobjectives-and-deploy-flow-control-router) specification, where **higher numerical values represent higher scheduling priority**.
+
+#### With Flow Control ON (`llm-d-router`)
+When `llm-d-router` is deployed with Flow Control enabled (`featureGates: [flowControl]` in `flow-control.yaml`):
+- **Centralized Priority Bands:** When model server capacity saturates (detected in real time via `concurrency-detector` or `utilization-detector`), requests are held in memory across priority bands matching the `InferenceObjective` priority (100, 60, 30, 10, 0, -10).
+- **Strict Band Dispatch:** The gateway scheduler drains highest-priority bands first: all `reserved` bands (100, 60, 30) dispatch before any `overflow` band (10, 0, -10) is admitted.
+- **Band Capacity & Drops on Full Bands:** Each priority band enforces isolated buffer limits via `maxRequests` and `maxBytes`. When a priority band reaches capacity, new incoming requests for that band are **dropped immediately (HTTP 429) regardless of that band's priority**. A high priority level does not grant unbounded buffer capacity; an overloaded priority 100 band drops its own incoming traffic rather than evicting queued requests from other bands.
+- **Retries with Backoff in `llm-d-async`:** Requests dropped or rejected by router flow control (e.g., when a priority band is full or during in-flight eviction, returning HTTP 429) are caught by `llm-d-async` and **retried with exponential backoff and jitter** (honoring `Retry-After` headers if returned), provided the request's deadline has not expired.
+- **Multi-Tenant Fairness:** Within any single priority band, the router enforces tenant fairness (`round-robin-fairness-policy` over `x-llm-d-inference-fairness-id`, which is stamped from `metadata.team`). No single tenant can monopolize a priority tier.
+- **Order Preservation:** Within each tenant's individual flow, requests dispatch in arrival order (`fcfs-ordering-policy`).
+- **In-Flight Eviction (`enableEviction: true`):** When eviction is enabled for Flow Control, only **negative-priority in-flight requests** (`priority < 0`, such as `overflow-batch` at priority `-10`) can be canceled and evicted after already being sent to the model server. While standard gated dispatch only holds back newly arriving work, in-flight eviction actively reclaims occupied GPU compute and KV cache from sheddable background requests when higher-priority traffic is blocked by pool saturation.
+- For detailed architecture, lifecycle, and policy plugins, see the [Flow Control Documentation](https://llm-d.ai/docs/architecture/core/router/epp/flow-control).
+
+#### With Flow Control OFF (Baseline Router with Saturation Detection)
+When `llm-d-router` operates in standard baseline mode (without the `flowControl` feature gate):
+- **Pass-Through Scheduling:** The router does not maintain priority band queues or tenant fairness buffers.
+- **Immediate Rejection of Sheddable Requests:** When the pool is saturated, **"sheddable" requests (those with negative priority, `priority < 0`) are immediately rejected with HTTP 429 (Too Many Requests)**. All other requests pass directly to the model servers and are scheduled via baseline routing plugins (such as `prefix-cache-scorer` and `queue-scorer`).
+- **Saturation Telemetry:** The router still exposes real-time pool saturation metrics (`inference_extension_flow_control_pool_saturation` or vLLM metrics).
+- **Upstream Priority & Backpressure in `llm-d-async`:** Priority enforcement shifts entirely **upstream to the Async Processor**:
+  - The `tier-priority` merge policy ensures that all `reserved` requests are dequeued and dispatched before `overflow` traffic, and higher tiers dispatch before lower tiers.
+  - When downstream saturation is detected via Prometheus, the worker pool gate (`wait-on-refuse` or `tier-priority-admission`) intervenes directly in `llm-d-async` by parking workers in-memory (`ActionWait`), refusing messages (`ActionRefuse`), or dropping them (`ActionDrop`).
+  - As a result, model servers remain protected against overload even without router-side priority queuing.
+
+#### With Flow Control OFF (Baseline Router with Saturation Detection)
+When saturation detection is disabled (no saturation detector configured in `llm-d-router`) every request is immediately dispatched to available model servers regardless of its assigned priority value.
 
 > [!NOTE]
 > **Over-quota is deprioritized, not dropped.** In `classifying` mode, requests beyond a team's
@@ -73,16 +113,16 @@ This guide layers on the base [asynchronous-processing](../README.md) guide — 
 [Prerequisites](../README.md#prerequisites) first (client tools, cluster, GAIE CRDs,
 [`guides/env.sh`](../../../env.sh), the HF-token secret), then add the following.
 
-- **Two model stacks behind one gateway.** The model-isolation story needs **two `InferencePool`s**
-  (`POOL_A`, `POOL_B`) behind a single inference gateway that routes by `payload.model` to the matching
-  pool. Bring these up by applying the [optimized-baseline](../../../optimized-baseline/README.md) guide
-  twice with two different models / pool names, or point the guide at your existing multi-model
-  gateway.
+- **Inference Gateway with Flow Control.** This guide uses `llm-d-router` configured with **Flow Control**
+  enabled rather than the standard baseline router. Flow Control assigns incoming requests to priority bands
+  based on the `InferenceObjective` CRD referenced by each request.
 
-> [!NOTE]
-> **Single-model variant.** If you only have one model/pool, point both `model-a` and `model-b` at
-> the same model and `InferencePool` (use the same value for `POOL_A`/`POOL_B` and `MODEL_A`/`MODEL_B`
-> below). You lose the model-isolation demonstration, but the quota and tier behavior is unchanged.
+- **InferenceObjective CRD and Resources.** Requests dispatched by `llm-d-async` carry the
+  `x-llm-d-inference-objective` header matching the request's priority lane. You must install the
+  `InferenceObjective` CRD and define the objective resources in your cluster matching your `InferencePool`.
+
+- **Model Serving Stack.** Either two `InferencePool`s (`POOL_A`, `POOL_B`) for two-model isolation, or a
+  single model server (e.g., vLLM serving `Qwen/Qwen3-8B`) pointed to by both pools.
 
 - **Environment.** In addition to the base guide's variables:
 
@@ -92,36 +132,34 @@ This guide layers on the base [asynchronous-processing](../README.md) guide — 
   export MT=${REPO_ROOT}/guides/batch-serving/asynchronous-processing/multitenant
 
   export NAMESPACE=llm-d-async
-  export ASYNC_VERSION=v0.9.0          # latest llm-d-async release (includes tier-priority + classifying quota)
+  export ASYNC_VERSION=v0.9.1          # llm-d-async release (supports lane_objectives & tier-priority)
 
-  # The shared inference gateway (EPP) address, and the two InferencePool + model names:
-  export IP=$(kubectl get service optimized-baseline-epp -n llm-d-optimized-baseline -o jsonpath='{.spec.clusterIP}')
-  export POOL_A=<pool-a> POOL_B=<pool-b>       # InferencePool names (saturation-gate scope)
-  export MODEL_A=<model-a> MODEL_B=<model-b>   # served model names (go in payload.model)
+  # InferencePool names (saturation-gate scope) and served model names (go in payload.model):
+  export POOL_A=llm-d-router POOL_B=llm-d-router       # InferencePool names (saturation-gate scope)
+  export MODEL_A=Qwen/Qwen3-8B MODEL_B=Qwen/Qwen3-8B   # served model names (go in payload.model)
 
   # Scenario C only: the base URL the saturation gates read PromQL from. The default
-  # matches the kube-prometheus-stack install in Observability below; override it if
-  # your Prometheus lives somewhere else.
-  export PROM_URL=http://kps-kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+  # matches the monitoring setup; override it if your Prometheus lives somewhere else:
+  export PROM_URL=http://llmd-kube-prometheus-stack-prometheus.llm-d-monitoring.svc.cluster.local:9090
 
   # Scenario C only: concurrent requests per model at which that model's pool counts as
-  # saturated. Must be BELOW the pool's worker count (8 in the overlays) — see Scenario C.
+  # saturated. Must be BELOW the pool's worker count (8 in the overlays) — see Scenario C:
   export SAT_CAP=4
   ```
 
 ## Configuration and Deployment
 
 The value overlays live in [`values/`](values/) with literal placeholders (`NAMESPACE`, `IGW_HOST`,
-`POOL_A`, `POOL_B`, `SAT_CAP` in the saturation overlays, `PROM_URL` on the self-hosted-Prometheus
-saturation overlays, and — Pub/Sub only — `PROJECT_ID`). Render one for your environment before
-installing:
+`POOL_A`, `POOL_B`, `POOL_NAME`, `SAT_CAP` in the saturation overlays, and `PROM_URL`). Render one for your
+environment before installing:
 
 ```bash
 render() {   # render <overlay-path> -> stdout
   sed -e "s/NAMESPACE/${NAMESPACE}/g" -e "s#IGW_HOST#${IP}#g" \
       -e "s/POOL_A/${POOL_A}/g" -e "s/POOL_B/${POOL_B}/g" \
+      -e "s/POOL_NAME/${POOL_A}/g" \
       -e "s/SAT_CAP/${SAT_CAP:-4}/g" \
-      -e "s#PROM_URL#${PROM_URL:-http://kps-kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090}#g" "$1"
+      -e "s#PROM_URL#${PROM_URL:-http://llmd-kube-prometheus-stack-prometheus.llm-d-monitoring.svc.cluster.local:9090}#g" "$1"
 }
 ```
 
@@ -129,23 +167,57 @@ render() {   # render <overlay-path> -> stdout
 comments. The served model names reach the system through `payload.model`, which the `publish()`
 helper below fills in from `${MODEL_A}` / `${MODEL_B}`.
 
-### Redis SortedSet (default)
+### 1. Install CRDs and Deploy the Backend Model Server
 
-The bundled Redis backs both the per-team request queues and the quota counters (the overlays point at
-a `redis` service in `${NAMESPACE}`).
+Install the `InferenceObjective` CRD and deploy the vLLM model server:
 
 ```bash
-kubectl create namespace ${NAMESPACE}
+kubectl create namespace ${NAMESPACE} --dry-run=client -o yaml | kubectl apply -f -
+
+# 1. Install InferenceObjective CRD (ROUTER_RELEASE_URL exported from guides/env.sh)
+kubectl apply -f https://github.com/llm-d/llm-d-router/${ROUTER_RELEASE_URL}/manifests.yaml
+
+# 2. Deploy vLLM backend (copy secret & deploy manifest)
+kubectl apply -n ${NAMESPACE} -f ${MT}/manifests/vllm.yaml
+```
+
+> [!TIP]
+> **Prometheus and Grafana:** If you do not already have Prometheus running, deploy the standard stack using the central [Observability Setup Guide](../../../docs/operations/observability/setup.md) (`${REPO_ROOT}/guides/recipes/observability/install-prometheus-grafana.sh`). On GKE, you can also leverage [Google Managed Prometheus (GMP)](#observability).
+
+### 2. Configure llm-d-router and Apply InferenceObjectives
+
+Deploy `llm-d-router` configured with Flow Control and apply the 6 lane `InferenceObjective`s:
+
+```bash
+# 1. Apply InferenceObjectives for the 6 tier-priority lanes
+render ${MT}/manifests/inferenceobjectives.yaml | kubectl apply -f -
+
+# 2. Deploy llm-d-router with Flow Control priority bands
+helm upgrade --install llm-d-router \
+    ${ROUTER_STANDALONE_CHART} \
+    -f ${REPO_ROOT}/guides/recipes/router/base.values.yaml \
+    -f ${MT}/values/router/flow-control.yaml \
+    -n ${NAMESPACE} --version ${ROUTER_CHART_VERSION}
+
+# Get router ClusterIP
+export IP=$(kubectl get service llm-d-router-epp -n ${NAMESPACE} -o jsonpath='{.spec.clusterIP}')
+```
+
+### 3. Deploy Redis and llm-d-async
+
+The bundled Redis backs both the per-team request queues and the quota counters.
+
+```bash
 kubectl apply -n ${NAMESPACE} -f ${MT}/manifests/redis.yaml
 
 render ${MT}/values/redis/quota-only.yaml > /tmp/mt-redis.yaml
 helm install llm-d-async \
     oci://ghcr.io/llm-d/charts/llm-d-async \
     -f /tmp/mt-redis.yaml \
-    -n ${NAMESPACE} --create-namespace --version ${ASYNC_VERSION}
+    -n ${NAMESPACE} --version ${ASYNC_VERSION}
 
-kubectl -n ${NAMESPACE} get deploy llm-d-async -o yaml | grep message-queue-impl
-# -> --message-queue-impl=redis-sortedset
+kubectl -n ${NAMESPACE} get deploy llm-d-async -o yaml | grep transport
+# -> --transport=redis-sortedset
 ```
 
 Queues are just sorted-set keys — no per-team resource creation needed; they appear on first publish.
@@ -180,14 +252,26 @@ Workload Identity, follow the printed binding to map the GSA onto the chart's `l
 </details>
 
 > [!NOTE]
-> Config-only Helm changes are read once at startup — after changing the queue/quota config, run
-> `kubectl rollout restart deploy/llm-d-async -n ${NAMESPACE}`.
+> **Configuration Updates & Dynamic Reloading:**
+> - **Hot-Reloadable Redis Queue Transport:** When running `llm-d-async` with `--transport redis-sortedset`, `--transport-config-file`, and `--transport-config-watch-interval`, changes to the `queues` array (such as adding, updating, or removing queues and quota parameters) are watched and dynamically reloaded at runtime without dropping in-flight requests or requiring pod restarts.
+> - **Static Helm Configurations:** When using inline Helm values without watch intervals, or when altering immutable transport settings (such as Redis URL, worker pool concurrency, merge policy, or on the GCP Pub/Sub backend), configuration is read once at pod startup. Apply changes with:
+>   ```bash
+>   kubectl rollout restart deploy/llm-d-async -n ${NAMESPACE}
+>   ```
 
 ## Publishing requests
 
 A request is a JSON body — `id`, `created`, `deadline`, a `payload` (a completions body whose **`model`
-selects the model/pool at the gateway**), and `metadata.team` (the key the quota gate reads). Publish
-to the **`(team, model)`** queue; the helper takes a team and a model (`a`|`b`).
+selects the model/pool at the gateway**), and `metadata.team` (the tenant identifier that the quota gate
+and downstream fairness policy evaluate).
+
+### Queues as Serving Dimensions vs. Team Identity
+- **The Queue is a Serving Dimension:** A queue corresponds to an SLA tier and model pair (e.g., `interactive` tier for `model-a`), not an isolated single-tenant partition.
+- **Multiple Teams in One Queue:** Requests from different teams can be published into the **exact same queue**. The team identity is carried per-request inside `metadata.team` (e.g., `team: "marketing"` vs. `team: "engineering"`).
+- **Per-Team Quota Accounting:** The `redis-quota` gate dynamically reads `metadata.team` on each request and increments/decrements that specific team's counter (`quota:<model>:team:<team>`). If Team A saturates its reserved limit, Team A's excess traffic is deprioritized to `overflow`, while Team B publishing to that same queue continues to receive `reserved` capacity.
+- **Gateway Fairness ID:** At dispatch, `llm-d-async` stamps `metadata.team` into the `x-llm-d-inference-fairness-id` header so that `llm-d-router`'s Flow Control fairness policy treats tenants equitably during gateway queue contention.
+
+In this demo walkthrough, queues are labeled with team names (e.g. `team-premium-a`) for clear attribution, but you can pass any team name into `publish <team> <a|b> [count]`:
 
 ```bash
 publish() {                                   # publish <team> <a|b> [count]
@@ -234,6 +318,19 @@ publish() {                                   # publish <team> <a|b> [count]
 ```
 <!-- llm-d-cicd:skip end -->
 </details>
+
+### Stress Testing Scripts
+
+Two end-to-end stress testing scripts are provided in [`scripts/`](scripts/) to drive sustained multi-tenant traffic (team × tier × model) concurrently with background gateway saturation to test quota, priority lanes, and populate dashboard metrics:
+
+- **GCP Pub/Sub:** [`scripts/stress-test-pubsub.py`](scripts/stress-test-pubsub.py)
+  ```bash
+  PROJECT_ID=${PROJECT_ID} ./scripts/stress-test-pubsub.py
+  ```
+- **Redis SortedSet:** [`scripts/stress-test-redis.py`](scripts/stress-test-redis.py)
+  ```bash
+  NAMESPACE=${NAMESPACE} ./scripts/stress-test-redis.py
+  ```
 
 ## Scenarios A & B — reserved vs. overflow
 
@@ -323,9 +420,9 @@ keeps dispatching at full rate** (its own gate reads only `POOL_B`). As `model-a
 merge policy drains the highest lanes first. Query each model's budget independently:
 
 ```bash
-# Assumes the kube-prometheus-stack install from Observability below; point this at
+# Assumes the central Prometheus install from Observability below; point this at
 # whatever ${PROM_URL} resolves to if your Prometheus lives elsewhere.
-kubectl port-forward -n monitoring svc/kps-kube-prometheus-stack-prometheus 9090:9090 &
+kubectl port-forward -n llm-d-monitoring svc/llmd-kube-prometheus-stack-prometheus 9090:9090 &
 curl -s localhost:9090/api/v1/query --data-urlencode \
   "query=clamp(1 - sum(vllm:num_requests_running{inference_pool=\"${POOL_A}\"})/${SAT_CAP}, 0, 1)"  # model-a budget -> 0
 curl -s localhost:9090/api/v1/query --data-urlencode \
@@ -357,19 +454,73 @@ against the sizing rule below before concluding the gate worked.
 > In production the divisor is a capacity number, not a demo knob: size it to the pool's real
 > concurrent-request capacity (`ready pods × per-pod concurrency`) and give the pool enough workers
 > to reach it. The gate is back-pressure against **all** traffic on the pool — including synchronous
-> clients — so there the count is not bounded by this processor's workers.
+> traffic that does not go through llm-d-async — so there the count is not bounded by this processor's workers.
+
+## Scenario D — tier-priority-admission with prometheus-saturation
+
+An advanced alternative to `wait-on-refuse(prometheus-query)` is the **`tier-priority-admission`** worker pool gate,
+paired with **`prometheus-saturation`** as its inner saturation detector.
+
+While `wait-on-refuse` applies a uniform park action to all requests when the pool is saturated, `tier-priority-admission`
+issues a **three-way verdict** based on saturation × tier × classification:
+
+| Pool Status | Request Classification & Tier | Gate Verdict | Behavior |
+| :-- | :-- | :-- | :-- |
+| **Unsaturated** | Any | `ActionContinue` | Dispatches immediately to the gateway |
+| **Saturated** | `reserved` (any tier) | `ActionWait` | Parks the worker in-memory until capacity frees |
+| **Saturated** | `overflow` + `interactive` | `ActionDrop` | Drops immediately with an HTTP 429 payload |
+| **Saturated** | `overflow` + `async` / `batch` | `ActionRefuse` | Refuses message and re-enqueues for later delivery |
+
+The configurations are provided in:
+- **Redis SortedSet:** [`values/redis/tier-priority-admission.yaml`](values/redis/tier-priority-admission.yaml)
+- **GCP Pub/Sub:** [`values/pubsub/tier-priority-admission.yaml`](values/pubsub/tier-priority-admission.yaml)
+
+To deploy on **Redis**:
+
+```bash
+render ${MT}/values/redis/tier-priority-admission.yaml > /tmp/mt-tier-priority-admission.yaml
+helm upgrade llm-d-async \
+    oci://ghcr.io/llm-d/charts/llm-d-async \
+    -f /tmp/mt-tier-priority-admission.yaml -n ${NAMESPACE} --version ${ASYNC_VERSION}
+```
+
+<details>
+<summary><b>GCP Pub/Sub deployment</b></summary>
+
+```bash
+sed -e "s/NAMESPACE/${NAMESPACE}/g" -e "s#IGW_HOST#${IP}#g" \
+    -e "s/POOL_A/${POOL_A}/g" -e "s/POOL_B/${POOL_B}/g" \
+    -e "s/PROJECT_ID/${PROJECT_ID}/g" \
+    -e "s#PROM_URL#${PROM_URL:-http://llmd-kube-prometheus-stack-prometheus.llm-d-monitoring.svc.cluster.local:9090}#g" \
+    ${MT}/values/pubsub/tier-priority-admission.yaml > /tmp/mt-pubsub-tier-priority.yaml
+
+helm upgrade llm-d-async \
+    oci://ghcr.io/llm-d/charts/llm-d-async \
+    -f /tmp/mt-pubsub-tier-priority.yaml -n ${NAMESPACE} --version ${ASYNC_VERSION}
+```
+</details>
+
+The inner `prometheus-saturation` gate queries `inference_extension_flow_control_pool_saturation` (or `llm_d_epp_flow_control_pool_saturation`) directly from `llm-d-router`'s metrics endpoint. Verify that the gate evaluates metrics live:
+
+```bash
+# Verify the gate initialized with the inner prometheus-saturation source:
+kubectl logs -n ${NAMESPACE} deploy/llm-d-async | grep -i "tier-priority-admission"
+
+# Check gate evaluation and source availability metrics:
+ASYNC_POD_IP=$(kubectl get pod -l app.kubernetes.io/name=llm-d-async -n ${NAMESPACE} -o jsonpath='{.items[0].status.podIP}')
+kubectl run curl-prom --rm -i --restart=Never -n ${NAMESPACE} --image=curlimages/curl -- \
+    curl -s "http://${ASYNC_POD_IP}:9090/metrics" | grep "async_gate_metric"
+```
 
 ## Observability
 
 Self-hosted Prometheus + Grafana works on any cluster and the gates query it in **real time**; it is
-the path for the Redis backend. The chart ships a `PodMonitor`, `PrometheusRule`, and Grafana
-dashboard; the saturation overlays turn them on.
+the path for the Redis backend. You can leverage the centralized [Observability Setup Guide](../../../docs/operations/observability/setup.md)
+to install the standard Prometheus and Grafana stack:
 
 ```bash
-# 1. Prometheus Operator + Prometheus + Grafana
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm install kps prometheus-community/kube-prometheus-stack \
-  -n monitoring --create-namespace -f ${MT}/values/kube-prometheus-stack.yaml
+# 1. Install standard Prometheus + Grafana stack
+${REPO_ROOT}/guides/recipes/observability/install-prometheus-grafana.sh
 
 # 2. Scrape the vLLM model server (adjust selector/namespace/port in the manifest)
 kubectl apply -f ${MT}/manifests/prometheus-vllm-podmonitor.yaml
@@ -395,11 +546,13 @@ or frozen `async_gate_metric_value` means the gate is running on its fallback bu
 against Prometheus directly as in [Scenario C](#scenario-c--priority-under-saturation).
 
 <details>
-<summary><b>GCP Cloud Monitoring (Pub/Sub on GKE)</b></summary>
+<summary><b>GCP Cloud Monitoring (GKE)</b></summary>
 
 <!-- llm-d-cicd:skip start -->
 ```bash
 kubectl apply -n ${NAMESPACE} -f ${MT}/manifests/gmp-podmonitoring.yaml    # AP metrics -> Cloud Monitoring
+
+# Deploy Cloud Monitoring dashboard (supports both Redis and Pub/Sub backends):
 gcloud monitoring dashboards create --project ${PROJECT_ID} \
   --config-from-file=${MT}/dashboards/cloud-monitoring.json
 
@@ -414,10 +567,12 @@ helm upgrade llm-d-async oci://ghcr.io/llm-d/charts/llm-d-async \
 ```
 <!-- llm-d-cicd:skip end -->
 
-The `PodMonitoring` ingests the AP metrics; the dashboard charts request/success rate, in-flight, p95
-latency, plus **Pub/Sub backlog per team**. The gate-metric panels need an image newer than v0.7.2. GMP
-/ Monarch lags real time ~1–2 min, so gate control is bang-bang on that timescale; the self-hosted
-Prometheus path reacts within one scrape.
+The `PodMonitoring` ingests the AP metrics; the dashboards chart request/success rate, in-flight, p95
+latency, broker backlog (`llm_d_async_async_broker_backlog`), in-process queue depth (`llm_d_async_async_queue_depth`),
+exceeded deadlines, deadline proximity (`llm_d_async_async_deadline_proximity_millis`), and token throughput.
+Note that deadline proximity only works when Redis Sorted Set queues are used (`--transport=redis-sortedset`).
+The gate-metric panels need an image newer than v0.7.2. GMP / Monarch lags real time ~1–2 min, so gate control
+is bang-bang on that timescale; the self-hosted Prometheus path reacts within one scrape.
 </details>
 
 ## Notes & gotchas
@@ -441,15 +596,17 @@ Prometheus path reacts within one scrape.
   a budget of 1 is a fully open gate. If `PROM_URL` is wrong, or the vLLM `PodMonitor` matches nothing,
   Scenario C completes cleanly and demonstrates nothing — no error, no parked pool. Run the three
   checks in [Scenario C](#scenario-c--priority-under-saturation) before drawing conclusions from a run.
+- **Deadline Proximity.** `llm_d_async_async_deadline_proximity_millis` is only supported when using Redis Sorted Set queues (`--transport=redis-sortedset`). Cloud Pub/Sub cannot expose per-item deadlines, so this metric is only emitted on Redis.
 
 ## Cleanup
 
 ```bash
 helm uninstall llm-d-async -n ${NAMESPACE}
+helm uninstall llm-d-router -n ${NAMESPACE}
+render ${MT}/manifests/inferenceobjectives.yaml | kubectl delete -f -
+kubectl delete -n ${NAMESPACE} -f ${MT}/manifests/vllm.yaml
 kubectl delete -n ${NAMESPACE} -f ${MT}/manifests/redis.yaml
-# self-hosted Prometheus/Grafana:
 kubectl delete -f ${MT}/manifests/prometheus-vllm-podmonitor.yaml
-helm uninstall kps -n monitoring && kubectl delete ns monitoring
 ```
 
 <details>

--- a/guides/batch-serving/asynchronous-processing/multitenant/README.md
+++ b/guides/batch-serving/asynchronous-processing/multitenant/README.md
@@ -137,6 +137,7 @@ This guide layers on the base [asynchronous-processing](../README.md) guide — 
   # InferencePool names (saturation-gate scope) and served model names (go in payload.model).
   # In this single-router demo, both logical model pools point to the deployed llm-d-router instance:
   export POOL_A=llm-d-router POOL_B=llm-d-router       # InferencePool names (saturation-gate scope)
+  export POOL_NAME=llm-d-router                       # Shared pool name for InferenceObjectives
   export MODEL_A=Qwen/Qwen3-8B MODEL_B=Qwen/Qwen3-8B   # served model names (go in payload.model)
 
   # Scenario C only: the base URL the saturation gates read PromQL from. The default
@@ -158,7 +159,7 @@ environment before installing:
 render() {   # render <overlay-path> -> stdout
   sed -e "s/NAMESPACE/${NAMESPACE}/g" -e "s#IGW_HOST#${IP}#g" \
       -e "s/POOL_A/${POOL_A}/g" -e "s/POOL_B/${POOL_B}/g" \
-      -e "s/POOL_NAME/${POOL_A}/g" \
+      -e "s/POOL_NAME/${POOL_NAME:-${POOL_A}}/g" \
       -e "s/SAT_CAP/${SAT_CAP:-4}/g" \
       -e "s#PROM_URL#${PROM_URL:-http://llmd-kube-prometheus-stack-prometheus.llm-d-monitoring.svc.cluster.local:9090}#g" "$1"
 }
@@ -205,7 +206,9 @@ export IP=$(kubectl get service llm-d-router-epp -n ${NAMESPACE} -o jsonpath='{.
 ```
 
 > [!NOTE]
-> **Single Router & InferencePool in Demo:** Deploying llm-d Router creates a single `InferencePool` named `llm-d-router`. Both `model-a` and `model-b` worker pools dispatch through this shared llm-d Router. In production environments with multiple distinct models and pools, each pool can be addressed individually via separate `InferencePool` resources or multi-model HTTPRoutes.
+> **Single Router & InferencePool in Demo:** Deploying llm-d Router creates a single `InferencePool` named `llm-d-router`. Both `model-a` and `model-b` worker pools dispatch through this shared llm-d Router, so `render` maps `POOL_NAME` to `${POOL_NAME:-${POOL_A}}` (`llm-d-router`), binding all 6 `InferenceObjective`s to this shared pool.
+>
+> **Multi-Pool Isolation Architecture:** An `InferenceObjective` resource binds to a single `poolRef.name`, and Kubernetes resource names are unique per namespace. In a production multi-tenant architecture with separate Inference Pools (`POOL_A != POOL_B`), the recommended pattern isolates each pool and router in its own namespace (e.g., `ns-pool-a` and `ns-pool-b`). In that case, apply `manifests/inferenceobjectives.yaml` in each namespace with `POOL_NAME` set to that namespace's respective pool name.
 
 ### 3. Deploy Redis and llm-d-async
 
@@ -504,17 +507,29 @@ helm upgrade llm-d-async \
 ```
 </details>
 
-The inner `prometheus-saturation` gate queries `inference_extension_flow_control_pool_saturation` (or `llm_d_epp_flow_control_pool_saturation`) directly from llm-d Router's metrics endpoint. Verify that the gate evaluates metrics live:
+The inner `prometheus-saturation` gate queries the Prometheus server (`${PROM_URL}`) for the metric `inference_extension_flow_control_pool_saturation` exported by llm-d Router's EPP `/metrics` endpoint.
+
+> [!IMPORTANT]
+> **Router Metrics Scraping:** `values/router/flow-control.yaml` configures `router.monitoring.prometheus.enabled: true`, which automatically deploys `ServiceMonitor/llm-d-router-epp-monitor` when the router chart is installed. This ensures Prometheus actively scrapes `inference_extension_flow_control_pool_saturation` (and `llm_d_epp_flow_control_pool_saturation`). Without these metrics in Prometheus, the gate receives empty data and silently falls back to `fallback: 1.0` (budget 1.0, wide open), preventing the gate from ever closing under saturation.
+
+Verify that the metric is being scraped and that the gate evaluates metrics live:
 
 ```bash
-# Verify the gate initialized with the inner prometheus-saturation source:
+# 1. Verify Prometheus has scraped the saturation metric from llm-d-router:
+curl -s localhost:9090/api/v1/query --data-urlencode \
+    "query=inference_extension_flow_control_pool_saturation{inference_pool=\"${POOL_A}\"}"
+
+# 2. Verify the gate initialized with the inner prometheus-saturation source:
 kubectl logs -n ${NAMESPACE} deploy/llm-d-async | grep -i "tier-priority-admission"
 
-# Check gate evaluation and source availability metrics:
+# 3. Check gate evaluation and verify source availability (must report 1, not 0):
 ASYNC_POD_IP=$(kubectl get pod -l app.kubernetes.io/name=llm-d-async -n ${NAMESPACE} -o jsonpath='{.items[0].status.podIP}')
 kubectl run curl-prom --rm -i --restart=Never -n ${NAMESPACE} --image=curlimages/curl -- \
-    curl -s "http://${ASYNC_POD_IP}:9090/metrics" | grep "async_gate_metric"
+    curl -s "http://${ASYNC_POD_IP}:9090/metrics" | grep "async_gate_metric_source_available"
 ```
+
+> [!NOTE]
+> `async_gate_metric_source_available` must be `1`. If it reports `0`, the gate failed to query Prometheus or received no metric samples, causing it to fall back to an open budget (`fallback: 1.0`). A value of `1` confirms that the gate is receiving real live measurements from Prometheus.
 
 ## Observability
 
@@ -526,7 +541,7 @@ to install the standard Prometheus and Grafana stack:
 # 1. Install standard Prometheus + Grafana stack
 ${REPO_ROOT}/guides/recipes/observability/install-prometheus-grafana.sh
 
-# 2. Scrape the vLLM model server (adjust selector/namespace/port in the manifest)
+# 2. Scrape the vLLM model server (llm-d Router EPP is scraped automatically via its Helm chart ServiceMonitor)
 kubectl apply -f ${MT}/manifests/prometheus-vllm-podmonitor.yaml
 ```
 
@@ -589,9 +604,9 @@ is bang-bang on that timescale; the self-hosted Prometheus path reacts within on
   keep the **sum** of that model's reserved quotas at or below the pool's worker count.
 - **Per-model quota counters** are keyed `quota:<a|b>:team:<team>`, so a team's reserved capacity on
   model A is independent of its capacity on model B.
-- **Saturation gate.** These overlays use `prometheus-query` over `vllm:num_requests_running`. The
-  `prometheus-saturation` gate instead expects the EPP metric
-  `llm_d_epp_flow_control_pool_saturation`.
+- **Saturation gate.** The Scenario C overlays use `prometheus-query` over `vllm:num_requests_running`. The
+  `prometheus-saturation` gate (Scenario D) instead expects the EPP metric
+  `inference_extension_flow_control_pool_saturation`.
 - **Saturation divisor vs. pool size.** `SAT_CAP` is the concurrency at which a model counts as
   saturated, and the gate closes only when the budget hits 0 — i.e. only once `SAT_CAP` requests are
   running. Keep it **below** that pool's `workers`, or async load alone can never close the gate; see

--- a/guides/batch-serving/asynchronous-processing/multitenant/README.md
+++ b/guides/batch-serving/asynchronous-processing/multitenant/README.md
@@ -18,12 +18,12 @@ walkthroughs are identical across both; only the queue wiring and how you publis
 
 ## Overview
 
-The demo runs **two models**, each served by its own `InferencePool` behind one gateway. Each model
-gets its **own worker pool** (`model-a`, `model-b`) — so concurrency and saturation are isolated per
-model — and within each pool three teams contend by **tier** and **quota**. That's **6 queues**
-(3 teams × 2 models) → **2 pools**:
+The demo simulates **two model pipelines** (`model-a`, `model-b`) behind llm-d Router. Each model
+pipeline gets its **own worker pool** in `llm-d-async` — isolating worker concurrency, queue draining, and saturation
+back-off per model — and within each pool three teams contend by **tier** and **quota**. That's **6 queues**
+(3 teams × 2 models) → **2 worker pools**:
 
-| Model → pool | Team | Queue (Redis) | Tier | Reserved quota | Quota prefix |
+| Model Pipeline → Worker Pool | Team | Queue (Redis) | Tier | Reserved quota | Quota prefix |
 | :-- | :-- | :-- | :-- | :-- | :-- |
 | **`model-a`** | premium | `team-premium-a` | `interactive` | concurrency **2** | `quota:a:` |
 | | standard | `team-standard-a` | `async` | concurrency **2** | `quota:a:` |
@@ -32,11 +32,12 @@ model — and within each pool three teams contend by **tier** and **quota**. Th
 | | standard | `team-standard-b` | `async` | concurrency **2** | `quota:b:` |
 | | batch | `team-batch-b` | `batch` | concurrency **1** | `quota:b:` |
 
+> [!NOTE]
+> **Single-Router Demo vs. Multi-Model Production:** In a full multi-model production environment, each model is typically served by its own `InferencePool` behind a gateway (e.g. using Gateway API HTTPRoutes with dedicated llm-d Routers). To keep this demo lightweight and runnable on a single GPU (or CPU test cluster), the walkthrough deploys a **single `llm-d-router` instance** and a single vLLM model server (`Qwen/Qwen3-8B`), with both logical model pipelines (`model-a` and `model-b`) pointing to that shared llm-d Router pool (`POOL_A=llm-d-router`, `POOL_B=llm-d-router`). If your cluster already has multiple `InferencePool`s deployed, you can point `POOL_A` and `POOL_B` to distinct pools for full physical backend isolation.
+
 The three dimensions:
 
-- **Model → pool isolation.** The publisher sets `payload.model`, which the gateway routes to that model's
-  `InferencePool`. Each model gets its own worker pool (`model-a`, `model-b`) and independent saturation gate,
-  so one model saturating does not park the other.
+- **Model → worker pool isolation.** Each model track gets its own `llm-d-async` worker pool (`model-a`, `model-b`), independent concurrency limits, and dedicated saturation gates. In production with multiple `InferencePool`s, saturating one model pool parks only that model's workers without affecting the other. In this single-pool demo environment, both worker pools dispatch through the shared `llm-d-router` instance while demonstrating the independent queue, quota, and worker isolation mechanisms.
 - **Queue as the serving dimension (tier × model).** A queue represents a **serving tier** for a target model
   (e.g., interactive latency-sensitive, standard async, or batch throughput), **not a rigid single-tenant silo**.
   In production, multiple distinct teams can publish into the **same queue** concurrently. The request payload
@@ -55,7 +56,7 @@ The [**tier-priority merge policy**](https://github.com/llm-d/llm-d-async/pull/2
 By defining matching [`InferenceObjective`](#1-apply-inferenceobjectives-and-deploy-flow-control-router)
 resources in the cluster, `llm-d-async` and `llm-d-router` Flow Control speak the exact same language.
 Requests carry the authoritative objective and tenant identity (`x-llm-d-inference-fairness-id`), allowing
-`llm-d-router` to enforce multi-tenant fairness and priority band admission at the gateway:
+`llm-d-router` to enforce multi-tenant fairness and priority band admission:
 
 | Lane | Objective (`lane_objectives`) | Header `x-llm-d-inference-objective` | Router Band Priority | Who (within one model) |
 | :-- | :-- | :-- | :-- | :-- |
@@ -77,7 +78,7 @@ Downstream priority is propagated via lane objective stamping (**`x-llm-d-infere
 #### With Flow Control ON (`llm-d-router`)
 When `llm-d-router` is deployed with Flow Control enabled (`featureGates: [flowControl]` in `flow-control.yaml`):
 - **Centralized Priority Bands:** When model server capacity saturates (detected in real time via `concurrency-detector` or `utilization-detector`), requests are held in memory across priority bands matching the `InferenceObjective` priority (100, 60, 30, 10, 0, -10).
-- **Strict Band Dispatch:** The gateway scheduler drains highest-priority bands first: all `reserved` bands (100, 60, 30) dispatch before any `overflow` band (10, 0, -10) is admitted.
+- **Strict Band Dispatch:** llm-d router drains highest-priority bands first: all `reserved` bands (100, 60, 30) dispatch before any `overflow` band (10, 0, -10) is admitted.
 - **Band Capacity & Drops on Full Bands:** Each priority band enforces isolated buffer limits via `maxRequests` and `maxBytes`. When a priority band reaches capacity, new incoming requests for that band are **dropped immediately (HTTP 429) regardless of that band's priority**. A high priority level does not grant unbounded buffer capacity; an overloaded priority 100 band drops its own incoming traffic rather than evicting queued requests from other bands.
 - **Retries with Backoff in `llm-d-async`:** Requests dropped or rejected by router flow control (e.g., when a priority band is full or during in-flight eviction, returning HTTP 429) are caught by `llm-d-async` and **retried with exponential backoff and jitter** provided the request's deadline has not expired.
 - **Multi-Tenant Fairness:** Within any single priority band, the router enforces tenant fairness (`round-robin-fairness-policy` over `x-llm-d-inference-fairness-id`, which is stamped from `metadata.team`). No single tenant can monopolize a priority tier.
@@ -96,7 +97,7 @@ When `llm-d-router` operates in standard baseline mode (without the `flowControl
   - When downstream saturation is detected via Prometheus, the worker pool gate (`wait-on-refuse` or `tier-priority-admission`) intervenes directly in `llm-d-async` by parking workers in-memory (`ActionWait`), refusing messages (`ActionRefuse`), or dropping them (`ActionDrop`).
   - As a result, model servers remain protected against overload even without router-side priority queuing.
 
-#### With Flow Control OFF (Baseline Router with Saturation Detection)
+#### With Flow Control OFF (Baseline Router without Saturation Detection)
 When saturation detection is disabled (no saturation detector configured in `llm-d-router`) every request is immediately dispatched to available model servers regardless of its assigned priority value.
 
 > [!NOTE]
@@ -111,7 +112,7 @@ This guide layers on the base [asynchronous-processing](../README.md) guide — 
 [Prerequisites](../README.md#prerequisites) first (client tools, cluster, GAIE CRDs,
 [`guides/env.sh`](../../../env.sh), the HF-token secret), then add the following.
 
-- **Inference Gateway with Flow Control.** This guide uses `llm-d-router` configured with **Flow Control**
+- **llm-d router with Flow Control.** This guide uses `llm-d-router` configured with **Flow Control**
   enabled rather than the standard baseline router. Flow Control assigns incoming requests to priority bands
   based on the `InferenceObjective` CRD referenced by each request.
 
@@ -119,8 +120,9 @@ This guide layers on the base [asynchronous-processing](../README.md) guide — 
   `x-llm-d-inference-objective` header matching the request's priority lane. You must install the
   `InferenceObjective` CRD and define the objective resources in your cluster matching your `InferencePool`.
 
-- **Model Serving Stack.** Either two `InferencePool`s (`POOL_A`, `POOL_B`) for two-model isolation, or a
-  single model server (e.g., vLLM serving `Qwen/Qwen3-8B`) pointed to by both pools.
+- **Model Serving Stack & Router.** The walkthrough deploys a single `llm-d-router` instance (which creates
+  the `llm-d-router` InferencePool) and a single vLLM model server serving `Qwen/Qwen3-8B`. In a multi-model
+  environment, you can point `POOL_A` and `POOL_B` to separate `InferencePool`s for physical pool isolation.
 
 - **Environment.** In addition to the base guide's variables:
 
@@ -132,7 +134,8 @@ This guide layers on the base [asynchronous-processing](../README.md) guide — 
   export NAMESPACE=llm-d-async
   export ASYNC_VERSION=v0.9.1          # llm-d-async release (supports lane_objectives & tier-priority)
 
-  # InferencePool names (saturation-gate scope) and served model names (go in payload.model):
+  # InferencePool names (saturation-gate scope) and served model names (go in payload.model).
+  # In this single-router demo, both logical model pools point to the deployed llm-d-router instance:
   export POOL_A=llm-d-router POOL_B=llm-d-router       # InferencePool names (saturation-gate scope)
   export MODEL_A=Qwen/Qwen3-8B MODEL_B=Qwen/Qwen3-8B   # served model names (go in payload.model)
 
@@ -201,6 +204,9 @@ helm upgrade --install llm-d-router \
 export IP=$(kubectl get service llm-d-router-epp -n ${NAMESPACE} -o jsonpath='{.spec.clusterIP}')
 ```
 
+> [!NOTE]
+> **Single Router & InferencePool in Demo:** Deploying `llm-d-router` creates a single `InferencePool` named `llm-d-router`. Both `model-a` and `model-b` worker pools dispatch through this shared llm-d Router. In production environments with multiple distinct models and pools, each pool can be addressed individually via separate `InferencePool` resources or multi-model HTTPRoutes.
+
 ### 3. Deploy Redis and llm-d-async
 
 The bundled Redis backs both the per-team request queues and the quota counters.
@@ -259,15 +265,13 @@ Workload Identity, follow the printed binding to map the GSA onto the chart's `l
 
 ## Publishing requests
 
-A request is a JSON body — `id`, `created`, `deadline`, a `payload` (a completions body whose **`model`
-selects the model/pool at the gateway**), and `metadata.team` (the tenant identifier that the quota gate
-and downstream fairness policy evaluate).
+A request is a JSON body — `id`, `created`, `deadline`, a `payload` (the inference request that is dispatched to llm-d Router), and `metadata.team` (the tenant identifier that the quota gate evaluates).
 
 ### Queues as Serving Dimensions vs. Team Identity
 - **The Queue is a Serving Dimension:** A queue corresponds to an service tier and model pair (e.g., `interactive` tier for `model-a`), not an isolated single-tenant partition although it is used as such in this demo because each team uses a separate queue. 
 - **Multiple Teams in One Queue:** Requests from different teams can be published into the **exact same queue**. The team identity is carried per-request inside `metadata.team` (e.g., `team: "marketing"` vs. `team: "engineering"`).
 - **Per-Team Quota Accounting:** The `redis-quota` gate dynamically reads `metadata.team` on each request and increments/decrements that specific team's counter (`quota:<model>:team:<team>`). If Team A saturates its reserved limit, Team A's excess traffic is deprioritized to `overflow`, while Team B publishing to that same queue continues to receive `reserved` capacity.
-- **Gateway Fairness ID:** At dispatch, `llm-d-async` stamps `metadata.team` into the `x-llm-d-inference-fairness-id` header so that `llm-d-router`'s Flow Control fairness policy treats tenants equitably during gateway queue contention.
+- **Fairness ID:** At dispatch, `llm-d-async` stamps `metadata.team` into the `x-llm-d-inference-fairness-id` header so that `llm-d-router`'s Flow Control fairness policy treats tenants equitably during queue contention.
 
 In this demo walkthrough, queues are labeled with team names (e.g. `team-premium-a`) for clear attribution, but you can pass any team name into `publish <team> <a|b> [count]`:
 
@@ -319,7 +323,7 @@ publish() {                                   # publish <team> <a|b> [count]
 
 ### Stress Testing Scripts
 
-Two end-to-end stress testing scripts are provided in [`scripts/`](scripts/) to drive sustained multi-tenant traffic (team × tier × model) concurrently with background gateway saturation to test quota, priority lanes, and populate dashboard metrics:
+Two end-to-end stress testing scripts are provided in [`scripts/`](scripts/) to drive sustained multi-tenant traffic (team × tier × model) concurrently to test quota, priority lanes, and populate dashboard metrics:
 
 - **GCP Pub/Sub:** [`scripts/stress-test-pubsub.py`](scripts/stress-test-pubsub.py)
   ```bash
@@ -414,7 +418,9 @@ wait
 
 As model A's `InferencePool` saturates, `model-a`'s budget → 0 and its workers **park in-memory
 (`ActionWait`)** — so `model-a` stops pulling new work without churning the backlog, while **`model-b`
-keeps dispatching at full rate** (its own gate reads only `POOL_B`). As `model-a`'s capacity frees, its
+keeps dispatching at full rate** when `POOL_B` points to an independent, unsaturated pool. *(Note: In this
+single-router demo where both `POOL_A` and `POOL_B` point to `llm-d-router`, both gates monitor the shared model
+server; in a multi-pool setup where `POOL_A != POOL_B`, only model A parks.)* As capacity frees, the
 merge policy drains the highest lanes first. Query each model's budget independently:
 
 ```bash
@@ -464,7 +470,7 @@ issues a **three-way verdict** based on saturation × tier × classification:
 
 | Pool Status | Request Classification & Tier | Gate Verdict | Behavior |
 | :-- | :-- | :-- | :-- |
-| **Unsaturated** | Any | `ActionContinue` | Dispatches immediately to the gateway |
+| **Unsaturated** | Any | `ActionContinue` | Dispatches immediately to llm-d router |
 | **Saturated** | `reserved` (any tier) | `ActionWait` | Parks the worker in-memory until capacity frees |
 | **Saturated** | `overflow` + `interactive` | `ActionDrop` | Drops immediately with an HTTP 429 payload |
 | **Saturated** | `overflow` + `async` / `batch` | `ActionRefuse` | Refuses message and re-enqueues for later delivery |

--- a/guides/batch-serving/asynchronous-processing/multitenant/README.md
+++ b/guides/batch-serving/asynchronous-processing/multitenant/README.md
@@ -33,11 +33,11 @@ back-off per model — and within each pool three teams contend by **tier** and 
 | | batch | `team-batch-b` | `batch` | concurrency **1** | `quota:b:` |
 
 > [!NOTE]
-> **Single-Router Demo vs. Multi-Model Production:** In a full multi-model production environment, each model is typically served by its own `InferencePool` behind a gateway (e.g. using Gateway API HTTPRoutes with dedicated llm-d Routers). To keep this demo lightweight and runnable on a single GPU (or CPU test cluster), the walkthrough deploys a **single `llm-d-router` instance** and a single vLLM model server (`Qwen/Qwen3-8B`), with both logical model pipelines (`model-a` and `model-b`) pointing to that shared llm-d Router pool (`POOL_A=llm-d-router`, `POOL_B=llm-d-router`). If your cluster already has multiple `InferencePool`s deployed, you can point `POOL_A` and `POOL_B` to distinct pools for full physical backend isolation.
+> **Single-Router Demo vs. Multi-Model Production:** In a full multi-model production environment, each model is typically served by its own `InferencePool` behind a gateway (e.g. using Gateway API HTTPRoutes with dedicated llm-d Routers). To keep this demo lightweight and runnable on a single GPU (or CPU test cluster), the walkthrough deploys a **single llm-d Router instance** and a single vLLM model server (`Qwen/Qwen3-8B`), with both logical model pipelines (`model-a` and `model-b`) pointing to that shared llm-d Router pool (`POOL_A=llm-d-router`, `POOL_B=llm-d-router`). If your cluster already has multiple `InferencePool`s deployed, you can point `POOL_A` and `POOL_B` to distinct pools for full physical backend isolation.
 
 The three dimensions:
 
-- **Model → worker pool isolation.** Each model track gets its own `llm-d-async` worker pool (`model-a`, `model-b`), independent concurrency limits, and dedicated saturation gates. In production with multiple `InferencePool`s, saturating one model pool parks only that model's workers without affecting the other. In this single-pool demo environment, both worker pools dispatch through the shared `llm-d-router` instance while demonstrating the independent queue, quota, and worker isolation mechanisms.
+- **Model → worker pool isolation.** Each model track gets its own `llm-d-async` worker pool (`model-a`, `model-b`), independent concurrency limits, and dedicated saturation gates. In production with multiple `InferencePool`s, saturating one model pool parks only that model's workers without affecting the other. In this single-pool demo environment, both worker pools dispatch through the shared llm-d Router instance while demonstrating the independent queue, quota, and worker isolation mechanisms.
 - **Queue as the serving dimension (tier × model).** A queue represents a **serving tier** for a target model
   (e.g., interactive latency-sensitive, standard async, or batch throughput), **not a rigid single-tenant silo**.
   In production, multiple distinct teams can publish into the **same queue** concurrently. The request payload
@@ -54,9 +54,9 @@ The [**tier-priority merge policy**](https://github.com/llm-d/llm-d-async/pull/2
 `(classification, tier)`, dispatches them in order, and stamps **`x-llm-d-inference-objective`** via `lane_objectives`.
 
 By defining matching [`InferenceObjective`](#1-apply-inferenceobjectives-and-deploy-flow-control-router)
-resources in the cluster, `llm-d-async` and `llm-d-router` Flow Control speak the exact same language.
+resources in the cluster, `llm-d-async` and llm-d Router Flow Control speak the exact same language.
 Requests carry the authoritative objective and tenant identity (`x-llm-d-inference-fairness-id`), allowing
-`llm-d-router` to enforce multi-tenant fairness and priority band admission:
+llm-d Router to enforce multi-tenant fairness and priority band admission:
 
 | Lane | Objective (`lane_objectives`) | Header `x-llm-d-inference-objective` | Router Band Priority | Who (within one model) |
 | :-- | :-- | :-- | :-- | :-- |
@@ -75,8 +75,8 @@ is earliest-deadline-first (the deadline is the sorted-set score).
 
 Downstream priority is propagated via lane objective stamping (**`x-llm-d-inference-objective`**), which maps each request to a Kubernetes [`InferenceObjective`](#1-apply-inferenceobjectives-and-deploy-flow-control-router) resource where **higher numerical values represent higher scheduling priority** (100 down to -10).
 
-#### With Flow Control ON (`llm-d-router`)
-When `llm-d-router` is deployed with Flow Control enabled (`featureGates: [flowControl]` in `flow-control.yaml`):
+#### With Flow Control ON (llm-d Router)
+When llm-d Router is deployed with Flow Control enabled (`featureGates: [flowControl]` in `flow-control.yaml`):
 - **Centralized Priority Bands:** When model server capacity saturates (detected in real time via `concurrency-detector` or `utilization-detector`), requests are held in memory across priority bands matching the `InferenceObjective` priority (100, 60, 30, 10, 0, -10).
 - **Strict Band Dispatch:** llm-d router drains highest-priority bands first: all `reserved` bands (100, 60, 30) dispatch before any `overflow` band (10, 0, -10) is admitted.
 - **Band Capacity & Drops on Full Bands:** Each priority band enforces isolated buffer limits via `maxRequests` and `maxBytes`. When a priority band reaches capacity, new incoming requests for that band are **dropped immediately (HTTP 429) regardless of that band's priority**. A high priority level does not grant unbounded buffer capacity; an overloaded priority 100 band drops its own incoming traffic rather than evicting queued requests from other bands.
@@ -87,7 +87,7 @@ When `llm-d-router` is deployed with Flow Control enabled (`featureGates: [flowC
 - For detailed architecture, lifecycle, and policy plugins, see the [Flow Control Documentation](https://llm-d.ai/docs/architecture/core/router/epp/flow-control).
 
 #### With Flow Control OFF (Baseline Router with Saturation Detection)
-When `llm-d-router` operates in standard baseline mode (without the `flowControl` feature gate):
+When llm-d Router operates in standard baseline mode (without the `flowControl` feature gate):
 - **Pass-Through Scheduling:** The router does not maintain priority band queues or tenant fairness buffers.
 - **Immediate Rejection of Sheddable Requests:** When the pool is saturated, **"sheddable" requests (those with negative priority, `priority < 0`) are immediately rejected with HTTP 429 (Too Many Requests)**. All other requests pass directly to the model servers and are scheduled via baseline routing plugins (such as `prefix-cache-scorer` and `queue-scorer`).
 - **Retries with Backoff in `llm-d-async`:** Requests dropped or rejected are caught by `llm-d-async` and **retried with exponential backoff and jitter** provided the request's deadline has not expired.
@@ -98,7 +98,7 @@ When `llm-d-router` operates in standard baseline mode (without the `flowControl
   - As a result, model servers remain protected against overload even without router-side priority queuing.
 
 #### With Flow Control OFF (Baseline Router without Saturation Detection)
-When saturation detection is disabled (no saturation detector configured in `llm-d-router`) every request is immediately dispatched to available model servers regardless of its assigned priority value.
+When saturation detection is disabled (no saturation detector configured in llm-d Router) every request is immediately dispatched to available model servers regardless of its assigned priority value.
 
 > [!NOTE]
 > **Over-quota is deprioritized, not dropped.** In `classifying` mode, requests beyond a team's
@@ -112,7 +112,7 @@ This guide layers on the base [asynchronous-processing](../README.md) guide — 
 [Prerequisites](../README.md#prerequisites) first (client tools, cluster, GAIE CRDs,
 [`guides/env.sh`](../../../env.sh), the HF-token secret), then add the following.
 
-- **llm-d router with Flow Control.** This guide uses `llm-d-router` configured with **Flow Control**
+- **llm-d router with Flow Control.** This guide uses llm-d Router configured with **Flow Control**
   enabled rather than the standard baseline router. Flow Control assigns incoming requests to priority bands
   based on the `InferenceObjective` CRD referenced by each request.
 
@@ -120,8 +120,8 @@ This guide layers on the base [asynchronous-processing](../README.md) guide — 
   `x-llm-d-inference-objective` header matching the request's priority lane. You must install the
   `InferenceObjective` CRD and define the objective resources in your cluster matching your `InferencePool`.
 
-- **Model Serving Stack & Router.** The walkthrough deploys a single `llm-d-router` instance (which creates
-  the `llm-d-router` InferencePool) and a single vLLM model server serving `Qwen/Qwen3-8B`. In a multi-model
+- **Model Serving Stack & Router.** The walkthrough deploys a single llm-d Router instance (which creates
+  the llm-d Router InferencePool) and a single vLLM model server serving `Qwen/Qwen3-8B`. In a multi-model
   environment, you can point `POOL_A` and `POOL_B` to separate `InferencePool`s for physical pool isolation.
 
 - **Environment.** In addition to the base guide's variables:
@@ -187,7 +187,7 @@ kubectl apply -n ${NAMESPACE} -f ${MT}/manifests/vllm.yaml
 
 ### 2. Configure llm-d-router and Apply InferenceObjectives
 
-Deploy `llm-d-router` configured with Flow Control and apply the 6 lane `InferenceObjective`s:
+Deploy llm-d Router configured with Flow Control and apply the 6 lane `InferenceObjective`s:
 
 ```bash
 # 1. Apply InferenceObjectives for the 6 tier-priority lanes
@@ -205,7 +205,7 @@ export IP=$(kubectl get service llm-d-router-epp -n ${NAMESPACE} -o jsonpath='{.
 ```
 
 > [!NOTE]
-> **Single Router & InferencePool in Demo:** Deploying `llm-d-router` creates a single `InferencePool` named `llm-d-router`. Both `model-a` and `model-b` worker pools dispatch through this shared llm-d Router. In production environments with multiple distinct models and pools, each pool can be addressed individually via separate `InferencePool` resources or multi-model HTTPRoutes.
+> **Single Router & InferencePool in Demo:** Deploying llm-d Router creates a single `InferencePool` named `llm-d-router`. Both `model-a` and `model-b` worker pools dispatch through this shared llm-d Router. In production environments with multiple distinct models and pools, each pool can be addressed individually via separate `InferencePool` resources or multi-model HTTPRoutes.
 
 ### 3. Deploy Redis and llm-d-async
 
@@ -271,7 +271,7 @@ A request is a JSON body — `id`, `created`, `deadline`, a `payload` (the infer
 - **The Queue is a Serving Dimension:** A queue corresponds to an service tier and model pair (e.g., `interactive` tier for `model-a`), not an isolated single-tenant partition although it is used as such in this demo because each team uses a separate queue. 
 - **Multiple Teams in One Queue:** Requests from different teams can be published into the **exact same queue**. The team identity is carried per-request inside `metadata.team` (e.g., `team: "marketing"` vs. `team: "engineering"`).
 - **Per-Team Quota Accounting:** The `redis-quota` gate dynamically reads `metadata.team` on each request and increments/decrements that specific team's counter (`quota:<model>:team:<team>`). If Team A saturates its reserved limit, Team A's excess traffic is deprioritized to `overflow`, while Team B publishing to that same queue continues to receive `reserved` capacity.
-- **Fairness ID:** At dispatch, `llm-d-async` stamps `metadata.team` into the `x-llm-d-inference-fairness-id` header so that `llm-d-router`'s Flow Control fairness policy treats tenants equitably during queue contention.
+- **Fairness ID:** At dispatch, `llm-d-async` stamps `metadata.team` into the `x-llm-d-inference-fairness-id` header so that llm-d Router's Flow Control fairness policy treats tenants equitably during queue contention.
 
 In this demo walkthrough, queues are labeled with team names (e.g. `team-premium-a`) for clear attribution, but you can pass any team name into `publish <team> <a|b> [count]`:
 
@@ -504,7 +504,7 @@ helm upgrade llm-d-async \
 ```
 </details>
 
-The inner `prometheus-saturation` gate queries `inference_extension_flow_control_pool_saturation` (or `llm_d_epp_flow_control_pool_saturation`) directly from `llm-d-router`'s metrics endpoint. Verify that the gate evaluates metrics live:
+The inner `prometheus-saturation` gate queries `inference_extension_flow_control_pool_saturation` (or `llm_d_epp_flow_control_pool_saturation`) directly from llm-d Router's metrics endpoint. Verify that the gate evaluates metrics live:
 
 ```bash
 # Verify the gate initialized with the inner prometheus-saturation source:

--- a/guides/batch-serving/asynchronous-processing/multitenant/README.md
+++ b/guides/batch-serving/asynchronous-processing/multitenant/README.md
@@ -37,7 +37,7 @@ The three dimensions:
 - **Model → pool isolation.** The publisher sets `payload.model`, which the gateway routes to that model's
   `InferencePool`. Each model gets its own worker pool (`model-a`, `model-b`) and independent saturation gate,
   so one model saturating does not park the other.
-- **Queue as the serving dimension (tier × model).** A queue represents a **serving SLA tier** for a target model
+- **Queue as the serving dimension (tier × model).** A queue represents a **serving tier** for a target model
   (e.g., interactive latency-sensitive, standard async, or batch throughput), **not a rigid single-tenant silo**.
   In production, multiple distinct teams can publish into the **same queue** concurrently. The request payload
   identifies the team via `metadata.team`.
@@ -46,7 +46,7 @@ The three dimensions:
   each team maintains its own independent concurrency counter in Redis. When multiple teams share a serving queue,
   one team exceeding its quota does not exhaust another team's budget: within quota → `reserved` (org-guaranteed),
   over quota → `overflow` (admitted and deprioritized, **not** nacked).
-- **Tier → priority.** A per-queue `tier` label: `interactive` (premium SLA) > `async` (standard SLA) > `batch`.
+- **Tier → priority.** A per-queue `tier` label: `interactive` (premium tier) > `async` (standard tier) > `batch`.
 
 The [**tier-priority merge policy**](https://github.com/llm-d/llm-d-async/pull/294) runs
 **per pool independently**: within each model it buckets requests into **6 strict lanes** by
@@ -82,7 +82,7 @@ When `llm-d-router` is deployed with Flow Control enabled (`featureGates: [flowC
 - **Centralized Priority Bands:** When model server capacity saturates (detected in real time via `concurrency-detector` or `utilization-detector`), requests are held in memory across priority bands matching the `InferenceObjective` priority (100, 60, 30, 10, 0, -10).
 - **Strict Band Dispatch:** The gateway scheduler drains highest-priority bands first: all `reserved` bands (100, 60, 30) dispatch before any `overflow` band (10, 0, -10) is admitted.
 - **Band Capacity & Drops on Full Bands:** Each priority band enforces isolated buffer limits via `maxRequests` and `maxBytes`. When a priority band reaches capacity, new incoming requests for that band are **dropped immediately (HTTP 429) regardless of that band's priority**. A high priority level does not grant unbounded buffer capacity; an overloaded priority 100 band drops its own incoming traffic rather than evicting queued requests from other bands.
-- **Retries with Backoff in `llm-d-async`:** Requests dropped or rejected by router flow control (e.g., when a priority band is full or during in-flight eviction, returning HTTP 429) are caught by `llm-d-async` and **retried with exponential backoff and jitter** (honoring `Retry-After` headers if returned), provided the request's deadline has not expired.
+- **Retries with Backoff in `llm-d-async`:** Requests dropped or rejected by router flow control (e.g., when a priority band is full or during in-flight eviction, returning HTTP 429) are caught by `llm-d-async` and **retried with exponential backoff and jitter** provided the request's deadline has not expired.
 - **Multi-Tenant Fairness:** Within any single priority band, the router enforces tenant fairness (`round-robin-fairness-policy` over `x-llm-d-inference-fairness-id`, which is stamped from `metadata.team`). No single tenant can monopolize a priority tier.
 - **Order Preservation:** Within each tenant's individual flow, requests dispatch in arrival order (`fcfs-ordering-policy`).
 - **In-Flight Eviction (`enableEviction: true`):** When eviction is enabled for Flow Control, only **negative-priority in-flight requests** (`priority < 0`, such as `overflow-batch` at priority `-10`) can be canceled and evicted after already being sent to the model server. While standard gated dispatch only holds back newly arriving work, in-flight eviction actively reclaims occupied GPU compute and KV cache from sheddable background requests when higher-priority traffic is blocked by pool saturation.
@@ -92,6 +92,7 @@ When `llm-d-router` is deployed with Flow Control enabled (`featureGates: [flowC
 When `llm-d-router` operates in standard baseline mode (without the `flowControl` feature gate):
 - **Pass-Through Scheduling:** The router does not maintain priority band queues or tenant fairness buffers.
 - **Immediate Rejection of Sheddable Requests:** When the pool is saturated, **"sheddable" requests (those with negative priority, `priority < 0`) are immediately rejected with HTTP 429 (Too Many Requests)**. All other requests pass directly to the model servers and are scheduled via baseline routing plugins (such as `prefix-cache-scorer` and `queue-scorer`).
+- **Retries with Backoff in `llm-d-async`:** Requests dropped or rejected are caught by `llm-d-async` and **retried with exponential backoff and jitter** provided the request's deadline has not expired.
 - **Saturation Telemetry:** The router still exposes real-time pool saturation metrics (`inference_extension_flow_control_pool_saturation` or vLLM metrics).
 - **Upstream Priority & Backpressure in `llm-d-async`:** Priority enforcement shifts entirely **upstream to the Async Processor**:
   - The `tier-priority` merge policy ensures that all `reserved` requests are dequeued and dispatched before `overflow` traffic, and higher tiers dispatch before lower tiers.
@@ -266,7 +267,7 @@ selects the model/pool at the gateway**), and `metadata.team` (the tenant identi
 and downstream fairness policy evaluate).
 
 ### Queues as Serving Dimensions vs. Team Identity
-- **The Queue is a Serving Dimension:** A queue corresponds to an SLA tier and model pair (e.g., `interactive` tier for `model-a`), not an isolated single-tenant partition.
+- **The Queue is a Serving Dimension:** A queue corresponds to an service tier and model pair (e.g., `interactive` tier for `model-a`), not an isolated single-tenant partition although it is used as such in this demo because each team uses a separate queue. 
 - **Multiple Teams in One Queue:** Requests from different teams can be published into the **exact same queue**. The team identity is carried per-request inside `metadata.team` (e.g., `team: "marketing"` vs. `team: "engineering"`).
 - **Per-Team Quota Accounting:** The `redis-quota` gate dynamically reads `metadata.team` on each request and increments/decrements that specific team's counter (`quota:<model>:team:<team>`). If Team A saturates its reserved limit, Team A's excess traffic is deprioritized to `overflow`, while Team B publishing to that same queue continues to receive `reserved` capacity.
 - **Gateway Fairness ID:** At dispatch, `llm-d-async` stamps `metadata.team` into the `x-llm-d-inference-fairness-id` header so that `llm-d-router`'s Flow Control fairness policy treats tenants equitably during gateway queue contention.

--- a/guides/batch-serving/asynchronous-processing/multitenant/README.md
+++ b/guides/batch-serving/asynchronous-processing/multitenant/README.md
@@ -50,8 +50,7 @@ The three dimensions:
 
 The [**tier-priority merge policy**](https://github.com/llm-d/llm-d-async/pull/294) runs
 **per pool independently**: within each model it buckets requests into **6 strict lanes** by
-`(classification, tier)`, dispatches them in order, and stamps both **`x-gateway-priority`** (0 = highest …
-5 = lowest) and **`x-llm-d-inference-objective`** via `lane_objectives`.
+`(classification, tier)`, dispatches them in order, and stamps **`x-llm-d-inference-objective`** via `lane_objectives`.
 
 By defining matching [`InferenceObjective`](#1-apply-inferenceobjectives-and-deploy-flow-control-router)
 resources in the cluster, `llm-d-async` and `llm-d-router` Flow Control speak the exact same language.
@@ -73,9 +72,7 @@ is earliest-deadline-first (the deadline is the sorted-set score).
 
 ### Priority Values: Flow Control ON vs. Flow Control OFF
 
-The system establishes two complementary priority representations:
-- **`x-gateway-priority` (0 to 5):** A scalar integer priority where **0 is highest and 5 is lowest**. This is standard for generic reverse proxies, HTTP load balancers, or Envoy ingress filters that order dispatch based on ascending integer rank.
-- **`x-llm-d-inference-objective` & Router Band Priority (100 to -10):** The Kubernetes [`InferenceObjective`](#1-apply-inferenceobjectives-and-deploy-flow-control-router) specification, where **higher numerical values represent higher scheduling priority**.
+Downstream priority is propagated via lane objective stamping (**`x-llm-d-inference-objective`**), which maps each request to a Kubernetes [`InferenceObjective`](#1-apply-inferenceobjectives-and-deploy-flow-control-router) resource where **higher numerical values represent higher scheduling priority** (100 down to -10).
 
 #### With Flow Control ON (`llm-d-router`)
 When `llm-d-router` is deployed with Flow Control enabled (`featureGates: [flowControl]` in `flow-control.yaml`):
@@ -342,7 +339,7 @@ for t in premium standard batch; do publish "$t" a 1 & done; wait
 ```
 
 Every request is within its team's quota, so all are `reserved` and dispatched in tier order
-(premium→standard→batch), stamped `x-gateway-priority` 0/1/2. Read results from the per-model list:
+(premium→standard→batch), stamped with their respective lane objectives (`reserved-interactive`, `reserved-async`, `reserved-batch`). Read results from the per-model list:
 
 ```bash
 kubectl -n ${NAMESPACE} exec deploy/redis -- redis-cli LRANGE results-a-list 0 -1   # model B -> results-b-list

--- a/guides/batch-serving/asynchronous-processing/multitenant/dashboards/cloud-monitoring.json
+++ b/guides/batch-serving/asynchronous-processing/multitenant/dashboards/cloud-monitoring.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "Async Processor \u2014 Multi-tenant Pub/Sub Demo",
+  "displayName": "LLM-D Async Processor",
   "mosaicLayout": {
     "columns": 12,
     "tiles": [
@@ -102,32 +102,46 @@
       {
         "xPos": 0,
         "yPos": 8,
-        "width": 12,
+        "width": 6,
         "height": 4,
         "widget": {
-          "title": "Pub/Sub backlog by team \u2014 undelivered messages (native Cloud Monitoring metric)",
+          "title": "Broker backlog by queue",
           "xyChart": {
             "dataSets": [
               {
                 "timeSeriesQuery": {
-                  "timeSeriesFilter": {
-                    "filter": "metric.type=\"pubsub.googleapis.com/subscription/num_undelivered_messages\" resource.type=\"pubsub_subscription\" resource.label.\"subscription_id\"=starts_with(\"team-\")",
-                    "aggregation": {
-                      "alignmentPeriod": "60s",
-                      "perSeriesAligner": "ALIGN_MEAN",
-                      "crossSeriesReducer": "REDUCE_NONE",
-                      "groupByFields": [
-                        "resource.label.\"subscription_id\""
-                      ]
-                    }
-                  }
+                  "prometheusQuery": "sum by (queue_name) (llm_d_async_async_broker_backlog)"
                 },
                 "plotType": "LINE",
-                "legendTemplate": "${resource.labels.subscription_id}"
+                "legendTemplate": "${metric.labels.queue_name}"
               }
             ],
             "yAxis": {
-              "label": "undelivered",
+              "label": "backlog",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "xPos": 6,
+        "yPos": 8,
+        "width": 6,
+        "height": 4,
+        "widget": {
+          "title": "In-process queue depth by queue",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "sum by (queue_name) (llm_d_async_async_queue_depth)"
+                },
+                "plotType": "LINE",
+                "legendTemplate": "${metric.labels.queue_name}"
+              }
+            ],
+            "yAxis": {
+              "label": "queue depth",
               "scale": "LINEAR"
             }
           }
@@ -226,6 +240,115 @@
               "label": "decisions/s",
               "scale": "LINEAR"
             }
+          }
+        }
+      },
+      {
+        "xPos": 0,
+        "yPos": 20,
+        "width": 6,
+        "height": 4,
+        "widget": {
+          "title": "Exceeded deadline request rate (req/s)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "sum by (pool_name) (rate(llm_d_async_async_exceeded_deadline_requests_total[5m]))"
+                },
+                "plotType": "LINE",
+                "legendTemplate": "${metric.labels.pool_name}"
+              }
+            ],
+            "yAxis": {
+              "label": "req/s",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "xPos": 6,
+        "yPos": 20,
+        "width": 6,
+        "height": 4,
+        "widget": {
+          "title": "Token processing rate by pool & direction (tokens/s)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "sum by (pool_name, direction) (rate(llm_d_async_async_tokens_total[5m]))"
+                },
+                "plotType": "LINE",
+                "legendTemplate": "${metric.labels.pool_name} \u00b7 ${metric.labels.direction}"
+              }
+            ],
+            "yAxis": {
+              "label": "tokens/s",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "xPos": 0,
+        "yPos": 24,
+        "width": 6,
+        "height": 4,
+        "widget": {
+          "title": "Deadline proximity by queue (p10 / p50 / p90 / p99) (s)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "histogram_quantile(0.10, sum by (le, queue_name) (llm_d_async_async_deadline_proximity_millis_bucket)) / 1000",
+                  "unitOverride": "s"
+                },
+                "plotType": "LINE",
+                "legendTemplate": "p10 · ${metric.labels.queue_name}"
+              },
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "histogram_quantile(0.50, sum by (le, queue_name) (llm_d_async_async_deadline_proximity_millis_bucket)) / 1000",
+                  "unitOverride": "s"
+                },
+                "plotType": "LINE",
+                "legendTemplate": "p50 · ${metric.labels.queue_name}"
+              },
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "histogram_quantile(0.90, sum by (le, queue_name) (llm_d_async_async_deadline_proximity_millis_bucket)) / 1000",
+                  "unitOverride": "s"
+                },
+                "plotType": "LINE",
+                "legendTemplate": "p90 · ${metric.labels.queue_name}"
+              },
+              {
+                "timeSeriesQuery": {
+                  "prometheusQuery": "histogram_quantile(0.99, sum by (le, queue_name) (llm_d_async_async_deadline_proximity_millis_bucket)) / 1000",
+                  "unitOverride": "s"
+                },
+                "plotType": "LINE",
+                "legendTemplate": "p99 · ${metric.labels.queue_name}"
+              }
+            ],
+            "yAxis": {
+              "label": "s",
+              "scale": "LINEAR"
+            }
+          }
+        }
+      },
+      {
+        "xPos": 6,
+        "yPos": 24,
+        "width": 6,
+        "height": 4,
+        "widget": {
+          "text": {
+            "content": "**Note:** Deadline proximity (`llm_d_async_async_deadline_proximity_millis`) only works when Redis Sorted Set queues are used (`--transport=redis-sortedset`). Cloud Pub/Sub cannot expose per-item deadlines.\n\n*Scrape Semantics:* This metric is a snapshot histogram of queued items rebuilt per poll from Redis `ZCOUNT`. Because it is not monotonic, do not use `rate()`. Evaluates to `NaN` when queues are empty.",
+            "format": "MARKDOWN"
           }
         }
       }

--- a/guides/batch-serving/asynchronous-processing/multitenant/dashboards/cloud-monitoring.json
+++ b/guides/batch-serving/asynchronous-processing/multitenant/dashboards/cloud-monitoring.json
@@ -1,5 +1,5 @@
 {
-  "displayName": "LLM-D Async Processor",
+  "displayName": "llm-d Async Processor Multi-tenant Demo",
   "mosaicLayout": {
     "columns": 12,
     "tiles": [

--- a/guides/batch-serving/asynchronous-processing/multitenant/manifests/inferenceobjectives.yaml
+++ b/guides/batch-serving/asynchronous-processing/multitenant/manifests/inferenceobjectives.yaml
@@ -1,0 +1,92 @@
+# InferenceObjectives mapping llm-d-async tier-priority lanes to llm-d-router Flow Control priority bands.
+#
+# Lane -> Objective -> Priority:
+#   reserved-interactive -> priority 100
+#   reserved-async       -> priority 60
+#   reserved-batch       -> priority 30
+#   overflow-interactive -> priority 10
+#   overflow-async       -> priority 0
+#   overflow-batch       -> priority -10
+apiVersion: llm-d.ai/v1alpha2
+kind: InferenceObjective
+metadata:
+  name: reserved-interactive
+  namespace: NAMESPACE
+  labels:
+    llm-d.ai/guide: "multitenant"
+    llm-d.ai/tier: "interactive"
+    llm-d.ai/classification: "reserved"
+spec:
+  priority: 100
+  poolRef:
+    name: POOL_NAME
+---
+apiVersion: llm-d.ai/v1alpha2
+kind: InferenceObjective
+metadata:
+  name: reserved-async
+  namespace: NAMESPACE
+  labels:
+    llm-d.ai/guide: "multitenant"
+    llm-d.ai/tier: "async"
+    llm-d.ai/classification: "reserved"
+spec:
+  priority: 60
+  poolRef:
+    name: POOL_NAME
+---
+apiVersion: llm-d.ai/v1alpha2
+kind: InferenceObjective
+metadata:
+  name: reserved-batch
+  namespace: NAMESPACE
+  labels:
+    llm-d.ai/guide: "multitenant"
+    llm-d.ai/tier: "batch"
+    llm-d.ai/classification: "reserved"
+spec:
+  priority: 30
+  poolRef:
+    name: POOL_NAME
+---
+apiVersion: llm-d.ai/v1alpha2
+kind: InferenceObjective
+metadata:
+  name: overflow-interactive
+  namespace: NAMESPACE
+  labels:
+    llm-d.ai/guide: "multitenant"
+    llm-d.ai/tier: "interactive"
+    llm-d.ai/classification: "overflow"
+spec:
+  priority: 10
+  poolRef:
+    name: POOL_NAME
+---
+apiVersion: llm-d.ai/v1alpha2
+kind: InferenceObjective
+metadata:
+  name: overflow-async
+  namespace: NAMESPACE
+  labels:
+    llm-d.ai/guide: "multitenant"
+    llm-d.ai/tier: "async"
+    llm-d.ai/classification: "overflow"
+spec:
+  priority: 0
+  poolRef:
+    name: POOL_NAME
+---
+apiVersion: llm-d.ai/v1alpha2
+kind: InferenceObjective
+metadata:
+  name: overflow-batch
+  namespace: NAMESPACE
+  labels:
+    llm-d.ai/guide: "multitenant"
+    llm-d.ai/tier: "batch"
+    llm-d.ai/classification: "overflow"
+spec:
+  priority: -10
+  poolRef:
+    name: POOL_NAME

--- a/guides/batch-serving/asynchronous-processing/multitenant/manifests/prometheus-vllm-podmonitor.yaml
+++ b/guides/batch-serving/asynchronous-processing/multitenant/manifests/prometheus-vllm-podmonitor.yaml
@@ -1,8 +1,8 @@
 # Prometheus Operator PodMonitor that scrapes the vLLM model server so the
 # self-hosted Prometheus has vllm:num_requests_running for the saturation gates.
 #
-# The vLLM pod lives in the `default` namespace and is labelled
-# app=vllm-llama3-8b-instruct, exposing metrics on the `http` port (8000).
+# The vLLM pod is deployed via manifests/vllm.yaml and is labelled
+# app=vllm-1, exposing metrics on the `modelserver` port (8000).
 # (The async-processor chart's modelServerMonitor selects llm-d.ai/role=decode,
 # which this stack's vLLM pod doesn't carry — hence this dedicated monitor.)
 #
@@ -11,17 +11,20 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: vllm-model-server
-  namespace: monitoring
   labels:
     app: vllm-model-server
 spec:
+  podTargetLabels:
+    - inference_pool
+    - model
   namespaceSelector:
     matchNames:
+      - llm-d-async
       - default
   selector:
     matchLabels:
-      app: vllm-llama3-8b-instruct
+      app: vllm-1
   podMetricsEndpoints:
-    - port: http
+    - port: modelserver
       path: /metrics
       interval: 15s

--- a/guides/batch-serving/asynchronous-processing/multitenant/manifests/vllm.yaml
+++ b/guides/batch-serving/asynchronous-processing/multitenant/manifests/vllm.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm
+  namespace: llm-d-async
+  labels:
+    app: vllm-1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm-1
+  template:
+    metadata:
+      labels:
+        app: vllm-1
+        model: qwen3-8b
+        inference_pool: llm-d-router
+    spec:
+      containers:
+      - name: vllm-server
+        image: vllm/vllm-openai:v0.19.1
+        command:
+        - python3
+        - -m
+        - vllm.entrypoints.openai.api_server
+        args:
+        - --model
+        - Qwen/Qwen3-8B
+        - --tensor-parallel-size
+        - "1"
+        - --gpu-memory-utilization
+        - "0.95"
+        - --max-model-len
+        - "4000"
+        env:
+        - name: VLLM_PORT
+          value: "8000"
+        - name: HUGGING_FACE_HUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: hf-secret
+              key: token
+        ports:
+        - name: modelserver
+          containerPort: 8000
+          protocol: TCP
+        resources:
+          limits:
+            nvidia.com/gpu: "1"
+          requests:
+            cpu: "7"
+            memory: "20Gi"
+            nvidia.com/gpu: "1"
+        startupProbe:
+          httpGet:
+            path: /health
+            port: modelserver
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 540
+        readinessProbe:
+          httpGet:
+            path: /v1/models
+            port: modelserver
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: modelserver
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
+        volumeMounts:
+        - name: shm
+          mountPath: /dev/shm
+      volumes:
+      - name: shm
+        emptyDir:
+          medium: Memory
+      nodeSelector:
+        cloud.google.com/compute-class: l4-dws-spot

--- a/guides/batch-serving/asynchronous-processing/multitenant/manifests/vllm.yaml
+++ b/guides/batch-serving/asynchronous-processing/multitenant/manifests/vllm.yaml
@@ -80,5 +80,3 @@ spec:
       - name: shm
         emptyDir:
           medium: Memory
-      nodeSelector:
-        cloud.google.com/compute-class: l4-dws-spot

--- a/guides/batch-serving/asynchronous-processing/multitenant/scripts/benchmark-heavy-redis.py
+++ b/guides/batch-serving/asynchronous-processing/multitenant/scripts/benchmark-heavy-redis.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+Heavy Multi-Tenant Benchmark for Async Processor (Redis SortedSet backend).
+Dispatches 600 requests across all 6 tier-priority queues (team × tier × model)
+and monitors multi-minute in-process queue draining and upstream completion.
+"""
+
+import argparse
+import json
+import random
+import subprocess
+import sys
+import time
+import urllib.request
+
+NAMESPACE = "llm-d-async"
+REDIS_DEPLOY = "deploy/redis"
+MODEL = "Qwen/Qwen3-8B"
+TTL = 3600  # 1 hour deadline
+
+QUEUES_SPEC = [
+    ("team-premium-a", "premium", "a", 150),
+    ("team-standard-a", "standard", "a", 100),
+    ("team-batch-a", "batch", "a", 50),
+    ("team-premium-b", "premium", "b", 150),
+    ("team-standard-b", "standard", "b", 100),
+    ("team-batch-b", "batch", "b", 50),
+]
+
+def clear_existing_results():
+    print("[*] Clearing previous results lists...")
+    subprocess.run(
+        ["kubectl", "-n", NAMESPACE, "exec", REDIS_DEPLOY, "--", "redis-cli", "DEL", "results-a-list", "results-b-list"],
+        capture_output=True, text=True
+    )
+
+def enqueue_all(model_name=MODEL, max_tokens=80):
+    now = int(time.time())
+    dl = now + TTL
+    run_id = f"{now}-{random.randint(1000, 9999)}"
+    total_enqueued = 0
+
+    print(f"[*] Enqueuing 600 multi-tenant requests across 6 queues (max_tokens={max_tokens}, TTL={TTL}s)...")
+    for q_name, team, model, count in QUEUES_SPEC:
+        zadd_args = []
+        for i in range(1, count + 1):
+            msg_id = f"bench-{team}-{model}-{run_id}-{i:04d}"
+            msg_obj = {
+                "internal": {},
+                "request_kind": "plain",
+                "data": {
+                    "id": msg_id,
+                    "created": now,
+                    "deadline": dl,
+                    "payload": {
+                        "model": model_name,
+                        "prompt": f"Write an informative paragraph explaining distributed asynchronous architectures and queue buffering, request #{i}.",
+                        "max_tokens": max_tokens
+                    },
+                    "metadata": {
+                        "team": team
+                    }
+                }
+            }
+            zadd_args.extend([str(dl), json.dumps(msg_obj)])
+
+        # Send in chunks of 50 pairs
+        for chunk_idx in range(0, len(zadd_args), 100):
+            chunk = zadd_args[chunk_idx:chunk_idx + 100]
+            cmd = ["kubectl", "-n", NAMESPACE, "exec", "-i", REDIS_DEPLOY, "--", "redis-cli", "ZADD", q_name] + chunk
+            res = subprocess.run(cmd, capture_output=True, text=True)
+            if res.returncode != 0:
+                print(f"[!] Error on {q_name}: {res.stderr.strip()}")
+        print(f"  [+] {q_name}: Enqueued {count} requests")
+        total_enqueued += count
+
+    print(f"[*] Total requests successfully enqueued into Redis: {total_enqueued}\n")
+    return total_enqueued
+
+def query_prom(query):
+    try:
+        cmd = [
+            "kubectl", "-n", NAMESPACE, "exec", "deploy/prometheus", "--",
+            "wget", "-qO-", f"http://localhost:9090/api/v1/query?query={urllib.parse.quote(query)}"
+        ]
+        res = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
+        data = json.loads(res.stdout)
+        results = data.get("data", {}).get("result", [])
+        if results:
+            return float(results[0]["value"][1])
+    except Exception:
+        pass
+    return 0.0
+
+def monitor_drain(total_enqueued, max_wait_sec=600):
+    import urllib.parse
+    globals()["urllib"].parse = urllib.parse
+
+    print("[*] Monitoring drain progress across Redis, In-Process Queues, and GPU...")
+    start_time = time.time()
+
+    while time.time() - start_time < max_wait_sec:
+        elapsed = int(time.time() - start_time)
+
+        # Query Redis results
+        res_a = subprocess.run(
+            ["kubectl", "-n", NAMESPACE, "exec", REDIS_DEPLOY, "--", "redis-cli", "LLEN", "results-a-list"],
+            capture_output=True, text=True
+        )
+        res_b = subprocess.run(
+            ["kubectl", "-n", NAMESPACE, "exec", REDIS_DEPLOY, "--", "redis-cli", "LLEN", "results-b-list"],
+            capture_output=True, text=True
+        )
+        try:
+            done_a = int(res_a.stdout.strip())
+            done_b = int(res_b.stdout.strip())
+        except Exception:
+            done_a, done_b = 0, 0
+
+        # Query Redis remaining backlog
+        q_backlog = 0
+        for q_name, _, _, _ in QUEUES_SPEC:
+            res = subprocess.run(
+                ["kubectl", "-n", NAMESPACE, "exec", REDIS_DEPLOY, "--", "redis-cli", "ZCARD", q_name],
+                capture_output=True, text=True
+            )
+            try:
+                q_backlog += int(res.stdout.strip())
+            except Exception:
+                pass
+
+        total_done = done_a + done_b
+        pct = (total_done / total_enqueued) * 100 if total_enqueued > 0 else 0
+
+        # Query Prometheus live gauges
+        in_flight = int(query_prom("sum(llm_d_async_async_inflight_requests)"))
+        q_depth = int(query_prom("sum(llm_d_async_async_queue_depth)"))
+
+        print(f"[{elapsed:03d}s] Completed: {total_done:3d}/{total_enqueued} ({pct:5.1f}%) | In-Flight: {in_flight:2d} | In-Process Depth: {q_depth:3d} | Redis ZCARD: {q_backlog:3d} | A: {done_a:3d}, B: {done_b:3d}")
+
+        if total_done >= total_enqueued:
+            print(f"\n[+] SUCCESS: All {total_enqueued} requests served and completed in {elapsed}s!")
+            return True
+
+        time.sleep(10)
+
+    print(f"\n[*] Reached max wait time of {max_wait_sec}s.")
+    return False
+
+def main():
+    parser = argparse.ArgumentParser(description="Heavy multi-tenant Redis benchmark")
+    parser.add_argument("--tokens", type=int, default=80, help="Max completion tokens per request")
+    parser.add_argument("--timeout", type=int, default=600, help="Max wait duration in seconds")
+    args = parser.parse_args()
+
+    clear_existing_results()
+    total = enqueue_all(max_tokens=args.tokens)
+    monitor_drain(total, max_wait_sec=args.timeout)
+
+if __name__ == "__main__":
+    main()

--- a/guides/batch-serving/asynchronous-processing/multitenant/scripts/benchmark-heavy-redis.py
+++ b/guides/batch-serving/asynchronous-processing/multitenant/scripts/benchmark-heavy-redis.py
@@ -7,15 +7,20 @@ and monitors multi-minute in-process queue draining and upstream completion.
 
 import argparse
 import json
+import os
 import random
+import socket
 import subprocess
 import sys
 import time
+import urllib.parse
 import urllib.request
 
-NAMESPACE = "llm-d-async"
-REDIS_DEPLOY = "deploy/redis"
-MODEL = "Qwen/Qwen3-8B"
+NAMESPACE = os.environ.get("NAMESPACE", "llm-d-async")
+REDIS_DEPLOY = os.environ.get("REDIS_DEPLOY", "deploy/redis")
+MODEL = os.environ.get("MODEL", "Qwen/Qwen3-8B")
+PROM_URL = os.environ.get("PROM_URL", "http://localhost:9090")
+MONITORING_NAMESPACE = os.environ.get("MONITORING_NAMESPACE", "llm-d-monitoring")
 TTL = 3600  # 1 hour deadline
 
 QUEUES_SPEC = [
@@ -26,6 +31,23 @@ QUEUES_SPEC = [
     ("team-standard-b", "standard", "b", 100),
     ("team-batch-b", "batch", "b", 50),
 ]
+
+def check_port_open(host="127.0.0.1", port=9090):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(1.0)
+        return s.connect_ex((host, port)) == 0
+
+def start_prom_port_forward(namespace=MONITORING_NAMESPACE, local_port=9090):
+    if check_port_open("127.0.0.1", local_port):
+        return None
+    print(f"[*] Starting background port-forward to svc/llmd-kube-prometheus-stack-prometheus on port {local_port}...")
+    proc = subprocess.Popen(
+        ["kubectl", "port-forward", "-n", namespace, "svc/llmd-kube-prometheus-stack-prometheus", f"{local_port}:9090"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL
+    )
+    time.sleep(2)
+    return proc
 
 def clear_existing_results():
     print("[*] Clearing previous results lists...")
@@ -77,25 +99,22 @@ def enqueue_all(model_name=MODEL, max_tokens=80):
     print(f"[*] Total requests successfully enqueued into Redis: {total_enqueued}\n")
     return total_enqueued
 
-def query_prom(query):
+def query_prom(query, prom_url=None):
+    if prom_url is None:
+        prom_url = PROM_URL
     try:
-        cmd = [
-            "kubectl", "-n", NAMESPACE, "exec", "deploy/prometheus", "--",
-            "wget", "-qO-", f"http://localhost:9090/api/v1/query?query={urllib.parse.quote(query)}"
-        ]
-        res = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
-        data = json.loads(res.stdout)
-        results = data.get("data", {}).get("result", [])
-        if results:
-            return float(results[0]["value"][1])
+        url = f"{prom_url}/api/v1/query?query={urllib.parse.quote(query)}"
+        req = urllib.request.Request(url)
+        with urllib.request.urlopen(req, timeout=4) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            results = data.get("data", {}).get("result", [])
+            if results:
+                return float(results[0]["value"][1])
     except Exception:
         pass
     return 0.0
 
-def monitor_drain(total_enqueued, max_wait_sec=600):
-    import urllib.parse
-    globals()["urllib"].parse = urllib.parse
-
+def monitor_drain(total_enqueued, max_wait_sec=600, prom_url=None):
     print("[*] Monitoring drain progress across Redis, In-Process Queues, and GPU...")
     start_time = time.time()
 
@@ -133,8 +152,8 @@ def monitor_drain(total_enqueued, max_wait_sec=600):
         pct = (total_done / total_enqueued) * 100 if total_enqueued > 0 else 0
 
         # Query Prometheus live gauges
-        in_flight = int(query_prom("sum(llm_d_async_async_inflight_requests)"))
-        q_depth = int(query_prom("sum(llm_d_async_async_queue_depth)"))
+        in_flight = int(query_prom("sum(llm_d_async_async_inflight_requests)", prom_url=prom_url))
+        q_depth = int(query_prom("sum(llm_d_async_async_queue_depth)", prom_url=prom_url))
 
         print(f"[{elapsed:03d}s] Completed: {total_done:3d}/{total_enqueued} ({pct:5.1f}%) | In-Flight: {in_flight:2d} | In-Process Depth: {q_depth:3d} | Redis ZCARD: {q_backlog:3d} | A: {done_a:3d}, B: {done_b:3d}")
 
@@ -151,11 +170,20 @@ def main():
     parser = argparse.ArgumentParser(description="Heavy multi-tenant Redis benchmark")
     parser.add_argument("--tokens", type=int, default=80, help="Max completion tokens per request")
     parser.add_argument("--timeout", type=int, default=600, help="Max wait duration in seconds")
+    parser.add_argument("--prom-url", type=str, default=PROM_URL, help="Prometheus base URL (default: http://localhost:9090)")
     args = parser.parse_args()
 
-    clear_existing_results()
-    total = enqueue_all(max_tokens=args.tokens)
-    monitor_drain(total, max_wait_sec=args.timeout)
+    pf_proc = None
+    if "localhost" in args.prom_url or "127.0.0.1" in args.prom_url:
+        pf_proc = start_prom_port_forward()
+
+    try:
+        clear_existing_results()
+        total = enqueue_all(max_tokens=args.tokens)
+        monitor_drain(total, max_wait_sec=args.timeout, prom_url=args.prom_url)
+    finally:
+        if pf_proc:
+            pf_proc.terminate()
 
 if __name__ == "__main__":
     main()

--- a/guides/batch-serving/asynchronous-processing/multitenant/scripts/stress-test-pubsub.py
+++ b/guides/batch-serving/asynchronous-processing/multitenant/scripts/stress-test-pubsub.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""
+Stress test script for Multi-Tenant Async Processing using GCP Pub/Sub backend.
+Generates multi-tenant traffic (team × tier × model) and drives background
+saturation load on the router to populate Prometheus, Grafana, and Cloud Monitoring metrics.
+
+Usage:
+  ./scripts/stress-test-pubsub.py
+  PROJECT_ID=my-project NAMESPACE=llm-d-async ./scripts/stress-test-pubsub.py
+"""
+
+import argparse
+import json
+import os
+import random
+import subprocess
+import sys
+import time
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+DEFAULT_PROJECT = os.environ.get("PROJECT_ID")
+if not DEFAULT_PROJECT:
+    try:
+        out = subprocess.check_output(
+            ["gcloud", "config", "get-value", "project"], text=True
+        ).strip()
+        if out and out != "(unset)":
+            DEFAULT_PROJECT = out
+    except Exception:
+        DEFAULT_PROJECT = None
+
+DEFAULT_NAMESPACE = os.environ.get("NAMESPACE", "llm-d-async")
+DEFAULT_MODEL_A = os.environ.get("MODEL_A", "Qwen/Qwen3-8B")
+DEFAULT_MODEL_B = os.environ.get("MODEL_B", "Qwen/Qwen3-8B")
+
+def check_port_open(host="127.0.0.1", port=8080):
+    import socket
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(1.0)
+        return s.connect_ex((host, port)) == 0
+
+def start_port_forward(namespace, local_port=8080):
+    if check_port_open("127.0.0.1", local_port):
+        print(f"[*] Port {local_port} is already open, using existing endpoint.")
+        return None
+    print(f"[*] Starting port-forward to svc/llm-d-router-epp on port {local_port}...")
+    proc = subprocess.Popen(
+        ["kubectl", "port-forward", "-n", namespace, "svc/llm-d-router-epp", f"{local_port}:80"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL
+    )
+    time.sleep(3)
+    return proc
+
+def send_background_load(igw_url, model_name, duration_sec=60, concurrency=6):
+    print(f"[*] Starting background saturation load ({concurrency} concurrent workers for {duration_sec}s)...")
+    start_time = time.time()
+    req_count = 0
+
+    def single_req():
+        payload = json.dumps({
+            "model": model_name,
+            "prompt": "Write an extensive scientific treatise on distributed asynchronous message systems with high token generation.",
+            "max_tokens": 160
+        }).encode("utf-8")
+        req = urllib.request.Request(
+            f"{igw_url}/v1/completions",
+            data=payload,
+            headers={"Content-Type": "application/json"}
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=45) as resp:
+                resp.read()
+                return True
+        except Exception:
+            return False
+
+    with ThreadPoolExecutor(max_workers=concurrency) as executor:
+        futures = []
+        while time.time() - start_time < duration_sec:
+            while len(futures) < concurrency and (time.time() - start_time < duration_sec):
+                futures.append(executor.submit(single_req))
+            done = [f for f in futures if f.done()]
+            for f in done:
+                futures.remove(f)
+                req_count += 1
+            time.sleep(0.2)
+        for f in as_completed(futures):
+            req_count += 1
+
+    print(f"[*] Background saturation load finished. Completed {req_count} completions.")
+
+def publish_message(project_id, topic, team, model_code, model_name, seq_id, ttl=600):
+    now = int(time.time())
+    dl = now + ttl
+    msg_id = f"stress-{team}-{model_code}-{now}-{seq_id:04d}"
+    payload = {
+        "id": msg_id,
+        "created": now,
+        "deadline": dl,
+        "payload": {
+            "model": model_name,
+            "prompt": f"Summarize key trends in async multi-tenant queue processing request #{seq_id}",
+            "max_tokens": 32
+        },
+        "metadata": {
+            "team": team
+        }
+    }
+    cmd = [
+        "gcloud", "pubsub", "topics", "publish", topic,
+        "--project", project_id,
+        "--attribute", f"team={team}",
+        "--message", json.dumps(payload)
+    ]
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    return res.returncode == 0, msg_id
+
+def publish_traffic(project_id, model_a, model_b):
+    topics_spec = [
+        ("team-premium-a-requests", "premium", "a", model_a, 15),
+        ("team-standard-a-requests", "standard", "a", model_a, 10),
+        ("team-batch-a-requests", "batch", "a", model_a, 5),
+        ("team-premium-b-requests", "premium", "b", model_b, 15),
+        ("team-standard-b-requests", "standard", "b", model_b, 10),
+        ("team-batch-b-requests", "batch", "b", model_b, 5),
+    ]
+    print(f"[*] Publishing multi-tenant requests across 6 Pub/Sub topics...")
+    tasks = []
+    with ThreadPoolExecutor(max_workers=12) as executor:
+        for topic, team, m_code, m_name, count in topics_spec:
+            for i in range(count):
+                tasks.append(executor.submit(
+                    publish_message, project_id, topic, team, m_code, m_name, i + 1
+                ))
+        success = 0
+        failed = 0
+        for f in as_completed(tasks):
+            ok, mid = f.result()
+            if ok:
+                success += 1
+            else:
+                failed += 1
+    print(f"[*] Finished publishing: {success} succeeded, {failed} failed.")
+
+def main():
+    parser = argparse.ArgumentParser(description="Multi-tenant async processor Pub/Sub stress test")
+    parser.add_argument("--project", default=DEFAULT_PROJECT, help="GCP Project ID")
+    parser.add_argument("--namespace", default=DEFAULT_NAMESPACE, help="Kubernetes namespace")
+    parser.add_argument("--model-a", default=DEFAULT_MODEL_A, help="Model A name")
+    parser.add_argument("--model-b", default=DEFAULT_MODEL_B, help="Model B name")
+    parser.add_argument("--duration", type=int, default=60, help="Saturation duration in seconds")
+    parser.add_argument("--igw-port", type=int, default=8080, help="Local port for router gateway")
+    args = parser.parse_args()
+
+    if not args.project:
+        print("[!] Error: GCP Project ID is required.")
+        print("    Please provide --project or set the PROJECT_ID environment variable.")
+        sys.exit(1)
+
+    print("==========================================================")
+    print("Multi-Tenant Async Processor — GCP Pub/Sub Stress Test")
+    print(f"Project:    {args.project}")
+    print(f"Namespace:  {args.namespace}")
+    print(f"Model A:    {args.model_a}")
+    print(f"Model B:    {args.model_b}")
+    print(f"Duration:   {args.duration}s")
+    print("==========================================================")
+
+    pf_proc = start_port_forward(args.namespace, args.igw_port)
+    igw_url = f"http://127.0.0.1:{args.igw_port}"
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as exec_main:
+            bg_future = exec_main.submit(send_background_load, igw_url, args.model_a, args.duration)
+            time.sleep(6)  # allow saturation to reach threshold
+            pub_future = exec_main.submit(publish_traffic, args.project, args.model_a, args.model_b)
+            pub_future.result()
+            bg_future.result()
+
+        print("[*] Load complete. Allowing 15s for queues to settle...")
+        time.sleep(15)
+        print("[+] Stress test finished successfully.")
+    finally:
+        if pf_proc:
+            pf_proc.terminate()
+            pf_proc.wait()
+            print("[*] Port-forward closed.")
+
+if __name__ == "__main__":
+    main()

--- a/guides/batch-serving/asynchronous-processing/multitenant/scripts/stress-test-redis.py
+++ b/guides/batch-serving/asynchronous-processing/multitenant/scripts/stress-test-redis.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""
+Stress test script for Multi-Tenant Async Processing using Redis SortedSet backend.
+Generates multi-tenant traffic (team × tier × model) and drives background
+saturation load on the router to test quota classification, priority lanes,
+and saturation back-off.
+
+Usage:
+  ./scripts/stress-test-redis.py
+  NAMESPACE=llm-d-async ./scripts/stress-test-redis.py
+"""
+
+import argparse
+import json
+import os
+import random
+import subprocess
+import sys
+import time
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+DEFAULT_NAMESPACE = os.environ.get("NAMESPACE", "llm-d-async")
+DEFAULT_MODEL_A = os.environ.get("MODEL_A", "Qwen/Qwen3-8B")
+DEFAULT_MODEL_B = os.environ.get("MODEL_B", "Qwen/Qwen3-8B")
+DEFAULT_REDIS = os.environ.get("REDIS_DEPLOY", "deploy/redis")
+
+def check_port_open(host="127.0.0.1", port=8080):
+    import socket
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(1.0)
+        return s.connect_ex((host, port)) == 0
+
+def start_port_forward(namespace, local_port=8080):
+    if check_port_open("127.0.0.1", local_port):
+        print(f"[*] Port {local_port} is already open, using existing endpoint.")
+        return None
+    print(f"[*] Starting port-forward to svc/llm-d-router-epp on port {local_port}...")
+    proc = subprocess.Popen(
+        ["kubectl", "port-forward", "-n", namespace, "svc/llm-d-router-epp", f"{local_port}:80"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL
+    )
+    time.sleep(3)
+    return proc
+
+def send_background_load(igw_url, model_name, duration_sec=60, concurrency=6):
+    print(f"[*] Starting background saturation load ({concurrency} concurrent workers for {duration_sec}s)...")
+    start_time = time.time()
+    req_count = 0
+
+    def single_req():
+        payload = json.dumps({
+            "model": model_name,
+            "prompt": "Write an extensive scientific treatise on distributed asynchronous message systems with high token generation.",
+            "max_tokens": 160
+        }).encode("utf-8")
+        req = urllib.request.Request(
+            f"{igw_url}/v1/completions",
+            data=payload,
+            headers={"Content-Type": "application/json"}
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=45) as resp:
+                resp.read()
+                return True
+        except Exception:
+            return False
+
+    with ThreadPoolExecutor(max_workers=concurrency) as executor:
+        futures = []
+        while time.time() - start_time < duration_sec:
+            while len(futures) < concurrency and (time.time() - start_time < duration_sec):
+                futures.append(executor.submit(single_req))
+            done = [f for f in futures if f.done()]
+            for f in done:
+                futures.remove(f)
+                req_count += 1
+            time.sleep(0.2)
+        for f in as_completed(futures):
+            req_count += 1
+
+    print(f"[*] Background saturation load finished. Completed {req_count} completions.")
+
+def publish_redis_queue(namespace, redis_deploy, queue_name, team, model_code, model_name, count, ttl=300):
+    now = int(time.time())
+    dl = now + ttl
+    run_id = f"{now}-{random.randint(1000, 9999)}"
+    
+    # Build ZADD args in batches of 50
+    batch_size = 50
+    for chunk_start in range(1, count + 1, batch_size):
+        chunk_end = min(chunk_start + batch_size, count + 1)
+        zadd_args = []
+        for i in range(chunk_start, chunk_end):
+            msg_id = f"{team}-{model_code}-{run_id}-{i:04d}"
+            msg_obj = {
+                "internal": {},
+                "request_kind": "plain",
+                "data": {
+                    "id": msg_id,
+                    "created": now,
+                    "deadline": dl,
+                    "payload": {
+                        "model": model_name,
+                        "prompt": f"Summarize key trends in async multi-tenant queue processing request #{i}",
+                        "max_tokens": 32
+                    },
+                    "metadata": {
+                        "team": team
+                    }
+                }
+            }
+            zadd_args.extend([str(dl), json.dumps(msg_obj)])
+
+        cmd = ["kubectl", "-n", namespace, "exec", "-i", redis_deploy, "--", "redis-cli", "ZADD", queue_name] + zadd_args
+        res = subprocess.run(cmd, capture_output=True, text=True)
+        if res.returncode != 0:
+            print(f"[!] Error publishing to {queue_name}: {res.stderr.strip()}")
+            return False
+
+    return True
+
+def publish_traffic(namespace, redis_deploy, model_a, model_b):
+    queues_spec = [
+        ("team-premium-a", "premium", "a", model_a, 40),
+        ("team-standard-a", "standard", "a", model_a, 25),
+        ("team-batch-a", "batch", "a", model_a, 15),
+        ("team-premium-b", "premium", "b", model_b, 40),
+        ("team-standard-b", "standard", "b", model_b, 25),
+        ("team-batch-b", "batch", "b", model_b, 15),
+    ]
+    print(f"[*] Publishing multi-tenant requests across 6 Redis SortedSet queues...")
+    with ThreadPoolExecutor(max_workers=6) as executor:
+        futures = {
+            executor.submit(
+                publish_redis_queue, namespace, redis_deploy, q_name, team, m_code, m_name, count
+            ): q_name for q_name, team, m_code, m_name, count in queues_spec
+        }
+        for f in as_completed(futures):
+            q_name = futures[f]
+            try:
+                ok = f.result()
+                if ok:
+                    print(f"  [+] Enqueued messages into {q_name}")
+            except Exception as e:
+                print(f"  [!] Failed {q_name}: {e}")
+
+def get_redis_stats(namespace, redis_deploy):
+    print("\n[*] Checking Redis Quota Counters & Results:")
+    try:
+        keys_to_check = [
+            "quota:a:team:premium", "quota:a:team:standard", "quota:a:team:batch",
+            "quota:b:team:premium", "quota:b:team:standard", "quota:b:team:batch"
+        ]
+        for k in keys_to_check:
+            res = subprocess.run(
+                ["kubectl", "-n", namespace, "exec", redis_deploy, "--", "redis-cli", "GET", k],
+                capture_output=True, text=True
+            )
+            val = res.stdout.strip() or "(nil)"
+            print(f"  - {k}: {val}")
+
+        for res_key in ["results-a-list", "results-b-list"]:
+            res = subprocess.run(
+                ["kubectl", "-n", namespace, "exec", redis_deploy, "--", "redis-cli", "LLEN", res_key],
+                capture_output=True, text=True
+            )
+            length = res.stdout.strip() or "0"
+            print(f"  - {res_key} length: {length}")
+    except Exception as e:
+        print(f"[!] Error querying Redis stats: {e}")
+
+def main():
+    parser = argparse.ArgumentParser(description="Multi-tenant async processor Redis stress test")
+    parser.add_argument("--namespace", default=DEFAULT_NAMESPACE, help="Kubernetes namespace")
+    parser.add_argument("--model-a", default=DEFAULT_MODEL_A, help="Model A name")
+    parser.add_argument("--model-b", default=DEFAULT_MODEL_B, help="Model B name")
+    parser.add_argument("--redis-deploy", default=DEFAULT_REDIS, help="Redis deployment name (default: deploy/redis)")
+    parser.add_argument("--duration", type=int, default=60, help="Saturation duration in seconds")
+    parser.add_argument("--igw-port", type=int, default=8080, help="Local port for router gateway")
+    args = parser.parse_args()
+
+    print("==========================================================")
+    print("Multi-Tenant Async Processor — Redis SortedSet Stress Test")
+    print(f"Namespace:    {args.namespace}")
+    print(f"Redis Deploy: {args.redis_deploy}")
+    print(f"Model A:      {args.model_a}")
+    print(f"Model B:      {args.model_b}")
+    print(f"Duration:     {args.duration}s")
+    print("==========================================================")
+
+    pf_proc = start_port_forward(args.namespace, args.igw_port)
+    igw_url = f"http://127.0.0.1:{args.igw_port}"
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as exec_main:
+            bg_future = exec_main.submit(send_background_load, igw_url, args.model_a, args.duration)
+            time.sleep(6)  # allow saturation to reach threshold
+            pub_future = exec_main.submit(publish_traffic, args.namespace, args.redis_deploy, args.model_a, args.model_b)
+            pub_future.result()
+            bg_future.result()
+
+        print("[*] Load complete. Allowing 15s for queues to drain...")
+        time.sleep(15)
+        get_redis_stats(args.namespace, args.redis_deploy)
+        print("\n[+] Redis stress test finished successfully.")
+    finally:
+        if pf_proc:
+            pf_proc.terminate()
+            pf_proc.wait()
+            print("[*] Port-forward closed.")
+
+if __name__ == "__main__":
+    main()

--- a/guides/batch-serving/asynchronous-processing/multitenant/values/pubsub/quota-only.yaml
+++ b/guides/batch-serving/asynchronous-processing/multitenant/values/pubsub/quota-only.yaml
@@ -14,7 +14,7 @@
 #   - TEAM  -> per-(team, model) reserved quota (redis-quota, classifying; per-model
 #     prefix quota:a: / quota:b:): within quota -> reserved, over -> overflow.
 #   - TIER  -> per-topic `tier` label; the tier-priority merge policy orders each
-#     pool's reserved/overflow × tier lanes and stamps x-gateway-priority.
+#     pool's reserved/overflow × tier lanes and stamps x-llm-d-inference-objective.
 #
 # Pub/Sub publishes all results to the single resultTopicId (unlike Redis, which
 # uses per-model result lists).
@@ -25,7 +25,6 @@ ap:
   requestMergePolicyConfig:
     type: "tier-priority"
     parameters:
-      priority_header: "x-gateway-priority"
       objective_header: "x-llm-d-inference-objective"
       fairness_header: "x-llm-d-inference-fairness-id"
       fairness_attribute: "team"

--- a/guides/batch-serving/asynchronous-processing/multitenant/values/pubsub/saturation-gmp.yaml
+++ b/guides/batch-serving/asynchronous-processing/multitenant/values/pubsub/saturation-gmp.yaml
@@ -12,8 +12,7 @@
 # requests at which a model is considered saturated).
 ap:
 
-  messageQueueImpl: "gcp-pubsub-gated"
-  igwBaseURL: "http://IGW_HOST:80"
+  transport: "gcp-pubsub"
 
   prometheusURL: "http://gmp-frontend.NAMESPACE.svc.cluster.local:9090"
   prometheusCacheTTL: "5s"
@@ -22,12 +21,21 @@ ap:
     type: "tier-priority"
     parameters:
       priority_header: "x-gateway-priority"
+      objective_header: "x-llm-d-inference-objective"
+      fairness_header: "x-llm-d-inference-fairness-id"
+      fairness_attribute: "team"
+      lane_objectives:
+        reserved-interactive: "reserved-interactive"
+        reserved-async: "reserved-async"
+        reserved-batch: "reserved-batch"
+        overflow-interactive: "overflow-interactive"
+        overflow-async: "overflow-async"
+        overflow-batch: "overflow-batch"
 
-  gcpPubSub:
-    enabled: true
-    projectId: "PROJECT_ID"
-    resultTopicId: "projects/PROJECT_ID/topics/results"
-    topicsConfig:
+  transportConfig:
+    project_id: "PROJECT_ID"
+    result_topic_id: "projects/PROJECT_ID/topics/results"
+    topics:
       # ---------- MODEL A ----------
       - subscriber_id: "projects/PROJECT_ID/subscriptions/team-premium-a-requests-sub"
         worker_pool_id: "model-a"

--- a/guides/batch-serving/asynchronous-processing/multitenant/values/pubsub/saturation-gmp.yaml
+++ b/guides/batch-serving/asynchronous-processing/multitenant/values/pubsub/saturation-gmp.yaml
@@ -20,7 +20,6 @@ ap:
   requestMergePolicyConfig:
     type: "tier-priority"
     parameters:
-      priority_header: "x-gateway-priority"
       objective_header: "x-llm-d-inference-objective"
       fairness_header: "x-llm-d-inference-fairness-id"
       fairness_attribute: "team"

--- a/guides/batch-serving/asynchronous-processing/multitenant/values/pubsub/saturation-prometheus.yaml
+++ b/guides/batch-serving/asynchronous-processing/multitenant/values/pubsub/saturation-prometheus.yaml
@@ -23,7 +23,6 @@ ap:
   requestMergePolicyConfig:
     type: "tier-priority"
     parameters:
-      priority_header: "x-gateway-priority"
       objective_header: "x-llm-d-inference-objective"
       fairness_header: "x-llm-d-inference-fairness-id"
       fairness_attribute: "team"

--- a/guides/batch-serving/asynchronous-processing/multitenant/values/pubsub/saturation-prometheus.yaml
+++ b/guides/batch-serving/asynchronous-processing/multitenant/values/pubsub/saturation-prometheus.yaml
@@ -15,8 +15,7 @@
 # vLLM is scraped by manifests/prometheus-vllm-podmonitor.yaml.
 ap:
 
-  messageQueueImpl: "gcp-pubsub-gated"
-  igwBaseURL: "http://IGW_HOST:80"
+  transport: "gcp-pubsub"
 
   prometheusURL: "PROM_URL"
   prometheusCacheTTL: "5s"
@@ -25,12 +24,21 @@ ap:
     type: "tier-priority"
     parameters:
       priority_header: "x-gateway-priority"
+      objective_header: "x-llm-d-inference-objective"
+      fairness_header: "x-llm-d-inference-fairness-id"
+      fairness_attribute: "team"
+      lane_objectives:
+        reserved-interactive: "reserved-interactive"
+        reserved-async: "reserved-async"
+        reserved-batch: "reserved-batch"
+        overflow-interactive: "overflow-interactive"
+        overflow-async: "overflow-async"
+        overflow-batch: "overflow-batch"
 
-  gcpPubSub:
-    enabled: true
-    projectId: "PROJECT_ID"
-    resultTopicId: "projects/PROJECT_ID/topics/results"
-    topicsConfig:
+  transportConfig:
+    project_id: "PROJECT_ID"
+    result_topic_id: "projects/PROJECT_ID/topics/results"
+    topics:
       # ---------- MODEL A ----------
       - subscriber_id: "projects/PROJECT_ID/subscriptions/team-premium-a-requests-sub"
         worker_pool_id: "model-a"

--- a/guides/batch-serving/asynchronous-processing/multitenant/values/pubsub/tier-priority-admission.yaml
+++ b/guides/batch-serving/asynchronous-processing/multitenant/values/pubsub/tier-priority-admission.yaml
@@ -1,26 +1,24 @@
-# Values for the multi-tenant Pub/Sub demo — team × tier × MODEL (Scenarios A + B).
+# Values for Multi-Tenant Async Processing using tier-priority-admission
+# worker pool gate with prometheus-saturation (GCP Pub/Sub backend).
 #
-# Replace: PROJECT_ID, NAMESPACE, IGW_HOST (one gateway routing by payload.model to
-# two InferencePools), POOL_A / POOL_B (used by the saturation overlay). 6 topics =
-# 3 teams × 2 models; the publisher sends model-a traffic to the *-a subscriptions
-# (payload.model = MODEL_A) and model-b to *-b.
+# Replace placeholders: PROJECT_ID, NAMESPACE, IGW_HOST, POOL_A, POOL_B, PROM_URL
 #
-# MODEL_A / MODEL_B below are the guide's ${MODEL_A} / ${MODEL_B} shell variables,
-# not placeholders in this file: the served model names reach the system through
-# payload.model in the publisher, never through these values.
-#
-#   - MODEL -> its own worker pool (model-a / model-b): independent concurrency and
-#     (saturation overlay) saturation back-off.
-#   - TEAM  -> per-(team, model) reserved quota (redis-quota, classifying; per-model
-#     prefix quota:a: / quota:b:): within quota -> reserved, over -> overflow.
-#   - TIER  -> per-topic `tier` label; the tier-priority merge policy orders each
-#     pool's reserved/overflow × tier lanes and stamps x-gateway-priority.
-#
-# Pub/Sub publishes all results to the single resultTopicId (unlike Redis, which
-# uses per-model result lists).
+#  - Worker Pool Gate: tier-priority-admission
+#    Uses an inner saturation gate (prometheus-saturation) querying
+#    flow_control_pool_saturation for the pool.
+#    When saturated:
+#      - reserved traffic parks cleanly in memory (ActionWait)
+#      - interactive overflow is dropped immediately (429)
+#      - async & batch overflow traffic is refused (ActionRefuse, returns to subscription)
+#    When not saturated:
+#      - all traffic continues freely (ActionContinue)
+#  - Merge Policy: tier-priority with lane_objectives mapping to InferenceObjectives
 ap:
 
   transport: "gcp-pubsub"
+
+  prometheusURL: "PROM_URL"
+  prometheusCacheTTL: "5s"
 
   requestMergePolicyConfig:
     type: "tier-priority"
@@ -41,10 +39,9 @@ ap:
     project_id: "PROJECT_ID"
     result_topic_id: "projects/PROJECT_ID/topics/results"
     topics:
-      # ---------- MODEL A (pool model-a, payload.model = MODEL_A) ----------
+      # ---------- MODEL A ----------
       - subscriber_id: "projects/PROJECT_ID/subscriptions/team-premium-a-requests-sub"
         worker_pool_id: "model-a"
-        inference_objective: "latency"
         request_path_url: "/v1/completions"
         igw_base_url: "http://IGW_HOST:80"
         labels: { tier: "interactive" }
@@ -71,7 +68,6 @@ ap:
           prefix: "quota:a:"
       - subscriber_id: "projects/PROJECT_ID/subscriptions/team-batch-a-requests-sub"
         worker_pool_id: "model-a"
-        inference_objective: "throughput"
         request_path_url: "/v1/completions"
         igw_base_url: "http://IGW_HOST:80"
         labels: { tier: "batch" }
@@ -84,10 +80,9 @@ ap:
           limit: "1"
           prefix: "quota:a:"
 
-      # ---------- MODEL B (pool model-b, payload.model = MODEL_B) ----------
+      # ---------- MODEL B ----------
       - subscriber_id: "projects/PROJECT_ID/subscriptions/team-premium-b-requests-sub"
         worker_pool_id: "model-b"
-        inference_objective: "latency"
         request_path_url: "/v1/completions"
         igw_base_url: "http://IGW_HOST:80"
         labels: { tier: "interactive" }
@@ -114,7 +109,6 @@ ap:
           prefix: "quota:b:"
       - subscriber_id: "projects/PROJECT_ID/subscriptions/team-batch-b-requests-sub"
         worker_pool_id: "model-b"
-        inference_objective: "throughput"
         request_path_url: "/v1/completions"
         igw_base_url: "http://IGW_HOST:80"
         labels: { tier: "batch" }
@@ -127,11 +121,22 @@ ap:
           limit: "1"
           prefix: "quota:b:"
 
+  # Worker pools with tier-priority-admission gate backed by prometheus-saturation
   workerPools:
     - id: "model-a"
       workers: 8
+      gate_type: "tier-priority-admission"
+      gate_params:
+        saturation_gate: "prometheus-saturation"
+        saturation_gate_params: '{"pool":"POOL_A","threshold":"0.8"}'
+        tier_label: "tier"
     - id: "model-b"
       workers: 8
+      gate_type: "tier-priority-admission"
+      gate_params:
+        saturation_gate: "prometheus-saturation"
+        saturation_gate_params: '{"pool":"POOL_B","threshold":"0.8"}'
+        tier_label: "tier"
 
   resources:
     requests:
@@ -143,12 +148,3 @@ ap:
 
   metrics:
     enabled: true
-  podMonitor:
-    enabled: false
-  modelServerMonitor:
-    enabled: false
-  prometheusRule:
-    enabled: false
-  grafana:
-    dashboards:
-      enabled: false

--- a/guides/batch-serving/asynchronous-processing/multitenant/values/pubsub/tier-priority-admission.yaml
+++ b/guides/batch-serving/asynchronous-processing/multitenant/values/pubsub/tier-priority-admission.yaml
@@ -23,7 +23,6 @@ ap:
   requestMergePolicyConfig:
     type: "tier-priority"
     parameters:
-      priority_header: "x-gateway-priority"
       objective_header: "x-llm-d-inference-objective"
       fairness_header: "x-llm-d-inference-fairness-id"
       fairness_attribute: "team"

--- a/guides/batch-serving/asynchronous-processing/multitenant/values/redis/quota-only.yaml
+++ b/guides/batch-serving/asynchronous-processing/multitenant/values/redis/quota-only.yaml
@@ -23,7 +23,7 @@
 # The tier-priority merge policy runs per pool independently: within each model it
 # dispatches the 6 (classification × tier) lanes in strict order (all reserved
 # before any overflow; interactive>async>batch within each) and stamps
-# x-gateway-priority and x-llm-d-inference-objective. Results land on a per-model
+# x-llm-d-inference-objective. Results land on a per-model
 # list (results-a-list / -b-list).
 ap:
 
@@ -32,7 +32,6 @@ ap:
   requestMergePolicyConfig:
     type: "tier-priority"
     parameters:
-      priority_header: "x-gateway-priority"
       objective_header: "x-llm-d-inference-objective"
       fairness_header: "x-llm-d-inference-fairness-id"
       fairness_attribute: "team"

--- a/guides/batch-serving/asynchronous-processing/multitenant/values/redis/quota-only.yaml
+++ b/guides/batch-serving/asynchronous-processing/multitenant/values/redis/quota-only.yaml
@@ -23,28 +23,37 @@
 # The tier-priority merge policy runs per pool independently: within each model it
 # dispatches the 6 (classification × tier) lanes in strict order (all reserved
 # before any overflow; interactive>async>batch within each) and stamps
-# x-gateway-priority. Results land on a per-model list (results-a-list / -b-list).
+# x-gateway-priority and x-llm-d-inference-objective. Results land on a per-model
+# list (results-a-list / -b-list).
 ap:
 
-  messageQueueImpl: "redis-sortedset"
-  igwBaseURL: "http://IGW_HOST:80"
+  transport: "redis-sortedset"
 
   requestMergePolicyConfig:
     type: "tier-priority"
     parameters:
       priority_header: "x-gateway-priority"
+      objective_header: "x-llm-d-inference-objective"
+      fairness_header: "x-llm-d-inference-fairness-id"
+      fairness_attribute: "team"
+      lane_objectives:
+        reserved-interactive: "reserved-interactive"
+        reserved-async: "reserved-async"
+        reserved-batch: "reserved-batch"
+        overflow-interactive: "overflow-interactive"
+        overflow-async: "overflow-async"
+        overflow-batch: "overflow-batch"
 
-  redis:
-    enabled: true
-    url: "redis://redis.NAMESPACE.svc.cluster.local:6379"
-    resultQueueName: "results-a-list"   # default; per-queue result_queue_name overrides below
-    pollIntervalMs: 500
-    batchSize: 10
-    queuesConfig:
+  transportConfig:
+    urlSecret:
+      url: "redis://redis.NAMESPACE.svc.cluster.local:6379"
+    result_queue_name: "results-a-list"   # default; per-queue result_queue_name overrides below
+    poll_interval_ms: 500
+    batch_size: 10
+    queues:
       # ---------- MODEL A (pool model-a, payload.model = MODEL_A) ----------
       - queue_name: "team-premium-a"
         worker_pool_id: "model-a"
-        inference_objective: "latency"
         request_path_url: "/v1/completions"
         igw_base_url: "http://IGW_HOST:80"
         result_queue_name: "results-a-list"
@@ -75,7 +84,6 @@ ap:
           prefix: "quota:a:"
       - queue_name: "team-batch-a"
         worker_pool_id: "model-a"
-        inference_objective: "throughput"
         request_path_url: "/v1/completions"
         igw_base_url: "http://IGW_HOST:80"
         result_queue_name: "results-a-list"
@@ -93,7 +101,6 @@ ap:
       # ---------- MODEL B (pool model-b, payload.model = MODEL_B) ----------
       - queue_name: "team-premium-b"
         worker_pool_id: "model-b"
-        inference_objective: "latency"
         request_path_url: "/v1/completions"
         igw_base_url: "http://IGW_HOST:80"
         result_queue_name: "results-b-list"
@@ -124,7 +131,6 @@ ap:
           prefix: "quota:b:"
       - queue_name: "team-batch-b"
         worker_pool_id: "model-b"
-        inference_objective: "throughput"
         request_path_url: "/v1/completions"
         igw_base_url: "http://IGW_HOST:80"
         result_queue_name: "results-b-list"

--- a/guides/batch-serving/asynchronous-processing/multitenant/values/redis/saturation-prometheus.yaml
+++ b/guides/batch-serving/asynchronous-processing/multitenant/values/redis/saturation-prometheus.yaml
@@ -1,4 +1,4 @@
-# Redis SortedSet backend + self-hosted Prometheus + Grafana — team × tier × MODEL
+# Redis SortedSet backend + Prometheus — team × tier × MODEL
 # with per-model saturation back-off.
 #
 #  - MODEL isolation: one worker pool per model (model-a / model-b), each with its
@@ -7,19 +7,13 @@
 #  - TEAM quota (redis-quota, classifying): within quota -> reserved, over ->
 #    overflow. Per-model prefix (quota:a: / quota:b:).
 #  - TIER: per-queue label; the tier-priority merge policy orders each pool's
-#    reserved/overflow × tier lanes and stamps x-gateway-priority.
+#    reserved/overflow × tier lanes and stamps x-gateway-priority and x-llm-d-inference-objective.
 #
 # Replace: NAMESPACE, IGW_HOST, POOL_A/POOL_B (InferencePool names), PROM_URL,
 # SAT_CAP (concurrent requests at which a model is considered saturated).
-# PROM_URL is the base URL the gates read PromQL from — the in-cluster
-# kube-prometheus-stack Prometheus if you followed the guide's Observability
-# section. Get it wrong and the gates fall back to a budget of 1 (wide open), so
-# the demo runs clean and proves nothing: verify it after the upgrade.
-# vLLM is scraped by manifests/prometheus-vllm-podmonitor.yaml.
 ap:
 
-  messageQueueImpl: "redis-sortedset"
-  igwBaseURL: "http://IGW_HOST:80"
+  transport: "redis-sortedset"
 
   prometheusURL: "PROM_URL"
   prometheusCacheTTL: "5s"
@@ -28,18 +22,27 @@ ap:
     type: "tier-priority"
     parameters:
       priority_header: "x-gateway-priority"
+      objective_header: "x-llm-d-inference-objective"
+      fairness_header: "x-llm-d-inference-fairness-id"
+      fairness_attribute: "team"
+      lane_objectives:
+        reserved-interactive: "reserved-interactive"
+        reserved-async: "reserved-async"
+        reserved-batch: "reserved-batch"
+        overflow-interactive: "overflow-interactive"
+        overflow-async: "overflow-async"
+        overflow-batch: "overflow-batch"
 
-  redis:
-    enabled: true
-    url: "redis://redis.NAMESPACE.svc.cluster.local:6379"
-    resultQueueName: "results-a-list"
-    pollIntervalMs: 500
-    batchSize: 10
-    queuesConfig:
+  transportConfig:
+    urlSecret:
+      url: "redis://redis.NAMESPACE.svc.cluster.local:6379"
+    result_queue_name: "results-a-list"
+    poll_interval_ms: 500
+    batch_size: 10
+    queues:
       # ---------- MODEL A ----------
       - queue_name: "team-premium-a"
         worker_pool_id: "model-a"
-        inference_objective: "latency"
         request_path_url: "/v1/completions"
         igw_base_url: "http://IGW_HOST:80"
         result_queue_name: "results-a-list"
@@ -68,7 +71,6 @@ ap:
           prefix: "quota:a:"
       - queue_name: "team-batch-a"
         worker_pool_id: "model-a"
-        inference_objective: "throughput"
         request_path_url: "/v1/completions"
         igw_base_url: "http://IGW_HOST:80"
         result_queue_name: "results-a-list"
@@ -85,7 +87,6 @@ ap:
       # ---------- MODEL B ----------
       - queue_name: "team-premium-b"
         worker_pool_id: "model-b"
-        inference_objective: "latency"
         request_path_url: "/v1/completions"
         igw_base_url: "http://IGW_HOST:80"
         result_queue_name: "results-b-list"
@@ -114,7 +115,6 @@ ap:
           prefix: "quota:b:"
       - queue_name: "team-batch-b"
         worker_pool_id: "model-b"
-        inference_objective: "throughput"
         request_path_url: "/v1/completions"
         igw_base_url: "http://IGW_HOST:80"
         result_queue_name: "results-b-list"
@@ -132,10 +132,7 @@ ap:
   #
   # SAT_CAP is the divisor: the concurrent-request count at which a model counts as
   # saturated. prometheus-query closes the gate at budget <= 0 and clamp() floors the
-  # budget at 0, so the gate closes only once SAT_CAP requests are running. A worker
-  # evaluates the gate while holding a message it has not dispatched yet, so at most
-  # `workers - 1` of this pool's requests are running at that moment: driven by async
-  # load alone, SAT_CAP must stay BELOW `workers` or the gate can never close.
+  # budget at 0, so the gate closes only once SAT_CAP requests are running.
   workerPools:
     - id: "model-a"
       workers: 8

--- a/guides/batch-serving/asynchronous-processing/multitenant/values/redis/saturation-prometheus.yaml
+++ b/guides/batch-serving/asynchronous-processing/multitenant/values/redis/saturation-prometheus.yaml
@@ -7,7 +7,7 @@
 #  - TEAM quota (redis-quota, classifying): within quota -> reserved, over ->
 #    overflow. Per-model prefix (quota:a: / quota:b:).
 #  - TIER: per-queue label; the tier-priority merge policy orders each pool's
-#    reserved/overflow × tier lanes and stamps x-gateway-priority and x-llm-d-inference-objective.
+#    reserved/overflow × tier lanes and stamps x-llm-d-inference-objective.
 #
 # Replace: NAMESPACE, IGW_HOST, POOL_A/POOL_B (InferencePool names), PROM_URL,
 # SAT_CAP (concurrent requests at which a model is considered saturated).
@@ -21,7 +21,6 @@ ap:
   requestMergePolicyConfig:
     type: "tier-priority"
     parameters:
-      priority_header: "x-gateway-priority"
       objective_header: "x-llm-d-inference-objective"
       fairness_header: "x-llm-d-inference-fairness-id"
       fairness_attribute: "team"

--- a/guides/batch-serving/asynchronous-processing/multitenant/values/redis/tier-priority-admission.yaml
+++ b/guides/batch-serving/asynchronous-processing/multitenant/values/redis/tier-priority-admission.yaml
@@ -1,26 +1,24 @@
-# Values for the multi-tenant Pub/Sub demo — team × tier × MODEL (Scenarios A + B).
+# Values for Multi-Tenant Async Processing using tier-priority-admission
+# worker pool gate with prometheus-saturation.
 #
-# Replace: PROJECT_ID, NAMESPACE, IGW_HOST (one gateway routing by payload.model to
-# two InferencePools), POOL_A / POOL_B (used by the saturation overlay). 6 topics =
-# 3 teams × 2 models; the publisher sends model-a traffic to the *-a subscriptions
-# (payload.model = MODEL_A) and model-b to *-b.
+# Replace placeholders: NAMESPACE, IGW_HOST, POOL_A, POOL_B, PROM_URL
 #
-# MODEL_A / MODEL_B below are the guide's ${MODEL_A} / ${MODEL_B} shell variables,
-# not placeholders in this file: the served model names reach the system through
-# payload.model in the publisher, never through these values.
-#
-#   - MODEL -> its own worker pool (model-a / model-b): independent concurrency and
-#     (saturation overlay) saturation back-off.
-#   - TEAM  -> per-(team, model) reserved quota (redis-quota, classifying; per-model
-#     prefix quota:a: / quota:b:): within quota -> reserved, over -> overflow.
-#   - TIER  -> per-topic `tier` label; the tier-priority merge policy orders each
-#     pool's reserved/overflow × tier lanes and stamps x-gateway-priority.
-#
-# Pub/Sub publishes all results to the single resultTopicId (unlike Redis, which
-# uses per-model result lists).
+#  - Worker Pool Gate: tier-priority-admission
+#    Uses an inner saturation gate (prometheus-saturation) querying
+#    flow_control_pool_saturation for the pool.
+#    When saturated:
+#      - reserved traffic parks cleanly in memory (ActionWait)
+#      - interactive overflow is dropped immediately (429)
+#      - async & batch overflow traffic is refused (ActionRefuse, returns to queue)
+#    When not saturated:
+#      - all traffic continues freely (ActionContinue)
+#  - Merge Policy: tier-priority with lane_objectives mapping to InferenceObjectives
 ap:
 
-  transport: "gcp-pubsub"
+  transport: "redis-sortedset"
+
+  prometheusURL: "PROM_URL"
+  prometheusCacheTTL: "5s"
 
   requestMergePolicyConfig:
     type: "tier-priority"
@@ -38,15 +36,18 @@ ap:
         overflow-batch: "overflow-batch"
 
   transportConfig:
-    project_id: "PROJECT_ID"
-    result_topic_id: "projects/PROJECT_ID/topics/results"
-    topics:
-      # ---------- MODEL A (pool model-a, payload.model = MODEL_A) ----------
-      - subscriber_id: "projects/PROJECT_ID/subscriptions/team-premium-a-requests-sub"
+    urlSecret:
+      url: "redis://redis.NAMESPACE.svc.cluster.local:6379"
+    result_queue_name: "results-a-list"
+    poll_interval_ms: 500
+    batch_size: 10
+    queues:
+      # ---------- MODEL A ----------
+      - queue_name: "team-premium-a"
         worker_pool_id: "model-a"
-        inference_objective: "latency"
         request_path_url: "/v1/completions"
         igw_base_url: "http://IGW_HOST:80"
+        result_queue_name: "results-a-list"
         labels: { tier: "interactive" }
         gate_type: "redis-quota"
         gate_params:
@@ -56,10 +57,11 @@ ap:
           gating_mode: "classifying"
           limit: "2"
           prefix: "quota:a:"
-      - subscriber_id: "projects/PROJECT_ID/subscriptions/team-standard-a-requests-sub"
+      - queue_name: "team-standard-a"
         worker_pool_id: "model-a"
         request_path_url: "/v1/completions"
         igw_base_url: "http://IGW_HOST:80"
+        result_queue_name: "results-a-list"
         labels: { tier: "async" }
         gate_type: "redis-quota"
         gate_params:
@@ -69,11 +71,11 @@ ap:
           gating_mode: "classifying"
           limit: "2"
           prefix: "quota:a:"
-      - subscriber_id: "projects/PROJECT_ID/subscriptions/team-batch-a-requests-sub"
+      - queue_name: "team-batch-a"
         worker_pool_id: "model-a"
-        inference_objective: "throughput"
         request_path_url: "/v1/completions"
         igw_base_url: "http://IGW_HOST:80"
+        result_queue_name: "results-a-list"
         labels: { tier: "batch" }
         gate_type: "redis-quota"
         gate_params:
@@ -84,12 +86,12 @@ ap:
           limit: "1"
           prefix: "quota:a:"
 
-      # ---------- MODEL B (pool model-b, payload.model = MODEL_B) ----------
-      - subscriber_id: "projects/PROJECT_ID/subscriptions/team-premium-b-requests-sub"
+      # ---------- MODEL B ----------
+      - queue_name: "team-premium-b"
         worker_pool_id: "model-b"
-        inference_objective: "latency"
         request_path_url: "/v1/completions"
         igw_base_url: "http://IGW_HOST:80"
+        result_queue_name: "results-b-list"
         labels: { tier: "interactive" }
         gate_type: "redis-quota"
         gate_params:
@@ -99,10 +101,11 @@ ap:
           gating_mode: "classifying"
           limit: "2"
           prefix: "quota:b:"
-      - subscriber_id: "projects/PROJECT_ID/subscriptions/team-standard-b-requests-sub"
+      - queue_name: "team-standard-b"
         worker_pool_id: "model-b"
         request_path_url: "/v1/completions"
         igw_base_url: "http://IGW_HOST:80"
+        result_queue_name: "results-b-list"
         labels: { tier: "async" }
         gate_type: "redis-quota"
         gate_params:
@@ -112,11 +115,11 @@ ap:
           gating_mode: "classifying"
           limit: "2"
           prefix: "quota:b:"
-      - subscriber_id: "projects/PROJECT_ID/subscriptions/team-batch-b-requests-sub"
+      - queue_name: "team-batch-b"
         worker_pool_id: "model-b"
-        inference_objective: "throughput"
         request_path_url: "/v1/completions"
         igw_base_url: "http://IGW_HOST:80"
+        result_queue_name: "results-b-list"
         labels: { tier: "batch" }
         gate_type: "redis-quota"
         gate_params:
@@ -127,11 +130,22 @@ ap:
           limit: "1"
           prefix: "quota:b:"
 
+  # Worker pools with tier-priority-admission gate backed by prometheus-saturation
   workerPools:
     - id: "model-a"
       workers: 8
+      gate_type: "tier-priority-admission"
+      gate_params:
+        saturation_gate: "prometheus-saturation"
+        saturation_gate_params: '{"pool":"POOL_A","threshold":"0.8"}'
+        tier_label: "tier"
     - id: "model-b"
       workers: 8
+      gate_type: "tier-priority-admission"
+      gate_params:
+        saturation_gate: "prometheus-saturation"
+        saturation_gate_params: '{"pool":"POOL_B","threshold":"0.8"}'
+        tier_label: "tier"
 
   resources:
     requests:

--- a/guides/batch-serving/asynchronous-processing/multitenant/values/redis/tier-priority-admission.yaml
+++ b/guides/batch-serving/asynchronous-processing/multitenant/values/redis/tier-priority-admission.yaml
@@ -23,7 +23,6 @@ ap:
   requestMergePolicyConfig:
     type: "tier-priority"
     parameters:
-      priority_header: "x-gateway-priority"
       objective_header: "x-llm-d-inference-objective"
       fairness_header: "x-llm-d-inference-fairness-id"
       fairness_attribute: "team"

--- a/guides/batch-serving/asynchronous-processing/multitenant/values/router/flow-control.yaml
+++ b/guides/batch-serving/asynchronous-processing/multitenant/values/router/flow-control.yaml
@@ -7,6 +7,7 @@ router:
       targetPort: 8081
   monitoring:
     prometheus:
+      enabled: true
       auth:
         enabled: false
   epp:

--- a/guides/batch-serving/asynchronous-processing/multitenant/values/router/flow-control.yaml
+++ b/guides/batch-serving/asynchronous-processing/multitenant/values/router/flow-control.yaml
@@ -1,0 +1,90 @@
+# Router values for Multi-Tenant Async Processing using Flow Control
+router:
+  extraServicePorts:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8081
+  monitoring:
+    prometheus:
+      auth:
+        enabled: false
+  epp:
+    resources:
+      requests:
+        cpu: "1"
+        memory: "2Gi"
+      limits:
+        memory: "8Gi"
+    pluginsConfigFile: "flow-control-plugins.yaml"
+    pluginsCustomConfig:
+      flow-control-plugins.yaml: |
+        apiVersion: llm-d.ai/v1alpha1
+        kind: EndpointPickerConfig
+        featureGates:
+        - flowControl
+        plugins:
+        - type: queue-scorer
+        - type: kv-cache-utilization-scorer
+        - type: prefix-cache-scorer
+        - type: round-robin-fairness-policy
+        - type: fcfs-ordering-policy
+        - type: concurrency-detector
+          parameters:
+            maxConcurrency: 10
+            concurrencyMode: requests
+            headroom: 0.0
+
+        schedulingProfiles:
+        - name: default
+          plugins:
+          - pluginRef: queue-scorer
+            weight: 2
+          - pluginRef: kv-cache-utilization-scorer
+            weight: 2
+          - pluginRef: prefix-cache-scorer
+            weight: 3
+
+        flowControl:
+          maxBytes: "10Gi"
+          maxRequests: "1k"
+          defaultRequestTTL: "300s"
+          saturationDetector:
+            pluginRef: concurrency-detector
+          priorityBands:
+          - priority: 100
+            maxRequests: "500"
+            fairnessPolicyRef: round-robin-fairness-policy
+            orderingPolicyRef: fcfs-ordering-policy
+          - priority: 60
+            maxRequests: "500"
+            fairnessPolicyRef: round-robin-fairness-policy
+            orderingPolicyRef: fcfs-ordering-policy
+          - priority: 30
+            maxRequests: "500"
+            fairnessPolicyRef: round-robin-fairness-policy
+            orderingPolicyRef: fcfs-ordering-policy
+          - priority: 10
+            maxRequests: "500"
+            fairnessPolicyRef: round-robin-fairness-policy
+            orderingPolicyRef: fcfs-ordering-policy
+          - priority: 0
+            maxRequests: "500"
+            fairnessPolicyRef: round-robin-fairness-policy
+            orderingPolicyRef: fcfs-ordering-policy
+          - priority: -10
+            maxRequests: "500"
+            fairnessPolicyRef: round-robin-fairness-policy
+            orderingPolicyRef: fcfs-ordering-policy
+
+  proxy:
+    resources:
+      requests:
+        cpu: "1"
+        memory: "2Gi"
+      limits:
+        memory: "8Gi"
+
+  modelServers:
+    matchLabels:
+      app: vllm-1

--- a/guides/batch-serving/asynchronous-processing/redis/README.md
+++ b/guides/batch-serving/asynchronous-processing/redis/README.md
@@ -21,7 +21,7 @@ This implementation uses Redis Sorted Sets as the backend for the request queue.
      helm install redis bitnami/redis -n redis --create-namespace --set auth.enabled=true --set auth.password=$REDIS_PASSWORD
 
      # Create a secret holding the full connection URL for the Async Processor
-     # (referenced via ap.redis.secretName / ap.redis.secretKey in values.yaml):
+     # (referenced via ap.transportConfig.urlSecret.name / ap.transportConfig.urlSecret.key in values.yaml):
      kubectl create secret generic redis-creds -n llm-d-async \
        --from-literal=url="redis://:$REDIS_PASSWORD@redis-master.redis.svc.cluster.local:6379"
      ```
@@ -34,12 +34,19 @@ Edit the `values.yaml` file with your specific Redis connection:
 
 ```yaml
 ap:
-  redis:
+  transport: "redis-sortedset"
+  transportConfig:
     # No auth: the connection URL directly (the chart creates the Secret).
-    url: "redis://redis-master.redis.svc.cluster.local:6379"
-    # With auth: reference the Secret created above instead of `url`.
-    # secretName: "redis-creds"
-    # secretKey: "url"
+    urlSecret:
+      url: "redis://redis-master.redis.svc.cluster.local:6379"
+    # With auth: reference the Secret created above instead of `urlSecret.url`.
+    # urlSecret:
+    #   name: "redis-creds"
+    #   key: "url"
+    queues:
+      - queue_name: "request-sortedset"
+        request_path_url: "/v1/completions"
+        igw_base_url: "http://<igw-host>:80"
 ```
 
 For deployment instructions, please refer to the [main README](../README.md#installation).

--- a/guides/batch-serving/asynchronous-processing/redis/values.yaml
+++ b/guides/batch-serving/asynchronous-processing/redis/values.yaml
@@ -1,13 +1,18 @@
 ap:
-  messageQueueImpl: "redis-sortedset"
-  redis:
-    enabled: true
+  transport: "redis-sortedset"
+  transportConfig:
     # Option 1 (no auth): the connection URL directly. The chart creates the Secret.
-    url: "redis://redis-master.redis.svc.cluster.local:6379"
+    urlSecret:
+      url: "redis://redis-master.redis.svc.cluster.local:6379"
     # Option 2 (auth): reference a pre-existing Secret holding the full redis URL
-    # (see the "With Authentication" prerequisite). When set, `url` is ignored.
-    # secretName: "redis-creds"
-    # secretKey: "url"
-    requestPathURL: "/v1/completions"
-    requestQueueName: "request-sortedset"
-    resultQueueName: "result-list"
+    # (see the "With Authentication" prerequisite). When set, `urlSecret.url` is ignored.
+    # urlSecret:
+    #   name: "redis-creds"
+    #   key: "url"
+    result_queue_name: "result-list"
+    poll_interval_ms: 1000
+    batch_size: 10
+    queues:
+      - queue_name: "request-sortedset"
+        request_path_url: "/v1/completions"
+        igw_base_url: "http://REPLACE_WITH_IGW_HOST:80"

--- a/guides/batch-serving/asynchronous-processing/test/kind-e2e.sh
+++ b/guides/batch-serving/asynchronous-processing/test/kind-e2e.sh
@@ -29,7 +29,7 @@ BASELINE_NAMESPACE="${BASELINE_NAMESPACE:-llm-d-optimized-baseline}"
 BASELINE_GUIDE="${BASELINE_GUIDE:-optimized-baseline}"
 
 MODEL="${MODEL:-facebook/opt-125m}"        # tiny, ungated, CPU-friendly
-ASYNC_VERSION="${ASYNC_VERSION:-v0.9.0}"     # chart + image are public under ghcr.io/llm-d (latest llm-d-async release)
+ASYNC_VERSION="${ASYNC_VERSION:-v0.9.1}"     # chart + image are public under ghcr.io/llm-d (latest llm-d-async release)
 
 BASELINE_TIMEOUT="${BASELINE_TIMEOUT:-1800}"  # seconds to wait for vLLM ready
 ASYNC_POLL_TRIES="${ASYNC_POLL_TRIES:-120}"   # smoke-test result polls

--- a/guides/recipes/observability/install-prometheus-grafana.sh
+++ b/guides/recipes/observability/install-prometheus-grafana.sh
@@ -136,6 +136,16 @@ is_openshift() {
   return 1
 }
 
+is_autopilot() {
+  if $KCMD get ns gke-managed-system &>/dev/null; then
+    return 0
+  fi
+  if $KCMD get nodes -o jsonpath='{.items[0].metadata.name}' 2>/dev/null | grep -q '^gk3-'; then
+    return 0
+  fi
+  return 1
+}
+
 check_servicemonitor_crd() {
   log_info "🔍 Checking for ServiceMonitor CRD (monitoring.coreos.com)..."
   if ! $KCMD get crd servicemonitors.monitoring.coreos.com &>/dev/null; then
@@ -161,6 +171,10 @@ check_servicemonitor_crd() {
 
 check_existing_node_exporter() {
   log_info "🔍 Checking for existing node-exporter installations..."
+  if is_autopilot; then
+    log_info "ℹ️ GKE Autopilot detected - node-exporter will be disabled (host namespaces restricted in Autopilot)"
+    return 0
+  fi
   # Shared clusters with existing monitoring commonly have pre-existing node-exporters,
   # and it's not necessary to have multiple of these running (they would conflict on port 9100)
   local existing_exporters=$($KCMD get pods --all-namespaces -l app=node-exporter -o name 2>/dev/null | wc -l)
@@ -408,6 +422,18 @@ install_prometheus_grafana() {
 
   if [[ "$CENTRAL_MODE" == "true" ]]; then
     cat <<EOF > /tmp/prometheus-values.yaml
+kubeControllerManager:
+  enabled: false
+kubeScheduler:
+  enabled: false
+kubeProxy:
+  enabled: false
+kubeEtcd:
+  enabled: false
+coreDns:
+  enabled: false
+kubeDns:
+  enabled: false
 grafana:
   adminPassword: admin
   service:
@@ -459,6 +485,18 @@ $(if [[ -n "$DISABLE_NODE_EXPORTER" ]]; then echo -e "$DISABLE_NODE_EXPORTER"; f
 EOF
   else
     cat <<EOF > /tmp/prometheus-values.yaml
+kubeControllerManager:
+  enabled: false
+kubeScheduler:
+  enabled: false
+kubeProxy:
+  enabled: false
+kubeEtcd:
+  enabled: false
+coreDns:
+  enabled: false
+kubeDns:
+  enabled: false
 grafana:
   adminPassword: admin
   service:


### PR DESCRIPTION
- Update multitenant guide to integrate Flow Control router InferenceObjectives, tier-priority merge policy, and per-model worker pools
- Unify Cloud Monitoring dashboard across Redis and Pub/Sub backends using pure llm_d_async_* Prometheus metrics:
  - Add separate tiles for broker backlog and in-process queue depth
  - Add tiles for exceeded deadline request rate and token processing throughput
  - Add documentation note that deadline proximity is specific to Redis Sorted Sets
- Add multi-tenant end-to-end stress testing and heavy benchmark scripts
- Add standalone manifests for vLLM, Prometheus, Grafana, and InferenceObjectives
- Update Helm value overlays to modern unified transport configuration