### PR TITLE
fix(scripts): lint scripts on RUN continuation lines

### DIFF
--- a/docker/scripts/cuda/builder/build-gdrcopy.sh
+++ b/docker/scripts/cuda/builder/build-gdrcopy.sh
@@ -7,7 +7,6 @@ set -Eeux
 # - USE_SCCACHE: whether to use sccache (true/false)
 # - GDRCOPY_REPO: git repo to build GDRCopy from
 # - GDRCOPY_VERSION: git ref to build GDRCopy from
-# - GDRCOPY_PREFIX: location to install GDR Copy to
 # Optional environment variables:
 # - TARGETPLATFORM: platform target (linux/arm64 or linux/amd64)
 # - TARGETOS: OS type (ubuntu or rhel)

--- a/scripts/lint-dockerfile-envvars.py
+++ b/scripts/lint-dockerfile-envvars.py
@@ -114,11 +114,16 @@ def find_script_runs(dockerfile_content: str) -> List[Tuple[str, str, int]]:
     """find all RUN commands that execute scripts, return (stage, script_path, line_num)"""
     runs = []
     current_stage = None
-    line_num = 0
+    lines = dockerfile_content.split('\n')
+    i = 0
 
-    for line in dockerfile_content.split('\n'):
-        line_num += 1
-        stripped = line.strip()
+    while i < len(lines):
+        line_num = i + 1
+        stripped = lines[i].strip()
+
+        while stripped.endswith('\\') and i + 1 < len(lines):
+            i += 1
+            stripped = stripped[:-1] + ' ' + lines[i].strip()
 
         # track stage
         if stripped.upper().startswith('FROM'):
@@ -132,10 +137,12 @@ def find_script_runs(dockerfile_content: str) -> List[Tuple[str, str, int]]:
         if stripped.upper().startswith('RUN'):
             # match: RUN /path/to/script.sh or RUN chmod ... && /path/to/script.sh
             script_matches = re.findall(r'(/[^\s]+\.sh)', stripped)
-            for script in script_matches:
+            for script in dict.fromkeys(script_matches):
                 # normalize path (remove /tmp/ prefix if present)
                 script_name = Path(script).name
                 runs.append((current_stage, script_name, line_num))
+
+        i += 1
 
     return runs
 

--- a/scripts/tests/test_lint_dockerfile_envvars.py
+++ b/scripts/tests/test_lint_dockerfile_envvars.py
@@ -32,3 +32,30 @@ def test_child_stage_inherits_base_arg_and_env(tmp_path):
     ok, errors = lint.lint_dockerfile(dockerfile, scripts_dir)
 
     assert ok, errors
+
+
+def test_script_on_run_continuation_line_is_linted(tmp_path):
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "check.sh").write_text(
+        "#!/bin/sh\n"
+        "# Required environment variables:\n"
+        "# - MISSING_VAR: never declared by the Dockerfile\n"
+    )
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        "FROM ubuntu:22.04 AS build\n"
+        "RUN --mount=type=cache,target=/var/cache/dnf \\\n"
+        "    /tmp/check.sh && \\\n"
+        "    rm -f /tmp/check.sh\n"
+    )
+
+    runs = lint.find_script_runs(dockerfile.read_text())
+    assert runs == [("build", "check.sh", 2)]
+
+    ok, errors = lint.lint_dockerfile(dockerfile, scripts_dir)
+
+    assert not ok
+    assert len(errors) == 1
+    assert "MISSING_VAR" in errors[0]
+    assert "Dockerfile:2:" in errors[0]


### PR DESCRIPTION
Fixes #2481

`find_script_runs` only scanned the line starting with `RUN`, so scripts invoked after `RUN --mount=... \` were never checked — 10 of 12 in `Dockerfile.cuda`. Follow-up noted in #2416.

- Join `\` continuations (as `DockerfileParser.parse` already does) and report each script once per `RUN`.
- Drop the `GDRCOPY_PREFIX` header line from `build-gdrcopy.sh`; the script never reads it and no Dockerfile declares it. Surfaced by the fixed check.
- Regression test in `scripts/tests/test_lint_dockerfile_envvars.py`.

`python3 -m pytest scripts/tests/`: 38 passed, 1 skipped; the new test fails on `main`.

Running the linter over all Dockerfiles still reports `UCCL_DEVICE` until #2416 lands (Optional-block false positive fixed there). Happy to rebase once it merges.

Related: #2445 also edits `find_script_runs` (inline `VAR=x /script.sh` assignments) but still scans line by line, so it does not cover this. The two changes are independent; whichever lands second needs a trivial rebase.
