### PR TITLE
Fix: Align AWS GPT-OSS-120B prefill and decode at TP2

### DIFF
--- a/guides/pd-disaggregation/modelserver/gpu/sglang/aws/patch-prefill.yaml
+++ b/guides/pd-disaggregation/modelserver/gpu/sglang/aws/patch-prefill.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   name: prefill
 spec:
-  replicas: 2
   template:
     spec:
       affinity:
@@ -30,26 +29,6 @@ spec:
                 topologyKey: "kubernetes.io/hostname"
       containers:
         - name: modelserver
-          command: ["python3", "-m", "sglang.launch_server"]
-          args:
-            - "--model-path=openai/gpt-oss-120b"
-            - "--port=8000"
-            - "--host=0.0.0.0"
-            - "--disaggregation-mode=prefill"
-            - "--disaggregation-transfer-backend=nixl"
-            - "--tensor-parallel-size=4"
-            - "--log-level=info"
-            - "--enable-metrics"
-            - "--uvicorn-access-log-exclude-prefixes=/metrics"
-          resources:
-            limits:
-              cpu: "16"
-              memory: 64Gi
-              nvidia.com/gpu: "4"
-            requests:
-              cpu: "16"
-              memory: 64Gi
-              nvidia.com/gpu: "4"
           securityContext:
             capabilities:
               add:


### PR DESCRIPTION

Follow-up to #2442.

The AWS SGLang prefill overlay duplicated shared settings from `base/patch-prefill.yaml`, including the SGLang arguments and GPU resources. Those overrides left AWS prefill at TP=4 and 4 GPUs after the base configuration moved to TP=2.

Remove the duplicated AWS overrides so prefill inherits the shared base configuration, including TP=2 and 2 GPU requests/limits.


