### PR TITLE
Hardware support: Rebellions NPU (optimized-baseline)

### DIFF
--- a/docs/getting-started/accelerators.md
+++ b/docs/getting-started/accelerators.md
@@ -13,7 +13,7 @@ Maintainers for each accelerator type are listed below. See our well-lit path gu
 | Google | [TPU](../infrastructure/providers/gke/README.md#llm-d-on-google-kubernetes-engine-gke) | Edwin Hernandez (@Edwinhr716), Cong Liu (@liu-cong, <congliu.thu@gmail.com>) |
 | Intel | XPU | Yuan Wu (@yuanwu2017, <yuan.wu@intel.com>) |
 | NVIDIA | GPU | Will Eaton (<weaton@redhat.com>), Greg (<grpereir@redhat.com>) |
-| Rebellions | NPU | Jinmoo Seok (@rebel-jinmoo, <jinmoo_seok@rebellions.ai>), Minwook Ahn (@rebel-minwook, <minwook.ahn@rebellions.ai>) |
+| Rebellions | NPU | Jinmoo Seok (@rebel-jinmoo, <jinmoo_seok@rebellions.ai>), Minwook Ahn (@rebel-minwook, <minwook.ahn@rebellions.ai>), Minho Park (@rebel-minhopark, <minho.park@rebellions.ai>) |
 
 ## Requirements
 
@@ -74,6 +74,48 @@ For P/D disaggregation with RDMA-accelerated KV-cache transfer on Intel XPU, the
 - UCX transport configured with `ib,rc,ze_copy`.
 
 The RDMA overlay (`modelserver/xpu/vllm-rdma/`) reuses the standard XPU vLLM base and adds one RDMA DRA claim per pod plus RDMA-specific UCX transport settings. See the [P/D Disaggregation guide](../../guides/pd-disaggregation/README.md) for deployment instructions.
+
+## Rebellions NPU
+
+Rebellions NPUs are supported through `vllm-rbln`, an out-of-tree vLLM platform
+plugin that registers on the `vllm.platform_plugins` entry point, shipped in a publicly
+pullable container image. The optimized-baseline overlay (`modelserver/npu/vllm/`)
+serves `openai/gpt-oss-120b` on two replicas of one NPU each, so the router balances
+across two model servers.
+
+**Cluster prerequisites:**
+
+- [RBLN NPU Operator](https://docs.rbln.ai/latest/software/system_management/kubernetes/about_npu_operator.html),
+  which installs the driver and the `npu.rebellions.ai` DRA DeviceClass
+- Kubernetes 1.34 with the `resource.k8s.io/v1` DRA APIs
+
+**Device allocation.** NPUs are requested through DRA, not an extended resource. One
+DeviceClass serves every Rebellions product, so a claim reaches a specific NPU only by
+filtering on `productName` in a CEL selector — see
+`resource-claim-template.yaml` in the overlay. Omitting the selector lets the claim bind to
+a different Rebellions product than the guide was measured on.
+
+**NUMA alignment.** This overlay claims one NPU and no NIC, so it sets no
+`resource.kubernetes.io/numaNode` match constraint — such a constraint needs two or more
+requests in one claim to bind together.
+
+**Prefix caching is off, so layer the NPU router values.** The runtime disables prefix
+caching for sliding-window models, and `openai/gpt-oss-120b` is one: enabling it reports
+0 hits over every query. The guide's default scheduling profile is prefix-cache aware, so
+apply [`router/npu.values.yaml`](../../guides/optimized-baseline/router/npu.values.yaml)
+after the guide's own values to fall back to the load scorer alone. Both the flag and that
+file go away once the runtime supports prefix caching here.
+
+**Set `MODEL` when running the guide's steps.** The overlay pins
+`openai/gpt-oss-120b`, while the guide defaults `MODEL` to `Qwen/Qwen3-32B`. Export
+`MODEL=openai/gpt-oss-120b` so the validation and benchmark steps address the served model.
+
+**Out of scope for this release:** [fast model actuation](../../guides/fast-model-actuation/README.md),
+because the runtime does not support sleep and wake; LoRA adapters; and multimodal models,
+which on this runtime need a code path that cannot run alongside a KV connector.
+
+**Verification.** The maintainers listed above stand up the optimized-baseline overlay once
+per llm-d release tag against the release image and record the result.
 
 ## CPU Inferencing
 

--- a/docs/getting-started/accelerators.md
+++ b/docs/getting-started/accelerators.md
@@ -107,7 +107,7 @@ requests in one claim to bind together.
 **Prefix caching is off, so layer the NPU router values.** The runtime disables prefix
 caching for sliding-window models, and `openai/gpt-oss-120b` is one: enabling it reports
 0 hits over every query. The guide's default scheduling profile is prefix-cache aware, so
-apply [`router/npu.values.yaml`](../../guides/optimized-baseline/router/npu.values.yaml)
+apply [`router/npu.rbln.values.yaml`](../../guides/optimized-baseline/router/npu.rbln.values.yaml)
 after the guide's own values to fall back to the load scorer alone. Both the flag and that
 file go away once the runtime supports prefix caching here.
 

--- a/guides/optimized-baseline/README.md
+++ b/guides/optimized-baseline/README.md
@@ -40,6 +40,7 @@ This guide includes configurations for the following accelerators:
 | Intel XPU           | `xpu`              | Intel Data Center GPU Max 1550+                                 |
 | Google TPU v6e      | `tpu/v6`           | GKE TPU                                                         |
 | Google TPU v7       | `tpu/v7`           | GKE TPU                                                         |
+| Rebellions NPU      | `npu`              | Rebellions NPU via DRA                                          |
 | CPU                 | `cpu`              | x86 with bf16 acceleration                                      |
 
 > [!NOTE]
@@ -82,7 +83,7 @@ export HF_TOKEN=HF_TOKEN_PLACEHOLDER
 ```bash
 export MONITORING_VALUES=
 export PROVIDER_NAME=none # options: none, gke, agentgateway, istio
-export ACCELERATOR_TYPE=gpu # options: gpu, amd, xpu, hpu, tpu/v6, tpu/v7, cpu
+export ACCELERATOR_TYPE=gpu # options: gpu, amd, xpu, hpu, tpu/v6, tpu/v7, npu, cpu
 export MODEL_SERVER=vllm # options: vllm, sglang, trtllm
 export INFRA_PROVIDER=base # options: base, gke
 export MODEL=Qwen/Qwen3-32B
@@ -255,7 +256,7 @@ Apply the Kustomize overlays for your specific backend:
 kubectl apply -n ${NAMESPACE} \
   -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/${ACCELERATOR_TYPE}/${MODEL_SERVER}/${INFRA_PROVIDER}/
 
-# only when ACCELERATOR_TYPE=amd or xpu or hpu or tpu/v6 or tpu/v7 or cpu:
+# only when ACCELERATOR_TYPE=amd or xpu or hpu or tpu/v6 or tpu/v7 or npu or cpu:
 #
 # Comment out the above `kubectl apply` and uncomment the below to run on `NON GPU` accelerators
 #
@@ -503,7 +504,7 @@ helm uninstall ${GUIDE_NAME} -n ${NAMESPACE}
 # only when ACCELERATOR_TYPE=gpu:
 kubectl delete -n ${NAMESPACE} -k ${REPO_ROOT}/guides/${GUIDE_NAME}/modelserver/${ACCELERATOR_TYPE}/${MODEL_SERVER}/${INFRA_PROVIDER}
 
-# only when ACCELERATOR_TYPE=amd or xpu or hpu or tpu/v6 or tpu/v7 or cpu:
+# only when ACCELERATOR_TYPE=amd or xpu or hpu or tpu/v6 or tpu/v7 or npu or cpu:
 #
 # Comment out the above `kubectl delete` and uncomment the below to run on `NON GPU` accelerators
 #

--- a/guides/optimized-baseline/guide.yaml
+++ b/guides/optimized-baseline/guide.yaml
@@ -1,7 +1,7 @@
 name: optimized-baseline
 
 _lists:
-  non_gpu: &non_gpu [amd, xpu, hpu, "tpu/v6", "tpu/v7", cpu]
+  non_gpu: &non_gpu [amd, xpu, hpu, "tpu/v6", "tpu/v7", npu, cpu]
 
 env:
   static:
@@ -16,7 +16,7 @@ env:
     MONITORING_VALUES: {default: ""}
 
     PROVIDER_NAME: {default: none, values: [none, gke, agentgateway, istio]}
-    ACCELERATOR_TYPE: {default: gpu, values: [gpu, amd, xpu, hpu, "tpu/v6", "tpu/v7", cpu]}
+    ACCELERATOR_TYPE: {default: gpu, values: [gpu, amd, xpu, hpu, "tpu/v6", "tpu/v7", npu, cpu]}
     MODEL_SERVER: {default: vllm, values: [vllm, sglang, trtllm]}
     INFRA_PROVIDER: {default: base, values: [base, gke]}
 

--- a/guides/optimized-baseline/modelserver/npu/vllm/kustomization.yaml
+++ b/guides/optimized-baseline/modelserver/npu/vllm/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../recipes/modelserver/base/single-host/default
+  - resource-claim-template.yaml
+
+namePrefix: optimized-baseline-npu-vllm-
+
+components:
+  - ../../../../recipes/modelserver/components/images/npu-vllm/release
+
+labels:
+  - pairs:
+      llm-d.ai/guide: optimized-baseline
+      llm-d.ai/model: gpt-oss-120b
+      llm-d.ai/accelerator-variant: npu
+      llm-d.ai/accelerator-vendor: rebellions
+    includeSelectors: true
+    includeTemplates: true
+
+patches:
+  - path: patch-vllm.yaml

--- a/guides/optimized-baseline/modelserver/npu/vllm/patch-vllm.yaml
+++ b/guides/optimized-baseline/modelserver/npu/vllm/patch-vllm.yaml
@@ -76,15 +76,16 @@ spec:
             - name: VLLM_RBLN_USE_VLLM_MODEL
               value: "1"
           resources:
-            # Anonymous memory measured 51Gi both idle and under load; the rest of
-            # this limit is headroom for the page cache the model read charges to
-            # the cgroup. Keep cpu even — a node with an SMT-aligned static CPU
-            # manager rejects odd counts.
+            # cpu is the host's core count divided by its NPU count, so a pod gets the
+            # share that goes with the one NPU it claims. Keep it even — a node with an
+            # SMT-aligned static CPU manager rejects odd counts. Anonymous memory
+            # measured 51Gi both idle and under load; the rest of that limit is headroom
+            # for the page cache the model read charges to the cgroup.
             limits:
-              cpu: "10"
+              cpu: "16"
               memory: 157Gi
             requests:
-              cpu: "10"
+              cpu: "16"
               memory: 157Gi
             claims:
               - name: npu-decode-claim

--- a/guides/optimized-baseline/modelserver/npu/vllm/patch-vllm.yaml
+++ b/guides/optimized-baseline/modelserver/npu/vllm/patch-vllm.yaml
@@ -1,0 +1,123 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decode
+spec:
+  replicas: 2
+  # A rolling update keeps the old and the new pod of a replica both holding a
+  # claim, so neither becomes ready where there is no spare accelerator.
+  strategy:
+    type: Recreate
+  # Matches the startupProbe budget below. Left at the 600s default, a compile
+  # still running inside its budget trips ProgressDeadlineExceeded at ten minutes
+  # and anything reading Deployment conditions calls the rollout degraded.
+  progressDeadlineSeconds: 7215
+  template:
+    spec:
+      securityContext:
+        runAsUser: 2000
+        runAsGroup: 0
+        fsGroup: 1600
+      containers:
+        - name: modelserver
+          command: ["vllm", "serve"]
+          args:
+            - "openai/gpt-oss-120b"
+            - "--served-model-name=openai/gpt-oss-120b"
+            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+            - "--max-model-len=131072"
+            - "--block-size=4096"
+            - "--enable-chunked-prefill"
+            - "--max-num-batched-tokens=512"
+            # The runtime turns prefix caching off for sliding-window models, so leaving
+            # it on reports 0 hits over every query. Drop this once that support lands.
+            - "--no-enable-prefix-caching"
+            # Both measured on one Rebellions NPU at this data-parallel size. The block floor
+            # is ceil(max-model-len / block-size) = 32, so 34 leaves one spare.
+            - "--num-gpu-blocks-override=34"
+            - "--max-num-seqs=1"
+          env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: llm-d-hf-token
+                  key: HF_TOKEN
+            - name: VLLM_CACHE_ROOT
+              value: /workspace/.cache
+            - name: RBLN_COMP_DTYPE
+              value: dlfloat
+            - name: RBLN_LOCAL_IP
+              value: 127.0.0.1
+            - name: RBLN_ROOT_IP
+              value: 127.0.0.1
+            - name: RBLN_WEIGHT_FREE
+              value: "1"
+            # Unreachable in practice: the startupProbe budget below is 7215s.
+            - name: VLLM_ENGINE_READY_TIMEOUT_S
+              value: "9600"
+            - name: VLLM_RBLN_AUTO_PORT
+              value: "1"
+            - name: VLLM_RBLN_BATCH_ATTN_OPT
+              value: "1"
+            - name: VLLM_RBLN_COMPILE_STRICT_MODE
+              value: "1"
+            - name: VLLM_RBLN_METRICS
+              value: "1"
+            - name: VLLM_RBLN_MOE_REDUCE_SCATTER
+              value: "1"
+            - name: VLLM_RBLN_SAMPLER
+              value: "1"
+            - name: VLLM_RBLN_SORT_BATCH
+              value: "1"
+            - name: VLLM_RBLN_SUB_BLOCK_CACHE
+              value: "False"
+            - name: VLLM_RBLN_USE_DEVICE_TENSOR
+              value: "1"
+            - name: VLLM_RBLN_USE_VLLM_MODEL
+              value: "1"
+          resources:
+            # Anonymous memory measured 51Gi both idle and under load; the rest of
+            # this limit is headroom for the page cache the model read charges to
+            # the cgroup. Keep cpu even — a node with an SMT-aligned static CPU
+            # manager rejects odd counts.
+            limits:
+              cpu: "10"
+              memory: 157Gi
+            requests:
+              cpu: "10"
+              memory: 157Gi
+            claims:
+              - name: npu-decode-claim
+          volumeMounts:
+            - mountPath: /workspace/.cache
+              name: rbln-compile-cache
+            - mountPath: /dev/shm
+              name: shm
+          # 15 + 30x240 = 7215s, wider than the 3615s the other overlays in this
+          # guide use. A cold compile measured 314s on one Rebellions NPU and the cache
+          # is an emptyDir, so a restart pays that again — but the first start also
+          # pulls 65GiB of weights, which on its own ran past half the narrower
+          # budget. The vendor's own reference deployment allows the same 240 checks.
+          startupProbe:
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 240
+          livenessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+      resourceClaims:
+        - name: npu-decode-claim
+          resourceClaimTemplateName: npu-claim-template-decode
+      volumes:
+        - name: rbln-compile-cache
+          emptyDir: {}
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 20Gi

--- a/guides/optimized-baseline/modelserver/npu/vllm/patch-vllm.yaml
+++ b/guides/optimized-baseline/modelserver/npu/vllm/patch-vllm.yaml
@@ -23,17 +23,15 @@ spec:
           command: ["vllm", "serve"]
           args:
             - "openai/gpt-oss-120b"
-            - "--served-model-name=openai/gpt-oss-120b"
             - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
-            - "--max-model-len=131072"
             - "--block-size=4096"
-            - "--enable-chunked-prefill"
             - "--max-num-batched-tokens=512"
             # The runtime turns prefix caching off for sliding-window models, so leaving
             # it on reports 0 hits over every query. Drop this once that support lands.
             - "--no-enable-prefix-caching"
             # Both measured on one Rebellions NPU at this data-parallel size. The block floor
-            # is ceil(max-model-len / block-size) = 32, so 34 leaves one spare.
+            # is ceil(131072 / block-size) = 32 at the model's own context length, so 34
+            # leaves one spare.
             - "--num-gpu-blocks-override=34"
             - "--max-num-seqs=1"
           env:
@@ -46,10 +44,6 @@ spec:
               value: /workspace/.cache
             - name: RBLN_COMP_DTYPE
               value: dlfloat
-            - name: RBLN_LOCAL_IP
-              value: 127.0.0.1
-            - name: RBLN_ROOT_IP
-              value: 127.0.0.1
             - name: RBLN_WEIGHT_FREE
               value: "1"
             # Unreachable in practice: the startupProbe budget below is 7215s.

--- a/guides/optimized-baseline/modelserver/npu/vllm/resource-claim-template.yaml
+++ b/guides/optimized-baseline/modelserver/npu/vllm/resource-claim-template.yaml
@@ -1,0 +1,19 @@
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: npu-claim-template-decode
+  labels:
+    llm-d.ai/role: decode
+spec:
+  spec:
+    devices:
+      requests:
+        - name: rebel
+          exactly:
+            count: 1
+            deviceClassName: npu.rebellions.ai
+            # One DeviceClass serves every Rebellions product, so a claim reaches a
+            # specific NPU only by filtering here. productName carries no domain prefix.
+            selectors:
+              - cel:
+                  expression: device.attributes["npu.rebellions.ai"].productName.startsWith("RBLN-CR")

--- a/guides/optimized-baseline/router/npu.rbln.values.yaml
+++ b/guides/optimized-baseline/router/npu.rbln.values.yaml
@@ -1,5 +1,6 @@
 # Rebellions NPU overrides for optimized-baseline.values.yaml. Apply after it;
-# everything not named here is inherited.
+# everything not named here is inherited. Named for the RBLN runtime rather than
+# for NPUs in general, since the limitation below is that runtime's.
 #
 # The NPU path serves gpt-oss-120b with prefix caching off, so the scheduling
 # profile drops the prefix-cache-affinity-filter and keeps the load scorer.

--- a/guides/optimized-baseline/router/npu.values.yaml
+++ b/guides/optimized-baseline/router/npu.values.yaml
@@ -1,0 +1,29 @@
+# Rebellions NPU overrides for optimized-baseline.values.yaml. Apply after it;
+# everything not named here is inherited.
+#
+# The NPU path serves gpt-oss-120b with prefix caching off, so the scheduling
+# profile drops the prefix-cache-affinity-filter and keeps the load scorer.
+# Leaving the filter in place would make the router treat endpoints as
+# cache-warm and pin requests to them while the model servers reuse nothing,
+# trading load balance for an affinity that does not exist. Remove this file
+# once the RBLN runtime supports prefix caching for sliding-window models and
+# the overlay drops --no-enable-prefix-caching.
+router:
+  epp:
+    pluginsCustomConfig:
+      optimized-baseline-plugins.yaml: |
+        apiVersion: llm-d.ai/v1alpha1
+        kind: EndpointPickerConfig
+        plugins:
+        - type: inflight-load-producer
+        - type: token-load-scorer
+        schedulingProfiles:
+        - name: default
+          plugins:
+          - pluginRef: token-load-scorer
+
+  modelServers:
+    matchLabels:
+      llm-d.ai/guide: "optimized-baseline"
+      llm-d.ai/accelerator-variant: "npu"
+      llm-d.ai/accelerator-vendor: "rebellions"

--- a/guides/recipes/modelserver/components/images/README.md
+++ b/guides/recipes/modelserver/components/images/README.md
@@ -36,6 +36,8 @@ This directory contains Kustomize Components that define the **default container
 │   └── release
 ├── gpu-vllm-omni
 │   └── release
+├── npu-vllm
+│   └── release
 ├── routing-sidecar
 │   ├── nightly
 │   └── release

--- a/guides/recipes/modelserver/components/images/npu-vllm/release/kustomization.yaml
+++ b/guides/recipes/modelserver/components/images/npu-vllm/release/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Rebellions publishes this image while the RBLN SDK is pre-GA: some packages it carries
+# are internal dev builds. Moves to a docker/Dockerfile.rbln built by llm-d at GA.
+images:
+  - name: REPLACE_MODEL_SERVER_IMAGE
+    newName: ghcr.io/rbln-sw/rbln-serve
+    newTag: 0.11.3a1
+
+# Workaround for https://github.com/vllm-project/vllm/issues/44548, required with vLLM v0.20.0+ due to torch 2.11+
+# This image pins vLLM 0.24.0 on torch 2.11.0, so it is in range.
+patches:
+  - target:
+      kind: Deployment
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: USER
+          value: llm-d

--- a/guides/recipes/router/calibration/configuration-matrix.md
+++ b/guides/recipes/router/calibration/configuration-matrix.md
@@ -29,6 +29,7 @@ rows because the serving engine changes prefill throughput.
 | `amd/sglang`  | AMD GPU · SGLang          | v0.5.13.post1 (rocm) | 2 | Qwen3-32B               | 30720 ‡ |
 | `tpu/v6/vllm` | Google TPU v6e · vLLM     | tpu v0.22.0          | 8 | Qwen3-32B               | **26290** |
 | `tpu/v7/vllm` | Google TPU v7x · vLLM     | tpu v0.22.0          | 8 | Qwen3-32B               | **27336** |
+| `npu/vllm`  | Rebellions NPU · vLLM       | vllm-rbln 0.11.3a7 | 1 | gpt-oss-120B          | **12884** |
 | `xpu/vllm`    | Intel XPU · vLLM          | xpu v0.7.0           | 1 | Qwen3-0.6B              | 1970 ‡ |
 | `cpu/vllm`    | CPU · vLLM (AMX)          | cpu v0.6.0           | 1 | Llama-3.2-3B-Instruct   | **1970** |
 
@@ -48,6 +49,10 @@ rows because the serving engine changes prefill throughput.
 - The GPU/TPU paths run at the vLLM default `--max-num-batched-tokens=8192`, so calibrate those
   with `CHUNK_SIZE=8192`. **Re-measure** if you change TP, chunk size, quantization, or
   `--max-model-len` — those move the number more than the model identity does.
+- **`npu/vllm`** — gpt-oss-120B on one Rebellions NPU at dp1 and `--max-num-seqs=1`,
+  `--max-num-batched-tokens=512`, so calibrate this path with `CHUNK_SIZE=512`. This path
+  does not borrow a proxy: the closest measured row (`gpu/vllm/gpt-oss`, 39065) is an H100
+  MXFP4 number and applying it here would open the saturation gate when it should stay shut.
 - **‡ proxy, not measured** — these paths are not yet calibrated, so they borrow the closest
   measured value as a starting point: the **AMD** paths use the same-engine H100 values
   (`amd/vllm` ← `gpu/vllm` 15928, `amd/sglang` ← `gpu/sglang` 30720), and **XPU** uses the

--- a/guides/recipes/router/calibration/configuration-matrix.md
+++ b/guides/recipes/router/calibration/configuration-matrix.md
@@ -29,7 +29,7 @@ rows because the serving engine changes prefill throughput.
 | `amd/sglang`  | AMD GPU · SGLang          | v0.5.13.post1 (rocm) | 2 | Qwen3-32B               | 30720 ‡ |
 | `tpu/v6/vllm` | Google TPU v6e · vLLM     | tpu v0.22.0          | 8 | Qwen3-32B               | **26290** |
 | `tpu/v7/vllm` | Google TPU v7x · vLLM     | tpu v0.22.0          | 8 | Qwen3-32B               | **27336** |
-| `npu/vllm`  | Rebellions NPU · vLLM       | vllm-rbln 0.11.3a7 | 1 | gpt-oss-120B          | **12884** |
+| `npu/vllm`  | Rebellions NPU · vLLM       | vllm-rbln 0.11.3a7 | 1 | gpt-oss-120B          | **12582** |
 | `xpu/vllm`    | Intel XPU · vLLM          | xpu v0.7.0           | 1 | Qwen3-0.6B              | 1970 ‡ |
 | `cpu/vllm`    | CPU · vLLM (AMX)          | cpu v0.6.0           | 1 | Llama-3.2-3B-Instruct   | **1970** |
 


### PR DESCRIPTION
## What this adds

An `optimized-baseline` model server overlay for Rebellions NPUs, plus the image component
and accelerator docs it needs. Modeled on the `xpu` and `amd` overlays.

- `guides/optimized-baseline/modelserver/npu/vllm/` — two replicas of `openai/gpt-oss-120b`,
  one NPU each, consuming `recipes/modelserver/base/single-host`
- `guides/recipes/modelserver/components/images/npu-vllm/release/` — the image component
- `docs/getting-started/accelerators.md` — a Rebellions NPU section and a support-table row
- `guides/optimized-baseline/router/npu.rbln.values.yaml` — a load-only scheduling profile
- `guides/recipes/router/calibration/configuration-matrix.md` — the measured
  `peakPrefillThroughput` for this configuration

`ACCELERATOR_TYPE=npu`. Rebellions' operator advertises one resource name and one DRA
DeviceClass across its product families, so the accelerator is spelled `npu` rather than a
family name.

## Prefix caching, and what it does to routing

The runtime disables prefix caching for sliding-window models and `gpt-oss-120b` is one, so
the overlay passes `--no-enable-prefix-caching`. Enabling it anyway is not a workaround:
the server starts and counts queries but returns no hits, measured at
`vllm:prefix_cache_queries_total` 112640 against `vllm:prefix_cache_hits_total` 0, with
warm and cold TTFT within 2 ms of each other at both 2k and 8k prompts.

That matters for this guide because its default scheduling profile is prefix-cache aware.
Left alone, the `prefix-cache-affinity-filter` would pin requests to endpoints it believes
are cache-warm while the model servers reuse nothing, trading load balance for an affinity
that does not exist. `router/npu.rbln.values.yaml` replaces the profile with the
`token-load-scorer` alone. Rebellions expects prefix caching for these models in the GA
runtime; the flag and that file both go away then.

## Device allocation

NPUs come through DRA, not an extended resource. A single `npu.rebellions.ai` DeviceClass
covers every Rebellions product, so the claim narrows to the REBEL family with a CEL
selector on `device.attributes["npu.rebellions.ai"].productName`. This needs
`resource.k8s.io/v1`, which is Kubernetes 1.34 or later — `kubeconform -strict` finds no
schema for the claim template at `--kubernetes-version 1.33.0` and validates all three
resources at 1.34.0. The accelerator docs state that requirement.

This overlay claims one NPU and no NIC, so it sets no NUMA constraint.

## Verification

Run on one bare-metal node, Kubernetes 1.36.3, image `ghcr.io/rbln-sw/rbln-serve:0.11.3a1`
pulled anonymously with no pull secret.

| | |
| :-- | :-- |
| Both replicas ready | 458 s, on separate NPUs |
| `/v1/completions` | returns, `vllm 0.24.0` on `torch 2.11.0`, `vllm_rbln 0.11.3a7` |
| Load, per replica | `vllm bench serve`, random 1k in / 1k out, 64 requests, concurrency 8 |
| Replica A | 64/64 succeeded, 201.8 output tok/s, TPOT p99 4.95 ms |
| Replica B | 64/64 succeeded, 201.7 output tok/s, TPOT p99 4.94 ms |
| Anonymous memory | 50.7 GiB against the 157Gi limit |
| Restarts | 0 |

The calibration recipe defines peak prefill throughput as `CHUNK_SIZE / median(TTFT)` with
`CHUNK_SIZE` matching `--max-num-batched-tokens`, which is 512 here. Five runs of 20
requests spread from 12467 to 13467; the matrix row carries their median, 12582. The
overlay does not set the value on the filter — the guide's "Adapting to other hardware"
section directs readers to the matrix instead.

## Three deliberate deviations from the base

The compile runs inside the pod on first start, so the startup budget is 7215 s and
`progressDeadlineSeconds` matches it rather than tripping at the 600 s default. A rolling
update would leave a replica's old and new pod both holding a claim with no spare
accelerator, hence `Recreate`. And `--num-gpu-blocks-override` carries a measured count
rather than a profiled one, because the KV cache lives in NPU memory that vLLM's profiling
pass cannot size; that also makes `--gpu-memory-utilization` redundant, so the overlay does
not set it.

## On the container image

`ghcr.io/rbln-sw/rbln-serve` is published by Rebellions. Most accelerators here take their
image from the engine project (`docker.io/vllm/*`, `docker.io/lmsysorg/sglang`) or from
llm-d itself (`ghcr.io/llm-d/llm-d-xpu` and friends, thin layers in `docker/`), with MetaX
the one vendor-published exception so far. @Gregory-Pereira raised the policy on #2308 and
we would rather answer it up front.

`vllm-rbln` is not a fork. It is an out-of-tree platform plugin that registers on the
`vllm.platform_plugins` entry point, and the image carries unmodified vLLM 0.24.0. So the
llm-d-built path is open in principle: a `docker/Dockerfile.rbln` layered on an upstream
vLLM release, the way `docker/Dockerfile.xpu` is.

What blocks it today is that the RBLN SDK is pre-GA. `vllm-rbln`, `optimum-rbln` and
`torch-rbln` are open source and on public PyPI, but the image also carries
`rebel-compiler`, `lmcache-rbln` and `nixl-rbln`, which are still internal projects, and
every RBLN package in it is a development build rather than a release. All of them become
public releases at GA. Until then llm-d CI cannot build the image, so we are asking for the
vendor image as a stop gap and will contribute a `docker/Dockerfile.rbln` once the packages
are published. The image component carries a comment saying so, and we are happy to track
it in an issue.

## Follow-up

A `pd-disaggregation` overlay is written and has run on eight NPUs with RoCE over DRA and
NIXL KV transfer, including NUMA-aligned NPU and VF placement, though that run predates the
image and naming this PR settles and will be repeated. Keeping it out of this PR per the
maintainers' preference for separate PRs; it will follow once this lands.

A nightly e2e lane needs a cluster with an Actions Runner Controller, which we do not have
registered yet. That is tracked separately and is not part of this PR.
