### PR TITLE
ci(workload-autoscaling): add AMD ROCm WVA nightly workflows

### DIFF
--- a/.github/workflows/consolidate-status-workload-autoscaling-amd-acc-rocm-vllm-x.yaml
+++ b/.github/workflows/consolidate-status-workload-autoscaling-amd-acc-rocm-vllm-x.yaml
@@ -1,0 +1,29 @@
+name: Past Status - Workload Autoscaling E2E (AMD ROCm)
+
+on:
+  workflow_dispatch:
+    inputs:
+      workflow_name_query:
+        description: 'Name of the workflow to be queried'
+        required: false
+        type: 'string'
+        default: 'nightly-e2e-workload-autoscaling-amd-acc-rocm-vllm-x.yaml'
+      time_window_query:
+        description: 'How many days in the past to query'
+        required: true
+        type: 'string'
+        default: '5'
+      branch_query:
+        description: 'Branch to be queried'
+        required: false
+        type: string
+        default: 'main'
+
+jobs:
+  check_for_success:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-query-success-past-runs.yaml@main
+    with:
+      workflow_name_query: ${{ inputs.workflow_name_query || 'nightly-e2e-workload-autoscaling-amd-acc-rocm-vllm-x.yaml' }}
+      time_window_query: ${{ inputs.time_window_query || '5' }}
+      branch_query: ${{ inputs.branch_query || 'main' }}
+    secrets: inherit

