### PR TITLE
feat(observability): wire metric-to-trace navigation for EPP exemplars

### DIFF
--- a/guides/recipes/observability/grafana/dashboards/llm-d-failure-saturation-dashboard.json
+++ b/guides/recipes/observability/grafana/dashboards/llm-d-failure-saturation-dashboard.json
@@ -446,6 +446,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
+          "exemplar": true,
           "expr": "histogram_quantile(0.99, sum by(le) (rate(llm_d_epp_request_duration_seconds_bucket{namespace=~\"$namespace\",model_name=~\"$model_name\"}[5m])))",
           "hide": false,
           "instant": false,

--- a/guides/recipes/observability/install-prometheus-grafana.sh
+++ b/guides/recipes/observability/install-prometheus-grafana.sh
@@ -12,6 +12,9 @@ KUBERNETES_CONTEXT=""
 DEBUG=""
 CENTRAL_MODE=true
 ENABLE_TLS=false
+# Namespace holding the tracing stack (installed separately by
+# install-otel-collector-jaeger.sh). Auto-detected when unset.
+TRACING_NAMESPACE="${TRACING_NAMESPACE:-}"
 
 ### HELP & LOGGING ###
 print_help() {
@@ -32,6 +35,8 @@ Options:
 
 Environment Variables:
   MONITORING_NAMESPACE        Override default monitoring namespace
+  TRACING_NAMESPACE           Namespace of the Jaeger install to link exemplars to
+                              (auto-detected when unset)
 
 Examples:
   $(basename "$0")                              # Install central monitoring in llm-d-monitoring (watches all namespaces)
@@ -220,6 +225,23 @@ check_prometheus_operator() {
   fi
 }
 
+detect_jaeger() {
+  # The tracing stack is installed separately by install-otel-collector-jaeger.sh
+  # into a namespace the operator picks, so locate it rather than assume one.
+  # Echoes the namespace when found, nothing otherwise.
+  if [[ -n "$TRACING_NAMESPACE" ]]; then
+    if $KCMD get svc jaeger-collector -n "$TRACING_NAMESPACE" &>/dev/null; then
+      echo "$TRACING_NAMESPACE"
+    else
+      log_info "⚠️ No jaeger-collector service in TRACING_NAMESPACE=${TRACING_NAMESPACE}" >&2
+    fi
+    return 0
+  fi
+
+  $KCMD get svc --all-namespaces --field-selector metadata.name=jaeger-collector \
+    -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || true
+}
+
 setup_tls_certificates() {
   if [[ "$ENABLE_TLS" != "true" ]]; then
     return 0
@@ -406,6 +428,44 @@ install_prometheus_grafana() {
     WEB_TLS_CONFIG=""
   fi
 
+  # Grafana datasource wiring for metric-to-trace navigation.
+  #
+  # The EPP attaches the OpenTelemetry trace ID to its latency histograms as a
+  # Prometheus exemplar (llm-d/llm-d-router#2637). Three things have to line up
+  # for that to be clickable in Grafana, and none of them error when missing:
+  #   1. Prometheus must be started with the exemplar-storage feature, or it
+  #      parses the exemplar off the scrape and discards it (see enableFeatures
+  #      in prometheusSpec below).
+  #   2. Grafana needs a traces datasource to send the operator to.
+  #   3. The Prometheus datasource needs exemplarTraceIdDestinations to turn the
+  #      trace_id label into a link into that traces datasource.
+  # Tracing is an optional add-on, so 2 and 3 are wired only when Jaeger is found.
+  JAEGER_NAMESPACE="$(detect_jaeger)"
+  PROMETHEUS_JSONDATA=""
+  JAEGER_DATASOURCE=""
+
+  if [[ "$ENABLE_TLS" == "true" ]]; then
+    PROMETHEUS_JSONDATA="          tlsSkipVerify: true"
+  fi
+
+  if [[ -n "$JAEGER_NAMESPACE" ]]; then
+    log_info "🔗 Found Jaeger in ${JAEGER_NAMESPACE}, linking exemplars to traces"
+    PROMETHEUS_JSONDATA="${PROMETHEUS_JSONDATA:+${PROMETHEUS_JSONDATA}\n}          exemplarTraceIdDestinations:
+            - name: trace_id
+              datasourceUid: jaeger"
+    JAEGER_DATASOURCE="      - name: Jaeger
+        type: jaeger
+        uid: jaeger
+        url: http://jaeger-collector.${JAEGER_NAMESPACE}.svc.cluster.local:16686
+        access: proxy"
+  else
+    log_info "ℹ️ No Jaeger install found, skipping exemplar-to-trace links"
+  fi
+
+  if [[ -n "$PROMETHEUS_JSONDATA" ]]; then
+    PROMETHEUS_JSONDATA="        jsonData:\n${PROMETHEUS_JSONDATA}"
+  fi
+
   if [[ "$CENTRAL_MODE" == "true" ]]; then
     cat <<EOF > /tmp/prometheus-values.yaml
 grafana:
@@ -428,13 +488,15 @@ grafana:
         url: ${PROMETHEUS_PROTOCOL}://${RELEASE_NAME}-kube-prometheus-stack-prometheus.${MONITORING_NAMESPACE}.svc.cluster.local:${PROMETHEUS_PORT}
         access: proxy
         isDefault: true
-$(if [[ "$ENABLE_TLS" == "true" ]]; then echo "        jsonData:
-          tlsSkipVerify: true"; fi)
+$(if [[ -n "$PROMETHEUS_JSONDATA" ]]; then echo -e "$PROMETHEUS_JSONDATA"; fi)
+$(if [[ -n "$JAEGER_DATASOURCE" ]]; then echo -e "$JAEGER_DATASOURCE"; fi)
 prometheus:
   service:
     type: ClusterIP
     sessionAffinity: ""
   prometheusSpec:
+    enableFeatures:
+      - exemplar-storage
 $(if [[ -n "$PROMETHEUS_IMAGE_CONFIG" ]]; then echo -e "$PROMETHEUS_IMAGE_CONFIG"; fi)
 $(if [[ -n "$WEB_TLS_CONFIG" ]]; then echo -e "$WEB_TLS_CONFIG"; fi)
     serviceMonitorSelectorNilUsesHelmValues: false
@@ -481,13 +543,15 @@ grafana:
         url: ${PROMETHEUS_PROTOCOL}://${RELEASE_NAME}-kube-prometheus-stack-prometheus.${MONITORING_NAMESPACE}.svc.cluster.local:${PROMETHEUS_PORT}
         access: proxy
         isDefault: true
-$(if [[ "$ENABLE_TLS" == "true" ]]; then echo "        jsonData:
-          tlsSkipVerify: true"; fi)
+$(if [[ -n "$PROMETHEUS_JSONDATA" ]]; then echo -e "$PROMETHEUS_JSONDATA"; fi)
+$(if [[ -n "$JAEGER_DATASOURCE" ]]; then echo -e "$JAEGER_DATASOURCE"; fi)
 prometheus:
   service:
     type: ClusterIP
     sessionAffinity: ""
   prometheusSpec:
+    enableFeatures:
+      - exemplar-storage
 $(if [[ -n "$PROMETHEUS_IMAGE_CONFIG" ]]; then echo -e "$PROMETHEUS_IMAGE_CONFIG"; fi)
 $(if [[ -n "$WEB_TLS_CONFIG" ]]; then echo -e "$WEB_TLS_CONFIG"; fi)
     serviceMonitorSelectorNilUsesHelmValues: false

--- a/scripts/test-prometheus-exemplar-config.sh
+++ b/scripts/test-prometheus-exemplar-config.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Verifies the Grafana/Prometheus wiring that metric-to-trace navigation needs
+# (llm-d#2462). Exemplars are dropped silently at every stage they are not
+# configured for, so each of these is asserted on the values file that would
+# actually be handed to helm rather than on the script source.
+#
+# The installer is run for real against stubbed kubectl/helm binaries: no
+# cluster is required, and the helm stub captures the rendered values file
+# before the installer deletes it.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALLER="${SCRIPT_DIR}/../guides/recipes/observability/install-prometheus-grafana.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+FAILURES=0
+PROM_DS='.grafana.datasources."datasources.yaml".datasources[] | select(.type=="prometheus")'
+JAEGER_DS='.grafana.datasources."datasources.yaml".datasources[] | select(.type=="jaeger")'
+
+for cmd in yq jq bash; do
+  command -v "$cmd" >/dev/null || { echo "missing required tool: $cmd" >&2; exit 1; }
+done
+
+check() { # description expected actual
+  if [[ "$2" == "$3" ]]; then
+    printf '  ok   %s\n' "$1"
+  else
+    printf '  FAIL %s: expected [%s], got [%s]\n' "$1" "$2" "$3"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+write_stubs() {
+  mkdir -p "$WORK/bin"
+
+  # A plain, empty, non-OpenShift cluster. JAEGER_NS unset means no tracing
+  # stack is installed, which is the case the wiring has to degrade for.
+  cat > "$WORK/bin/kubectl" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  *"cluster-info"*)              exit 0 ;;
+  *"get clusterversion"*)        exit 1 ;;
+  *"get crd servicemonitors"*)   exit 1 ;;
+  *"--field-selector metadata.name=jaeger-collector"*)
+      [[ -n "${JAEGER_NS:-}" ]] && printf '%s' "$JAEGER_NS"
+      exit 0 ;;
+  *"get svc jaeger-collector"*)
+      # only the namespace that actually holds jaeger answers
+      for a in "$@"; do
+        [[ "$prev" == "-n" ]] && req="$a"
+        prev="$a"
+      done
+      [[ -n "${JAEGER_NS:-}" && "${req:-}" == "${JAEGER_NS}" ]] && exit 0 || exit 1 ;;
+  *)                             exit 0 ;;
+esac
+EOF
+
+  # The installer removes the values file once helm has consumed it, so the
+  # stub keeps a copy of exactly what helm was given.
+  cat > "$WORK/bin/helm" <<'EOF'
+#!/usr/bin/env bash
+prev=""
+for arg in "$@"; do
+  if [[ "$prev" == "-f" && -f "$arg" ]]; then cp "$arg" "$CAPTURE_TO"; fi
+  prev="$arg"
+done
+exit 0
+EOF
+
+  chmod +x "$WORK/bin/kubectl" "$WORK/bin/helm"
+}
+
+render() { # name [installer args...]
+  local name="$1"; shift
+  CAPTURE_TO="$WORK/$name.yaml" PATH="$WORK/bin:$PATH" \
+    bash "$INSTALLER" "$@" >"$WORK/$name.log" 2>&1 || true
+
+  if [[ ! -f "$WORK/$name.yaml" ]]; then
+    printf '  FAIL %s: installer produced no values file (see %s)\n' "$name" "$WORK/$name.log"
+    FAILURES=$((FAILURES + 1))
+    return 1
+  fi
+}
+
+assert_common() { # yaml-file
+  local y="$1"
+  yq e '.' "$y" >/dev/null 2>&1 \
+    && printf '  ok   values file is valid yaml\n' \
+    || { printf '  FAIL values file is not valid yaml\n'; FAILURES=$((FAILURES + 1)); return; }
+
+  # Without this feature flag Prometheus parses the exemplar off the scrape and
+  # discards it, with no error anywhere.
+  check "exemplar-storage enabled" "true" \
+    "$(yq e '.prometheus.prometheusSpec.enableFeatures | contains(["exemplar-storage"])' "$y")"
+
+  # Two jsonData keys under one datasource is valid yaml in which one block
+  # silently wins. There must never be more than one.
+  local blocks
+  blocks="$(grep -c 'jsonData:' "$y" || true)"
+  if (( blocks <= 1 )); then
+    printf '  ok   at most one jsonData block (%s)\n' "$blocks"
+  else
+    printf '  FAIL duplicate jsonData blocks: %s\n' "$blocks"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+assert_linked() { # yaml-file namespace
+  local y="$1" ns="$2"
+  check "jaeger datasource present" "1" "$(yq e "[$JAEGER_DS] | length" "$y")"
+  check "jaeger url uses detected namespace" \
+    "http://jaeger-collector.${ns}.svc.cluster.local:16686" "$(yq e "$JAEGER_DS | .url" "$y")"
+  # The link is what turns the trace_id label from text into a click.
+  check "exemplar link targets the jaeger datasource" "jaeger" \
+    "$(yq e "[$PROM_DS.jsonData.exemplarTraceIdDestinations[]? | select(.name==\"trace_id\") | .datasourceUid] | .[0] // \"none\"" "$y")"
+  check "link uid matches the jaeger datasource uid" "jaeger" "$(yq e "$JAEGER_DS | .uid" "$y")"
+}
+
+assert_unlinked() { # yaml-file
+  local y="$1"
+  check "no jaeger datasource" "0" "$(yq e "[$JAEGER_DS] | length" "$y")"
+  check "no exemplar link" "none" \
+    "$(yq e "[$PROM_DS.jsonData.exemplarTraceIdDestinations[]? | .datasourceUid] | .[0] // \"none\"" "$y")"
+}
+
+write_stubs
+
+echo "tracing not installed (central mode)"
+JAEGER_NS="" render no-tracing && { assert_common "$WORK/no-tracing.yaml"; assert_unlinked "$WORK/no-tracing.yaml"; }
+
+echo "tracing installed (central mode)"
+JAEGER_NS="tracing" render central && { assert_common "$WORK/central.yaml"; assert_linked "$WORK/central.yaml" tracing; }
+
+echo "tracing installed, tls enabled (central mode)"
+JAEGER_NS="tracing" render central-tls -t && {
+  assert_common "$WORK/central-tls.yaml"
+  assert_linked "$WORK/central-tls.yaml" tracing
+  # The tls branch writes its own jsonData; both settings have to survive.
+  check "tlsSkipVerify kept alongside the link" "true" "$(yq e "$PROM_DS.jsonData.tlsSkipVerify" "$WORK/central-tls.yaml")"
+}
+
+echo "tracing installed (individual mode)"
+JAEGER_NS="tracing" render individual -i -n my-namespace && {
+  assert_common "$WORK/individual.yaml"
+  assert_linked "$WORK/individual.yaml" tracing
+}
+
+echo "explicit TRACING_NAMESPACE override"
+JAEGER_NS="observability" TRACING_NAMESPACE="observability" render override && {
+  assert_common "$WORK/override.yaml"
+  assert_linked "$WORK/override.yaml" observability
+}
+
+echo "TRACING_NAMESPACE points at a namespace with no jaeger"
+# The detect helper logs a warning on this path. If that warning went to stdout
+# it would be captured as the namespace and rendered into the datasource url,
+# producing a values file that is silently wrong rather than simply unlinked.
+JAEGER_NS="tracing" TRACING_NAMESPACE="wrong-namespace" render bad-override && {
+  assert_common "$WORK/bad-override.yaml"
+  assert_unlinked "$WORK/bad-override.yaml"
+}
+
+echo "dashboard panel is wired to the metric that carries the exemplar"
+DASHBOARD="${SCRIPT_DIR}/../guides/recipes/observability/grafana/dashboards/llm-d-failure-saturation-dashboard.json"
+EXEMPLAR_METRIC="llm_d_epp_request_duration_seconds_bucket"
+
+if jq -e . "$DASHBOARD" >/dev/null 2>&1; then
+  printf '  ok   dashboard is valid json\n'
+
+  # A query with exemplars enabled on a metric that carries none renders an
+  # empty panel with no error, which is the failure this whole path is about.
+  check "every exemplar query uses ${EXEMPLAR_METRIC}" "0" \
+    "$(jq "[.panels[]?.targets[]? | select(.exemplar == true) | select(.expr | contains(\"${EXEMPLAR_METRIC}\") | not)] | length" "$DASHBOARD")"
+
+  check "at least one panel requests exemplars" "true" \
+    "$(jq '[.panels[]?.targets[]? | select(.exemplar == true)] | length > 0' "$DASHBOARD")"
+
+  # The EPP renamed this metric; queries left on the old name return nothing.
+  check "no query uses the retired objective latency metric" "0" \
+    "$(jq '[.panels[]?.targets[]? | select(.expr // "" | contains("inference_objective_request_duration_seconds"))] | length' "$DASHBOARD")"
+else
+  printf '  FAIL dashboard is not valid json\n'
+  FAILURES=$((FAILURES + 1))
+fi
+
+echo
+if (( FAILURES > 0 )); then
+  echo "${FAILURES} assertion(s) failed"
+  exit 1
+fi
+echo "all assertions passed"


### PR DESCRIPTION
Closes #2462.

The EPP attaches trace IDs to `llm_d_epp_request_duration_seconds` as Prometheus exemplars (llm-d/llm-d-router#2774), but nothing in the recipe made them usable. Three things were missing, and none of them error when absent - the exemplar just quietly isn't there:

- `enableFeatures: [exemplar-storage]` - without it Prometheus parses the exemplar off the scrape and drops it
- a Jaeger datasource in Grafana - the tracing script installs Jaeger, the prometheus script only registered Prometheus, so the exemplar had nowhere to point
- `exemplarTraceIdDestinations` on the Prometheus datasource - without it `trace_id` renders as plain text instead of a link

The values file is written twice, once per mode, so all three go into both branches. The TLS branch already wrote its own `jsonData`; both settings are now built into a single block, because two `jsonData` keys under one datasource is valid YAML in which one silently wins.

Jaeger is optional and its namespace is chosen at install time, so the link is wired only when a `jaeger-collector` service is found, with `TRACING_NAMESPACE` to override.

The only dashboard change is `"exemplar": true` on the P99 query of the existing latency panel. All three quantiles read the same buckets, so enabling them all would draw the same points three times.

### Verifying

`scripts/test-prometheus-exemplar-config.sh` runs the real installer against stubbed `kubectl`/`helm` - no cluster needed - and asserts on the values file helm would actually receive. 43 assertions over six configurations: no tracing installed, central mode, central + TLS, individual mode, explicit `TRACING_NAMESPACE`, and a `TRACING_NAMESPACE` holding no Jaeger.