--- a/.github/workflows/nightly-e2e-workload-autoscaling-amd-acc-rocm-vllm-x.yaml
+++ b/.github/workflows/nightly-e2e-workload-autoscaling-amd-acc-rocm-vllm-x.yaml
@@ -1,0 +1,200 @@
+name: Nightly - Workload Autoscaling E2E (AMD ROCm)
+
+# Nightly regression test for WVA (Workload Variant Autoscaler) on the AMD ROCm
+# CI cluster. Deploys the workload-autoscaling guide stack via the consolidated
+# kustomize reusable workflow and runs the e2e-validate.sh smoke-test suite.
+#
+# Builds the WVA controller image from main before testing, since the helm
+# chart on main may require features not yet in a tagged release image.
+#
+# The ROCm cluster is shared with four other nightlies, so this run does not
+# preempt: allow_gpu_preemption stays false and the deploy script sets no
+# PriorityClass.
+#
+# Dispatch-only for now. The 13:00 UTC schedule, which is clear of the
+# 03:00/05:00/07:00/10:00 slots the other four ROCm nightlies hold, is added
+# alongside the deploy script this lane calls.
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'WVA image tag (leave empty to build from main)'
+        required: false
+        default: ''
+      caller_ref:
+        description: 'WVA repo ref to checkout for tests and image build (branch, tag, or SHA)'
+        required: false
+        default: 'main'
+      skip_cleanup:
+        description: 'Skip cleanup after tests (for debugging)'
+        required: false
+        default: 'false'
+      pr_number:
+        description: 'PR number for comment-back (set by /test-nightly)'
+        required: false
+        default: ''
+      pr_repo:
+        description: 'Repo for PR comment-back'
+        required: false
+        default: 'llm-d/llm-d'
+      decode_pods:
+        description: 'Number of decode (vllm "standalone") pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      prefill_pods:
+        description: 'Number of prefill pods (default "auto", means what was configured on the scenario)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      gateway_class:
+        description: 'Class of gateway used ("istio", "agentgateway", "epponly" (i.e., "standalone"), "none")'
+        required: false
+        default: 'epponly'
+      monitoring_enabled:
+        description: 'Enabled monitoring ("true", "false")'
+        required: true
+        type: 'string'
+        default: 'false'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode ("true", "false")'
+        required: false
+        default: 'true'
+      verbose:
+        description: 'Execute workflow in "verbose" mode ("true", "false")'
+        required: false
+        default: 'false'
+        type: 'string'
+      harness:
+        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
+        required: false
+        default: 'inference-perf'
+        type: 'string'
+      workload:
+        description: 'Workload profile to be used during "run" operation (check list under "workload/profiles")'
+        required: false
+        default: 'sanity_random.yaml'
+        type: 'string'
+      cleanup:
+        description: 'Cleanup the llm-d stack stood up by this workflow'
+        required: false
+        default: 'true'
+        type: string
+      update_badge:
+        description: 'Update the badge on gh-pages ("true", "false")'
+        required: false
+        default: 'true'
+        type: string
+      matrix_type:
+        description: 'Will this workflow be part of a "nightly" (default) run or "release-X.Y.Z[rc]" run?'
+        required: false
+        default: 'nightly'
+        type: 'string'
+      llm_d_ref:
+        description: 'llm-d ref to test, e.g. "refs/pull/1234/merge" to run against an unmerged PR (empty tests the ref this workflow runs from)'
+        required: false
+        default: ''
+        type: 'string'
+
+permissions:
+  contents: write
+  actions: read
+  packages: write
+
+concurrency:
+  group: nightly-e2e-wva-amd-rocm
+  cancel-in-progress: true
+
+jobs:
+  # Build the WVA controller image from main so the chart and binary match.
+  # The chart on main may include flags (e.g. --config-file) that only exist
+  # in the latest code, not in the last tagged release.
+  build-wva-image:
+    if: github.repository == 'llm-d/llm-d' && github.event.inputs.image_tag == ''
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.build.outputs.image_tag }}
+    steps:
+      - name: Checkout WVA source
+        uses: actions/checkout@v7
+        with:
+          repository: llm-d/llm-d-workload-variant-autoscaler
+          ref: ${{ github.event.inputs.caller_ref || 'main' }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USER }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Build and push image
+        id: build
+        run: |
+          SHA=$(git rev-parse --short=8 HEAD)
+          IMAGE_TAG="nightly-${SHA}"
+          FULL_IMAGE="ghcr.io/llm-d/llm-d-workload-variant-autoscaler:${IMAGE_TAG}"
+          echo "Building WVA controller from main: $FULL_IMAGE"
+          for attempt in 1 2 3; do
+            echo "Build attempt $attempt/3"
+            if make docker-build IMG="$FULL_IMAGE"; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "Build failed after 3 attempts"
+              exit 1
+            fi
+            echo "Build failed (likely transient registry error), retrying in 30s..."
+            sleep 30
+          done
+          make docker-push IMG="$FULL_IMAGE"
+          echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+
+  nightly:
+    needs: build-wva-image
+    if: github.repository == 'llm-d/llm-d' && always() && (needs.build-wva-image.result == 'success' || needs.build-wva-image.result == 'skipped')
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-nightly-e2e-amd.yaml@main
+    with:
+      guide_name: workload-autoscaling
+      namespace: llm-d-nightly-wva-rocm
+      # release-e2e.yaml dispatches every nightly-e2e lane with matrix_type set to the
+      # release branch, so that branch is what should be tested. The AMD reusable takes
+      # the ref directly rather than a matrix_type, so translate here. An explicit
+      # llm_d_ref wins, which is how a dispatch tests an unmerged PR.
+      llm_d_ref: ${{ inputs.llm_d_ref || ((inputs.matrix_type != '' && inputs.matrix_type != 'nightly') && inputs.matrix_type || '') }}
+      # Service name is truncated to 63 chars: ...-inferencepoo-epp (not ...-inferencepool-epp)
+      gateway_host: 'workload-variant-autoscaler-inferencepoo-epp'
+      custom_deploy_script: |
+        export WVA_TAG="${{ needs.build-wva-image.outputs.image_tag || github.event.inputs.image_tag }}"
+        bash guides/workload-autoscaling/scripts/nightly-deploy-amd.sh
+      # Two decode replicas at TP2, and the ScaledObject is capped at two, so the
+      # run neither needs nor can use headroom beyond four GPUs.
+      required_gpus: 4
+      recommended_gpus: 4
+      # Qwen3-32B is pulled cold: this guide's model server keeps the emptyDir
+      # cache rather than the RWX PVC the benchmark nightlies reuse.
+      pod_wait_timeout: '40m'
+      pod_readiness_delay: 180
+      allow_gpu_preemption: false
+      skip_cleanup: ${{ github.event.inputs.skip_cleanup == 'true' }}
+      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_repo: ${{ github.event.inputs.pr_repo }}
+    secrets: inherit
+
+  update-badge:
+    needs: [nightly]
+    if: always() && inputs.update_badge != 'false'
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-update-badge.yaml@main
+    with:
+      badge_name: wva-rocm
+      badge_label: "VLLM ROCm"
+      result: ${{ needs.nightly.result }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      failure_category: ${{ needs.nightly.outputs.failure_category }}
+      matrix_type: ${{ inputs.matrix_type || 'nightly' }}


### PR DESCRIPTION
## What this adds

The CI half of the Workload Variant Autoscaler nightly lane for the AMD ROCm cluster, split out of #2467 so it can be merged and dispatched ahead of the code:

- `.github/workflows/nightly-e2e-workload-autoscaling-amd-acc-rocm-vllm-x.yaml`, the nightly caller
- `.github/workflows/consolidate-status-workload-autoscaling-amd-acc-rocm-vllm-x.yaml`, its past-status companion

The caller builds the WVA controller image from the autoscaler repo before testing, since the chart on main can require flags that are not present in the last tagged release image, then hands off to `reusable-nightly-e2e-amd.yaml` in llm-d-infra with the guide's deploy script, a 4 GPU request, and preemption disabled so the run coexists with the four other nightlies on the shared cluster.

## Dispatch-only for now

Both workflows omit their schedules here. The deploy script the caller invokes, `guides/workload-autoscaling/scripts/nightly-deploy-amd.sh`, lands in #2467, so a scheduled run against main before that merges could only fail. The 13:00 and 15:00 UTC crons are added in #2467 alongside the script, which keeps main free of a lane that cannot pass at any point.

Dispatch covers what is needed in the meantime. The caller takes an `llm_d_ref` input that overrides the ref the reusable checks out, so this lane can be run against the unmerged code by dispatching from main with `llm_d_ref` set to `refs/pull/2467/merge`. The same input also carries the release branch through when `release-e2e.yaml` dispatches the lane with `matrix_type`.

A dispatch holds 4 GPUs on the shared ROCm cluster for roughly 25 minutes.

## Validation

The lane has been run end to end on the ROCm CI cluster with the #2467 code in place: the autoscaler made real scaling decisions off live vLLM metrics, KEDA consumed the published desired replica count, `e2e-validate.sh` passed 10/10, and teardown left no residue.

## Related

- Code half: #2467
- Reusable workflow this calls: llm-d/llm-d-infra#243
